### PR TITLE
Show results for failure cases

### DIFF
--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -54,6 +54,7 @@ function isTimestamp(arg: unknown): arg is Timestamp {
 }
 
 export function formatDuration(duration: Duration | string): string {
+  if (duration === null) return '';
   if (typeof duration === 'string') duration = fromSeconds(duration);
   return durationToString(duration, { delimiter: ', ' });
 }


### PR DESCRIPTION
Results are shown not just when a workflow complete, but also when it fails. This change adds additional cases.