### PR TITLE
Check for first group event id before setting path

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/[eventId].svelte
@@ -33,9 +33,9 @@
       (event: HistoryEventWithId) => event.id === eventId,
     );
 
-    const eventGroup: CompactEventGroup = getGroupForEvent(event, eventGroups);
-
     if (!event) return { status: 404 };
+
+    const eventGroup: CompactEventGroup = getGroupForEvent(event, eventGroups);
 
     if (shouldRedirect(event, eventGroup, stuff, params)) {
       url.pathname = routeForEventHistory(params as EventHistoryParameters);

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/index.svelte
@@ -11,7 +11,7 @@
 
     const [first] = items;
 
-    if (stuff.matchingEvents.length && first) {
+    if (matchingEvents.length && first?.id) {
       url.pathname = `${url.pathname}/${first.id}`;
 
       return {


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

## Why?
 If the first item in the grouped events does not have an id, the UI redirects to /compact/undefined, which then causes an error with getGroupForEvent

## Checklist
<!--- add/delete as needed --->

1. Closes 357

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
