### PR TITLE
Add modal with reason input to terminate workflow

### DIFF
--- a/src/lib/components/button.svelte
+++ b/src/lib/components/button.svelte
@@ -8,6 +8,7 @@
   export let destroy: boolean = false;
   export let loading: boolean = false;
   export let login: boolean = false;
+  export let thin: boolean = false;
   export let as: 'button' | 'anchor' = 'button';
   export let active: boolean = false;
   export let large: boolean = false;
@@ -25,6 +26,7 @@
     class:secondary
     class:destroy
     class:login
+    class:thin
     {disabled}
   >
     {#if icon}
@@ -45,6 +47,7 @@
     class:destroy
     class:disabled
     class:login
+    class:thin
     {disabled}
   >
     {#if icon}
@@ -74,7 +77,7 @@
   }
 
   .secondary {
-    @apply text-white bg-secondary border-2 rounded-lg px-2 transition-colors;
+    @apply text-gray-800 bg-white border-2 rounded-lg py-2 px-4 transition-colors;
   }
 
   .secondary:disabled {
@@ -86,7 +89,7 @@
   }
 
   .destroy {
-    @apply text-white bg-danger border-2 rounded-lg py-1 px-5 transition-colors;
+    @apply text-white bg-danger border-2 rounded-lg px-5 transition-colors;
   }
 
   .destroy:disabled {
@@ -103,5 +106,9 @@
 
   .login {
     @apply bg-gray-900 mx-auto py-4;
+  }
+
+  .thin {
+    @apply py-1;
   }
 </style>

--- a/src/lib/components/modal.svelte
+++ b/src/lib/components/modal.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Button from './button.svelte';
+
+  export let open = false;
+  export let confirmText = 'Confirm';
+
+  const dispatch = createEventDispatcher();
+</script>
+
+{#if open}
+  <div class="modal">
+    <div class="overlay" />
+    <div class="body">
+      <div class="title">
+        <slot name="title">
+          <span>Title</span>
+        </slot>
+      </div>
+      <div class="content">
+        <slot name="content">
+          <span>Content</span>
+        </slot>
+      </div>
+      <div
+        class="flex items-center p-6 space-x-2 rounded-b border-t border-gray-200 dark:border-gray-600"
+      >
+        <Button secondary on:click={() => dispatch('cancelModal', {})}
+          >Cancel</Button
+        >
+        <Button on:click={() => dispatch('confirmModal', {})}
+          >{confirmText}</Button
+        >
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style lang="postcss">
+  .modal {
+    @apply z-50 fixed w-full h-full top-0 left-0 flex items-center justify-center p-8 lg:p-0;
+  }
+
+  .overlay {
+    @apply fixed w-full h-full bg-gray-900 opacity-50;
+  }
+
+  .body {
+    @apply bg-white w-full lg:h-max lg:w-1/2  mx-auto rounded-lg shadow-xl z-50 overflow-y-auto;
+  }
+
+  .title {
+    @apply bg-gray-100 py-5 px-8 text-2xl;
+  }
+
+  .content {
+    @apply p-8;
+  }
+</style>

--- a/src/lib/components/modal.svelte
+++ b/src/lib/components/modal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import Icon from 'svelte-fa';
+  import { faTimes } from '@fortawesome/free-solid-svg-icons';
   import { createEventDispatcher } from 'svelte';
   import Button from './button.svelte';
 
@@ -12,9 +14,15 @@
   <div class="modal">
     <div class="overlay" />
     <div class="body">
+      <div
+        class="float-right cursor-pointer p-6"
+        on:click={() => dispatch('cancelModal', {})}
+      >
+        <Icon icon={faTimes} />
+      </div>
       <div class="title">
         <slot name="title">
-          <span>Title</span>
+          <h3>Title</h3>
         </slot>
       </div>
       <div class="content">
@@ -22,13 +30,11 @@
           <span>Content</span>
         </slot>
       </div>
-      <div
-        class="flex items-center p-6 space-x-2 rounded-b border-t border-gray-200 dark:border-gray-600"
-      >
+      <div class="flex justify-end items-center p-6 space-x-2">
         <Button secondary on:click={() => dispatch('cancelModal', {})}
           >Cancel</Button
         >
-        <Button on:click={() => dispatch('confirmModal', {})}
+        <Button destroy on:click={() => dispatch('confirmModal', {})}
           >{confirmText}</Button
         >
       </div>
@@ -46,11 +52,11 @@
   }
 
   .body {
-    @apply bg-white w-full lg:h-max lg:w-1/2  mx-auto rounded-lg shadow-xl z-50 overflow-y-auto;
+    @apply bg-white w-full md:h-max lg:w-1/3  mx-auto rounded-lg shadow-xl z-50 overflow-y-auto;
   }
 
   .title {
-    @apply bg-gray-100 py-5 px-8 text-2xl;
+    @apply bg-white pt-8 pb-0 px-8 text-2xl;
   }
 
   .content {

--- a/src/lib/components/terminate-workflow.svelte
+++ b/src/lib/components/terminate-workflow.svelte
@@ -7,25 +7,25 @@
   import { notifications } from '$lib/stores/notifications';
 
   import Button from '$lib/components/button.svelte';
+  import Modal from '$lib/components/modal.svelte';
 
   export let workflow: WorkflowExecution;
   export let namespace: string;
 
   let reason = '';
+  let showConfirmation = false;
+
+  const show = () => (showConfirmation = true);
+  const cancel = () => (showConfirmation = false);
 
   const isEligibleForTermination = (workflow: WorkflowExecution) =>
     String(workflow.status) === 'Running';
 
   const handleSuccessfulTermination = () => {
+    showConfirmation = false;
     reason = '';
     notifications.add('success', 'Workflow Terminated');
-    goto(
-      routeForWorkflow({
-        namespace,
-        workflow: workflow.id,
-        run: workflow.runId,
-      }),
-    );
+    window.location.reload();
   };
 
   const terminate = () => {
@@ -40,5 +40,22 @@
 </script>
 
 {#if isEligibleForTermination(workflow)}
-  <Button destroy on:click={terminate}>Terminate</Button>
+  <Button destroy on:click={show}>Terminate</Button>
+  <Modal
+    open={showConfirmation}
+    confirmText="Terminate"
+    on:cancelModal={cancel}
+    on:confirmModal={terminate}
+  >
+    <span slot="title">
+      Are you sure you want to terminate this workflow?
+    </span>
+    <span slot="content">
+      <input
+        class="block w-full border border-gray-200 p-4"
+        placeholder="Reason"
+        bind:value={reason}
+      />
+    </span>
+  </Modal>
 {/if}

--- a/src/lib/components/terminate-workflow.svelte
+++ b/src/lib/components/terminate-workflow.svelte
@@ -1,7 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
-
-  import { routeForWorkflow } from '$lib/utilities/route-for';
   import { handleError } from '$lib/utilities/handle-error';
   import { terminateWorkflow } from '$lib/services/terminate-service';
   import { notifications } from '$lib/stores/notifications';
@@ -40,22 +37,24 @@
 </script>
 
 {#if isEligibleForTermination(workflow)}
-  <Button destroy on:click={show}>Terminate</Button>
+  <Button destroy thin on:click={show}>Terminate</Button>
   <Modal
     open={showConfirmation}
     confirmText="Terminate"
     on:cancelModal={cancel}
     on:confirmModal={terminate}
   >
-    <span slot="title">
-      Are you sure you want to terminate this workflow?
-    </span>
-    <span slot="content">
+    <h3 slot="title">Terminate Workflow</h3>
+    <div slot="content">
+      <p>
+        Are you sure you want to terminate this workflow? This action cannot be
+        undone.
+      </p>
       <input
-        class="block w-full border border-gray-200 p-4"
-        placeholder="Reason"
+        class="block w-full border border-gray-200 rounded-md p-2 mt-4"
+        placeholder="Enter a reason"
         bind:value={reason}
       />
-    </span>
+    </div>
   </Modal>
 {/if}


### PR DESCRIPTION
## What was changed
Added a modal that allows a user to input a termination reason and confirm the termination.


<img width="1535" alt="Screen Shot 2022-03-22 at 1 51 17 PM" src="https://user-images.githubusercontent.com/7967403/159554482-d71530d0-ef95-451b-9b81-9933d4dbf7ff.png">
<img width="1536" alt="Screen Shot 2022-03-22 at 1 51 28 PM" src="https://user-images.githubusercontent.com/7967403/159554495-9de73b2c-81b5-4cca-bac2-4af3290e714f.png">

## Why?
Terminating a workflow is a permanent change and so a user should need to confirm the termination as well as get the opportunity to add an option reason for termination.
<!-- Tell your future self why have you made these changes -->

## Checklist

1. Closes 325

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
