### PR TITLE
Fix edge case where there can be an invalid date

### DIFF
--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -13,11 +13,11 @@ export function formatDate(
 ): string {
   if (!date) return '';
 
-  if (isTimestamp(date)) {
-    date = timestampToDate(date);
-  }
-
   try {
+    if (isTimestamp(date)) {
+      date = timestampToDate(date);
+    }
+
     const parsed = parseJSON(date);
 
     if (timeFormat === 'local') return format(parsed, pattern);

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -12,7 +12,6 @@ export function formatDate(
   timeFormat: TimeFormat = 'UTC',
 ): string {
   if (!date) return '';
-
   if (isTimestamp(date)) {
     date = timestampToDate(date);
   }
@@ -21,6 +20,8 @@ export function formatDate(
 
   if (timeFormat === 'local') return format(parsed, pattern);
   if (timeFormat === 'relative') return formatDistanceToNow(parsed) + ' ago';
+
+  if (String(parsed) === 'Invalid Date') return String(parsed);
 
   return formatInTimeZone(parsed, 'UTC', pattern);
 }

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -12,6 +12,7 @@ export function formatDate(
   timeFormat: TimeFormat = 'UTC',
 ): string {
   if (!date) return '';
+
   if (isTimestamp(date)) {
     date = timestampToDate(date);
   }
@@ -21,8 +22,6 @@ export function formatDate(
   try {
     if (timeFormat === 'local') return format(parsed, pattern);
     if (timeFormat === 'relative') return formatDistanceToNow(parsed) + ' ago';
-
-    if (String(parsed) === 'Invalid Date') return String(parsed);
 
     return formatInTimeZone(parsed, 'UTC', pattern);
   } catch {

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -17,9 +17,9 @@ export function formatDate(
     date = timestampToDate(date);
   }
 
-  const parsed = parseJSON(date);
-
   try {
+    const parsed = parseJSON(date);
+
     if (timeFormat === 'local') return format(parsed, pattern);
     if (timeFormat === 'relative') return formatDistanceToNow(parsed) + ' ago';
 

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -18,12 +18,16 @@ export function formatDate(
 
   const parsed = parseJSON(date);
 
-  if (timeFormat === 'local') return format(parsed, pattern);
-  if (timeFormat === 'relative') return formatDistanceToNow(parsed) + ' ago';
+  try {
+    if (timeFormat === 'local') return format(parsed, pattern);
+    if (timeFormat === 'relative') return formatDistanceToNow(parsed) + ' ago';
 
-  if (String(parsed) === 'Invalid Date') return String(parsed);
+    if (String(parsed) === 'Invalid Date') return String(parsed);
 
-  return formatInTimeZone(parsed, 'UTC', pattern);
+    return formatInTimeZone(parsed, 'UTC', pattern);
+  } catch {
+    return '';
+  }
 }
 
 function timestampToDate(ts: Timestamp): Date {


### PR DESCRIPTION
Temporal's system namespace can create a date that cannot be formatted to UTC. Instead of blowing up, this causes the date formatting to fail gracefully.