### PR TITLE
Simplify event attributes with one key/value to just their value

### DIFF
--- a/src/lib/models/event-history/index.ts
+++ b/src/lib/models/event-history/index.ts
@@ -6,6 +6,7 @@ import { findAttributesAndKey } from '$lib/utilities/is-event-type';
 import { groupEvents } from '../group-events';
 import { getEventCategory } from './get-event-categorization';
 import { getEventClassification } from './get-event-classification';
+import { simplifyAttributes } from './simplify-attributes';
 
 export async function getEventAttributes(
   historyEvent: HistoryEvent,
@@ -27,7 +28,9 @@ const toEvent = async (
   const timestamp = formatDate(String(historyEvent.eventTime));
   const classification = getEventClassification(eventType);
   const category = getEventCategory(eventType);
-  const attributes = await getEventAttributes(historyEvent);
+  const attributes = await getEventAttributes(historyEvent).then(
+    simplifyAttributes,
+  );
 
   return {
     ...historyEvent,

--- a/src/lib/models/event-history/simplify-attributes.test.ts
+++ b/src/lib/models/event-history/simplify-attributes.test.ts
@@ -1,0 +1,32 @@
+import { simplifyAttributes } from './simplify-attributes';
+
+const createAttributes = () => {
+  return {
+    shouldBeSimple: {
+      name: 'SimpleResult',
+    },
+    notSoSimple: {
+      name: 'NotSimple',
+      type: 'NotSimple',
+    },
+  };
+};
+
+describe(simplifyAttributes, () => {
+  it('should take single key attributes and reduce them down to their values', () => {
+    const attributes = createAttributes();
+    const { shouldBeSimple } = simplifyAttributes(attributes);
+
+    expect(shouldBeSimple).toBe('SimpleResult');
+  });
+
+  it('should take single key attributes and reduce them down to their values', () => {
+    const attributes = createAttributes();
+    const { notSoSimple } = simplifyAttributes(attributes);
+
+    expect(notSoSimple).toEqual({
+      name: 'NotSimple',
+      type: 'NotSimple',
+    });
+  });
+});

--- a/src/lib/models/event-history/simplify-attributes.ts
+++ b/src/lib/models/event-history/simplify-attributes.ts
@@ -1,0 +1,31 @@
+const canBeSimplified = (value: unknown): value is Record<string, string> => {
+  if (value === null) return false;
+  if (value === undefined) return false;
+  if (typeof value !== 'object') return false;
+
+  const keys = Object.keys(value);
+  const [key] = keys;
+
+  if (keys.length !== 1) return false;
+  if (typeof value[key] !== 'string') return false;
+
+  return true;
+};
+
+const getValueForFirstKey = (value: Record<string, string>): string => {
+  for (const v of Object.values(value)) {
+    return v;
+  }
+};
+
+export const simplifyAttributes = (
+  attributes: EventAttributesWithType,
+): EventAttributesWithType => {
+  for (const [key, value] of Object.entries(attributes)) {
+    if (canBeSimplified(value)) {
+      attributes[key] = getValueForFirstKey(value);
+    }
+  }
+
+  return attributes;
+};


### PR DESCRIPTION
If an event attribute only has one property, just show that one property. This is useful for Workflow Type Names.