### PR TITLE
Add eventTime into compact view

### DIFF
--- a/src/lib/components/event/_format-attributes.ts
+++ b/src/lib/components/event/_format-attributes.ts
@@ -1,0 +1,22 @@
+import { formatDate } from '$lib/utilities/format-date';
+
+type CombinedAttributes = EventAttribute & {
+  eventTime?: string;
+};
+
+const keysToOmit: Readonly<Set<string>> = new Set(['header']);
+
+export const formatAttributes = (
+  event: IterableEvent,
+  { compact } = { compact: false },
+): CombinedAttributes => {
+  const attributes: CombinedAttributes = {};
+
+  if (compact) attributes.eventTime = formatDate(event.eventTime);
+
+  for (const [key, value] of Object.entries(event.attributes)) {
+    if (!keysToOmit.has(key)) attributes[key] = value;
+  }
+
+  return attributes;
+};

--- a/src/lib/components/event/event-details.svelte
+++ b/src/lib/components/event/event-details.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { formatDate } from '$lib/utilities/format-date';
+
   import {
     getSingleAttributeForEvent,
     shouldDisplayAttribute,
@@ -8,11 +10,16 @@
   export let event: IterableEvent;
   export let summaryEvent = event;
   export let expanded = false;
+  export let compact = false;
+
+  $: attributes = compact
+    ? { eventTime: formatDate(event.eventTime), ...event.attributes }
+    : event.attributes;
 </script>
 
 <section>
   {#if expanded}
-    {#each Object.entries(event.attributes) as [key, value] (key)}
+    {#each Object.entries(attributes) as [key, value] (key)}
       {#if shouldDisplayAttribute(key, value)}
         <EventDetailsRow {key} {value} />
       {/if}

--- a/src/lib/components/event/event-details.svelte
+++ b/src/lib/components/event/event-details.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
-  import { formatDate } from '$lib/utilities/format-date';
-
   import {
     getSingleAttributeForEvent,
     shouldDisplayAttribute,
   } from '$lib/utilities/get-single-attribute-for-event';
   import EventDetailsRow from './event-details-row.svelte';
 
+  import { formatAttributes } from './_format-attributes';
+
   export let event: IterableEvent;
   export let summaryEvent = event;
   export let expanded = false;
   export let compact = false;
 
-  $: attributes = compact
-    ? { eventTime: formatDate(event.eventTime), ...event.attributes }
-    : event.attributes;
+  $: attributes = formatAttributes(event, { compact });
 </script>
 
 <section>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -46,7 +46,12 @@
   </div>
 
   <div class="cell links">
-    <EventDetails event={currentEvent} {expanded} summaryEvent={event} />
+    <EventDetails
+      event={currentEvent}
+      summaryEvent={event}
+      {expanded}
+      {compact}
+    />
   </div>
 </article>
 


### PR DESCRIPTION
The new tables display all of the attributes, but when we're in the compact view, it shows the date and time for the group. This change adds in the `eventTime` into the the list of attributes when in the compact view.