### PR TITLE
Fix API calls not properly setting CSRF

### DIFF
--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -87,7 +87,7 @@ const withSecurityOptions = (options: RequestInit): RequestInit => {
 
 const withCsrf = (headers: HeadersInit): HeadersInit => {
   if (!browser) return headers;
-  if (!headers) headers = new Headers();
+  if (!headers) headers = {};
 
   const csrfCookie = '_csrf=';
   const csrfHeader = 'X-CSRF-TOKEN';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Changes from Headers() to plain struct

## Why?
<!-- Tell your future self why have you made these changes -->

With Headers object the headers were not sent with the requests

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tested with server side PR https://github.com/temporalio/ui-server/pull/85

- Terminated workflows from a UI served under different Origin

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
