### PR TITLE
Fix issue with active links not displaying properly in Event History

### DIFF
--- a/src/lib/components/event-table.svelte
+++ b/src/lib/components/event-table.svelte
@@ -22,7 +22,7 @@
       <div
         class="flex flex-col h-full w-1/3 border-r-2 border-gray-300 rounded-bl-lg"
       >
-        <div class="h-full rounded-bl-lg overflow-y-scroll">
+        <div class="rounded-bl-lg overflow-y-scroll h-screen">
           {#each visibleItems as event (event.id)}
             <Event {event} />
           {/each}

--- a/src/lib/components/event.svelte
+++ b/src/lib/components/event.svelte
@@ -28,7 +28,7 @@
   sveltekit:prefetch
   class="flex border-b-2 border-gray-300 w-full items-center hover:bg-gray-50"
   class:pending
-  class:active={$page.url.pathname.includes(href)}
+  class:active={$page.params.id === event.id}
 >
   <article class="flex gap-4 items-center p-4">
     <p class="w-5 text-center text-gray-500">{id}</p>


### PR DESCRIPTION
Adding query parameters for the filters broke the logic for adding the `.active` class to the currently active link. This uses the `page.params.id` instead.