### PR TITLE
Make npm start script POSIX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "start": "npm run dev:local -- --open",
-    "dev:local": "source ./.env && TEMPORAL_UI_BUILD_TARGET=local svelte-kit dev",
+    "dev:local": ". ./.env && TEMPORAL_UI_BUILD_TARGET=local svelte-kit dev",
     "dev:cloud": "TEMPORAL_UI_BUILD_TARGET=cloud svelte-kit dev",
     "build:local": "TEMPORAL_UI_BUILD_TARGET=local svelte-kit build",
     "build:cloud": "TEMPORAL_UI_BUILD_TARGET=cloud svelte-kit build",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

`source` wouldn't work with some shells such as ubuntu dash (and wsl ubuntu)

from what i've read `.` seems more universal and POSIX compliant https://ss64.com/bash/source.html

## Why?
<!-- Tell your future self why have you made these changes -->

Fixes `npm start` in wsl & ubuntu

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
