### PR TITLE
Load queries at runtime and remove temporal-system from the list of namespaces

### DIFF
--- a/src/lib/components/select/namespace-select.svelte
+++ b/src/lib/components/select/namespace-select.svelte
@@ -10,8 +10,8 @@
   const isCloud = $page.stuff.settings.runtimeEnvironment;
 
   $: namespaces = (getAppContext('namespaces') ?? [])
-    .map((namespace) => namespace?.namespaceInfo?.name ?? undefined)
-    .filter((namespace) => namespace);
+    .map((namespace) => namespace?.namespaceInfo?.name)
+    .filter((namespace) => namespace && namespace !== 'temporal-system');
 
   $: selectedNamespace = $currentNamespace;
 

--- a/src/lib/utilities/atob.ts
+++ b/src/lib/utilities/atob.ts
@@ -1,0 +1,3 @@
+import { browser } from '$app/env';
+
+export const atob = browser ? window.atob : (str: string) => str;

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -3,9 +3,7 @@ import { dataConverterWebsocket } from '$lib/utilities/data-converter-websocket'
 import type { DataConverterWebsocketInterface } from '$lib/utilities/data-converter-websocket';
 
 import { convertPayload } from '$lib/services/data-converter';
-import { browser } from '$app/env';
-
-const atob = browser ? window.atob : (str: string) => str;
+import { atob } from './atob';
 
 export function decodePayload(
   payload: Payload,

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -22,6 +22,7 @@ type RequestFromAPIOptions = {
   options?: Parameters<typeof fetch>[1];
   token?: string;
   onError?: ErrorCallback;
+  notifyOnError?: boolean;
   shouldRetry?: boolean;
   retryInterval?: number;
 };
@@ -53,6 +54,7 @@ export const requestFromAPI = async <T>(
     request = fetch,
     token,
     shouldRetry = false,
+    notifyOnError = true,
     onError,
     retryInterval = 5000,
   } = init;
@@ -87,14 +89,18 @@ export const requestFromAPI = async <T>(
 
     return body;
   } catch (error: unknown) {
-    handleError(error);
+    if (notifyOnError) {
+      handleError(error);
 
-    if (shouldRetry && retryCount > 0) {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve(requestFromAPI(endpoint, init, retryCount - 1));
-        }, retryInterval);
-      });
+      if (shouldRetry && retryCount > 0) {
+        return new Promise((resolve) => {
+          setTimeout(() => {
+            resolve(requestFromAPI(endpoint, init, retryCount - 1));
+          }, retryInterval);
+        });
+      }
+    } else {
+      throw error;
     }
   }
 };

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
@@ -5,16 +5,10 @@
     const { namespace } = params;
     const { workflow } = stuff;
 
-    const stackTrace = await getWorkflowStackTrace({
-      workflow,
-      namespace,
-    });
-
     return {
       props: {
         workflow,
         namespace,
-        stackTrace,
       },
     };
   };
@@ -30,37 +24,53 @@
   import EmptyState from '$lib/components/empty-state.svelte';
 
   export let namespace: string;
-  export let stackTrace: string;
   export let workflow: WorkflowExecution;
 
   let currentdate = new Date();
   let isLoading = false;
 
-  const refreshStackTrace = async () => {
-    isLoading = true;
-
-    stackTrace = await getWorkflowStackTrace({
+  const getStackTrace = () =>
+    getWorkflowStackTrace({
       workflow,
       namespace,
     });
 
-    isLoading = false;
-    currentdate = new Date();
+  let stackTrace = getStackTrace();
+
+  const refreshStackTrace = () => {
+    stackTrace = getWorkflowStackTrace({
+      workflow,
+      namespace,
+    });
+
+    stackTrace.then(() => {
+      currentdate = new Date();
+    });
   };
 </script>
 
 <section>
   {#if String(workflow.status) === 'Running'}
-    <div class="flex items-center gap-4">
-      <Button on:click={refreshStackTrace} icon={faRedo} loading={isLoading}>
-        Refresh
-      </Button>
-      <p>Stack Trace at {currentdate.toLocaleTimeString()}</p>
-    </div>
-    {#await stackTrace then result}
+    {#await stackTrace}
+      <div class="text-center">
+        <h2 class="font-bold text-2xl mb-4">Loading…</h2>
+        <p>(This will fail if you have no workers running.)</p>
+      </div>
+    {:then result}
+      <div class="flex items-center gap-4">
+        <Button on:click={refreshStackTrace} icon={faRedo} loading={isLoading}>
+          Refresh
+        </Button>
+        <p>Stack Trace at {currentdate.toLocaleTimeString()}</p>
+      </div>
       <div class="flex items-start h-full">
         <CodeBlock content={result} language="text" />
       </div>
+    {:catch error}
+      <EmptyState
+        title="An Error Occured"
+        content="Please make sure you have at least one worker running."
+      />
     {/await}
   {:else}
     <EmptyState title="No Stack Traces Found" />

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/stack-trace.svelte
@@ -66,7 +66,7 @@
       <div class="flex items-start h-full">
         <CodeBlock content={result} language="text" />
       </div>
-    {:catch error}
+    {:catch _error}
       <EmptyState
         title="An Error Occured"
         content="Please make sure you have at least one worker running."


### PR DESCRIPTION
Fixes issue where the UI would crash if a worker was not running when fetching stack traces or queries.

Fixes #291 and #308.