### PR TITLE
Decrease row padding, lower line-height, event details as Inter

### DIFF
--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -17,7 +17,7 @@
 <article
   class="flex flex-col lg:flex-row gap-2 lg:gap-4 py-2 last:border-b-0 border-gray-200 first:pt-0 {$$props.class}"
 >
-  <h4 class="w-1/3 text-normal">{format(key)}</h4>
+  <p class="w-1/3 text-normal">{format(key)}</p>
   <div class="flex-grow w-full">
     {#if typeof value === 'object'}
       <CodeBlock content={value} />

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/stores';
-
   import { getGroupForEvent, isEventGroup } from '$lib/models/group-events';
 
   import { formatDate } from '$lib/utilities/format-date';
@@ -31,9 +29,8 @@
 
 <article class="row" id={event.id}>
   <div class="cell">
-    <a
-      class="text-gray-500 text-normal mx-1 text-lg md:text-base"
-      href="#{event.id}">{event.id}</a
+    <a class="text-gray-500 mx-1 text-lg md:text-base" href="#{event.id}"
+      >{event.id}</a
     >
     <span
       class="md:mx-2 text-lg md:text-base font-semibold"
@@ -55,7 +52,7 @@
 
 <style lang="postcss">
   .cell {
-    @apply md:table-cell md:border-b-2 text-left py-1 px-3 pt-2;
+    @apply md:table-cell md:border-b-2 text-left py-1 px-3 leading-4;
   }
 
   .row {

--- a/src/lib/utilities/format-camel-case.test.ts
+++ b/src/lib/utilities/format-camel-case.test.ts
@@ -34,4 +34,8 @@ describe(format, () => {
   it('should format requestIdSomething as "Request ID Something"', () => {
     expect(format('requestIdSomething')).toBe('Request ID Something');
   });
+
+  it('should format undefined as ""', () => {
+    expect(format()).toBe('');
+  });
 });

--- a/src/lib/utilities/format-camel-case.ts
+++ b/src/lib/utilities/format-camel-case.ts
@@ -7,7 +7,7 @@ export const format = (label: string): string => {
   let result = '';
   let index = 0;
 
-  while (index < label.length) {
+  while (index < label?.length) {
     const current = label[index];
     const next = label[index + 1];
 

--- a/src/lib/utilities/format-camel-case.ts
+++ b/src/lib/utilities/format-camel-case.ts
@@ -3,7 +3,7 @@ const isUpperCase = (label: string, index: number): boolean => {
   return charCode >= 65 && charCode <= 90;
 };
 
-export const format = (label: string): string => {
+export const format = (label?: string): string => {
   let result = '';
   let index = 0;
 


### PR DESCRIPTION
## What was changed
Decrease row padding and line-height for more compact visual of table, make event details Inter font, check for label.length incase label doesn't exist.
<img width="1701" alt="Screen Shot 2022-04-12 at 3 34 44 PM" src="https://user-images.githubusercontent.com/7967403/163049498-8f89ef8a-aa2b-42a5-86c6-34da3f32aa68.png">

