### PR TITLE
added tab to switch between json and grid view

### DIFF
--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -27,18 +27,21 @@
 {#if content}
   <div class="relative group w-full mb-2">
     <div id="clipboard" />
-    <h3 class="text-lg mb-2 w-full">{heading}</h3>
+
+    {#if heading}
+      <h3 class="text-lg mb-2 w-full">{heading}</h3>
+    {/if}
     <Highlight class="p-4" language={json} code={formatJSON(content)} />
     <button on:click={copy}>
       {#if copied}
         <Icon
           src={Check}
-          class="w-8 h-8 text-purple-900 bg-gray-300 border-2 border-gray-200 absolute right-0 top-9 hidden group-hover:block hover:bg-gray-400 hover:border-gray-400"
+          class="w-8 h-8 text-purple-900 bg-gray-300 border-2 border-gray-200 absolute right-0 top-0 hidden group-hover:block hover:bg-gray-400 hover:border-gray-400"
         />
       {:else}
         <Icon
           src={Clipboard}
-          class="w-8 h-8 text-purple-900 bg-gray-300 border-2 border-gray-200 absolute right-0 top-9 hidden group-hover:block hover:bg-gray-400 hover:border-gray-400"
+          class="w-8 h-8 text-purple-900 bg-gray-300 border-2 border-gray-200 absolute right-0 top-0 hidden group-hover:block hover:bg-gray-400 hover:border-gray-400"
         />
       {/if}
     </button>

--- a/src/lib/utilities/get-component-for-event-type.ts
+++ b/src/lib/utilities/get-component-for-event-type.ts
@@ -87,6 +87,5 @@ type EventTypes = typeof eventTypes;
 export const getComponentForEventType = (
   event: HistoryEvent,
 ): EventTypes[keyof EventTypes] => {
-  console.log(event.eventType);
   return eventTypes[event.eventType];
 };

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_event.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/events/_event.svelte
@@ -4,11 +4,13 @@
   import { formatDate } from '$lib/utilities/format-date';
   import type { HistoryEvent } from '$types/temporal/api/history/v1/message';
   import ExecutionInformation from '../_execution-information.svelte';
+  import CodeBlock from '$lib/components/code-block.svelte';
 
   export let event: HistoryEvent;
   export let index: number;
 
   let even = !(index % 2);
+  $: isJSONView = false;
 </script>
 
 <tr class:even>
@@ -21,7 +23,15 @@
       <ExecutionInformation title="Task ID" value={event.taskId} />
     </div>
 
-    <svelte:component this={getComponentForEventType(event)} {event} />
+    <button on:click={() => (isJSONView = !isJSONView)}
+      >{!isJSONView ? 'GRID' : 'JSON'} VIEW</button
+    >
+
+    {#if isJSONView}
+      <CodeBlock heading={``} content={JSON.stringify(event)} />
+    {:else}
+      <svelte:component this={getComponentForEventType(event)} {event} />
+    {/if}
   </td>
 </tr>
 
@@ -42,5 +52,18 @@
 
   .even {
     @apply bg-gray-100;
+  }
+
+  button {
+    font-weight: bold;
+    text-align: center;
+    background: #343436;
+    color: #fff;
+    height: 25px;
+    width: 15%;
+  }
+
+  button:hover {
+    @apply bg-purple-400;
   }
 </style>


### PR DESCRIPTION
## What was changed
Added tab that can switch between the two views on the main event screen

## Why?
Was suppose to be in for sprint

## Video

https://user-images.githubusercontent.com/43492172/131194081-17e1f9a5-31ea-44e0-b361-2b6d72f13965.mov


