### PR TITLE
Add better support for query params

### DIFF
--- a/src/lib/utilities/get-workflow-execution-url.test.ts
+++ b/src/lib/utilities/get-workflow-execution-url.test.ts
@@ -1,0 +1,29 @@
+import type { WorkflowExecution } from '../models/workflow-execution';
+import { getWorkflowExecutionUrl } from './get-workflow-execution-url';
+
+describe(getWorkflowExecutionUrl, () => {
+  it('should display a workflow URL with just the workflow information', () => {
+    const workflow = { id: 'id', runId: 'run' } as WorkflowExecution;
+
+    expect(getWorkflowExecutionUrl(workflow)).toBe('/workflows/id/run');
+  });
+
+  it('should display a workflow URL with query params', () => {
+    const workflow = { id: 'id', runId: 'run' } as WorkflowExecution;
+    const query = new URLSearchParams({ fullScreen: 'true' });
+
+    expect(getWorkflowExecutionUrl(workflow, query)).toBe(
+      '/workflows/id/run?fullScreen=true',
+    );
+  });
+
+  it('should display a workflow URL with overiding query params', () => {
+    const workflow = { id: 'id', runId: 'run' } as WorkflowExecution;
+    const query = new URLSearchParams({ a: '1', b: '2' });
+    const overrides = new URLSearchParams({ b: '3' });
+
+    expect(getWorkflowExecutionUrl(workflow, query, overrides)).toBe(
+      '/workflows/id/run?a=1&b=3',
+    );
+  });
+});

--- a/src/lib/utilities/get-workflow-execution-url.ts
+++ b/src/lib/utilities/get-workflow-execution-url.ts
@@ -1,0 +1,21 @@
+import type { WorkflowExecution } from '$lib/models/workflow-execution';
+
+import {
+  mergeSearchParams,
+  toSearchParams,
+  URLSearchParamLike,
+} from './url-search-params';
+
+export const getWorkflowExecutionUrl = (
+  workflow: WorkflowExecution,
+  query?: URLSearchParamLike,
+  queryOverrides?: URLSearchParamLike,
+) => {
+  const url = `/workflows/${workflow.id}/${workflow.runId}`;
+
+  const search = queryOverrides
+    ? mergeSearchParams(toSearchParams(query), toSearchParams(queryOverrides))
+    : toSearchParams(query);
+
+  return query ? `${url}?${search}` : `${url}`;
+};

--- a/src/lib/utilities/url-search-params.test.ts
+++ b/src/lib/utilities/url-search-params.test.ts
@@ -1,0 +1,54 @@
+import {
+  mergeSearchParams,
+  toSearchParams,
+  urlSearchParamsToObject,
+} from './url-search-params';
+
+describe(urlSearchParamsToObject, () => {
+  it('should parse URL search params and turn it into an object', () => {
+    const search = new URLSearchParams();
+
+    search.set('a', '1');
+    search.set('b', '2');
+
+    expect(urlSearchParamsToObject(search)).toEqual({ a: '1', b: '2' });
+  });
+});
+
+describe(toSearchParams, () => {
+  it('should take an object of search params and turn it into a URLSearchParam object', () => {
+    const result = toSearchParams({ a: 1, b: 2 });
+
+    expect(result).toBeInstanceOf(URLSearchParams);
+  });
+
+  it('should correctly match the parameters', () => {
+    const expected = new URLSearchParams();
+
+    expected.set('a', '1');
+    expected.set('b', '2');
+
+    const result = toSearchParams({ a: 1, b: 2 });
+
+    expect(result.get('a')).toBe(expected.get('a'));
+    expect(result.get('b')).toBe(expected.get('b'));
+  });
+});
+
+describe(mergeSearchParams, () => {
+  it('should produce a URLSearchParamsObject that is the combination of two URLSearchParams', () => {
+    const first = new URLSearchParams();
+    const second = new URLSearchParams();
+
+    first.set('a', '1');
+    first.set('b', '2');
+    second.set('b', '3');
+    second.set('c', '4');
+
+    const result = mergeSearchParams(first, second);
+
+    expect(result.get('a')).toBe('1');
+    expect(result.get('b')).toBe('3');
+    expect(result.get('c')).toBe('4');
+  });
+});

--- a/src/lib/utilities/url-search-params.ts
+++ b/src/lib/utilities/url-search-params.ts
@@ -1,0 +1,29 @@
+export type URLSearchParamLike =
+  | { [key: string]: string | number | boolean }
+  | URLSearchParams;
+
+export const toSearchParams = (query: URLSearchParamLike) => {
+  if (query instanceof URLSearchParams) return query;
+  return new URLSearchParams(query as Record<string, string>);
+};
+
+export const urlSearchParamsToObject = (search: URLSearchParams) => {
+  return search
+    .toString()
+    .split('&')
+    .map((param) => param.split('='))
+    .reduce((result: { [key: string]: string }, pair: string[]) => {
+      const [key, value] = pair;
+      return { ...result, [key]: value };
+    }, {});
+};
+
+export const mergeSearchParams = (
+  first: URLSearchParams,
+  second: URLSearchParams,
+): URLSearchParams => {
+  return toSearchParams({
+    ...urlSearchParamsToObject(first),
+    ...urlSearchParamsToObject(second),
+  });
+};

--- a/src/routes/workflows/_workflows-summary-row.svelte
+++ b/src/routes/workflows/_workflows-summary-row.svelte
@@ -1,23 +1,30 @@
 <script lang="ts">
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
-  import WorkflowStatus from '$lib/components/workflow-status.svelte';
-
   import { page } from '$app/stores';
+
+  import type { WorkflowExecution } from '$lib/models/workflow-execution';
+  import { getWorkflowExecutionUrl } from '$lib/utilities/get-workflow-execution-url';
   import { pathMatches } from '$lib/utilities/path-matches';
+
+  import WorkflowStatus from '$lib/components/workflow-status.svelte';
 
   export let workflow: WorkflowExecution;
 
-  $: href = workflow.url;
+  $: href = getWorkflowExecutionUrl(workflow, $page.query);
   $: isActive = pathMatches(href, $page.path);
 </script>
 
 <tr class:active={isActive}>
-  <td>
+  <td class="workflow">
     <a {href}>
       <h3>
         {workflow.name}
       </h3>
       <p>
+        <strong>Workflow:</strong>
+        {workflow.id}
+      </p>
+      <p>
+        <strong>Execution:</strong>
         {workflow.runId}
       </p>
     </a>
@@ -57,7 +64,11 @@
   }
 
   td {
-    @apply p-0 w-1/4;
+    @apply p-0;
+  }
+
+  td.workflow {
+    @apply w-1/3;
   }
 
   a {


### PR DESCRIPTION
## What was changed

- Added utility methods for getting a workflow URL so that we can convert the model from a class instance to a simple JavaScript object that we can serialize.
- Added three utility methods for working with query params that are TypeScript friendly: `mergeSearchParams`, `toSearchParams`, and `urlSearchParamsToObject`.