### PR TITLE
Remove duplication from workflow fetching function

### DIFF
--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -31,8 +31,6 @@ type WorkflowRouteParameters = Pick<
 >;
 type TaskQueueRouteParameters = Pick<APIRouteParameters, 'namespace' | 'queue'>;
 
-type ValidWorkflowEndpoints =
-  | WorkflowsAPIRoutePath
-  | WorkflowsAPIArchivalRoutePath;
+type ValidWorkflowEndpoints = WorkflowsAPIRoutePath;
 
 type ValidWorkflowParameters = ArchiveFilterParameters | FilterParameters;

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -35,6 +35,4 @@ type ValidWorkflowEndpoints =
   | WorkflowsAPIRoutePath
   | WorkflowsAPIArchivalRoutePath;
 
-type ValidWorkflowParameters<T> = T extends true
-  ? ArchiveFilterParameters
-  : FilterParameters;
+type ValidWorkflowParameters = ArchiveFilterParameters | FilterParameters;

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -1,0 +1,40 @@
+type WorkflowsAPIRoutePath = 'workflows' | 'workflows.archived';
+
+type WorkflowAPIRoutePath =
+  | 'workflow'
+  | 'workflow.terminate'
+  | 'events'
+  | 'query';
+
+type TaskQueueAPIRoutePath = 'task-queue';
+type ParameterlessAPIRoutePath = 'cluster' | 'settings' | 'user' | 'namespaces';
+
+type APIRoutePath =
+  | WorkflowsAPIRoutePath
+  | WorkflowAPIRoutePath
+  | ParameterlessAPIRoutePath
+  | TaskQueueAPIRoutePath
+  | WorkflowsAPIArchivalRoutePath;
+
+type APIRouteParameters = {
+  namespace: string;
+  executionId: string;
+  runId: string;
+  queue: string;
+};
+
+type WorkflowListRouteParameters = Pick<APIRouteParameters, 'namespace'>;
+
+type WorkflowRouteParameters = Pick<
+  APIRouteParameters,
+  'namespace' | 'executionId' | 'runId'
+>;
+type TaskQueueRouteParameters = Pick<APIRouteParameters, 'namespace' | 'queue'>;
+
+type ValidWorkflowEndpoints =
+  | WorkflowsAPIRoutePath
+  | WorkflowsAPIArchivalRoutePath;
+
+type ValidWorkflowParameters<T> = T extends true
+  ? ArchiveFilterParameters
+  : FilterParameters;

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -4,7 +4,6 @@ import {
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
-import type { WorkflowRouteParameters } from '$lib/utilities/route-for-api';
 import { getQueryTypesFromError } from '$lib/utilities/get-query-types-from-error';
 
 type QueryRequestParameters = {

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -25,7 +25,7 @@ export type CombinedWorkflowExecutionsResponse = {
 
 export const fetchAllWorkflows = async (
   namespace: string,
-  parameters: ValidWorkflowParameters<typeof archived>,
+  parameters: ValidWorkflowParameters,
   request = fetch,
   archived = false,
 ): Promise<CombinedWorkflowExecutionsResponse> => {

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -23,11 +23,6 @@ export type CombinedWorkflowExecutionsResponse = {
   error?: string;
 };
 
-const allWorkflowsEndpoint: ValidWorkflowEndpoints =
-  'workflows' as ValidWorkflowEndpoints;
-const archivedWorkflowsEndpoint: ValidWorkflowEndpoints =
-  'workflows.archived' as ValidWorkflowEndpoints;
-
 export const fetchAllWorkflows = async (
   namespace: string,
   parameters: ValidWorkflowParameters<typeof archived>,
@@ -35,7 +30,9 @@ export const fetchAllWorkflows = async (
   archived = false,
 ): Promise<CombinedWorkflowExecutionsResponse> => {
   const query = parameters.query || toListWorkflowQuery(parameters);
-  const endpoint = archived ? archivedWorkflowsEndpoint : allWorkflowsEndpoint;
+  const endpoint: ValidWorkflowEndpoints = archived
+    ? 'workflows.archived'
+    : 'workflows';
 
   let onError: ErrorCallback;
   let error: string;

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -23,12 +23,19 @@ export type CombinedWorkflowExecutionsResponse = {
   error?: string;
 };
 
+const allWorkflowsEndpoint: ValidWorkflowEndpoints =
+  'workflows' as ValidWorkflowEndpoints;
+const archivedWorkflowsEndpoint: ValidWorkflowEndpoints =
+  'workflows.archived' as ValidWorkflowEndpoints;
+
 export const fetchAllWorkflows = async (
   namespace: string,
-  parameters: FilterParameters,
+  parameters: ValidWorkflowParameters<typeof archived>,
   request = fetch,
+  archived = false,
 ): Promise<CombinedWorkflowExecutionsResponse> => {
   const query = parameters.query || toListWorkflowQuery(parameters);
+  const endpoint = archived ? archivedWorkflowsEndpoint : allWorkflowsEndpoint;
 
   let onError: ErrorCallback;
   let error: string;
@@ -41,7 +48,7 @@ export const fetchAllWorkflows = async (
 
   const { executions, nextPageToken } =
     (await requestFromAPI<ListWorkflowExecutionsResponse>(
-      routeForApi('workflows', { namespace }),
+      routeForApi(endpoint, { namespace }),
       {
         params: { query },
         onError,
@@ -61,32 +68,7 @@ export const fetchAllArchivedWorkflows = async (
   parameters: ArchiveFilterParameters,
   request = fetch,
 ): Promise<CombinedWorkflowExecutionsResponse> => {
-  const query = parameters.query || toListWorkflowQuery(parameters);
-
-  let onError: ErrorCallback;
-  let error: string;
-
-  if (parameters.query) {
-    onError = (response) => {
-      error = response.body.message;
-    };
-  }
-
-  const { executions, nextPageToken } =
-    (await requestFromAPI<ListWorkflowExecutionsResponse>(
-      routeForApi('archive', { namespace }),
-      {
-        params: { query },
-        onError,
-        request,
-      },
-    )) ?? { executions: [], nextPageToken: '' };
-
-  return {
-    workflows: toWorkflowExecutions({ executions }),
-    nextPageToken: String(nextPageToken),
-    error,
-  };
+  return fetchAllWorkflows(namespace, parameters, request, true);
 };
 
 export async function fetchWorkflow(

--- a/src/lib/utilities/route-for-api.test.ts
+++ b/src/lib/utilities/route-for-api.test.ts
@@ -8,18 +8,6 @@ const parameters = {
 };
 
 describe(routeForApi, () => {
-  it('should return a route for workflows.open', () => {
-    expect(routeForApi('workflows.open', parameters)).toBe(
-      'http://localhost:8080/api/v1/namespaces/namespace/workflows/open',
-    );
-  });
-
-  it('should return a route for workflows.closed', () => {
-    expect(routeForApi('workflows.closed', parameters)).toBe(
-      'http://localhost:8080/api/v1/namespaces/namespace/workflows/closed',
-    );
-  });
-
   it('should return a route for workflow', () => {
     expect(routeForApi('workflow', parameters)).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/execution/executions/run',

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,44 +1,3 @@
-type WorkflowsAPIRoutePath =
-  | 'workflows'
-  | 'workflows.open'
-  | 'workflows.closed';
-
-type WorkflowsAPIArchivalRoutePath = 'archive';
-
-type WorkflowAPIRoutePath =
-  | 'workflow'
-  | 'workflow.terminate'
-  | 'events'
-  | 'query';
-
-type TaskQueueAPIRoutePath = 'task-queue';
-type ParameterlessAPIRoutePath = 'cluster' | 'settings' | 'user' | 'namespaces';
-type APIArchivalParameters = Pick<APIRouteParameters, 'namespace'>;
-
-type APIRoutePath =
-  | WorkflowsAPIRoutePath
-  | WorkflowAPIRoutePath
-  | ParameterlessAPIRoutePath
-  | TaskQueueAPIRoutePath
-  | WorkflowsAPIArchivalRoutePath;
-
-type APIRouteParameters = {
-  namespace: string;
-  executionId: string;
-  runId: string;
-  queue: string;
-};
-
-export type WorkflowListRouteParameters = Pick<APIRouteParameters, 'namespace'>;
-export type WorkflowRouteParameters = Pick<
-  APIRouteParameters,
-  'namespace' | 'executionId' | 'runId'
->;
-export type TaskQueueRouteParameters = Pick<
-  APIRouteParameters,
-  'namespace' | 'queue'
->;
-
 let base = (import.meta.env?.VITE_API as string) ?? process.env.VITE_API;
 if (base.endsWith('/')) base = base.slice(0, -1);
 
@@ -66,11 +25,6 @@ export function routeForApi(
   route: TaskQueueAPIRoutePath,
   parameters: TaskQueueRouteParameters,
 ): string;
-export function routeForApi(
-  route: WorkflowsAPIArchivalRoutePath,
-  parameters: APIArchivalParameters,
-): string;
-
 export function routeForApi(route: ParameterlessAPIRoutePath): string;
 export function routeForApi(
   route: APIRoutePath,
@@ -83,11 +37,9 @@ export function routeForApi(
     namespaces: '/namespaces',
     'task-queue': `/namespaces/${parameters?.namespace}/task-queues/${parameters?.queue}`,
     workflows: `/namespaces/${parameters?.namespace}/workflows`,
-    'workflows.open': `/namespaces/${parameters?.namespace}/workflows/open`,
-    'workflows.closed': `/namespaces/${parameters?.namespace}/workflows/closed`,
+    'workflows.archived': `/namespaces/${parameters?.namespace}/workflows/archived`,
     workflow: `/namespaces/${parameters?.namespace}/workflows/${parameters?.executionId}/executions/${parameters?.runId}`,
     'workflow.terminate': `/namespaces/${parameters?.namespace}/workflows/${parameters?.executionId}/executions/${parameters?.runId}/terminate`,
-    archive: `/namespaces/${parameters?.namespace}/workflows/archived`,
     events: `/namespaces/${parameters?.namespace}/workflows/${parameters?.executionId}/executions/${parameters?.runId}/events`,
     query: `/namespaces/${parameters?.namespace}/workflows/${parameters?.executionId}/executions/${parameters?.runId}/query`,
   };


### PR DESCRIPTION
Removes duplication in `fetchAllWorkflows` and `fetchAllArchivedWorkflows`.

@GiantRobots, can you take this for a spin and make sure it doesn't break anything in your work?