### PR TITLE
Add path alias for types

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import preprocess from 'svelte-preprocess';
 import adapter from '@sveltejs/adapter-static';
 import chalk from 'chalk';
@@ -42,6 +43,11 @@ const config = {
     vite: {
       optimizeDeps: {
         include: ['svelte-hero-icons'],
+      },
+      resolve: {
+        alias: {
+          $types: path.resolve('./src/types'),
+        },
       },
     },
   },


### PR DESCRIPTION
## What was changed

Adds the ability to import types using the `$types` alias.

Example:

```ts
import type { WorkflowExecutionInfo } from '$types/temporal/api/workflow/v1/message';
```