### PR TITLE
Make the inputs and selects look consistent in the workflow filters

### DIFF
--- a/src/lib/components/filter-input.svelte
+++ b/src/lib/components/filter-input.svelte
@@ -5,6 +5,6 @@
 </script>
 
 <div>
-  <label for={id} class="text-gray-600 text-xs block">{name}</label>
-  <input class="block border-2 text-sm p-2 h-10" {id} bind:value />
+  <label for={id} class="text-gray-600 text-xs">{name}</label>
+  <input class="block border-2 text-sm p-2 w-full h-10" {id} bind:value />
 </div>

--- a/src/lib/components/filter-select.svelte
+++ b/src/lib/components/filter-select.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <div>
-  <label for={id} class="text-gray-600 text-xs" class:hidden={condensed}>
+  <label for={id} class="text-gray-600 text-xs " class:hidden={condensed}>
     {name}
   </label>
   <select


### PR DESCRIPTION
Use the same styling for both workflow execution filter selects and inputs.