### PR TITLE
Fix bug where running workflows are omitted from the absence of a filter

### DIFF
--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -36,6 +36,7 @@ const emptyWorkflowRequest = (): Promise<ListWorkflowExecutionsResponse> => {
 const checkForStatus =
   (workflowStatus: WorkflowStatus, value: boolean) =>
   ({ status }: FilterParameters): boolean => {
+    if (!status) return false;
     if (status === workflowStatus) return value;
     return !value;
   };


### PR DESCRIPTION
There was a bug where a status of `null` caused an erroneous filter value. This fixes it.