### PR TITLE
Add an additional fallback when viewing an event not in a group

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -5,6 +5,17 @@
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import type { EventHistoryParameters } from '$lib/utilities/route-for';
 
+  const isIneligible = (
+    event: HistoryEventWithId,
+    eventGroup: CompactEventGroup,
+    { matchingEvents }: Partial<App.Stuff>,
+    { view }: Record<string, string>,
+  ): boolean => {
+    if (!matchingEvents.includes(event)) return true;
+    if (view === 'compact' && !eventGroup) return true;
+    return false;
+  };
+
   export const load: Load = async function ({ params, stuff, url }) {
     const { eventId } = params;
     const { events, eventGroups, matchingEvents } = stuff;
@@ -17,7 +28,7 @@
 
     if (!event) return { status: 404 };
 
-    if (!matchingEvents.includes(event)) {
+    if (isIneligible(event, eventGroup, stuff, params)) {
       url.pathname = routeForEventHistory(params as EventHistoryParameters);
 
       return {

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -11,7 +11,7 @@
    *
    * @param event The event as determined by the route
    * @param eventGroup The event group that its a member of
-   * @param stuff SvelteKit's stuff object
+   * @param stuff SvelteKit's `stuff` object
    * @param params Route parameters
    */
   const shouldRedirect = (

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -5,7 +5,7 @@
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import type { EventHistoryParameters } from '$lib/utilities/route-for';
 
-  const isIneligible = (
+  const shouldRedirect = (
     event: HistoryEventWithId,
     eventGroup: CompactEventGroup,
     { matchingEvents }: Partial<App.Stuff>,
@@ -28,7 +28,7 @@
 
     if (!event) return { status: 404 };
 
-    if (isIneligible(event, eventGroup, stuff, params)) {
+    if (shouldRedirect(event, eventGroup, stuff, params)) {
       url.pathname = routeForEventHistory(params as EventHistoryParameters);
 
       return {

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -5,6 +5,15 @@
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import type { EventHistoryParameters } from '$lib/utilities/route-for';
 
+  /**
+   * Returns `true` if we're trying to view an event that has been filtered
+   * out from the sidebar.
+   *
+   * @param event The event as determined by the route
+   * @param eventGroup The event group that its a member of
+   * @param stuff SvelteKit's stuff object
+   * @param params Route parameters
+   */
   const shouldRedirect = (
     event: HistoryEventWithId,
     eventGroup: CompactEventGroup,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -18,7 +18,7 @@
 
   export const load: Load = async function ({ params, stuff, url }) {
     const { eventId } = params;
-    const { events, eventGroups, matchingEvents } = stuff;
+    const { events, eventGroups } = stuff;
 
     const event: HistoryEventWithId = events.find(
       (event: HistoryEventWithId) => event.id === eventId,


### PR DESCRIPTION
Adds an additional fallback to jump to the first event group when switching from summary to compact views.