### PR TITLE
Allow fetching from relative paths

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VITE_API="http://localhost:8080/api/v1"
+VITE_API="http://localhost:8080"
 VITE_MODE="development"

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@
 static/**
 build/**
 node_modules/**
+build-local/**
+build-cloud/**

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ npm run build:cloud
 The resulting assets will be placed in either `build-local` or `build-cloud` respectively.
 
 > You can preview the built app with `npm run preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.
+
+## Configuration
+
+Set these environment variables if you want to change their defaults
+
+| Variable  | Description                                                      | Default               | Stage |
+| --------- | ---------------------------------------------------------------- | --------------------- | ----- |
+| VITE_API  | Temporal HTTP API address. Set to empty `` to use relative paths | http://localhost:8080 | Build |
+| VITE_MODE | Build target                                                     | development           | Build |

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -43,7 +43,10 @@ export const requestFromAPI = async <T>(
   if (!endpoint.startsWith('/')) endpoint = '/' + endpoint;
   const nextPageToken = token ? { next_page_token: token } : {};
 
-  const url = toURL(base + endpoint, { ...params, ...nextPageToken });
+  const url = toURL(base + '/api/v1' + endpoint, {
+    ...params,
+    ...nextPageToken,
+  });
 
   try {
     const response = await request(url, options);

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -1,12 +1,11 @@
 <script context="module" lang="ts">
   import type { LoadInput } from '@sveltejs/kit';
 
+  import { requestFromAPI } from '$lib/utilities/request-from-api';
   import NamespaceDropdown from '$lib/components/namespace-dropdown.svelte';
 
   export async function load({ fetch }: LoadInput) {
-    const user = await fetch(import.meta.env.VITE_API + '/api/v1/me/').then(
-      (response) => response.json(),
-    );
+    const { user }: any = await requestFromAPI('/me', { request: fetch });
 
     return {
       props: { user },

--- a/src/routes/cluster/index.svelte
+++ b/src/routes/cluster/index.svelte
@@ -2,11 +2,12 @@
   import type { GetClusterInfoResponse } from '$types';
 
   import type { LoadInput } from '@sveltejs/kit';
+  import { requestFromAPI } from '$lib/utilities/request-from-api';
 
   export async function load({ fetch }: LoadInput) {
-    const cluster: GetClusterInfoResponse = await fetch(
-      import.meta.env.VITE_API + '/api/v1/cluster',
-    ).then((response) => response.json());
+    const cluster: GetClusterInfoResponse = await requestFromAPI('/cluster', {
+      request: fetch,
+    });
 
     return {
       props: { cluster },

--- a/src/routes/search-attributes/index.svelte
+++ b/src/routes/search-attributes/index.svelte
@@ -1,11 +1,13 @@
 <script context="module" lang="ts">
   import type { GetSearchAttributesResponse } from '$types';
   import type { LoadInput } from '@sveltejs/kit';
+  import { requestFromAPI } from '$lib/utilities/request-from-api';
 
   export async function load({ fetch }: LoadInput) {
-    const searchAttributes: GetSearchAttributesResponse = await fetch(
-      import.meta.env.VITE_API + '/search-attributes',
-    ).then((response) => response.json());
+    const searchAttributes: GetSearchAttributesResponse = await requestFromAPI(
+      '/search-attributes',
+      { request: fetch },
+    );
 
     return {
       props: { searchAttributes },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Added option to work with relative API paths by setting `VITE_API=""`
- Fixed fetching cluster info `/api/v1/cluster`
- Fixed fetching user data `/api/v1/me`

## Why?
<!-- Tell your future self why have you made these changes -->

- Allows to change the PORT and start up time `/ui`. Needed for https://github.com/temporalio/ui-server/blob/670b884489e2de086d2c8f5236d7f138100788c2/docker/README.md?plain=1#L25
-  few fixes

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

- Set VITE_API to `` and ran with `/ui-server` 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
