### PR TITLE
Refactor fetching from the API

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -19,6 +19,8 @@ type WorkflowStatus =
   | 'Terminated'
   | null;
 
+type NamespaceScopedRequest = { namespace: string };
+
 type WorkflowType = string | null;
 
 type WorkflowExecutionFilters = {

--- a/src/lib/components/filter-input.svelte
+++ b/src/lib/components/filter-input.svelte
@@ -6,11 +6,5 @@
 
 <div>
   <label for={id} class="text-gray-600 text-xs block">{name}</label>
-  <input class="block border-2 text-sm p-2" {id} bind:value />
+  <input class="block border-2 text-sm p-2 h-10" {id} bind:value />
 </div>
-
-<style>
-  input {
-    height: 40px;
-  }
-</style>

--- a/src/lib/components/filter-select.svelte
+++ b/src/lib/components/filter-select.svelte
@@ -6,7 +6,12 @@
 
 <div>
   <label for={id} class="text-gray-600 text-xs block">{name}</label>
-  <select class="block border-2 text-base p-2" {id} bind:value on:change>
+  <select
+    class="block border-2 text-base p-2 min-w-full"
+    {id}
+    bind:value
+    on:change
+  >
     <slot />
   </select>
 </div>

--- a/src/lib/components/filter-select.svelte
+++ b/src/lib/components/filter-select.svelte
@@ -7,7 +7,7 @@
 <div>
   <label for={id} class="text-gray-600 text-xs block">{name}</label>
   <select
-    class="block border-2 text-base p-2 min-w-full"
+    class="block border-2 text-base p-2 w-full h-10"
     {id}
     bind:value
     on:change
@@ -15,9 +15,3 @@
     <slot />
   </select>
 </div>
-
-<style>
-  select {
-    height: 40px;
-  }
-</style>

--- a/src/lib/models/workflow-execution.ts
+++ b/src/lib/models/workflow-execution.ts
@@ -29,7 +29,7 @@ export const toWorkflowExecutions = (
  * execution API responses.
  */
 
-export interface WorkflowExecution {
+interface WorkflowExecution {
   name: string;
   id: string;
   runId: string;
@@ -46,7 +46,7 @@ type WorkflowExecutionAPIResponse = Optional<
   'executionConfig' | 'pendingActivities' | 'pendingChildren'
 >;
 
-export class WorkflowExecution {
+class WorkflowExecution {
   constructor({
     executionConfig,
     workflowExecutionInfo,

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -1,0 +1,72 @@
+import type { PollerInfo, TaskQueueStatus } from '$types';
+
+export type GetAllPollersRequest = NamespaceScopedRequest & { queue: string };
+export type GetPollersResponse = {
+  pollers: PollerInfo[];
+  taskQueueStatus: TaskQueueStatus;
+};
+
+const base = import.meta.env.VITE_API;
+
+export async function getPollers(
+  { queue, namespace }: GetAllPollersRequest,
+  request = fetch,
+): Promise<GetPollersResponse> {
+  const pollersWorkflow: GetPollersResponse = await request(
+    `${base}/namespaces/${namespace}/task-queues/${queue}?task_queue_type=1`,
+  )
+    .then((response) => response.json())
+    .catch(console.error);
+
+  const pollersActivity: GetPollersResponse = await request(
+    `${base}/namespaces/${namespace}/task-queues/${queue}?task_queue_type=2`,
+  )
+    .then((response) => response.json())
+    .catch(console.error);
+
+  pollersActivity.pollers.forEach((poller) => {
+    poller[`taskQueueTypes`] = ['ACTIVITY'];
+  });
+
+  pollersWorkflow.pollers.forEach((poller) => {
+    poller[`taskQueueTypes`] = ['WORKFLOW'];
+  });
+
+  const r = (type) => (o, poller) => {
+    const i = o[poller.identity] || {};
+
+    o[poller.identity] = {
+      lastAccessTime:
+        !i.lastAccessTime || i.lastAccessTime < poller.lastAccessTime
+          ? poller.lastAccessTime
+          : i.lastAccessTime,
+      taskQueueTypes: i.taskQueueTypes
+        ? i.taskQueueTypes.concat([type])
+        : [type],
+    };
+
+    return o;
+  };
+
+  pollersActivity.pollers.filter((pollerA) =>
+    pollersWorkflow.pollers.some((pollerW) => {
+      if (pollerA.identity === pollerW.identity) {
+        pollerA['taskQueueTypes'] = [
+          ...pollerW['taskQueueTypes'],
+          ...pollerA['taskQueueTypes'],
+        ];
+        return pollerA;
+      }
+    }),
+  );
+
+  pollersActivity.pollers.reduce(
+    r('ACTIVITY'),
+    pollersWorkflow.pollers.reduce(r('WORKFLOW'), {}),
+  );
+
+  return {
+    pollers: pollersActivity.pollers,
+    taskQueueStatus: pollersActivity.taskQueueStatus,
+  };
+}

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -4,7 +4,7 @@ import type { PollerInfo, TaskQueueStatus } from '$types';
 export type GetAllPollersRequest = NamespaceScopedRequest & { queue: string };
 
 export type GetPollersResponse = {
-  pollers: PollerInfo[];
+  pollers: PollerWithTaskQueueTypes[];
   taskQueueStatus: TaskQueueStatus;
 };
 
@@ -14,12 +14,12 @@ type PollersData = {
 
 type TaskQueueType = 'ACTIVITY' | 'WORKFLOW';
 
-type Poller = {
+export type Poller = {
   lastAccessTime: PollerInfo['lastAccessTime'];
   taskQueueTypes: TaskQueueType[];
 };
 
-type PollerWithTaskQueueTypes = PollerInfo & {
+export type PollerWithTaskQueueTypes = PollerInfo & {
   taskQueueTypes?: TaskQueueType[];
 };
 

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -3,8 +3,6 @@ import { sub, formatISO } from 'date-fns';
 import { paginated } from '$lib/utilities/paginated';
 import { toURL } from '$lib/utilities/to-url';
 import type {
-  PollerInfo,
-  TaskQueueStatus,
   DescribeWorkflowExecutionResponse,
   GetWorkflowExecutionHistoryResponse,
   ListWorkflowExecutionsResponse,
@@ -12,16 +10,9 @@ import type {
 
 const base = import.meta.env.VITE_API;
 
-export type NamespaceScopedRequest = { namespace: string };
 export type GetWorkflowExecutionRequest = NamespaceScopedRequest & {
   executionId: string;
   runId: string;
-};
-
-export type GetAllPollersRequest = NamespaceScopedRequest & { queue: string };
-export type GetPollersResponse = {
-  pollers: PollerInfo[];
-  taskQueueStatus: TaskQueueStatus;
 };
 
 type FetchWorkflows<T> = NamespaceScopedRequest & {
@@ -109,68 +100,5 @@ export async function get(
 
   return {
     execution,
-  };
-}
-
-export async function getPollers(
-  { queue, namespace }: GetAllPollersRequest,
-  request = fetch,
-): Promise<GetPollersResponse> {
-  const pollersWorkflow: GetPollersResponse = await request(
-    `${base}/namespaces/${namespace}/task-queues/${queue}?task_queue_type=1`,
-  )
-    .then((response) => response.json())
-    .catch(console.error);
-
-  const pollersActivity: GetPollersResponse = await request(
-    `${base}/namespaces/${namespace}/task-queues/${queue}?task_queue_type=2`,
-  )
-    .then((response) => response.json())
-    .catch(console.error);
-
-  pollersActivity.pollers.forEach((poller) => {
-    poller[`taskQueueTypes`] = ['ACTIVITY'];
-  });
-
-  pollersWorkflow.pollers.forEach((poller) => {
-    poller[`taskQueueTypes`] = ['WORKFLOW'];
-  });
-
-  const r = (type) => (o, poller) => {
-    const i = o[poller.identity] || {};
-
-    o[poller.identity] = {
-      lastAccessTime:
-        !i.lastAccessTime || i.lastAccessTime < poller.lastAccessTime
-          ? poller.lastAccessTime
-          : i.lastAccessTime,
-      taskQueueTypes: i.taskQueueTypes
-        ? i.taskQueueTypes.concat([type])
-        : [type],
-    };
-
-    return o;
-  };
-
-  pollersActivity.pollers.filter((pollerA) =>
-    pollersWorkflow.pollers.some((pollerW) => {
-      if (pollerA.identity === pollerW.identity) {
-        pollerA['taskQueueTypes'] = [
-          ...pollerW['taskQueueTypes'],
-          ...pollerA['taskQueueTypes'],
-        ];
-        return pollerA;
-      }
-    }),
-  );
-
-  pollersActivity.pollers.reduce(
-    r('ACTIVITY'),
-    pollersWorkflow.pollers.reduce(r('WORKFLOW'), {}),
-  );
-
-  return {
-    pollers: pollersActivity.pollers,
-    taskQueueStatus: pollersActivity.taskQueueStatus,
   };
 }

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -43,10 +43,12 @@ const fetchWorkflows =
         return requestFromAPI<ListWorkflowExecutionsResponse>(
           `/namespaces/${namespace}/workflows/${type}`,
           {
-            next_page_token: token,
-            'start_time_filter.earliest_time': createDate(startTime),
+            params: {
+              'start_time_filter.earliest_time': createDate(startTime),
+            },
+            token,
+            request,
           },
-          { request },
         );
       },
       { onUpdate },
@@ -68,7 +70,6 @@ export async function fetchWorkflow(
 ): Promise<DescribeWorkflowExecutionResponse> {
   return requestFromAPI(
     `/namespaces/${namespace}/workflows/${executionId}/executions/${runId}`,
-    {},
     { request },
   );
 }
@@ -82,9 +83,9 @@ export const fetchEvents = async (
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
         `/namespaces/${namespace}/workflows/${executionId}/executions/${runId}/events`,
         {
-          next_page_token: token,
+          token,
+          request,
         },
-        { request },
       );
     },
     { onUpdate },

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -9,7 +9,6 @@ import type {
 import { paginated } from '$lib/utilities/paginated';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 
-const base = import.meta.env.VITE_API;
 const id = <T>(x: T) => x;
 const createDate = (d: Duration) => formatISO(sub(new Date(), d));
 

--- a/src/lib/stores/activities.ts
+++ b/src/lib/stores/activities.ts
@@ -1,4 +1,4 @@
-import { derived, get, Readable } from 'svelte/store';
+import { derived, Readable } from 'svelte/store';
 import {
   isActivityTaskScheduledEvent,
   isActivityTaskStartedEvent,
@@ -115,6 +115,6 @@ export const createActivityStore = <
 
   return {
     ...activities,
-    getActivity: (id) => derived(store, ($store) => get(store)[id] || {}),
+    getActivity: (id) => derived(store, ($store) => $store[id] || {}),
   };
 };

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -18,27 +18,26 @@ export const createQueryStore = <T, S = QueryStore<T>>(
       ids: [],
       [key]: {},
     } as unknown as S,
-    createIntervalCallback(update),
+    () => {
+      let idleCallback: number;
+
+      const callback = () => {
+        if (browser) {
+          if (idleCallback) cancelIdleCallback(idleCallback);
+          idleCallback = requestIdleCallback(update);
+        }
+      };
+
+      setTimeout(callback, 0);
+      const interval = setInterval(callback, 30000);
+
+      return () => {
+        if (browser && idleCallback) cancelIdleCallback(idleCallback);
+        console.log('Unsubscribe!');
+        clearInterval(interval);
+      };
+    },
   );
 
   return store;
-};
-
-export const createIntervalCallback = (update: () => void): (() => void) => {
-  let idleCallback: number;
-
-  const callback = () => {
-    if (browser) {
-      if (idleCallback) cancelIdleCallback(idleCallback);
-      idleCallback = requestIdleCallback(update);
-    }
-  };
-
-  setTimeout(callback, 0);
-  const interval = setInterval(callback, 30000);
-
-  return () => {
-    if (browser && idleCallback) cancelIdleCallback(idleCallback);
-    clearInterval(interval);
-  };
 };

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -33,7 +33,6 @@ export const createQueryStore = <T, S = QueryStore<T>>(
 
       return () => {
         if (browser && idleCallback) cancelIdleCallback(idleCallback);
-        console.log('Unsubscribe!');
         clearInterval(interval);
       };
     },

--- a/src/lib/utilities/create-store-with-callback.ts
+++ b/src/lib/utilities/create-store-with-callback.ts
@@ -1,7 +1,8 @@
 import { Updater, Writable, writable } from 'svelte/store';
+import isFunction from 'lodash/isFunction';
 
 const call = (fn: () => void) => {
-  if (fn && typeof fn === 'function') fn();
+  if (isFunction(fn)) fn();
 };
 
 export const createStoreWithCallback = <T>(

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -3,16 +3,20 @@ import { merge } from './merge';
 
 type NextPageToken = Uint8Array | string;
 type WithNextPageToken = { nextPageToken?: NextPageToken };
+type WithoutNextPageToken<T> = Omit<T, keyof WithNextPageToken>;
 
-type PaginatedOptions<T> = {
+type PaginationCallbacks<T> = {
   onStart?: () => void;
   onUpdate?: (
-    full: Omit<T, keyof WithNextPageToken>,
-    current: Omit<T, keyof WithNextPageToken>,
+    full: WithoutNextPageToken<T>,
+    current: WithoutNextPageToken<T>,
   ) => void;
-  onComplete?: (finalProps: Omit<T, keyof WithNextPageToken>) => void;
+  onComplete?: (finalProps: WithoutNextPageToken<T>) => void;
+};
+
+type PaginatedOptions<T> = PaginationCallbacks<T> & {
   token?: NextPageToken;
-  previousProps?: Omit<T, keyof WithNextPageToken>;
+  previousProps?: WithoutNextPageToken<T>;
 };
 
 /**
@@ -34,7 +38,7 @@ export const paginated = async <T extends WithNextPageToken>(
     token,
     previousProps,
   }: PaginatedOptions<T> = {},
-): Promise<Omit<T, keyof WithNextPageToken>> => {
+): Promise<WithoutNextPageToken<T>> => {
   if (!previousProps && isFunction(onStart)) onStart();
 
   const { nextPageToken, ...props } = await fn(token);

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -3,6 +3,7 @@ import { merge } from './merge';
 
 type NextPageToken = Uint8Array | string;
 type WithNextPageToken = { nextPageToken?: NextPageToken };
+
 type PaginatedOptions<T> = {
   onStart?: () => void;
   onUpdate?: (
@@ -14,6 +15,16 @@ type PaginatedOptions<T> = {
   previousProps?: Omit<T, keyof WithNextPageToken>;
 };
 
+/**
+ * Takes a function that receives a `nextPageToken`. If the promise
+ * returned from that function has a `nextPageToken`, this function
+ * will recursively call the function again, passing in the new
+ * `nextPageToken`.
+ *
+ * - `onUpdate` fires on each exection.
+ * - `onComplete` fires when there are no more `nextPageTokens`.
+ * - `onError` fires when a promise is rejected.
+ */
 export const paginated = async <T extends WithNextPageToken>(
   fn: (token?: NextPageToken) => Promise<T>,
   {
@@ -30,6 +41,7 @@ export const paginated = async <T extends WithNextPageToken>(
   const mergedProps = merge(previousProps, props);
 
   if (isFunction(onUpdate)) onUpdate(mergedProps, props);
+
   if (!nextPageToken) {
     if (isFunction(onComplete)) onComplete(mergedProps);
     return mergedProps;

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -2,19 +2,21 @@ import { toURL } from './to-url';
 
 type toURLParams = Parameters<typeof toURL>;
 type RequestFromAPIOptions = {
-  request: typeof fetch;
+  params?: toURLParams[1];
+  request?: typeof fetch;
+  token?: string;
 };
 
 const base = import.meta.env.VITE_API;
 
 export const requestFromAPI = async <T>(
   endpoint: toURLParams[0],
-  params: toURLParams[1] = {},
-  { request = fetch }: RequestFromAPIOptions,
+  { params = {}, request = fetch, token }: RequestFromAPIOptions = {},
 ): Promise<T> => {
   if (!endpoint.startsWith('/')) endpoint = '/' + endpoint;
+  const nextPageToken = token ? { next_page_token: token } : {};
 
-  const url = toURL(base + endpoint, params);
+  const url = toURL(base + endpoint, { ...params, ...nextPageToken });
 
   const response = await request(url);
   return await response.json();

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -1,0 +1,21 @@
+import { toURL } from './to-url';
+
+type toURLParams = Parameters<typeof toURL>;
+type RequestFromAPIOptions = {
+  request: typeof fetch;
+};
+
+const base = import.meta.env.VITE_API;
+
+export const requestFromAPI = async <T>(
+  endpoint: toURLParams[0],
+  params: toURLParams[1] = {},
+  { request = fetch }: RequestFromAPIOptions,
+): Promise<T> => {
+  if (!endpoint.startsWith('/')) endpoint = '/' + endpoint;
+
+  const url = toURL(base + endpoint, params);
+
+  const response = await request(url);
+  return await response.json();
+};

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -9,6 +9,19 @@ type RequestFromAPIOptions = {
 
 const base = import.meta.env.VITE_API;
 
+/**
+ *  A utility method for making requests to the Temporal API.
+ *
+ * @param endpoint The path of the API endpoint you want to request data from.
+ *
+ * @param options Additional options to be used when making the API request.
+ * @param options.params Query (or search) parameters to be suffixed to the
+ * path.
+ * @param options.token Shorthand for a `nextPageToken` query parameter.
+ * @param options.request A replacement for the native `fetch` function.
+ *
+ * @returns Promise with the response from the API parsed into an object.
+ */
 export const requestFromAPI = async <T>(
   endpoint: toURLParams[0],
   { params = {}, request = fetch, token }: RequestFromAPIOptions = {},

--- a/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
@@ -19,8 +19,8 @@
 </script>
 
 <section class="flex flex-col items-start">
-  <header>
-    <h3>Pollers</h3>
+  <header class="p-3 mb-5">
+    <h3 class="text-2xl">Pollers</h3>
   </header>
   <div class="w-full h-full overflow-x-scroll">
     <QueuePollersTable>
@@ -40,14 +40,3 @@
     </QueuePollersTable>
   </div>
 </section>
-
-<style lang="postcss">
-  header {
-    padding: 12px;
-    margin-bottom: 18px;
-  }
-
-  h3 {
-    font-size: 24px;
-  }
-</style>

--- a/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
@@ -1,9 +1,7 @@
 <script context="module" lang="ts">
   import type { LoadInput } from '@sveltejs/kit';
-  import {
-    GetPollersResponse,
-    getPollers,
-  } from '$lib/services/workflow-execution-service';
+  import type { GetPollersResponse } from '$lib/services/pollers-service';
+  import { getPollers } from '$lib/services/pollers-service';
 
   export async function load({ fetch, page }: LoadInput) {
     const { namespace, queue } = page.params;

--- a/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/queues/[queue]/__layout.svelte
@@ -2,15 +2,12 @@
   import type { LoadInput } from '@sveltejs/kit';
   import {
     GetPollersResponse,
-    WorkflowExecutionAPI,
+    getPollers,
   } from '$lib/services/workflow-execution-service';
 
   export async function load({ fetch, page }: LoadInput) {
     const { namespace, queue } = page.params;
-    return await WorkflowExecutionAPI.getPollers(
-      { queue, namespace },
-      fetch,
-    ).then((pollers) => ({
+    return await getPollers({ queue, namespace }, fetch).then((pollers) => ({
       props: { pollers },
     }));
   }

--- a/src/routes/namespaces/[namespace]/queues/[queue]/_queue-pollers-row.svelte
+++ b/src/routes/namespaces/[namespace]/queues/[queue]/_queue-pollers-row.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import Icon, { Check } from 'svelte-hero-icons';
-  export let poller;
+
+  import type { PollerWithTaskQueueTypes } from '$lib/services/pollers-service';
+  import { formatDate } from '$lib/utilities/format-date';
+
+  export let poller: PollerWithTaskQueueTypes;
 </script>
 
 <tr>
@@ -10,7 +14,7 @@
     </h3>
   </td>
   <td>
-    <p>{new Date(poller.lastAccessTime)}</p>
+    <p>{formatDate(poller.lastAccessTime)}</p>
   </td>
   {#if poller.taskQueueTypes.includes('WORKFLOW')}
     <td>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import { get, getEvents } from '$lib/services/workflow-execution-service';
+  import { get, fetchEvents } from '$lib/services/workflow-execution-service';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ fetch, page }: LoadInput) {
@@ -14,7 +14,7 @@
       fetch,
     );
 
-    const { events } = await getEvents(
+    const events = await fetchEvents(
       {
         executionId,
         runId,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -1,12 +1,11 @@
 <script context="module" lang="ts">
-  import { WorkflowExecutionAPI } from '$lib/services/workflow-execution-service';
-
+  import { get, getEvents } from '$lib/services/workflow-execution-service';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ fetch, page }: LoadInput) {
     const { workflow: executionId, run: runId, namespace } = page.params;
 
-    const { execution } = await WorkflowExecutionAPI.get(
+    const { execution } = await get(
       {
         executionId,
         runId,
@@ -15,7 +14,7 @@
       fetch,
     );
 
-    const { events } = await WorkflowExecutionAPI.getEvents(
+    const { events } = await getEvents(
       {
         executionId,
         runId,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -1,11 +1,14 @@
 <script context="module" lang="ts">
-  import { get, fetchEvents } from '$lib/services/workflow-execution-service';
+  import {
+    fetchWorkflow,
+    fetchEvents,
+  } from '$lib/services/workflow-execution-service';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ fetch, page }: LoadInput) {
     const { workflow: executionId, run: runId, namespace } = page.params;
 
-    const { execution } = await get(
+    const { execution } = await fetchWorkflow(
       {
         executionId,
         runId,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -70,7 +70,7 @@
   .sidebar {
     width: 600px;
     overflow-y: scroll;
-    box-shadow: -5px 5px 10px 2px rgba(0, 0, 0, 0.2);
+    box-shadow: -2px 14px 20px 0px rgb(0 0 0 / 20%);
     z-index: 2;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -9,7 +9,7 @@
   export async function load({ fetch, page }: LoadInput) {
     const { workflow: executionId, run: runId, namespace } = page.params;
 
-    const { execution } = await fetchWorkflow(
+    const execution = await fetchWorkflow(
       {
         executionId,
         runId,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -1,9 +1,10 @@
 <script context="module" lang="ts">
+  import type { LoadInput } from '@sveltejs/kit';
+
   import {
     fetchWorkflow,
     fetchEvents,
   } from '$lib/services/workflow-execution-service';
-  import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ fetch, page }: LoadInput) {
     const { workflow: executionId, run: runId, namespace } = page.params;


### PR DESCRIPTION
Simplify and standardize fetching data from the server.

- Break out `getPollers` to its own file.
- Address TypeScript errors with `getPollers`.
- Standardize the API for functions that request data from the server.
- Remove fetching functions that are no longer being used.
- Add documentation for `paginated` and `requestFromAPI`.
- Adjust the shadow on the sidebar.
- Simplify `toWorkflowExectution`.
- Add a minimum with to workflow filter select menus when empty.
- Fixes bug where query stores were not refreshing.