### PR TITLE
reformated workflow details

### DIFF
--- a/src/lib/components/button.svelte
+++ b/src/lib/components/button.svelte
@@ -58,7 +58,7 @@
   }
 
   .destroy {
-    @apply text-white bg-danger border-2 rounded-md py-2 px-4 transition-colors;
+    @apply text-white bg-danger border-2 rounded-lg py-1 px-5 transition-colors;
   }
 
   .destroy:disabled {

--- a/src/lib/components/terminate-workflow.svelte
+++ b/src/lib/components/terminate-workflow.svelte
@@ -1,8 +1,4 @@
 <script lang="ts">
-  import { ArrowCircleDown, ArrowCircleUp } from 'svelte-hero-icons';
-  import { slide } from 'svelte/transition';
-  import Icon from 'svelte-hero-icons/Icon.svelte';
-
   import { terminateWorkflow } from '$lib/services/terminate-service';
   import type { WorkflowExecution } from '$lib/models/workflow-execution';
   import { notifications } from '$lib/stores/notifications';
@@ -14,7 +10,6 @@
   export let namespace: string;
   export let refresh: () => void = null;
 
-  let isOpen: boolean = false;
   let reason: string = '';
 
   const isEligibleForTermination = (workflow: WorkflowExecution) =>
@@ -28,7 +23,6 @@
     })
       .then(() => {
         reason = '';
-        isOpen = false;
         notifications.add('success', 'Workflow Terminated');
         if (isFunction(refresh)) refresh();
       })
@@ -37,36 +31,5 @@
 </script>
 
 {#if isEligibleForTermination(workflow)}
-  <div class="flex flex-col border-2 p-2 my-4">
-    <div class="flex gap-2" class:mb-2={isOpen}>
-      <h4>Terminate Execution</h4>
-      <span on:click={() => (isOpen = !isOpen)}>
-        <Icon
-          src={isOpen ? ArrowCircleDown : ArrowCircleUp}
-          class={`mt-1 w-5 h-5 text-gray-500 cursor-pointer`}
-        />
-      </span>
-    </div>
-
-    {#if isOpen}
-      <div transition:slide class="flex gap-4 justify-between">
-        <input
-          placeholder="Enter Reason (Optional)"
-          bind:value={reason}
-          class="w-full"
-        />
-        <Button variant="destroy" on:click={terminate}>Terminate</Button>
-      </div>
-    {/if}
-  </div>
+  <Button variant="destroy" size="small" on:click={terminate}>Terminate</Button>
 {/if}
-
-<style lang="postcss">
-  h4 {
-    @apply font-semibold;
-  }
-
-  input {
-    @apply py-2 px-4;
-  }
-</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -11,7 +11,7 @@
     });
 
     return {
-      props: { workflow },
+      props: { workflow, namespace },
       stuff: { workflow, events },
     };
   }
@@ -22,11 +22,12 @@
   import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
   export let workflow: WorkflowExecution;
+  export let namespace: string;
 </script>
 
 <section class="border-l-2 h-screen">
   <main class="w-full">
-    <Header {workflow} />
+    <Header {workflow} {namespace} />
     <slot />
   </main>
 </section>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -4,12 +4,14 @@
   import Icon from 'svelte-hero-icons/Icon.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
+  import Tabs from './_tabs.svelte';
+
   export let workflow: WorkflowExecution;
   export let namespace: string;
 </script>
 
-<header class="flex flex-col justify-between mb-2">
-  <main class="px-6">
+<header class="flex flex-col justify-between">
+  <main class="px-6 mb-2">
     <div class="flex m-0 mt-6 justify-between items-center">
       <h1 class="text-lg">
         <a href={`/namespaces/${namespace}/workflows`}>
@@ -30,6 +32,7 @@
       {workflow.id}
     </p>
   </main>
+  <Tabs />
 </header>
 
 <style lang="postcss">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -1,30 +1,39 @@
 <script lang="ts">
   import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
-  import Tabs from './_tabs.svelte';
+  import { ArrowLeft } from 'svelte-hero-icons';
+  import Icon from 'svelte-hero-icons/Icon.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
-
+  import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
   export let workflow: WorkflowExecution;
