### PR TITLE
Keep history tab active if in the event view

### DIFF
--- a/src/lib/components/tab.svelte
+++ b/src/lib/components/tab.svelte
@@ -4,9 +4,10 @@
   export let href: string;
   export let label: string;
   export let amount: number | Long.Long = null;
+  export let active: boolean = $page.path.includes(href);
 </script>
 
-<a class="block" class:active={$page.path.includes(href)} {href}>
+<a class="block" class:active {href}>
   {#if amount}
     {label}
     <span class="px-2 text-blue-700 bg-blue-100 rounded-sm">{amount}</span>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
@@ -15,7 +15,7 @@
 <nav class="flex gap-6">
   <Tab
     label="History"
-    href={routeFor('workflow.events.full', { namespace, workflowId, runId })}
+    href={routeFor('workflow.events', { namespace, workflowId, runId })}
     amount={historyEvents}
   />
   <Tab label="Workers" href="#not-implemented" />


### PR DESCRIPTION
- Uses the parent route to determine if the tab should be highlighted and then redirects to the full history view.
- Turns `active` status in a prop with a default of the current implementation.