### PR TITLE
added multiple json view to events

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_events.svelte
@@ -27,6 +27,11 @@
   {/if}
 
   {#if eventFormat === 'json'}
-    <CodeBlock heading="" content={JSON.stringify(history.events)} />
+    {#each history.events as event}
+      <CodeBlock
+        heading={`Event ID: ${event.eventId}`}
+        content={JSON.stringify(event)}
+      />
+    {/each}
   {/if}
 </section>


### PR DESCRIPTION
## What was changed
Changed JSON event view from one huge view to code blocks of each eventId

## Why?
Gives a better sense of what is happening in each event, and still gives the option of the user to get the full json view if they export

## Images
### Old View
<img width="1434" alt="Screen Shot 2021-08-23 at 10 48 23 AM" src="https://user-images.githubusercontent.com/43492172/130486192-dbf9a3cb-ce68-4829-9c31-e1b27c9c92ba.png">

### New View
<img width="1436" alt="Screen Shot 2021-08-26 at 2 14 51 PM" src="https://user-images.githubusercontent.com/43492172/131029847-06e862f6-5799-4978-bfe3-5730834f9e46.png">