+  export let namespace: string;
 </script>
 
-<header class="flex flex-col justify-between">
+<header class="flex flex-col justify-between mb-2">
   <main class="px-6">
     <div class="flex m-0 mt-6 justify-between items-center">
       <h1 class="text-lg">
+        <a href={`/namespaces/${namespace}/workflows`}>
+          <Icon
+            src={ArrowLeft}
+            class={`inline w-5 h-5 text-gray-500 cursor-pointer`}
+          />
+        </a>
         {workflow.name}
+        <span class="inline">
+          <WorkflowStatus status={workflow?.status} />
+        </span>
       </h1>
-      <span class="inline">
-        <WorkflowStatus status={workflow?.status} />
-      </span>
+      <TerminateWorkflow {workflow} {namespace} />
     </div>
     <p class="text-gray-500 text-xs">
       <span class="uppercase text-gray-400 mr-2">Workflow ID</span>
       {workflow.id}
     </p>
-    <p class="text-gray-500 text-xs">
-      <span class="uppercase text-gray-400 mr-2">Run ID</span>
-      {workflow.runId}
-    </p>
   </main>
-  <Tabs />
 </header>
+
+<style lang="postcss">
+  p {
+    @apply ml-6;
+  }
+</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/index.svelte
@@ -20,39 +20,21 @@
 </script>
 
 <script lang="ts">
-  import { getWorkflowStartedAndCompletedEvents } from '$lib/utilities/get-started-and-completed-events';
-  import { getTaskQueueUrl } from '$lib/utilities/get-task-queue-url';
-
-  import ExecutionInformation from './_execution-information.svelte';
-  import TaskQueueInformation from './_task-queue-information.svelte';
   import PendingActivities from './_pending-activities.svelte';
   import CodeBlock from '$lib/components/code-block.svelte';
-  import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
   import Event from './_event.svelte';
+  import Tabs from './_tabs.svelte';
 
   export let workflow: WorkflowExecution;
   export let events: HistoryEvent[];
-  export let namespace: string;
 
   let format: EventFormat = 'grid';
 
-  $: inputAndResults = getWorkflowStartedAndCompletedEvents(events);
   $: pendingActivities = workflow?.pendingActivities;
-  $: taskQueue = workflow?.taskQueue;
-  $: historyEvents = workflow?.historyEvents;
-  $: href = getTaskQueueUrl(namespace, taskQueue);
 </script>
 
 <div class="execution-information px-6 py-6">
-  <div class="w-full flex">
-    <ExecutionInformation title="Start Time" value={workflow.startTime} />
-    <ExecutionInformation title="End Time" value={workflow.endTime} />
-    <TaskQueueInformation title="Task Queue" value={taskQueue} {href} />
-    <ExecutionInformation title="History Events" value={historyEvents} />
-    <CodeBlock heading="Input" content={inputAndResults.input} />
-    <CodeBlock heading="Result" content={inputAndResults.result} />
-  </div>
-  <TerminateWorkflow {namespace} {workflow} />
+  <Tabs />
   <div class="flex w-full mt-4">
     <PendingActivities activities={pendingActivities} />
   </div>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/index.svelte
@@ -23,7 +23,6 @@
   import PendingActivities from './_pending-activities.svelte';
   import CodeBlock from '$lib/components/code-block.svelte';
   import Event from './_event.svelte';
-  import Tabs from './_tabs.svelte';
 
   export let workflow: WorkflowExecution;
   export let events: HistoryEvent[];
@@ -34,7 +33,6 @@
 </script>
 
 <div class="execution-information px-6 py-6">
-  <Tabs />
   <div class="flex w-full mt-4">
     <PendingActivities activities={pendingActivities} />
   </div>


### PR DESCRIPTION
## What was changed
Removed and rearrange components to match figma, and just put the tabs below since it will be a tab just a different style and links like history, stack trace, etc.

#### Image
<img width="1429" alt="Screen Shot 2021-12-02 at 12 07 20 PM" src="https://user-images.githubusercontent.com/43492172/144495070-60110cdd-b2d4-4f2b-8af6-73d023e31f92.png">

