### PR TITLE
Remove additional from the event details table, closes #333, #334, #335, and #336

### DIFF
--- a/src/lib/components/event-details.svelte
+++ b/src/lib/components/event-details.svelte
@@ -3,6 +3,13 @@
 
   import CodeBlock from './code-block.svelte';
 
+  const shouldDisplay = (value: unknown): boolean => {
+    if (value === null) return false;
+    if (value === undefined) return false;
+    if (value === '') return false;
+    return true;
+  };
+
   export let attributes:
     | EventAttribute
     | PendingActivity
@@ -10,7 +17,7 @@
 </script>
 
 {#each Object.entries(attributes) as [key, value] (key)}
-  {#if value !== null && value !== undefined}
+  {#if shouldDisplay(value)}
     <article
       class="flex items-center content-start w-full border-b-2 last:border-b-0 border-gray-200 py-1"
     >
@@ -18,10 +25,8 @@
       <div class="flex-grow w-full">
         {#if typeof value === 'object'}
           <CodeBlock content={value} />
-        {:else if value}
-          <p><span class="bg-gray-300 text-gray-700 px-2">{value}</span></p>
         {:else}
-          <p class="text-gray-500">Undefined</p>
+          <p><span class="bg-gray-300 text-gray-700 px-2">{value}</span></p>
         {/if}
       </div>
     </article>

--- a/src/lib/components/event-details.svelte
+++ b/src/lib/components/event-details.svelte
@@ -7,6 +7,7 @@
     if (value === null) return false;
     if (value === undefined) return false;
     if (value === '') return false;
+    if (value === '0s') return false;
     return true;
   };
 

--- a/src/lib/components/event-details.svelte
+++ b/src/lib/components/event-details.svelte
@@ -3,11 +3,12 @@
 
   import CodeBlock from './code-block.svelte';
 
-  const shouldDisplay = (value: unknown): boolean => {
+  const shouldDisplay = (key: string, value: unknown): boolean => {
     if (value === null) return false;
     if (value === undefined) return false;
     if (value === '') return false;
     if (value === '0s') return false;
+    if (key === 'type') return false;
     return true;
   };
 
@@ -18,7 +19,7 @@
 </script>
 
 {#each Object.entries(attributes) as [key, value] (key)}
-  {#if shouldDisplay(value)}
+  {#if shouldDisplay(key, value)}
     <article
       class="flex items-center content-start w-full border-b-2 last:border-b-0 border-gray-200 py-1"
     >

--- a/src/lib/components/input-and-result.svelte
+++ b/src/lib/components/input-and-result.svelte
@@ -9,7 +9,6 @@
 
 <section class="flex flex-col gap-4">
   {#await inputAndResult then { input, result }}
-    <h3 class="text-lg font-medium">Input & Results</h3>
     <div class="flex gap-4">
       <CodeBlock heading="Input" content={input} framed />
       <CodeBlock heading="Result" content={result} framed />


### PR DESCRIPTION
Remove empty strings and zero second values. Remove the `type` property we add when creating the `HistoryEventWithId` model. Remove heading from workflow inputs and results.