### PR TITLE
Update type imports

### DIFF
--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -2,10 +2,8 @@ import { derived, writable } from 'svelte/store';
 
 import { unique } from '$lib/utilities/unique';
 
-import {
-  toWorkflowExecutions,
-  WorkflowExecution,
-} from '$lib/models/workflow-execution';
+import type { WorkflowExecution } from '$lib/models/workflow-execution';
+import { toWorkflowExecutions } from '$lib/models/workflow-execution';
 
 import { fetchAllWorkflows } from '$lib/services/workflow-execution-service';
 import { createQueryStore } from '$lib/utilities/create-query-store';

--- a/src/lib/utilities/get-workflow-execution-url.ts
+++ b/src/lib/utilities/get-workflow-execution-url.ts
@@ -1,10 +1,7 @@
 import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
-import {
-  mergeSearchParams,
-  toSearchParams,
-  URLSearchParamLike,
-} from './url-search-params';
+import type { URLSearchParamLike } from './url-search-params';
+import { mergeSearchParams, toSearchParams } from './url-search-params';
 
 export const getWorkflowExecutionUrl = (
   namespace: string,

--- a/src/lib/utilities/to-url.ts
+++ b/src/lib/utilities/to-url.ts
@@ -1,4 +1,5 @@
-import { toSearchParams, URLSearchParamLike } from './url-search-params';
+import type { URLSearchParamLike } from './url-search-params';
+import { toSearchParams } from './url-search-params';
 
 export const toURL = (url: string, params?: URLSearchParamLike): string => {
   let result = url;


### PR DESCRIPTION
The latest version of SvelteKit requires that we explicitly import our types.