### PR TITLE
Add event type to full view

### DIFF
--- a/src/lib/components/event/event-classification.svelte
+++ b/src/lib/components/event/event-classification.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  export let event: IterableEvent;
+</script>
+
+<span class="label {event.classification} font-semibold">
+  {event.name}
+</span>
+
+<style lang="postcss">
+  .label {
+    @apply px-2 text-gray-700 bg-gray-300;
+  }
+
+  .Open,
+  .New {
+    @apply text-indigo-700 bg-indigo-100;
+  }
+
+  .Started,
+  .Initiated {
+    @apply text-blue-700 bg-blue-100;
+  }
+
+  .Running,
+  .Completed,
+  .Fired {
+    @apply text-green-700 bg-green-100;
+  }
+
+  .CancelRequested,
+  .TimedOut,
+  .Signaled,
+  .Cancelled {
+    @apply text-yellow-700 bg-yellow-100;
+  }
+
+  .Failed,
+  .Terminated {
+    @apply text-red-700 bg-red-100;
+  }
+</style>

--- a/src/lib/components/event/event-full.svelte
+++ b/src/lib/components/event/event-full.svelte
@@ -3,6 +3,7 @@
 
   import Pagination from '$lib/components/pagination.svelte';
   import EventDetails from '$lib/components/event/event-details.svelte';
+  import EventClassification from './event-classification.svelte';
 
   export let events: HistoryEventWithId[];
 </script>
@@ -10,15 +11,19 @@
 <Pagination items={events} let:visibleItems>
   <section class="border-2 border-gray-300 rounded-lg w-full mb-6">
     <header class="flex table-header rounded-t-lg">
-      <h3 class="w-1/12">Workflow Events</h3>
+      <h3 class="w-3/12">Workflow Events</h3>
       <h3 class="w-2/12">Date & Time</h3>
-      <h3 class="w-3/4">Event Details</h3>
+      <h3 class="w-7/12">Event Details</h3>
     </header>
     {#each visibleItems as event (event.id)}
       <article class="table-row" id={event.id}>
-        <p class="w-1/12"><a href="#{event.id}">{event.id}</a></p>
+        <p class="w-3/12">
+          <a href="#{event.id}" class="mr-3">{event.id}</a><EventClassification
+            {event}
+          />
+        </p>
         <p class="w-2/12">{formatDate(event.eventTime)}</p>
-        <div class="w-3/4 relative">
+        <div class="w-7/12 relative">
           <EventDetails {event} />
         </div>
       </article>

--- a/src/lib/components/event/event-list-item.svelte
+++ b/src/lib/components/event/event-list-item.svelte
@@ -5,6 +5,7 @@
   import { page } from '$app/stores';
   import { isEvent } from '$lib/models/event-history';
   import { isEventGroup } from '$lib/models/group-events';
+  import EventClassification from './event-classification.svelte';
 
   export let event: IterableEvent;
 
@@ -30,9 +31,7 @@
     <p class="w-5 text-center text-gray-500">{event.id}</p>
     <div class="w-full">
       <h2 class="mb-2">
-        <span class="label {event.classification} font-semibold">
-          {event.name}
-        </span>
+        <EventClassification {event} />
       </h2>
       <p class="text-sm">
         <Icon icon={faCalendar} class="inline" />
@@ -57,37 +56,5 @@
 
   a:last-child {
     @apply border-b-0;
-  }
-
-  .label {
-    @apply px-2 text-gray-700 bg-gray-300;
-  }
-
-  .Open,
-  .New {
-    @apply text-indigo-700 bg-indigo-100;
-  }
-
-  .Started,
-  .Initiated {
-    @apply text-blue-700 bg-blue-100;
-  }
-
-  .Running,
-  .Completed,
-  .Fired {
-    @apply text-green-700 bg-green-100;
-  }
-
-  .CancelRequested,
-  .TimedOut,
-  .Signaled,
-  .Cancelled {
-    @apply text-yellow-700 bg-yellow-100;
-  }
-
-  .Failed,
-  .Terminated {
-    @apply text-red-700 bg-red-100;
   }
 </style>


### PR DESCRIPTION
## What was changed
Add Event Type to the Full View of Event History
<img width="1728" alt="Screen Shot 2022-03-29 at 7 36 47 PM" src="https://user-images.githubusercontent.com/7967403/160728384-2bd554c1-ea54-46d8-8da9-4f997aed0515.png">

## Why?
Necessary information for the full view

## Checklist
<!--- add/delete as needed --->

1. Closes 390

