### PR TITLE
Added Tabs for Grid and JSON views for event history

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -14,8 +14,3 @@ body {
 body {
   font-family: Inter, sans-serif;
 }
-
-.hljs {
-  height: 10em;
-  overflow-y: scroll;
-}

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -14,3 +14,8 @@ body {
 body {
   font-family: Inter, sans-serif;
 }
+
+.hljs {
+  max-height: 25em;
+  overflow-y: scroll;
+}

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -44,3 +44,10 @@
     </button>
   </div>
 {/if}
+
+<style lang="postcss">
+  .hljs {
+    height: 10em;
+    overflow-y: scroll;
+  }
+</style>

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -44,10 +44,3 @@
     </button>
   </div>
 {/if}
-
-<style lang="postcss">
-  .hljs {
-    height: 10em;
-    overflow-y: scroll;
-  }
-</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
@@ -8,8 +8,14 @@
 
 <section class="p-4 flex gap-2 items-center">
   <label for="format">View Format</label>
-  <button on:click={() => setFormat('grid')}>GRID</button>
-  <button on:click={() => setFormat('json')}>JSON</button>
+  <button
+    class:active={eventFormat === 'grid'}
+    on:click={() => setFormat('grid')}>GRID</button
+  >
+  <button
+    class:active={eventFormat === 'json'}
+    on:click={() => setFormat('json')}>JSON</button
+  >
 </section>
 
 <style lang="postcss">
@@ -22,5 +28,13 @@
 
   button:hover {
     @apply bg-purple-100;
+  }
+
+  .active:hover {
+    @apply text-purple-500;
+  }
+
+  .active {
+    @apply text-purple-100 bg-purple-500;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  
+    export let eventFormat: string = 'grid';
+
+    function setFormat(format) {
+        eventFormat = format;
+  }
+  </script>
+  
+  <section class="p-4 flex gap-8">
+    <button on:click={() => setFormat('grid')}>Grid</button>
+    <button on:click={() => setFormat('json')}>JSON</button>
+  </section>
+  
+  <style lang="postcss">
+    button {
+      @apply text-purple-700 py-4 px-6 border-purple-400 border-2 rounded-md;
+    }
+  
+    button:hover {
+      @apply bg-purple-100;
+    }
+  </style>
+  

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events-filters.svelte
@@ -1,24 +1,26 @@
 <script lang="ts">
-  
-    export let eventFormat: string = 'grid';
+  export let eventFormat: string = 'grid';
 
-    function setFormat(format) {
-        eventFormat = format;
+  function setFormat(format) {
+    eventFormat = format;
   }
-  </script>
-  
-  <section class="p-4 flex gap-8">
-    <button on:click={() => setFormat('grid')}>Grid</button>
-    <button on:click={() => setFormat('json')}>JSON</button>
-  </section>
-  
-  <style lang="postcss">
-    button {
-      @apply text-purple-700 py-4 px-6 border-purple-400 border-2 rounded-md;
-    }
-  
-    button:hover {
-      @apply bg-purple-100;
-    }
-  </style>
-  
+</script>
+
+<section class="p-4 flex gap-2 items-center">
+  <label for="format">View Format</label>
+  <button on:click={() => setFormat('grid')}>GRID</button>
+  <button on:click={() => setFormat('json')}>JSON</button>
+</section>
+
+<style lang="postcss">
+  label {
+    font-size: 14px;
+  }
+  button {
+    @apply text-purple-700 py-1 px-3 border-purple-400 border-2 rounded-md;
+  }
+
+  button:hover {
+    @apply bg-purple-100;
+  }
+</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
@@ -30,10 +30,3 @@
     <CodeBlock heading="" content={JSON.stringify(history.events)} />
   {/if}
 </section>
-
-<style lang="postcss">
-  .hljs {
-    height: 30em;
-    overflow-y: scroll;
-  }
-</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
@@ -3,9 +3,11 @@
   import type { History } from '$types/temporal/api/history/v1/message';
 
   export let history: History;
+  export let eventFormat;
 </script>
 
 <section>
+  {#if eventFormat === 'grid'}
   <table class="border-collapse w-full border-2 table-fixed">
     <thead>
       <tr>
@@ -21,6 +23,7 @@
       {/each}
     </tbody>
   </table>
+{/if}
 </section>
 
 <style lang="postcss">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Event from './_event.svelte';
   import type { History } from '$types/temporal/api/history/v1/message';
+  import CodeBlock from '$lib/components/code-block.svelte';
 
   export let history: History;
   export let eventFormat;
@@ -8,26 +9,31 @@
 
 <section>
   {#if eventFormat === 'grid'}
-  <table class="border-collapse w-full border-2 table-fixed">
-    <thead>
-      <tr>
-        <th class="w-1/12">ID</th>
-        <th class="w-2/12">Type</th>
-        <th class="w-2/12">Time</th>
-        <th class="w-7/12">Details</th>
-      </tr>
-    </thead>
-    <tbody>
-      {#each history.events as event, index}
-        <Event {event} {index} />
-      {/each}
-    </tbody>
-  </table>
-{/if}
+    <table class="border-collapse w-full border-2 table-fixed">
+      <thead>
+        <tr>
+          <th class="w-1/12">ID</th>
+          <th class="w-2/12">Type</th>
+          <th class="w-2/12">Time</th>
+          <th class="w-7/12">Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each history.events as event, index}
+          <Event {event} {index} />
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+
+  {#if eventFormat === 'json'}
+    <CodeBlock heading="" content={JSON.stringify(history.events)} />
+  {/if}
 </section>
 
 <style lang="postcss">
-  th {
-    @apply bg-gray-200 text-gray-500 text-xs h-6 m-0 p-3 text-left uppercase;
+  .hljs {
+    height: 30em;
+    overflow-y: scroll;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/index.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
   import type { GetWorkflowExecutionHistoryResponse } from '$types/temporal/api/workflowservice/v1/request_response';
-  import EventsFilter from './events-filters.svelte';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ context }: LoadInput) {
@@ -22,10 +21,9 @@
 
   let { history } = events;
   let eventFormat = 'grid';
-
 </script>
 
 <div class="px-6 py-6">
-  <EventsFilters  bind:eventFormat />
+  <EventsFilters bind:eventFormat />
   <Events {history} {eventFormat} />
 </div>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/index.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
   import type { GetWorkflowExecutionHistoryResponse } from '$types/temporal/api/workflowservice/v1/request_response';
-
+  import EventsFilter from './events-filters.svelte';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ context }: LoadInput) {
@@ -16,12 +16,16 @@
 
 <script lang="ts">
   import Events from './_events.svelte';
+  import EventsFilters from './_events-filters.svelte';
 
   export let events: GetWorkflowExecutionHistoryResponse;
 
   let { history } = events;
+  let eventFormat = 'grid';
+
 </script>
 
 <div class="px-6 py-6">
-  <Events {history} />
+  <EventsFilters  bind:eventFormat />
+  <Events {history} {eventFormat} />
 </div>

--- a/static/css/override.css
+++ b/static/css/override.css
@@ -1,4 +1,4 @@
 .hljs {
-    max-height: 20em;
+    max-height: 25em;
     overflow-y: scroll;
 }


### PR DESCRIPTION
## What was changed
Added filter tabs for event history to display JSON and GRID formats

## Why?
Apart of Sprint goal

2. How was this tested:
Tested locally

# Images 
<img width="1434" alt="Screen Shot 2021-08-23 at 10 48 23 AM" src="https://user-images.githubusercontent.com/43492172/130486192-dbf9a3cb-ce68-4829-9c31-e1b27c9c92ba.png">

