### PR TITLE
Fix history not rendering when event time is empty

### DIFF
--- a/src/lib/utilities/get-event-classification.ts
+++ b/src/lib/utilities/get-event-classification.ts
@@ -3,6 +3,7 @@ import { format } from './format-camel-case';
 import { routeFor } from './route-for';
 
 import type { WorkflowParameters } from './route-for';
+import type { Timestamp } from '$types';
 
 export type EventClassification = typeof eventClassifications[number];
 type EventOrActivity = HistoryEventWithId | PendingActivity | Activity;
@@ -85,9 +86,13 @@ const getName = (event: EventOrActivity): string => {
 };
 
 const getTime = (event: EventOrActivity): string => {
-  if (isEvent(event)) return String(event.eventTime);
-  if (isPendingActivity(event)) return String(event.lastStartedTime);
-  if (isActivity(event)) return String(event.last.eventTime);
+  let ts: Timestamp;
+
+  if (isEvent(event)) ts = event.eventTime;
+  if (isPendingActivity(event)) ts = event.lastStartedTime;
+  if (isActivity(event)) ts = event.last.eventTime;
+
+  return ts ? String(ts) : null;
 };
 
 const getId = (event: EventOrActivity): string => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Makes `null` timestamps render w/o throwing an error

## Why?
<!-- Tell your future self why have you made these changes -->

History page was broken when there was an event time == null

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

To repro the issue use https://github.com/temporalio/samples-go/tree/main/temporal-fixtures/stuck-workflows
Navigate to the history of workflow with name `xxxxxx_stuck_activity`

With the fix the page should render

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
