### PR TITLE
Add better path matching for active links

### DIFF
--- a/src/lib/components/navigation-link.svelte
+++ b/src/lib/components/navigation-link.svelte
@@ -1,8 +1,9 @@
 <script>
   import { page } from '$app/stores';
+  import { pathMatches } from '$lib/utilities/path-matches.ts';
 
   $: ({ href, src, alt, ...props } = $$props);
-  $: isActive = href === $page.path;
+  $: isActive = pathMatches(href, $page.path);
 </script>
 
 <a {href} class:active={isActive}

--- a/src/lib/utilities/path-matches.test.ts
+++ b/src/lib/utilities/path-matches.test.ts
@@ -1,0 +1,15 @@
+import { pathMatches } from './path-matches';
+
+describe(pathMatches, () => {
+  it('should return true if given two of the exact same paths', () => {
+    expect(pathMatches('/workflows', '/workflows')).toBe(true);
+  });
+
+  it('should return true if the second path is a subdirectory of the first', () => {
+    expect(pathMatches('/workflows', '/workflows/abc')).toBe(true);
+  });
+
+  it('should return false if the second path is not a subdirectory of the first', () => {
+    expect(pathMatches('/workflows', '/queries/abc')).toBe(false);
+  });
+});

--- a/src/lib/utilities/path-matches.ts
+++ b/src/lib/utilities/path-matches.ts
@@ -1,0 +1,13 @@
+export const pathMatches = (first: string, second: string): boolean => {
+  const firstSegments = first.split('/');
+  const secondSegments = second.split('/');
+
+  for (let index = 0; index < firstSegments.length; index++) {
+    const firstSegment = firstSegments[index];
+    const secondSegment = secondSegments[index];
+
+    if (firstSegment !== secondSegment) return false;
+  }
+
+  return true;
+};

--- a/src/routes/workflows/index.svelte
+++ b/src/routes/workflows/index.svelte
@@ -1,1 +1,0 @@
-<p>Select a workflow from above.</p>


### PR DESCRIPTION
## What was changed

Adds a `pathMatches` utility function for the `NavigationLink` component that works when the current path is a subdirectory—for lack of a better word—of the `NavigationLink`.

## Why?

Previous to this change, the Workflows icon would no longer be highlighted if you navigated from `/workflows` to `/workflows/:workflow_id/:run_id` or some variation on that that. This addresses that.