### PR TITLE
POC: Implement basic endpoint for fetching workflow executions

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,26 @@
 /// <reference types="@sveltejs/kit" />
+
+type WorkflowsAPIResponse = {
+  executions: WorkflowExecutionAPIReponse[];
+  nextPageToken: string;
+};
+
+type WorkflowExecutionAPIReponse = {
+  execution: {
+    workflowId: string;
+    runId: string;
+  };
+  type: { name: string };
+  startTime: string;
+  closeTime: string;
+  status: string;
+  historyLength: string;
+  parentNamespaceId: string;
+  parentExecution: any; // TODO: Refine this with a more percise type.
+  executionTime: string;
+  memo: any[]; // TODO: Refine this with a more percise type.
+  searchAttributes: string; // TODO: Refine this with a more percise type.
+  autoResetPoints: string; // TODO: Refine this with a more percise type.
+  taskQueue: string;
+  stateTransitionCount: string;
+};

--- a/src/routes/api/workflows.ts
+++ b/src/routes/api/workflows.ts
@@ -1,0 +1,36 @@
+const apiHost = process.env.TEMPORAL_API_HOST || 'http://localhost:8088';
+
+const fetchWorkflows: (
+  type: string,
+  query: URLSearchParams,
+) => Promise<WorkflowsAPIResponse> = async (type, query) => {
+  const response = await fetch(
+    `${apiHost}/api/namespaces/default/workflows/${type}?${query.toString()}`,
+  );
+  return await response.json();
+};
+
+export async function get({ query }: { query: URLSearchParams }) {
+  const openWorkflows = fetchWorkflows('open', query);
+  const closedWorkflows = fetchWorkflows('closed', query);
+
+  const workflows = await Promise.all([openWorkflows, closedWorkflows]).then(
+    ([open, closed]) => {
+      return {
+        executions: [...open.executions, ...closed.executions],
+        nextPageTokens: {
+          open: open.nextPageToken,
+          closed: closed.nextPageToken,
+        },
+      };
+    },
+  );
+
+  if (workflows) {
+    return {
+      body: {
+        workflows,
+      },
+    };
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,8 +24,9 @@
     "checkJs": true,
     "paths": {
       "$lib/*": ["src/lib/*"],
-      "$components/*": ["./src/components/*"],
-      "$utilities/*": ["./src/utilities/*"]
+      "$components/*": ["src/components/*"],
+      "$utilities/*": ["src/utilities/*"],
+      "$stores/*": ["src/stores/*"]
     }
   },
   "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"],


### PR DESCRIPTION
POC: Implement basic endpoint for fetching workflow executions from containerized Temporal

This is a very naive implementation of an endpoint that can talk to the containerized version of Temporal to fetch a list of workflow executions.

The types need work and there are clearly more query parameters that we'll need to support. There are edge cases left unhandled. But, it's a quick proof of concept that will allow us to work against the fixtures in the `samples-go` repository as we build out some of the pages.

To-do:

- Make this work with single-binary, web-v2 server.
- Figure out how we're going to bundle this with the single binary (we may choose not to and only use these endpoints in the cloud version).
- Add support for the rest of the query parameters currently supported.
- Add better handling.
- Refine types.
- Add support for respecting next page tokens.
- (Probably much more)