### PR TITLE
Standardize the API for individual and multiple workflows

### DIFF
--- a/src/lib/models/workflow-execution.ts
+++ b/src/lib/models/workflow-execution.ts
@@ -1,8 +1,8 @@
 import type {
   WorkflowExecutionStatus,
   PendingActivityInfo,
-  WorkflowExecutionInfo,
   DescribeWorkflowExecutionResponse,
+  ListWorkflowExecutionsResponse,
 } from '$types';
 
 import { formatDate } from '$lib/utilities/format-date';
@@ -66,9 +66,9 @@ export const toWorkflowExecution = (
 };
 
 export const toWorkflowExecutions = (
-  executions: WorkflowExecutionInfo[],
+  response: ListWorkflowExecutionsResponse,
 ): WorkflowExecution[] => {
-  return (executions || []).map((workflowExecutionInfo) =>
+  return (response.executions || []).map((workflowExecutionInfo) =>
     toWorkflowExecution({ workflowExecutionInfo }),
   );
 };

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -24,7 +24,7 @@ const stores: { [key: string]: ReturnType<typeof createStore> } = {};
 const updateWorkflows =
   (store: Writable<WorkflowStore>) =>
   (payload: ListWorkflowExecutionsResponse) => {
-    const workflowExecutions = toWorkflowExecutions(payload.executions);
+    const workflowExecutions = toWorkflowExecutions(payload);
     const ids = {};
     const workflows = {};
 


### PR DESCRIPTION
Modify `toWorkflowExecutions` so that it takes the API response directly, just like `toWorkflowExecution`.