### PR TITLE
Adjust spacing below workflow execution header

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -31,7 +31,7 @@
   $: setContext('workflow', workflow);
 </script>
 
-<main class="flex flex-col gap-4 h-full">
+<main class="flex flex-col gap-6 h-full">
   <Header {namespace} />
   <slot />
 </main>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -62,6 +62,5 @@
       <ToggleButton icon={faDownload} href={createDataUrl(events)} />
     </div>
   </nav>
+  <slot />
 </section>
-
-<slot />


### PR DESCRIPTION
Implements increased spacing below the header on the workflow execution page.

![image](https://user-images.githubusercontent.com/251000/149182971-3b6fea67-60b0-4d5b-a0ac-bf8a36f725d7.png)
