### PR TITLE
Check if default namespace from settings exists in namespaces

### DIFF
--- a/src/lib/components/error.svelte
+++ b/src/lib/components/error.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/stores';
   import { isNetworkError } from '$lib/utilities/is-network-error';
   import { createEventDispatcher } from 'svelte';
-  import { beforeNavigate, goto } from '$app/navigation';
+  import { beforeNavigate } from '$app/navigation';
 
   export let error: globalThis.Error = null;
   export let status = 500;

--- a/src/lib/components/error.svelte
+++ b/src/lib/components/error.svelte
@@ -3,7 +3,7 @@
   import { page } from '$app/stores';
   import { isNetworkError } from '$lib/utilities/is-network-error';
   import { createEventDispatcher } from 'svelte';
-  import { beforeNavigate } from '$app/navigation';
+  import { beforeNavigate, goto } from '$app/navigation';
 
   export let error: globalThis.Error = null;
   export let status = 500;

--- a/src/lib/utilities/get-namespace.test.ts
+++ b/src/lib/utilities/get-namespace.test.ts
@@ -1,0 +1,172 @@
+import { getDefaultNamespace } from './get-namespace';
+
+const temporalSystemNamespace = {
+  namespaceInfo: {
+    name: 'temporal-system',
+    state: 'Registered',
+    description: 'Temporal internal system namespace',
+    ownerEmail: 'temporal-core@temporal.io',
+    data: {},
+    id: '32049b68-7872-4094-8e63-d0dd59896a83',
+  },
+  config: {
+    workflowExecutionRetentionTtl: '604800s',
+    badBinaries: {
+      binaries: {},
+    },
+    historyArchivalState: 'Disabled',
+    historyArchivalUri: '',
+    visibilityArchivalState: 'Disabled',
+    visibilityArchivalUri: '',
+  },
+  replicationConfig: {
+    activeClusterName: 'active',
+    clusters: [
+      {
+        clusterName: 'active',
+      },
+    ],
+    state: 'Unspecified',
+  },
+  failoverVersion: '0',
+  isGlobalNamespace: false,
+};
+
+const canaryNamespace = {
+  namespaceInfo: {
+    name: 'canary',
+    state: 'Registered',
+    description: 'Namespace for running temporal canary workflows',
+    ownerEmail: 'canary',
+    data: {},
+    id: '6879d26a-d9ad-486b-a572-b11aeed816e8',
+  },
+  config: {
+    workflowExecutionRetentionTtl: '864000s',
+    badBinaries: {
+      binaries: {},
+    },
+    historyArchivalState: 'Disabled',
+    historyArchivalUri: '',
+    visibilityArchivalState: 'Disabled',
+    visibilityArchivalUri: '',
+  },
+  replicationConfig: {
+    activeClusterName: 'active',
+    clusters: [
+      {
+        clusterName: 'active',
+      },
+    ],
+    state: 'Unspecified',
+  },
+  failoverVersion: '0',
+  isGlobalNamespace: false,
+};
+
+const defaultNamespace = {
+  namespaceInfo: {
+    name: 'default',
+    state: 'Registered',
+    description: 'Default namespace',
+    ownerEmail: 'default',
+    data: {},
+    id: '6879d26a-d9ad-486b-a572-b11aeed816e8',
+  },
+  config: {
+    workflowExecutionRetentionTtl: '864000s',
+    badBinaries: {
+      binaries: {},
+    },
+    historyArchivalState: 'Disabled',
+    historyArchivalUri: '',
+    visibilityArchivalState: 'Disabled',
+    visibilityArchivalUri: '',
+  },
+  replicationConfig: {
+    activeClusterName: 'active',
+    clusters: [
+      {
+        clusterName: 'active',
+      },
+    ],
+    state: 'Unspecified',
+  },
+  failoverVersion: '0',
+  isGlobalNamespace: false,
+};
+
+const getSettings = (
+  defaultNamespace: string,
+  showTemporalSystemNamespace: boolean,
+) => {
+  return {
+    auth: {
+      enabled: false,
+      options: ['organization', 'invitation', 'audience'],
+    },
+    defaultNamespace,
+    showTemporalSystemNamespace,
+  };
+};
+
+describe(getDefaultNamespace, () => {
+  it('should return default namespace if it exists in namespaces and matches defaultNamespace setting', () => {
+    const namespaces = [defaultNamespace];
+    const settings = getSettings('default', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('default');
+  });
+  it('should return default namespace if it exists in namespaces and no defaultNamespace setting', () => {
+    const namespaces = [defaultNamespace];
+    const settings = getSettings('', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('default');
+  });
+  it('should return default namespace if it exists in namespaces and includes temporal system namespace with !ShowTemporalSystemNamespace', () => {
+    const namespaces = [temporalSystemNamespace, defaultNamespace];
+    const settings = getSettings('', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('default');
+  });
+  it('should return default namespace if it exists in namespaces and includes temporal system namespace with ShowTemporalSystemNamespace', () => {
+    const namespaces = [temporalSystemNamespace, defaultNamespace];
+    const settings = getSettings('', true);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual(
+      'temporal-system',
+    );
+  });
+  it('should return canary namespace if single namespace that does not match defaultNamespace setting', () => {
+    const namespaces = [canaryNamespace];
+    const settings = getSettings('default', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('canary');
+  });
+  it('should return default namespace if multiple namespaces and matching defaultNamespace setting', () => {
+    const namespaces = [canaryNamespace, defaultNamespace];
+    const settings = getSettings('default', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('default');
+  });
+  it('should return canary namespace if multiple namespaces and matching defaultNamespace setting', () => {
+    const namespaces = [canaryNamespace, defaultNamespace];
+    const settings = getSettings('canary', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('canary');
+  });
+  it('should return first namespace if multiple namespaces and no defaultNamespace setting', () => {
+    const namespaces = [canaryNamespace, defaultNamespace];
+    const settings = getSettings('', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('canary');
+  });
+  it('should return first namespace if multiple namespaces and no defaultNamespace setting and including ShowTemporalSystemNamespace', () => {
+    const namespaces = [
+      temporalSystemNamespace,
+      canaryNamespace,
+      defaultNamespace,
+    ];
+    const settings = getSettings('', true);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual(
+      'temporal-system',
+    );
+  });
+  it('should return defaultNamespace setting if no namespaces', () => {
+    const namespaces = [];
+    const settings = getSettings('default', false);
+    expect(getDefaultNamespace({ namespaces, settings })).toEqual('default');
+  });
+});

--- a/src/lib/utilities/get-namespace.ts
+++ b/src/lib/utilities/get-namespace.ts
@@ -6,6 +6,11 @@ type GetNamespaceParameters = {
   namespaces: DescribeNamespaceResponse[];
 };
 
+type GetDefaultNamespaceParameters = {
+  namespaces: DescribeNamespaceResponse[];
+  settings: Settings;
+};
+
 export const getNamespace = ({
   namespace,
   defaultNamespace,
@@ -20,4 +25,26 @@ export const getNamespace = ({
   }
 
   return defaultNamespace;
+};
+
+export const getDefaultNamespace = ({
+  namespaces,
+  settings,
+}: GetDefaultNamespaceParameters): string => {
+  const { showTemporalSystemNamespace, defaultNamespace } = settings;
+
+  const namespaceNames = namespaces
+    .map(
+      (namespace: DescribeNamespaceResponse) => namespace?.namespaceInfo?.name,
+    )
+    .filter(
+      (namespace: string) =>
+        showTemporalSystemNamespace || namespace !== 'temporal-system',
+    );
+
+  return (
+    namespaceNames.find((ns) => ns === defaultNamespace) ??
+    namespaceNames[0] ??
+    defaultNamespace
+  );
 };

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -9,6 +9,7 @@
   import { fetchUser } from '$lib/services/user-service';
   import { fetchCluster } from '$lib/services/cluster-service';
   import { fetchNamespaces } from '$lib/services/namespaces-service';
+  import { getDefaultNamespace } from '$lib/utilities/get-namespace';
 
   export const load: Load = async function ({ url, fetch }) {
     const settings: Settings = await fetchSettings({ url }, fetch);
@@ -18,12 +19,13 @@
       fetch,
     );
 
+    const defaultNamespace = getDefaultNamespace({ namespaces, settings });
     const user = await fetchUser(fetch);
     const cluster = await fetchCluster(settings, fetch);
 
     return {
-      props: { namespaces, user, cluster },
-      stuff: { namespaces, settings },
+      props: { user, cluster },
+      stuff: { namespaces, settings: { ...settings, defaultNamespace } },
     };
   };
 </script>

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -11,7 +11,8 @@
   import NavigationLink from './_navigation-link.svelte';
   import IsCloudGuard from '$lib/components/is-cloud-guard.svelte';
 
-  $: namespace = $page.params.namespace;
+  $: namespace =
+    $page.params.namespace || $page.stuff?.settings?.defaultNamespace;
 
   export let user: User;
 </script>


### PR DESCRIPTION
## What was changed
We were setting the default namespace based on settings.DefaultNamespace or if that doesn't exist, set to 'default'. But if a user has namespace(s) that doesn't include the settings.DefaultNamespace or 'default', it would return a 404.

## Why?
To check for fetched namespaces before setting the defaultNamespace in stuff.
