### PR TITLE
Fix issue where row headers were not being updated properly, fixes #287

### DIFF
--- a/src/lib/components/event-details.svelte
+++ b/src/lib/components/event-details.svelte
@@ -9,7 +9,7 @@
     | Record<string, unknown>;
 </script>
 
-{#each Object.entries(attributes) as [key, value]}
+{#each Object.entries(attributes) as [key, value] (key)}
   <article
     class="flex items-center content-start w-full border-b-2 last:border-b-0 border-gray-200 py-1"
   >


### PR DESCRIPTION
Adds a missing key for re-rendering rows headers properly and address issues where rows could have the wrong label.

Hat tip: @rylandg.