### PR TITLE
Update history header with state transitions, task queues, parent info

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -16,5 +16,6 @@ declare namespace App {
     settings: Settings;
     matchingEvents?: HistoryEventWithId[];
     matchingEventGroups?: CompactEventGroups;
+    workers?: GetPollersResponse;
   }
 }

--- a/src/app.postcss
+++ b/src/app.postcss
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
 
 @tailwind base;
 
@@ -12,8 +13,19 @@ body {
 }
 
 body {
-  font-family: Poppins, sans-serif;
+  font-family: Inter, sans-serif;
   position: relative;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+titles,
+labels {
+  font-family: Poppins, sans-serif;
 }
 
 .hljs {

--- a/src/lib/components/tab.svelte
+++ b/src/lib/components/tab.svelte
@@ -19,6 +19,6 @@
 
 <style lang="postcss">
   a.active {
-    @apply border-b-2 rounded-b-sm border-blue-700 font-medium;
+    @apply border-b-2 rounded-b-sm text-blue-700 border-blue-700 font-medium;
   }
 </style>

--- a/src/lib/models/workflow-execution.ts
+++ b/src/lib/models/workflow-execution.ts
@@ -22,7 +22,7 @@ export const toWorkflowExecution = (
   const parentNamespaceId = response?.workflowExecutionInfo?.parentNamespaceId;
   const parent = response?.workflowExecutionInfo?.parentExecution;
   const stateTransitionCount =
-    response?.workflowExecutionInfo?.stateTransitionCount;
+    response.workflowExecutionInfo.stateTransitionCount;
 
   const pendingActivities: PendingActivity[] = toPendingActivities(
     response.pendingActivities,

--- a/src/lib/models/workflow-execution.ts
+++ b/src/lib/models/workflow-execution.ts
@@ -19,6 +19,11 @@ export const toWorkflowExecution = (
   const historyEvents = response.workflowExecutionInfo.historyLength;
   const url = `/workflows/${id}/${runId}`;
   const taskQueue = response?.executionConfig?.taskQueue?.name;
+  const parentNamespaceId = response?.workflowExecutionInfo?.parentNamespaceId;
+  const parent = response?.workflowExecutionInfo?.parentExecution;
+  const stateTransitionCount =
+    response?.workflowExecutionInfo?.stateTransitionCount;
+
   const pendingActivities: PendingActivity[] = toPendingActivities(
     response.pendingActivities,
   );
@@ -34,6 +39,9 @@ export const toWorkflowExecution = (
     url,
     taskQueue,
     pendingActivities,
+    parentNamespaceId,
+    parent,
+    stateTransitionCount,
   };
 };
 

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout.svelte
@@ -2,6 +2,8 @@
   import type { Load } from '@sveltejs/kit';
 
   import { fetchWorkflow } from '$lib/services/workflow-service';
+  import { getPollers } from '$lib/services/pollers-service';
+  import type { GetPollersResponse } from '$lib/services/pollers-service';
 
   export const load: Load = async function ({ params, fetch }) {
     const { workflow: executionId, run: runId, namespace } = params;
@@ -13,10 +15,12 @@
     };
 
     const workflow = await fetchWorkflow(parameters, fetch);
+    const { taskQueue } = workflow;
+    const workers = await getPollers({ queue: taskQueue, namespace });
 
     return {
-      props: { workflow, namespace },
-      stuff: { workflow },
+      props: { workflow, namespace, workers },
+      stuff: { workflow, workers },
     };
   };
 </script>
@@ -26,9 +30,10 @@
 
   export let workflow: WorkflowExecution;
   export let namespace: string;
+  export let workers: GetPollersResponse;
 </script>
 
 <main class="flex flex-col gap-6 h-full">
-  <Header {namespace} {workflow} />
+  <Header {namespace} {workflow} {workers} />
   <slot />
 </main>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
@@ -1,15 +1,11 @@
 <script context="module" lang="ts">
   import type { Load } from '@sveltejs/kit';
 
-  import { getPollers } from '$lib/services/pollers-service';
   import type { GetPollersResponse } from '$lib/services/pollers-service';
 
   export const load: Load = async function ({ params, stuff }) {
-    const { namespace } = params;
-    const { workflow } = stuff;
+    const { workflow, workers } = stuff;
     const { taskQueue } = workflow as WorkflowExecution;
-
-    const workers = await getPollers({ queue: taskQueue, namespace });
 
     return {
       props: { workers, taskQueue },

--- a/src/workflow.d.ts
+++ b/src/workflow.d.ts
@@ -47,5 +47,8 @@ type WorkflowExecution = {
   taskQueue?: string;
   historyEvents: Long;
   pendingActivities: PendingActivity[];
+  stateTransitionCount: string;
+  parentNamespaceId?: string;
+  parent?: IWorkflowExecution;
   url: string;
 };


### PR DESCRIPTION
## What was changed
Included state transitions count, start/end times, links to the workers page with the name of the task queue, link to the worker parent if it exists. Also updated font family of headers vs. body.

<img width="1728" alt="Screen Shot 2022-03-29 at 2 39 12 PM" src="https://user-images.githubusercontent.com/7967403/160694272-98e16456-aeec-45b7-9564-69fbaa7e4beb.png">

## Why?
Gives more relevant information and links at the top of the page.

## Checklist
<!--- add/delete as needed --->

1. Closes 379, 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
