### PR TITLE
Fix time display; break out pagination and empty state

### DIFF
--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -45,11 +45,10 @@ const fetchWorkflows =
     request = fetch,
   }: FetchWorkflows<ListWorkflowExecutionsResponse>) => {
     const { executions } = await paginated(async (token: string) => {
+      const iso = formatISO(sub(new Date(), startTime));
       const url = toURL(`${base}/namespaces/${namespace}/workflows/${type}`, {
         next_page_token: token,
-        'start_time_filter.earliest_time': formatISO(
-          sub(new Date(), startTime),
-        ),
+        'start_time_filter.latest_time': iso,
       });
 
       const response = await request(url);

--- a/src/routes/namespaces/[namespace]/workflows/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/__layout.svelte
@@ -6,6 +6,8 @@
   import WorkflowsSummaryTable from './_workflows-summary-table.svelte';
   import WorkflowsSummaryRow from './_workflows-summary-row.svelte';
   import WorkflowFilters from './_workflow-filters.svelte';
+  import WorkflowPagination from './_workflow-pagination.svelte';
+  import WorkflowsEmptyState from './_workflows-empty.svelte';
 
   $: store = createWorkflowStore($namespace);
   $: workflows = store.filtered;
@@ -30,35 +32,15 @@
   {#if !$isFullScreen}
     <div class="w-full h-screen overflow-scroll">
       <header>
-        <WorkflowFilters {timeFormat} />
-        <section class="bg-gray-100 p-4 flex gap-4">
-          <button on:click={() => currentPage--} disabled={currentPage <= 0}>
-            Previous
-          </button>
-          <p>
-            Page {currentPage + 1} of {maximumPage}
-          </p>
-          <button
-            on:click={() => currentPage++}
-            disabled={currentPage >= maximumPage - 1}
-          >
-            Next
-          </button>
-        </section>
+        <WorkflowFilters bind:timeFormat />
+        <WorkflowPagination bind:currentPage {maximumPage} />
       </header>
       <WorkflowsSummaryTable>
         <tbody slot="rows">
           {#each visibleWorkflows as workflow}
             <WorkflowsSummaryRow {workflow} {timeFormat} />
           {:else}
-            <tr>
-              <td
-                colspan="5"
-                class="m-auto p-12 text-center font-extralight text-2xl"
-              >
-                No Results
-              </td>
-            </tr>
+            <WorkflowsEmptyState />
           {/each}
         </tbody>
       </WorkflowsSummaryTable>
@@ -67,13 +49,3 @@
 
   <slot />
 </section>
-
-<style lang="postcss">
-  button {
-    @apply rounded-lg border-purple-600 border-2 bg-white text-purple-600 px-2 text-sm;
-  }
-
-  button:disabled {
-    @apply text-purple-400 border-purple-400;
-  }
-</style>

--- a/src/routes/namespaces/[namespace]/workflows/_workflow-filters.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflow-filters.svelte
@@ -44,20 +44,6 @@
     <option value="Terminated">Terminated</option>
   </Select>
   <Select
-    id="filter-by-workflow-status"
-    name="Workflow Status"
-    bind:value={$status}
-  >
-    <option value={null} />
-    <option value="Running">Running</option>
-    <option value="TimedOut">Timed Out</option>
-    <option value="Completed">Completed</option>
-    <option value="Failed">Failed</option>
-    <option value="ContinuedAsNew">Continued as New</option>
-    <option value="Canceled">Canceled</option>
-    <option value="Terminated">Terminated</option>
-  </Select>
-  <Select
     id="filter-by-workflow-type"
     name="Workflow Type"
     bind:value={$workflowType}

--- a/src/routes/namespaces/[namespace]/workflows/_workflow-pagination.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflow-pagination.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  export let currentPage: number;
+  export let maximumPage: number;
+
+  const increment = () => currentPage++;
+  const decrement = () => currentPage++;
+
+  $: isFirstPage = currentPage <= 0;
+  $: isLastPage = currentPage >= maximumPage - 1;
+</script>
+
+<section class="bg-gray-100 p-4 flex gap-4">
+  <button on:click={decrement} disabled={isFirstPage}> Previous </button>
+  {#if maximumPage > 0}
+    <p>Page {currentPage + 1} of {maximumPage}</p>
+  {:else}
+    <p>No Workflow Executions</p>
+  {/if}
+  <button on:click={increment} disabled={isLastPage}> Next </button>
+</section>
+
+<style lang="postcss">
+  button {
+    @apply rounded-lg border-purple-600 border-2 bg-white text-purple-600 px-2 text-sm;
+  }
+
+  button:disabled {
+    @apply text-purple-400 border-purple-400;
+  }
+</style>

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-empty.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-empty.svelte
@@ -1,0 +1,5 @@
+<tr>
+  <td colspan="5" class="m-auto p-12 text-center font-extralight text-2xl">
+    No Results
+  </td>
+</tr>


### PR DESCRIPTION
Fixes bug with displaying the correct time format. Breaks out empty state and pagination controls into their own components. Gracefully hands no matching workflows better (e.g. displaying "No Workflows" instead of "Page 1 of 0").