### PR TITLE
Fix query for non-Elasticsearch instances (Closes #249)

### DIFF
--- a/src/lib/utilities/list-workflow-query.test.ts
+++ b/src/lib/utilities/list-workflow-query.test.ts
@@ -12,11 +12,14 @@ describe(toListWorkflowQuery, () => {
 
   it('should convert an timeRange with a Duration as a value', () => {
     jest.useFakeTimers().setSystemTime(new Date('2020-01-01').getTime());
+    const tomorrow = '2020-01-02T00:00:00Z';
     const twentyFourHoursEarlier = '2019-12-31T00:00:00Z';
 
     const query = toListWorkflowQuery({ timeRange: { hours: 24 } });
 
-    expect(query).toBe(`StartTime > "${twentyFourHoursEarlier}"`);
+    expect(query).toBe(
+      `StartTime BETWEEN "${twentyFourHoursEarlier}" AND "${tomorrow}"`,
+    );
   });
 
   it('should convert an two values using an "and"', () => {

--- a/src/lib/utilities/list-workflow-query.ts
+++ b/src/lib/utilities/list-workflow-query.ts
@@ -1,4 +1,4 @@
-import { isDuration, isDurationString, toDate } from './to-duration';
+import { isDuration, isDurationString, toDate, tomorrow } from './to-duration';
 
 type QueryKey =
   | 'WorkflowId'
@@ -55,7 +55,7 @@ const toQueryStatement = (key: FilterKey, value: FilterValue): string => {
   const queryKey = queryKeys[key];
 
   if (isDuration(value) || isDurationString(value)) {
-    return `${queryKey} > "${toDate(value)}"`;
+    return `${queryKey} BETWEEN "${toDate(value)}" AND "${tomorrow()}"`;
   }
 
   return `${queryKey}="${value}"`;

--- a/src/lib/utilities/to-duration.ts
+++ b/src/lib/utilities/to-duration.ts
@@ -1,4 +1,4 @@
-import { formatISO, sub } from 'date-fns';
+import { formatISO, sub, add } from 'date-fns';
 
 type DurationKey = typeof durationKeys;
 
@@ -103,4 +103,8 @@ export const fromDate = (targetDate: string | Date): Duration => {
   if (minutes >= 1) return { minutes };
 
   return { seconds: difference / 1000 };
+};
+
+export const tomorrow = () => {
+  return formatISO(add(new Date(), { hours: 24 }));
 };


### PR DESCRIPTION
Updates to a `StartTime` query that works with both Elasticsearch and Cassandra. 