### PR TITLE
Scroll to active event if not the first event

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/__layout.svelte
@@ -32,6 +32,7 @@
 
 <script lang="ts">
   import { page } from '$app/stores';
+  import { afterNavigate } from '$app/navigation';
 
   import EmptyState from '$lib/components/empty-state.svelte';
   import Pagination from '$lib/components/pagination.svelte';
@@ -45,6 +46,16 @@
   const startingIndex = items.findIndex(
     ({ id }) => $page.params.eventId === id,
   );
+
+  $: currentIndex = items.findIndex(({ id }) => $page.params.eventId === id);
+
+  afterNavigate(() => {
+    if (currentIndex > 0) {
+      document
+        .getElementById($page.params.eventId)
+        ?.scrollIntoView({ block: 'start' });
+    }
+  });
 </script>
 
 <Pagination {items} {startingIndex} let:visibleItems>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/_event-list-item.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/_event-list-item.svelte
@@ -3,7 +3,6 @@
   import { faCalendar } from '@fortawesome/free-solid-svg-icons';
 
   import { page } from '$app/stores';
-  import { afterNavigate } from '$app/navigation';
   import { isEvent } from '$lib/models/event-history';
   import { isEventGroup } from '$lib/models/group-events';
 
@@ -18,14 +17,6 @@
       return event.eventIds.has(currentId);
     }
   };
-
-  afterNavigate(() => {
-    if (isActive($page.params.eventId) && parseInt($page.params.eventId) > 1) {
-      document
-        .getElementById($page.params.eventId)
-        ?.scrollIntoView({ block: 'start' });
-    }
-  });
 </script>
 
 <a

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/_event-list-item.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/[view]/_event-list-item.svelte
@@ -3,6 +3,7 @@
   import { faCalendar } from '@fortawesome/free-solid-svg-icons';
 
   import { page } from '$app/stores';
+  import { afterNavigate } from '$app/navigation';
   import { isEvent } from '$lib/models/event-history';
   import { isEventGroup } from '$lib/models/group-events';
 
@@ -17,11 +18,20 @@
       return event.eventIds.has(currentId);
     }
   };
+
+  afterNavigate(() => {
+    if (isActive($page.params.eventId) && parseInt($page.params.eventId) > 1) {
+      document
+        .getElementById($page.params.eventId)
+        ?.scrollIntoView({ block: 'start' });
+    }
+  });
 </script>
 
 <a
   href={event.id + $page.url.search}
   sveltekit:noscroll
+  id={event.id}
   class="flex border-b-2 border-gray-300 w-full items-center hover:bg-gray-50"
   class:active={isActive($page.params.eventId)}
 >


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
## What was changed
Currently clicking on an event in the event history will always take you to the top of the page. This keeps the active event you clicked on in view.

## Why?
Users want to be able to stay on the event they click without having to scroll back down, especially if it is a large list of events.

## Checklist
<!--- add/delete as needed --->

1. Closes 344, 376
