### PR TITLE
Add different instructions for previewing versus developing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,25 @@
 
 **Nota bene**: This is pre-release software.
 
-## Developing
-
-### Prequisites
+## Prequisites
 
 While we're in pre-production, you need to do the following before you spin up the development server:
 
 1. Have Temporal running in development. ([See our documentation](https://docs.temporal.io/docs/server/quick-install) for details.)
 2. Clone, build, and start [the UI API Server](https://github.com/temporalio/ui-server).
 
-Once you've created a project and installed dependencies with `npm install`, start the development server:
+## Trying it out
+
+Once you have the prerequisites going, run the following:
+
+```bash
+npm run build:local
+npm run preview:cloud
+```
+
+## Developing
+
+Developing the UI has the same prequisites as trying it out. Once you've created a project and installed dependencies with `npm install`, start the development server:
 
 ```bash
 npm start

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once you have the prerequisites going, run the following:
 
 ```bash
 npm run build:local
-npm run preview:cloud
+npm run preview:local
 ```
 
 ## Developing


### PR DESCRIPTION
The built assets are more reliable than the development server right now and also more accurate of what the application will look like in production. If someone is kicking the tires on the UI—as opposed to actively working on the code—they should build and preview the output.