### PR TITLE
Encode API Requests

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -6,6 +6,12 @@ interface Window {
   };
 }
 
+interface ImportMeta {
+  env: {
+    VITE_API: string;
+  };
+}
+
 type Heroicon = { [key: string]: string }[][];
 
 type WorkflowStatus =

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -13,6 +13,13 @@ type RequestFromAPIOptions = {
 
 const base = import.meta.env.VITE_API;
 
+const encode = (component: string): string => {
+  return component
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+};
+
 /**
  *  A utility method for making requests to the Temporal API.
  *
@@ -47,7 +54,7 @@ export const requestFromAPI = async <T>(
     ...nextPageToken,
   });
 
-  const url = toURL(base + '/api/v1' + endpoint, query);
+  const url = toURL(base + '/api/v1' + encode(endpoint), query);
 
   try {
     const response = await request(url, options);


### PR DESCRIPTION
Handles the case where `#` and its friends might show up in a Workflow ID and subsequently the URL.