### PR TITLE
Refactor WorkflowExecution and related types to be globally available

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,5 +1,11 @@
 /// <reference types="@sveltejs/kit" />
 
+declare module '@crownframework/svelte-error-boundary';
+declare module '@sveltejs/svelte-virtual-list';
+
+type Optional<T extends unknown, K extends keyof T = keyof T> = Omit<T, K> &
+  Partial<Pick<T, K>>;
+
 interface Window {
   Prism: {
     highlightAll: () => void;
@@ -14,17 +20,6 @@ interface ImportMeta {
 }
 
 type Eventual<T> = T | PromiseLike<T>;
-
-type WorkflowStatus =
-  | 'Running'
-  | 'TimedOut'
-  | 'Completed'
-  | 'Failed'
-  | 'Completed'
-  | 'ContinuedAsNew'
-  | 'Canceled'
-  | 'Terminated'
-  | null;
 
 type NamespaceScopedRequest = { namespace: string };
 
@@ -52,27 +47,6 @@ interface NetworkError {
   response: Response;
 }
 
-type WorkflowType = string | null;
-
-type WorkflowExecutionFilters = {
-  type: WorkflowType;
-  status: WorkflowStatus;
-};
-
-type TimeFormat = 'UTC' | 'relative' | 'local';
-
-type FilterParameters = {
-  workflowId?: string;
-  workflowType?: string;
-  executionStatus?: WorkflowStatus;
-  timeRange?: Duration | string;
-  query?: string;
-};
-
-type ArchiveFilterParameters = Omit<FilterParameters, 'timeRange'> & {
-  closeTime: Duration | string;
-};
-
 type Settings = {
   auth: {
     enabled: boolean;
@@ -86,7 +60,6 @@ type User = {
   picture: string;
 };
 
-declare module '@crownframework/svelte-error-boundary';
-declare module '@sveltejs/svelte-virtual-list';
+type TimeFormat = 'UTC' | 'relative' | 'local';
 
 type SelectOptionValue = number | string | boolean;

--- a/src/lib/components/terminate-workflow.svelte
+++ b/src/lib/components/terminate-workflow.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
 
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
   import { routeFor } from '$lib/utilities/route-for';
   import { handleError } from '$lib/utilities/handle-error';
   import { terminateWorkflow } from '$lib/services/terminate-service';

--- a/src/lib/components/workflow-status.svelte
+++ b/src/lib/components/workflow-status.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { WorkflowExecutionStatus } from '$types';
   export let status: WorkflowExecutionStatus;
 
   const humanFriendlyNames = {

--- a/src/lib/models/workflow-execution.ts
+++ b/src/lib/models/workflow-execution.ts
@@ -1,30 +1,3 @@
-import type {
-  WorkflowExecutionStatus,
-  DescribeWorkflowExecutionResponse,
-  ListWorkflowExecutionsResponse,
-} from '$types';
-
-type Optional<T extends unknown, K extends keyof T = keyof T> = Omit<T, K> &
-  Partial<Pick<T, K>>;
-
-export type WorkflowExecution = {
-  name: string;
-  id: string;
-  runId: string;
-  startTime: string;
-  endTime: string;
-  status: WorkflowExecutionStatus;
-  taskQueue?: string;
-  historyEvents: Long;
-  pendingActivities: PendingActivity[];
-  url: string;
-};
-
-type WorkflowExecutionAPIResponse = Optional<
-  DescribeWorkflowExecutionResponse,
-  'executionConfig' | 'pendingActivities' | 'pendingChildren'
->;
-
 const toPendingActivities = (
   pendingActivity: PendingActivityInfo[] = [],
 ): PendingActivity[] => {

--- a/src/lib/services/terminate-service.ts
+++ b/src/lib/services/terminate-service.ts
@@ -1,8 +1,6 @@
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
-import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
 type TerminateWorkflowOptions = {
   workflow: WorkflowExecution;
   namespace: string;

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -1,5 +1,3 @@
-import type { ListWorkflowExecutionsResponse } from '$types';
-import type { WorkflowExecution } from '$lib/models/workflow-execution';
 import type { ErrorCallback } from '$lib/utilities/request-from-api';
 
 import { requestFromAPI } from '$lib/utilities/request-from-api';

--- a/src/lib/utilities/get-visible-events.ts
+++ b/src/lib/utilities/get-visible-events.ts
@@ -1,5 +1,3 @@
-import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
 import { eventTypeInCategory } from './get-event-categorization';
 
 export const getVisibleEvents = async (

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
   import type { LoadInput } from '@sveltejs/kit';
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
   import { fetchWorkflow } from '$lib/services/workflow-service';
 

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -2,8 +2,6 @@
   import Icon from 'svelte-fa';
   import { faChevronLeft } from '@fortawesome/free-solid-svg-icons';
 
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
   import Tabs from './_tabs.svelte';

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_tabs.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
   import { page } from '$app/stores';
   import { routeFor } from '$lib/utilities/route-for';
 

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/__layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts" context="module">
   import type { LoadInput } from '@sveltejs/kit';
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
   export const load = async ({ stuff }: LoadInput) => {
     const { workflow, events } = stuff;

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/pending-[id].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/pending-[id].svelte
@@ -1,6 +1,5 @@
 <script lang="ts" context="module">
   import type { LoadInput } from '@sveltejs/kit';
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
   export const load = async ({ stuff }: LoadInput) => {
     const { workflow, events } = stuff;

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
@@ -1,5 +1,4 @@
 <script context="module" lang="ts">
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
   import type { LoadInput } from '@sveltejs/kit';
 
   export async function load({ page, stuff }: LoadInput) {

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
   import type { LoadInput } from '@sveltejs/kit';
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
 
   import { getPollers } from '$lib/services/pollers-service';
   import type { GetPollersResponse } from '$lib/services/pollers-service';

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
@@ -2,8 +2,6 @@
   import { formatDate } from '$lib/utilities/format-date';
   import { namespace } from '$lib/stores/namespace';
 
-  import type { WorkflowExecution } from '$lib/models/workflow-execution';
-
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import { routeFor } from '$lib/utilities/route-for';
 

--- a/src/workflow.d.ts
+++ b/src/workflow.d.ts
@@ -1,0 +1,51 @@
+type WorkflowExecutionStatus = import('$types').WorkflowExecutionStatus;
+type ListWorkflowExecutionsResponse =
+  import('$types').ListWorkflowExecutionsResponse;
+
+type WorkflowExecutionAPIResponse = Optional<
+  DescribeWorkflowExecutionResponse,
+  'executionConfig' | 'pendingActivities' | 'pendingChildren'
+>;
+
+type WorkflowStatus =
+  | 'Running'
+  | 'TimedOut'
+  | 'Completed'
+  | 'Failed'
+  | 'Completed'
+  | 'ContinuedAsNew'
+  | 'Canceled'
+  | 'Terminated'
+  | null;
+
+type WorkflowType = string | null;
+
+type WorkflowExecutionFilters = {
+  type: WorkflowType;
+  status: WorkflowStatus;
+};
+
+type FilterParameters = {
+  workflowId?: string;
+  workflowType?: string;
+  executionStatus?: WorkflowStatus;
+  timeRange?: Duration | string;
+  query?: string;
+};
+
+type ArchiveFilterParameters = Omit<FilterParameters, 'timeRange'> & {
+  closeTime: Duration | string;
+};
+
+type WorkflowExecution = {
+  name: string;
+  id: string;
+  runId: string;
+  startTime: string;
+  endTime: string;
+  status: WorkflowExecutionStatus;
+  taskQueue?: string;
+  historyEvents: Long;
+  pendingActivities: PendingActivity[];
+  url: string;
+};


### PR DESCRIPTION
Just like we're doing with the events. This PR also cleans up `global.d.ts` a bit as well.