### PR TITLE
Show received signals in history compact view

### DIFF
--- a/src/lib/models/group-events/create-event-group.ts
+++ b/src/lib/models/group-events/create-event-group.ts
@@ -5,6 +5,7 @@ import {
   isMarkerRecordedEvent,
   isSignalExternalWorkflowExecutionInitiatedEvent,
   isStartChildWorkflowExecutionInitiatedEvent,
+  isWorkflowExecutionSignaledEvent,
   isTimerStartedEvent,
 } from '$lib/utilities/is-event-type';
 
@@ -23,6 +24,10 @@ export const getName = (event: CommonHistoryEvent): string => {
     return `Signal: ${event.signalExternalWorkflowExecutionInitiatedEventAttributes?.signalName}`;
   }
 
+  if (isWorkflowExecutionSignaledEvent(event)) {
+    return `Signal received: ${event.workflowExecutionSignaledEventAttributes?.signalName}`;
+  }
+
   if (isMarkerRecordedEvent(event)) {
     return `Marker: ${event.markerRecordedEventAttributes?.markerName}`;
   }
@@ -37,6 +42,7 @@ type StartingEvents = {
   ChildWorkflow: StartChildWorkflowExecutionInitiatedEvent;
   Timer: TimerStartedEvent;
   Signal: SignalExternalWorkflowExecutionInitiatedEvent;
+  SignalReceived: WorkflowExecutionSignaledEvent;
   Marker: MarkerRecordedEvent;
 };
 
@@ -78,6 +84,9 @@ export const createEventGroup = (event: CommonHistoryEvent) => {
 
   if (isSignalExternalWorkflowExecutionInitiatedEvent(event))
     return createGroupFor<'Signal'>(event);
+
+  if (isWorkflowExecutionSignaledEvent(event))
+    return createGroupFor<'SignalReceived'>(event);
 
   if (isMarkerRecordedEvent(event)) return createGroupFor<'Marker'>(event);
 };

--- a/src/lib/models/group-events/get-group-id.ts
+++ b/src/lib/models/group-events/get-group-id.ts
@@ -11,6 +11,7 @@ import {
   isMarkerRecordedEvent,
   isSignalExternalWorkflowExecutionInitiatedEvent,
   isStartChildWorkflowExecutionInitiatedEvent,
+  isWorkflowExecutionSignaledEvent,
   isTimerCanceledEvent,
   isTimerFiredEvent,
   isTimerStartedEvent,
@@ -24,6 +25,8 @@ export const getGroupId = (event: CommonHistoryEvent): string => {
   if (isTimerStartedEvent(event)) return event.id;
 
   if (isSignalExternalWorkflowExecutionInitiatedEvent(event)) return event.id;
+
+  if (isWorkflowExecutionSignaledEvent(event)) return event.id;
 
   if (isMarkerRecordedEvent(event)) return event.id;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

![image](https://user-images.githubusercontent.com/11838981/159082852-04dbe615-d65a-4bc0-8581-e2417683d11d.png)

## Why?
<!-- Tell your future self why have you made these changes -->

Before compact view would only show outgoing signals
Now it also shows received signals

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Using https://github.com/temporalio/samples-go/tree/main/temporal-fixtures/rainbow-statuses and navigating to the running workflow. See screenshot

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
