### PR TITLE
Fix UI rendering blank on namespaces and cluster fetch errors

### DIFF
--- a/src/lib/components/select/namespace-select.svelte
+++ b/src/lib/components/select/namespace-select.svelte
@@ -6,7 +6,7 @@
 
   import { getAppContext } from '$lib/utilities/get-context';
 
-  $: namespaces = getAppContext('namespaces').map(
+  $: namespaces = (getAppContext('namespaces') ?? []).map(
     (namespace) => namespace.namespaceInfo.name,
   );
 

--- a/src/lib/utilities/get-context.ts
+++ b/src/lib/utilities/get-context.ts
@@ -2,7 +2,9 @@ import type { DescribeNamespaceResponse } from '$types';
 import { getContext } from 'svelte';
 
 export function getAppContext(key: 'group'): boolean;
-export function getAppContext(key: 'namespaces'): DescribeNamespaceResponse[];
+export function getAppContext(
+  key: 'namespaces',
+): DescribeNamespaceResponse[] | undefined;
 
 export function getAppContext(key: string): unknown {
   return getContext(key);

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -3,6 +3,7 @@
 
   import { requestFromAPI } from '$lib/utilities/request-from-api';
   import { routeForApi } from '$lib/utilities/route-for-api';
+  import { notifications } from '$lib/stores/notifications';
 
   import { loadUser } from '$lib/stores/user';
   import { loadCluster } from '$lib/stores/cluster';
@@ -18,11 +19,16 @@
   export const load: Load = async function ({}) {
     const { namespaces }: ListNamespacesResponse = (await requestFromAPI(
       routeForApi('namespaces'),
-      { request: fetch },
+      {
+        request: fetch,
+        onError: () => notifications.add('error', 'Unable to fetch namespaces'),
+      },
     )) ?? { namespaces: [] };
 
     loadUser();
-    loadCluster();
+    loadCluster().catch(() =>
+      notifications.add('error', 'Unable to fetch cluster info'),
+    );
     loadSettings();
 
     return {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Adds handling for Namespaces and Cluster API calls to fetch locally rather than globally

## Why?
<!-- Tell your future self why have you made these changes -->

Namespaces and Cluster API calls should not be crucial for general UI operation
Just showing error notifications is enough

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Turn off Temporal service
Start the UI

expected: 
UI should still get rendered with 503 because of the Workflows fetch call

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
