### PR TITLE
Fix navigation to default namespace when it is empty string

### DIFF
--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -12,6 +12,6 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     auth: {
       enabled: !!settings?.Auth?.Enabled,
     },
-    defaultNamespace: settings?.DefaultNamespace ?? 'default',
+    defaultNamespace: settings?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
   };
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Treats empty value default namespace `""` as null value and replaces with `default`

## Why?
<!-- Tell your future self why have you made these changes -->

If the backend sends an empty value, it was resulting in UI not auto-navigating to the `default` namespace

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
