### PR TITLE
Remove gloss from selects in Safari

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -20,3 +20,7 @@ body {
   max-height: 25em;
   overflow-y: scroll;
 }
+
+select {
+  -webkit-appearance: none;
+}


### PR DESCRIPTION
### Before

<img width="1624" alt="Screen Shot 2022-03-15 at 1 47 26 PM" src="https://user-images.githubusercontent.com/251000/158459706-05396226-60d0-4346-bc32-98ef2bf589ee.png">

### After

<img width="1624" alt="Screen Shot 2022-03-15 at 1 48 38 PM" src="https://user-images.githubusercontent.com/251000/158459725-96901c16-dab6-4dea-80b1-4447ffb91be4.png">
