### PR TITLE
Fix issue with pulling from query parameters in event history view

### DIFF
--- a/src/lib/components/event.svelte
+++ b/src/lib/components/event.svelte
@@ -30,7 +30,7 @@
   class:pending
   class:active={$page.params.id === event.id}
 >
-  <article class="flex gap-4 items-center p-4">
+  <article class="flex gap-4 items-center p-4 w-full">
     <p class="w-5 text-center text-gray-500">{id}</p>
     <div class="w-full">
       <h2 class="mb-2 {tag}">

--- a/src/routes/namespaces/[namespace]/archival/index.svelte
+++ b/src/routes/namespaces/[namespace]/archival/index.svelte
@@ -2,15 +2,16 @@
   import type { Load } from '@sveltejs/kit';
 
   export const load: Load = async function ({ params, url, stuff }) {
-    const query = url.searchParams;
+    const { searchParams } = url;
 
-    if (!query.has('time-range')) query.set('time-range', '24 hours');
+    if (!searchParams.has('time-range'))
+      searchParams.set('time-range', '24 hours');
 
     const namespace = params.namespace;
-    const workflowId = query.get('workflow-id');
-    const workflowType = query.get('workflow-type');
-    const timeRange = query.get('time-range');
-    const executionStatus = query.get('status') as WorkflowStatus;
+    const workflowId = searchParams.get('workflow-id');
+    const workflowType = searchParams.get('workflow-type');
+    const timeRange = searchParams.get('time-range');
+    const executionStatus = searchParams.get('status') as WorkflowStatus;
 
     const parameters: ArchiveFilterParameters = {
       workflowId,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/full/__layout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts" context="module">
   import type { Load } from '@sveltejs/kit';
 
-  export const load: Load = async function ({ params, stuff }) {
+  export const load: Load = async function ({ params, url, stuff }) {
     const { workflow, events } = stuff;
-    const category = params.category;
+    const category = url.searchParams.get('category');
 
     return {
       props: { workflow, events, category },


### PR DESCRIPTION
Grabs the `searchParams` from the correct `url` object as opposed to `params`.