### PR TITLE
Add server settings with auth state 

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -81,3 +81,9 @@ type FilterParameters = {
   status?: WorkflowStatus;
   timeRange?: Duration | string;
 };
+
+type Settings = {
+  auth: {
+    enabled: boolean;
+  };
+};

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -1,0 +1,14 @@
+import { requestFromAPI } from '$lib/utilities/request-from-api';
+
+export const fetchSettings = async (request = fetch): Promise<Settings> => {
+  const settings: { Auth: { Enabled: boolean } } = await requestFromAPI(
+    `/settings`,
+    { request },
+  );
+
+  return {
+    auth: {
+      enabled: settings.Auth.Enabled,
+    },
+  };
+};

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,0 +1,16 @@
+import { writable } from 'svelte/store';
+
+import { fetchSettings } from '$lib/services/settings-service';
+
+export const settings = writable<Settings>({
+  auth: {
+    enabled: false,
+  },
+});
+
+const loadSettings = async (): Promise<void> => {
+  const settingsRes = await fetchSettings();
+  settings.set(settingsRes);
+};
+
+loadSettings();

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -16,6 +16,7 @@
 <script lang="ts">
   import { namespace } from '$lib/stores/namespace';
   import DataConvertorStatus from '$lib/components/data-convertor-status.svelte';
+  import { settings } from '$lib/stores/settings';
   import NavigationLink from './_navigation-link.svelte';
   export let user: { name?: string; email?: string; picture?: string } = {};
 </script>
@@ -47,14 +48,16 @@
     >
       Report Bug/Give Feedback
     </a>
-    {#if user.email}
-      <span href={`/namespaces/${$namespace}/settings`}>
-        {user.email}
-      </span>
-    {:else}
-      <a class="header-button" href={import.meta.env.VITE_API + '/auth/sso'}>
-        Sign In
-      </a>
+    {#if $settings.auth?.enabled}
+      {#if user.email}
+        <span href={`/namespaces/${$namespace}/settings`}>
+          {user.email}
+        </span>
+      {:else}
+        <a class="header-button" href={import.meta.env.VITE_API + '/auth/sso'}>
+          Sign In
+        </a>
+      {/if}
     {/if}
   </div>
 </header>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Adds settings store and loads it up from `/api/v1/settings` 
- Conditionally removes the `Sign in` button depending on auth setting 

related PR https://github.com/temporalio/ui-server/pull/77

## Why?
<!-- Tell your future self why have you made these changes -->

Removes unnecessary `Sign In` button when auth is disabled

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

1. Load server with enabled and disabled auths
2. Validate the sign in button only shows up when auth.enabled = false 

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
