### PR TITLE
Use a list of preferred event attributes

### DIFF
--- a/src/lib/components/event/view/event-summary.svelte
+++ b/src/lib/components/event/view/event-summary.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/stores';
-
   import LoadingRow from '$lib/components/loading-row.svelte';
   import Pagination from '$lib/components/pagination.svelte';
 

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -168,11 +168,6 @@ describe(shouldDisplayAsWorkflowLink, () => {
     expect(shouldDisplayAsWorkflowLink('continuedExecutionRunId')).toBe(true);
   });
 
-  it('should be case insensitive', () => {
-    expect(shouldDisplayAsWorkflowLink('originalExecutionRunId')).toBe(true);
-    expect(shouldDisplayAsWorkflowLink('OriginalExecutionrunid')).toBe(true);
-  });
-
   it('should return false for event keys that do not end with RunId', () => {
     expect(shouldDisplayAsWorkflowLink('')).toBe(false);
     expect(shouldDisplayAsWorkflowLink('workflowType.name')).toBe(false);

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -99,8 +99,7 @@ export const getSingleAttributeForEvent = ({
   event: HistoryEventWithId | null;
   eventGroup: CompactEventGroup | null;
 }): SummaryAttribute => {
-  let summaryAttribute = emptyAttribute;
-  if (!event && !eventGroup) return summaryAttribute;
+  if (!event && !eventGroup) return emptyAttribute;
 
   if (eventGroup) {
     return getSummaryForEventGroup(eventGroup);

--- a/src/routes/import/events/history/index.svelte
+++ b/src/routes/import/events/history/index.svelte
@@ -2,7 +2,7 @@
   import type { Load } from '@sveltejs/kit';
   import { routeForImport } from '$lib/utilities/route-for';
 
-  export const load: Load = async function ({ url }) {
+  export const load: Load = async function () {
     const redirect = routeForImport({ importType: 'events', view: 'summary' });
     return { status: 302, redirect };
   };

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
@@ -33,7 +33,7 @@
               <h4>Activity Name</h4>
               <p>
                 <span class="bg-gray-300 text-gray-700 px-2">
-                  {pendingActivity.activityType?.name}
+                  {pendingActivity.activityType}
                 </span>
               </p>
             </div>


### PR DESCRIPTION
This change checks a list of preferred activity types to display in the summary view. If none exists, then it falls back to using the first one.