### PR TITLE
Separate install and build steps in makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,17 @@ PROTO_IMPORTS := \
 	-I $(PROTO_ROOT)
 PROTO_REFS := Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/descriptor.proto=github.com/gogo/protobuf/protoc-gen-gogo/descriptor,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/api/annotations.proto=github.com/gogo/googleapis/google/api
 
+##### Install dependencies #####
+install: install-submodules
+
+install-submodules:
+	printf $(COLOR) "fetching submudules..."
+	git submodule update --init
+
 ##### Build #####
-build: clean build-types
+build: build-types
 
 build-types:
-	git submodule update --init
 	printf $(COLOR) "Compiling Typescript types..."
 	rm -rf $(PROTO_OUT)/*
 	mkdir -p $(PROTO_OUT)


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Separates gitsubmodule update from build step

## Why?
<!-- Tell your future self why have you made these changes -->
Improves performance of build step
Fixes running `make` as `install` script was missing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
ran `make`
ran `make` with `clean`, `install` and `build` separately

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
no