### PR TITLE
Make tabs reactive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,9 @@
       "version": "7.14.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
       "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+      "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
@@ -9,10 +9,10 @@
 
   export let workflow: WorkflowExecution;
 
-  const namespace = getContext('namespace') as string;
-  const workflowUrl = getWorkflowExecutionUrl(namespace, workflow);
-  const summaryUrl = workflowUrl + '/summary';
-  const eventsUrl = workflowUrl + '/events';
+  $: namespace = getContext('namespace') as string;
+  $: workflowUrl = getWorkflowExecutionUrl(namespace, workflow);
+  $: summaryUrl = workflowUrl + '/summary';
+  $: eventsUrl = workflowUrl + '/events';
 </script>
 
 <nav class="mt-6 border-b-2 px-2 flex">


### PR DESCRIPTION
Clicking directly on the "Summary" and "Events" tabs from the execution preview could potentially have the wrong URLs cached. This fixes that.