### PR TITLE
Create a better abstraction for storing and retrieving the current namespace

### DIFF
--- a/src/lib/components/namespace-select.svelte
+++ b/src/lib/components/namespace-select.svelte
@@ -99,7 +99,7 @@
               {namespace}
             </span>
             <span
-              class:text-indigo-600={$currentNamespace == namespace}
+              class:text-indigo-600={$currentNamespace === namespace}
               class="text-white absolute inset-y-0 right-0 flex items-center pr-4"
             >
               <!-- Heroicon name: solid/check -->

--- a/src/lib/components/namespace-select.svelte
+++ b/src/lib/components/namespace-select.svelte
@@ -1,18 +1,18 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
-
+  import { namespace as currentNamespace } from '$lib/stores/namespace';
   import { getContext } from 'svelte';
+  import { goto } from '$app/navigation';
 
   import type { DescribeNamespaceResponse } from '$types/temporal/api/workflowservice/v1/request_response';
 
-  $: currentNamespace = getContext('namespace') as string;
-  $: namespaces = (getContext('namespaces') as DescribeNamespaceResponse[]).map(
+  $: namespaces = getContext<DescribeNamespaceResponse[]>('namespaces').map(
     (namespace) => namespace.namespaceInfo.name,
   );
 
   let showDropdown = false;
   let userSelectedNamespace = null;
   let idx = 0;
+
   function nextNamespace() {
     if (userSelectedNamespace)
       idx = namespaces.findIndex(userSelectedNamespace);
@@ -25,10 +25,10 @@
       userSelectedNamespace = namespaces[idx];
     }
   }
+
   function switchNamespace(newNamespace: string) {
     showDropdown = false;
     goto('/namespaces/' + newNamespace);
-    // todo: this somehow doesnt update the getContext('namespace') correctly
   }
 </script>
 
@@ -46,7 +46,7 @@
       aria-labelledby="listbox-label"
       on:click={() => (showDropdown = !showDropdown)}
     >
-      <span class="block truncate"> {currentNamespace} </span>
+      <span class="block truncate"> {$currentNamespace} </span>
       <span
         class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none"
       >
@@ -93,13 +93,13 @@
             role="option"
           >
             <span
-              class:font-semibold={currentNamespace === namespace}
+              class:font-semibold={$currentNamespace === namespace}
               class="font-normal block truncate"
             >
               {namespace}
             </span>
             <span
-              class:text-indigo-600={currentNamespace === namespace}
+              class:text-indigo-600={$currentNamespace == namespace}
               class="text-white absolute inset-y-0 right-0 flex items-center pr-4"
             >
               <!-- Heroicon name: solid/check -->

--- a/src/lib/stores/namespace.ts
+++ b/src/lib/stores/namespace.ts
@@ -1,0 +1,17 @@
+import { page } from '$app/stores';
+import { derived } from 'svelte/store';
+import UrlPattern from 'url-pattern';
+
+const pattern = new UrlPattern('/namespaces/:namespace/*');
+
+export const namespace = derived(page, ($page) => {
+  const match = pattern.match($page.path);
+  const namespace = localStorage.getItem('currentNamespace') || 'default';
+
+  if (match) {
+    localStorage.setItem('currentNamespace', match.namespace);
+    return match.namespace;
+  }
+
+  return namespace;
+});

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -6,14 +6,12 @@
   } from '$types/temporal/api/workflowservice/v1/request_response';
 
   export async function load({ fetch, page }: LoadInput) {
-    const { namespace } = page.params;
-
     const { namespaces }: ListNamespacesResponse = await fetch(
       'http://localhost:8080/api/v1/namespaces',
     ).then((response) => response.json());
 
     return {
-      props: { namespaces, namespace },
+      props: { namespaces },
       context: { namespaces },
     };
   }
@@ -26,9 +24,7 @@
   import { setContext } from 'svelte';
 
   export let namespaces: DescribeNamespaceResponse[];
-  export let namespace: string;
 
-  setContext('namespace', namespace);
   setContext('namespaces', namespaces);
 </script>
 

--- a/src/routes/_navigation.svelte
+++ b/src/routes/_navigation.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext } from 'svelte';
+  import { namespace } from '$lib/stores/namespace';
 
   import {
     Photograph,
@@ -8,8 +8,6 @@
     Identification,
   } from 'svelte-hero-icons';
   import NavigationLink from './_navigation-link.svelte';
-
-  $: namespace = getContext('namespace') as string;
 </script>
 
 <nav
@@ -19,7 +17,7 @@
   <img src="/logo.svg" alt="Temporal Logo" class="rounded-full w-12" />
 
   <NavigationLink
-    href={`/namespaces/${namespace}/workflows`}
+    href={`/namespaces/${$namespace}/workflows`}
     label="Workflows"
     icon={Photograph}
   />
@@ -30,7 +28,7 @@
     icon={DocumentSearch}
   />
   <NavigationLink
-    href={`/namespaces/${namespace}/settings`}
+    href={`/namespaces/${$namespace}/settings`}
     label="Settings"
     icon={Identification}
   />


### PR DESCRIPTION
**Nota bene**:  We are not using context here because stores load outside of the Svelte lifecycle.