### PR TITLE
Make RunID keys in History navigate to worklow page

### DIFF
--- a/src/lib/components/event/event-details.svelte
+++ b/src/lib/components/event/event-details.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import { format } from '$lib/utilities/format-camel-case';
+  import { routeForWorkflow } from '$lib/utilities/route-for';
   import CodeBlock from '$lib/components/code-block.svelte';
-  import { shouldDisplayAttribute } from '$lib/utilities/get-single-attribute-for-event';
+  import TableLink from '$lib/components/table-link.svelte';
+  import {
+    shouldDisplayAttribute,
+    shouldDisplayAsWorkflowLink,
+  } from '$lib/utilities/get-single-attribute-for-event';
   export let event: HistoryEventWithId;
+
+  const { workflow, namespace } = $page.params;
 </script>
 
 <section>
@@ -15,6 +23,11 @@
         <div class="flex-grow w-full">
           {#if typeof value === 'object'}
             <CodeBlock content={value} />
+          {:else if shouldDisplayAsWorkflowLink(key)}
+            <TableLink
+              href={routeForWorkflow({ namespace, workflow, run: value })}
+              >{value}</TableLink
+            >
           {:else}
             <p><span class="bg-gray-300 text-gray-700 px-2">{value}</span></p>
           {/if}

--- a/src/lib/components/event/event-single-detail.svelte
+++ b/src/lib/components/event/event-single-detail.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
-  import { getSingleAttributeForEvent } from '$lib/utilities/get-single-attribute-for-event';
+  import { page } from '$app/stores';
+  import { routeForWorkflow } from '$lib/utilities/route-for';
+  import {
+    getSingleAttributeForEvent,
+    shouldDisplayAsWorkflowLink,
+  } from '$lib/utilities/get-single-attribute-for-event';
   import CodeBlock from '../code-block.svelte';
+  import TableLink from '$lib/components/table-link.svelte';
 
   export let event: HistoryEventWithId | null = null;
   export let eventGroup: CompactEventGroup | null = null;
 
   let { key, value } = getSingleAttributeForEvent({ event, eventGroup });
+  const { workflow, namespace } = $page.params;
 </script>
 
 <section>
@@ -16,6 +23,10 @@
     <div class="flex-grow w-full">
       {#if eventGroup}
         <CodeBlock content={value} />
+      {:else if shouldDisplayAsWorkflowLink(key)}
+        <TableLink href={routeForWorkflow({ namespace, workflow, run: value })}
+          >{value}</TableLink
+        >
       {:else}
         <p><span class="bg-gray-300 text-gray-700 px-2">{value}</span></p>
       {/if}

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -1,4 +1,7 @@
-import { getSingleAttributeForEvent } from './get-single-attribute-for-event';
+import {
+  getSingleAttributeForEvent,
+  shouldDisplayAsWorkflowLink,
+} from './get-single-attribute-for-event';
 
 describe(getSingleAttributeForEvent, () => {
   const workflowEvent = {
@@ -155,5 +158,25 @@ describe(getSingleAttributeForEvent, () => {
     expect(
       getSingleAttributeForEvent({ event, eventGroup: workflowEventGroup }),
     ).toStrictEqual({ key: 'input', value });
+  });
+});
+
+describe(shouldDisplayAsWorkflowLink, () => {
+  it('should return true for event keys that end with RunId', () => {
+    expect(shouldDisplayAsWorkflowLink('originalExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsWorkflowLink('firstExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsWorkflowLink('continuedExecutionRunId')).toBe(true);
+  });
+
+  it('should be case insensitive', () => {
+    expect(shouldDisplayAsWorkflowLink('originalExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsWorkflowLink('OriginalExecutionrunid')).toBe(true);
+  });
+
+  it('should return false for event keys that do not end with RunId', () => {
+    expect(shouldDisplayAsWorkflowLink('')).toBe(false);
+    expect(shouldDisplayAsWorkflowLink('workflowType.name')).toBe(false);
+    expect(shouldDisplayAsWorkflowLink('parentInitiatedEventId')).toBe(false);
+    expect(shouldDisplayAsWorkflowLink('inlineRunIdSample')).toBe(false);
   });
 });

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -10,6 +10,16 @@ export const shouldDisplayAttribute = (
   return true;
 };
 
+export const shouldDisplayAsWorkflowLink = (key: string) => {
+  if (!key) return false;
+
+  if (key.toLowerCase().endsWith('runid')) {
+    return true;
+  }
+
+  return false;
+};
+
 const mapObjectToPropertValue = (key: string, value: any) => {
   const firstKey = Object.keys(value)[0];
   return { key: `${key}.${firstKey}`, value: value[firstKey] };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Run IDs in History are now links to workflow pages

![image](https://user-images.githubusercontent.com/11838981/161910594-0e7a9686-dd0a-4757-ad1a-8cff2a90ba02.png)

## Why?
<!-- Tell your future self why have you made these changes -->

Helps to quickly navigate to Continued as new execution runs or find the previous run

addressed #377 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Unit test + manual

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
