### PR TITLE
Refactor query stores

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -21,6 +21,19 @@ type WorkflowStatus =
 
 type NamespaceScopedRequest = { namespace: string };
 
+type NextPageToken = Uint8Array | string;
+type WithNextPageToken = { nextPageToken?: NextPageToken };
+type WithoutNextPageToken<T> = Omit<T, keyof WithNextPageToken>;
+
+type PaginationCallbacks<T> = {
+  onStart?: () => void;
+  onUpdate?: (
+    full: WithoutNextPageToken<T>,
+    current: WithoutNextPageToken<T>,
+  ) => void;
+  onComplete?: (finalProps: WithoutNextPageToken<T>) => void;
+};
+
 type WorkflowType = string | null;
 
 type WorkflowExecutionFilters = {

--- a/src/lib/models/event-history.ts
+++ b/src/lib/models/event-history.ts
@@ -1,0 +1,12 @@
+import type { GetWorkflowExecutionHistoryResponse } from '$types';
+
+export type HistoryEventWithId = HistoryEvent & { id: string };
+
+export const toEventHistory = (
+  response: GetWorkflowExecutionHistoryResponse,
+): HistoryEventWithId[] => {
+  return response.history.events.map((event) => ({
+    ...event,
+    id: String(event.eventId),
+  }));
+};

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -33,7 +33,7 @@ type FetchEvents = FetchWorkflows<GetWorkflowExecutionHistoryResponse> & {
 /**
  * Utility function to fetch either opened or closed workflows from the
  * Temporal server. Unless you have a good reason, you should prefer to
- * use `fetchAllWorkflows`. This function is intentionall _not_ exported.
+ * use `fetchAllWorkflows`. This function is intentionally _not_ exported.
  */
 const fetchWorkflows =
   (type: 'open' | 'closed') =>

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -1,4 +1,5 @@
 import { sub, formatISO } from 'date-fns';
+import isFunction from 'lodash/isFunction';
 
 import type {
   DescribeWorkflowExecutionResponse,
@@ -8,7 +9,6 @@ import type {
 
 import { paginated } from '$lib/utilities/paginated';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
-import { isFunction } from 'lodash';
 
 const id = <T>(x: T) => x;
 const noop = () => {};
@@ -59,6 +59,11 @@ const fetchWorkflows =
     );
   };
 
+/**
+ * Fetches both open and closed workflows. Forwards all options to
+ * `fetchWorkflows` except for `onComplete` which is called when
+ * both open and closed requests have completed.
+ */
 export const fetchAllWorkflows = async (
   options: FetchWorkflows<ListWorkflowExecutionsResponse>,
 ) => {
@@ -110,7 +115,7 @@ export async function fetchWorkflow(
 }
 
 export const fetchEvents = async (
-  { namespace, executionId, runId, onUpdate }: FetchEvents,
+  { namespace, executionId, runId, onUpdate = id }: FetchEvents,
   request = fetch,
 ) => {
   const events: GetWorkflowExecutionHistoryResponse = await paginated(

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -30,6 +30,11 @@ type FetchEvents = FetchWorkflows<GetWorkflowExecutionHistoryResponse> & {
   runId: string;
 };
 
+/**
+ * Utility function to fetch either opened or closed workflows from the
+ * Temporal server. Unless you have a good reason, you should prefer to
+ * use `fetchAllWorkflows`. This function is intentionall _not_ exported.
+ */
 const fetchWorkflows =
   (type: 'open' | 'closed') =>
   async (

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -67,7 +67,9 @@ const fetchWorkflows =
 /**
  * Fetches both open and closed workflows. Forwards all options to
  * `fetchWorkflows` except for `onComplete` which is called when
- * both open and closed requests have completed.
+ * both open and closed requests have completed. If you're relying on
+ * the promise returned from this function, it will only include the
+ * first page of results from each API call.
  */
 export const fetchAllWorkflows = async (
   options: FetchWorkflows<ListWorkflowExecutionsResponse>,

--- a/src/lib/services/workflow-execution-service.ts
+++ b/src/lib/services/workflow-execution-service.ts
@@ -17,11 +17,17 @@ export type GetWorkflowExecutionRequest = NamespaceScopedRequest & {
   runId: string;
 };
 
-type FetchWorkflows<T> = NamespaceScopedRequest & {
+type Callbacks<T> = {
   onUpdate?: (results: Omit<T, 'nextPageToken'>) => void;
-  startTime?: Duration;
-  request?: typeof fetch;
+  onComplete?: (results: Omit<T, 'nextPageToken'>) => void;
+  onStart?: () => void;
 };
+
+type FetchWorkflows<T> = NamespaceScopedRequest &
+  Callbacks<T> & {
+    startTime?: Duration;
+    request?: typeof fetch;
+  };
 
 type FetchEvents = FetchWorkflows<GetWorkflowExecutionHistoryResponse> & {
   executionId: string;
@@ -75,7 +81,7 @@ export async function fetchWorkflow(
 }
 
 export const fetchEvents = async (
-  { namespace, executionId, runId, onUpdate = id }: FetchEvents,
+  { namespace, executionId, runId, onUpdate }: FetchEvents,
   request = fetch,
 ) => {
   const events: GetWorkflowExecutionHistoryResponse = await paginated(

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -19,7 +19,6 @@ export const createStore = (
   const store = createQueryStore<
     HistoryEventWithId,
     GetWorkflowExecutionHistoryResponse,
-    Parameters<typeof fetchEvents>,
     typeof fetchEvents
   >(fetchEvents, toEventHistory, {
     namespace,

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -1,40 +1,14 @@
-import { derived, Writable, writable } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+
 import get from 'lodash/get';
 import set from 'lodash/set';
 
-import type { GetWorkflowExecutionHistoryResponse, HistoryEvent } from '$types';
-
 import { fetchEvents } from '$lib/services/workflow-execution-service';
-import {
-  createQueryStore,
-  QueryStore,
-} from '$lib/utilities/create-query-store';
+import { createQueryStore } from '$lib/utilities/create-query-store';
 import { createActivityStore } from './activities';
-
-type EventHistoryStore = QueryStore<{
-  events: { [key: string]: HistoryEvent };
-}>;
+import { HistoryEventWithId, toEventHistory } from '$lib/models/event-history';
 
 const stores: { [key: string]: ReturnType<typeof createStore> } = {};
-
-const updateEvents =
-  (store: Writable<EventHistoryStore>) =>
-  (payload: GetWorkflowExecutionHistoryResponse) => {
-    const ids = {};
-    const events = {};
-
-    for (const event of payload.history.events) {
-      const id = String(event.eventId);
-      ids[id] = true;
-      events[id] = event;
-    }
-
-    store.update(($store) => ({
-      ...$store,
-      ids: Object.keys(ids),
-      events,
-    }));
-  };
 
 export const createStore = (
   namespace: string,
@@ -46,13 +20,13 @@ export const createStore = (
       namespace,
       executionId,
       runId,
-      onUpdate: updateEvents(store),
+      onUpdate: store.updateStore(toEventHistory),
     });
   };
 
-  const store = createQueryStore<EventHistoryStore>('events', update);
+  const store = createQueryStore<HistoryEventWithId>(update);
 
-  const all = derived(store, ($store) => Object.values($store.events), []);
+  const all = derived(store, ($store) => Object.values($store.data), []);
   const format = writable<EventFormat>('grid');
   const type = writable<string>(null);
 

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -7,6 +7,7 @@ import { fetchEvents } from '$lib/services/workflow-execution-service';
 import { createQueryStore } from '$lib/utilities/create-query-store';
 import { createActivityStore } from './activities';
 import { HistoryEventWithId, toEventHistory } from '$lib/models/event-history';
+import type { GetWorkflowExecutionHistoryResponse } from '$types';
 
 const stores: { [key: string]: ReturnType<typeof createStore> } = {};
 
@@ -15,16 +16,14 @@ export const createStore = (
   executionId: string,
   runId: string,
 ) => {
-  const update = () => {
-    fetchEvents({
-      namespace,
-      executionId,
-      runId,
-      onUpdate: store.updateStore(toEventHistory),
-    });
-  };
-
-  const store = createQueryStore<HistoryEventWithId>(update);
+  const store = createQueryStore<
+    HistoryEventWithId,
+    GetWorkflowExecutionHistoryResponse
+  >(fetchEvents, toEventHistory, {
+    namespace,
+    executionId,
+    runId,
+  });
 
   const all = derived(store, ($store) => Object.values($store.data), []);
   const format = writable<EventFormat>('grid');

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -18,7 +18,9 @@ export const createStore = (
 ) => {
   const store = createQueryStore<
     HistoryEventWithId,
-    GetWorkflowExecutionHistoryResponse
+    GetWorkflowExecutionHistoryResponse,
+    Parameters<typeof fetchEvents>,
+    typeof fetchEvents
   >(fetchEvents, toEventHistory, {
     namespace,
     executionId,

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -8,27 +8,23 @@ import {
 } from '$lib/models/workflow-execution';
 
 import { fetchAllWorkflows } from '$lib/services/workflow-execution-service';
-import { createStoreWithCallback } from '$lib/utilities/create-store-with-callback';
+// import { createStoreWithCallback } from '$lib/utilities/create-store-with-callback';
 import { createQueryStore } from '$lib/utilities/create-query-store';
+import type { ListWorkflowExecutionsResponse } from '$types';
 
 const stores: { [key: string]: ReturnType<typeof createStore> } = {};
 
 export const createStore = (namespace: string) => {
-  const update = () => {
-    const startTime = getFromStore(range);
-
-    fetchAllWorkflows({
-      namespace,
-      startTime,
-      onUpdate: store.updateStore(toWorkflowExecutions),
-    });
-  };
-
-  const store = createQueryStore<WorkflowExecution>(update);
+  const store = createQueryStore<
+    WorkflowExecution,
+    ListWorkflowExecutionsResponse
+  >(fetchAllWorkflows, toWorkflowExecutions, {
+    namespace,
+    startTime: { hours: 24 },
+  });
 
   const all = derived(store, ($store) => Object.values($store.data));
   const ids = derived(store, ($store) => Object.keys($store.ids));
-  const range = createStoreWithCallback<Duration>({ hours: 24 }, update);
 
   const status = writable<WorkflowStatus>(null);
   const workflowType = writable<WorkflowType>(null);
@@ -62,7 +58,7 @@ export const createStore = (namespace: string) => {
     all,
     filtered,
     workflowTypes,
-    range,
+    range: writable<Duration>({ hours: 24 }),
     filters: {
       status,
       workflowType,

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -17,7 +17,8 @@ const stores: { [key: string]: ReturnType<typeof createStore> } = {};
 export const createStore = (namespace: string) => {
   const store = createQueryStore<
     WorkflowExecution,
-    ListWorkflowExecutionsResponse
+    ListWorkflowExecutionsResponse,
+    typeof fetchAllWorkflows
   >(fetchAllWorkflows, toWorkflowExecutions, {
     namespace,
     startTime: { hours: 24 },

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -1,4 +1,4 @@
-import { derived, writable, get as getFromStore } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 
 import { unique } from '$lib/utilities/unique';
 

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -26,6 +26,7 @@ export const createStore = (namespace: string) => {
   const all = derived(store, ($store) => Object.values($store.data));
   const ids = derived(store, ($store) => Object.keys($store.ids));
 
+  const range = writable<Duration>({ hours: 24 });
   const status = writable<WorkflowStatus>(null);
   const workflowType = writable<WorkflowType>(null);
   const executionId = writable<string>(null);
@@ -58,7 +59,7 @@ export const createStore = (namespace: string) => {
     all,
     filtered,
     workflowTypes,
-    range: writable<Duration>({ hours: 24 }),
+    range,
     filters: {
       status,
       workflowType,

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -15,19 +15,26 @@ import type { ListWorkflowExecutionsResponse } from '$types';
 const stores: { [key: string]: ReturnType<typeof createStore> } = {};
 
 export const createStore = (namespace: string) => {
+  const range = writable<Duration>({ hours: 24 });
+  const startTime = derived(range, (startTime) => ({ startTime }));
+
   const store = createQueryStore<
     WorkflowExecution,
     ListWorkflowExecutionsResponse,
     typeof fetchAllWorkflows
-  >(fetchAllWorkflows, toWorkflowExecutions, {
-    namespace,
-    startTime: { hours: 24 },
-  });
+  >(
+    fetchAllWorkflows,
+    toWorkflowExecutions,
+    {
+      namespace,
+      startTime: { hours: 24 },
+    },
+    [startTime],
+  );
 
   const all = derived(store, ($store) => Object.values($store.data));
   const ids = derived(store, ($store) => Object.keys($store.ids));
 
-  const range = writable<Duration>({ hours: 24 });
   const status = writable<WorkflowStatus>(null);
   const workflowType = writable<WorkflowType>(null);
   const executionId = writable<string>(null);

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -8,7 +8,6 @@ import {
 } from '$lib/models/workflow-execution';
 
 import { fetchAllWorkflows } from '$lib/services/workflow-execution-service';
-// import { createStoreWithCallback } from '$lib/utilities/create-store-with-callback';
 import { createQueryStore } from '$lib/utilities/create-query-store';
 import type { ListWorkflowExecutionsResponse } from '$types';
 

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -86,7 +86,6 @@ export const updateStore =
     formatter: Formatter<ResponseType, FormattedType>,
   ) =>
   (response: ResponseType) => {
-    console.log(response);
     const formatted = formatter(response);
     const ids = {};
     const result: { [key: string]: FormattedType } = {};

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -11,11 +11,13 @@ export type QueryStore<T> = {
   };
 };
 
-type Formatter<ResponseType, FormattedType extends { id: string }> = (
+type HasId = { id: string };
+
+type Formatter<ResponseType, FormattedType extends HasId> = (
   response: ResponseType,
 ) => FormattedType[];
 
-export const createQueryStore = <FormattedType extends { id: string }>(
+export const createQueryStore = <FormattedType extends HasId>(
   update: () => void,
 ) => {
   const store = writable<QueryStore<FormattedType>>(
@@ -58,7 +60,7 @@ export const createQueryStore = <FormattedType extends { id: string }>(
 };
 
 export const updateStore =
-  <ResponseType, FormattedType extends { id: string }>(
+  <ResponseType, FormattedType extends HasId>(
     store: Writable<QueryStore<FormattedType>>,
     formatter: Formatter<ResponseType, FormattedType>,
   ) =>
@@ -78,11 +80,4 @@ export const updateStore =
       ids: [...$store.ids, ...Object.keys(ids)],
       data: { ...$store.data, ...result },
     }));
-  };
-
-export const setLoading =
-  <S>(store: Writable<S>) =>
-  (value: boolean) =>
-  () => {
-    store.update(($store) => ({ ...$store, loading: value }));
   };

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -1,23 +1,30 @@
+import { derived, Writable } from 'svelte/store';
 import { browser } from '$app/env';
 import { writable } from 'svelte/store';
 
-export type QueryStore<T> = T & {
+export type QueryStore<T> = {
   loading: boolean;
   updating: boolean;
   ids: string[];
+  data: {
+    [key: string]: T;
+  };
 };
 
-export const createQueryStore = <T, S = QueryStore<T>>(
-  key: string,
+type Formatter<ResponseType, FormattedType extends { id: string }> = (
+  response: ResponseType,
+) => FormattedType[];
+
+export const createQueryStore = <FormattedType extends { id: string }>(
   update: () => void,
 ) => {
-  const store = writable<S>(
+  const store = writable<QueryStore<FormattedType>>(
     {
       loading: true,
       updating: false,
       ids: [],
-      [key]: {},
-    } as unknown as S,
+      data: {},
+    } as unknown as QueryStore<FormattedType>,
     () => {
       let idleCallback: number;
 
@@ -38,5 +45,44 @@ export const createQueryStore = <T, S = QueryStore<T>>(
     },
   );
 
-  return store;
+  return {
+    subscribe: store.subscribe,
+    updateStore: <ResponseType>(
+      formatter: Formatter<ResponseType, FormattedType>,
+    ) => updateStore(store, formatter),
+    isEmpty: derived(
+      store,
+      ($store) => $store.loading === false && $store.ids.length === 0,
+    ),
+  };
 };
+
+export const updateStore =
+  <ResponseType, FormattedType extends { id: string }>(
+    store: Writable<QueryStore<FormattedType>>,
+    formatter: Formatter<ResponseType, FormattedType>,
+  ) =>
+  (response: ResponseType) => {
+    const formatted = formatter(response);
+    const ids = {};
+    const result: { [key: string]: FormattedType } = {};
+
+    for (const datum of formatted) {
+      const id = datum.id;
+      ids[id] = true;
+      result[id] = datum;
+    }
+
+    return store.update(($store) => ({
+      ...$store,
+      ids: [...$store.ids, ...Object.keys(ids)],
+      data: { ...$store.data, ...result },
+    }));
+  };
+
+export const setLoading =
+  <S>(store: Writable<S>) =>
+  (value: boolean) =>
+  () => {
+    store.update(($store) => ({ ...$store, loading: value }));
+  };

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -17,10 +17,14 @@ type Formatter<ResponseType, FormattedType extends HasId> = (
   response: ResponseType,
 ) => FormattedType[];
 
-export const createQueryStore = <FormattedType extends HasId, ResponseType>(
-  fetch: any,
+export const createQueryStore = <
+  FormattedType extends HasId,
+  ResponseType,
+  FetchType extends (options: any) => unknown,
+>(
+  fetch: FetchType,
   format: Formatter<ResponseType, FormattedType>,
-  options: any,
+  options: Parameters<FetchType>[0],
 ) => {
   const store = writable<QueryStore<FormattedType>>(
     {

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -17,21 +17,26 @@ type Formatter<ResponseType, FormattedType extends HasId> = (
   response: ResponseType,
 ) => FormattedType[];
 
+/**
+ * Takes an array of items and returns an object with an array
+ * of IDs and a hash map where the key is the item's ID and the
+ * value is the item itself.
+ */
 const collectData = <T extends HasId>(
-  formatted: T[],
+  items: T[],
 ): Pick<QueryStore<T>, 'ids' | 'data'> => {
   const ids = {};
-  const result: { [key: string]: T } = {};
+  const data: { [key: string]: T } = {};
 
-  for (const datum of formatted) {
-    const id = datum.id;
+  for (const item of items) {
+    const id = item.id;
     ids[id] = true;
-    result[id] = datum;
+    data[id] = item;
   }
 
   return {
     ids: Object.keys(ids),
-    data: result,
+    data: data,
   };
 };
 

--- a/src/lib/utilities/create-query-store.ts
+++ b/src/lib/utilities/create-query-store.ts
@@ -17,8 +17,10 @@ type Formatter<ResponseType, FormattedType extends HasId> = (
   response: ResponseType,
 ) => FormattedType[];
 
-export const createQueryStore = <FormattedType extends HasId>(
-  update: () => void,
+export const createQueryStore = <FormattedType extends HasId, ResponseType>(
+  fetch: any,
+  format: Formatter<ResponseType, FormattedType>,
+  options: any,
 ) => {
   const store = writable<QueryStore<FormattedType>>(
     {
@@ -33,7 +35,9 @@ export const createQueryStore = <FormattedType extends HasId>(
       const callback = () => {
         if (browser) {
           if (idleCallback) cancelIdleCallback(idleCallback);
-          idleCallback = requestIdleCallback(update);
+          idleCallback = requestIdleCallback(() => {
+            fetch({ ...options, onUpdate: updateStore(store, format) });
+          });
         }
       };
 

--- a/src/lib/utilities/get-activity-url.ts
+++ b/src/lib/utilities/get-activity-url.ts
@@ -1,8 +1,5 @@
-export const getActivityUrl = (
-  namespace: string,
-  executionId: string,
-  runId: string,
-  activityId = '',
-) => {
-  return `/namespaces/${namespace}/workflows/${executionId}/${runId}/activities/${activityId}`;
-};
+export const getActivityUrl =
+  (namespace: string, executionId: string, runId: string) =>
+  (activityId = '') => {
+    return `/namespaces/${namespace}/workflows/${executionId}/${runId}/activities/${activityId}`;
+  };

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -1,19 +1,6 @@
 import isFunction from 'lodash/isFunction';
 import { merge } from './merge';
 
-type NextPageToken = Uint8Array | string;
-type WithNextPageToken = { nextPageToken?: NextPageToken };
-type WithoutNextPageToken<T> = Omit<T, keyof WithNextPageToken>;
-
-type PaginationCallbacks<T> = {
-  onStart?: () => void;
-  onUpdate?: (
-    full: WithoutNextPageToken<T>,
-    current: WithoutNextPageToken<T>,
-  ) => void;
-  onComplete?: (finalProps: WithoutNextPageToken<T>) => void;
-};
-
 type PaginatedOptions<T> = PaginationCallbacks<T> & {
   token?: NextPageToken;
   previousProps?: WithoutNextPageToken<T>;

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -12,6 +12,7 @@ type PaginatedOptions<T> = PaginationCallbacks<T> & {
  * will recursively call the function again, passing in the new
  * `nextPageToken`.
  *
+ * - `onStart` fires at the beginning.
  * - `onUpdate` fires on each exection.
  * - `onComplete` fires when there are no more `nextPageTokens`.
  * - `onError` fires when a promise is rejected.

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/activities/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/activities/__layout.svelte
@@ -25,7 +25,7 @@
   export let runId: string;
 
   const { activities } = createEventStore(namespace, executionId, runId);
-  $: urlFor = getActivityUrl.bind(null, namespace, executionId, runId);
+  $: urlFor = getActivityUrl(namespace, executionId, runId);
   $: isActive = (id: string) => pathMatches(urlFor(id), $page.path);
 </script>
 


### PR DESCRIPTION
Removes lots of duplicate code and makes the QueryStore abstraction a little less leaky. This version also supports dependencies and does not empty out the story when the dependencies are updated like the previous version.

Things that still need to be done:

- Implement `loading` and `updating` states.
- Needs more testing