### PR TITLE
Show version banner only if recommend > current version

### DIFF
--- a/src/lib/components/banner.svelte
+++ b/src/lib/components/banner.svelte
@@ -9,11 +9,32 @@
     Low: 'low',
   } as const;
 
+  const isNewer = (version1: string, version2: string) => {
+    if (!version1 || !version2) {
+      return false;
+    }
+
+    const [major1, minor1, patch1] = version1.split('.').map(Number);
+    const [major2, minor2, patch2] = version2.split('.').map(Number);
+
+    if (major1 !== major2) {
+      return major1 > major2;
+    } else if (minor1 !== minor2) {
+      return minor1 > minor2;
+    } else {
+      return patch1 > patch2;
+    }
+  };
+
   $: recommended = cluster?.versionInfo?.recommended;
   $: current = cluster?.versionInfo?.current;
   $: alert = cluster?.versionInfo?.alerts?.[0];
   $: severity = alert ? severities[alert.severity] : severities.Low;
-  $: show = current?.version && current.version != $closedBannerId;
+  $: show =
+    current?.version &&
+    current.version != $closedBannerId &&
+    isNewer(recommended?.version, current.version);
+
   $: message =
     severity == severities.Low
       ? `📥 v${recommended?.version} version is available`

--- a/src/lib/components/banner.svelte
+++ b/src/lib/components/banner.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { closedBannerId, close } from '$lib/stores/banner';
+  import { isRecommendedVersionNewer } from '$lib/utilities/version-check';
 
   export let cluster: ClusterInformation;
 
@@ -9,23 +10,6 @@
     Low: 'low',
   } as const;
 
-  const isNewer = (version1: string, version2: string) => {
-    if (!version1 || !version2) {
-      return false;
-    }
-
-    const [major1, minor1, patch1] = version1.split('.').map(Number);
-    const [major2, minor2, patch2] = version2.split('.').map(Number);
-
-    if (major1 !== major2) {
-      return major1 > major2;
-    } else if (minor1 !== minor2) {
-      return minor1 > minor2;
-    } else {
-      return patch1 > patch2;
-    }
-  };
-
   $: recommended = cluster?.versionInfo?.recommended;
   $: current = cluster?.versionInfo?.current;
   $: alert = cluster?.versionInfo?.alerts?.[0];
@@ -33,7 +17,7 @@
   $: show =
     current?.version &&
     current.version != $closedBannerId &&
-    isNewer(recommended?.version, current.version);
+    isRecommendedVersionNewer(recommended?.version, current.version);
 
   $: message =
     severity == severities.Low

--- a/src/lib/utilities/version-check.test.ts
+++ b/src/lib/utilities/version-check.test.ts
@@ -1,0 +1,25 @@
+import { isRecommendedVersionNewer } from './version-check';
+
+describe(isRecommendedVersionNewer, () => {
+  it('should return true when recommended version is higher than current', () => {
+    expect(isRecommendedVersionNewer('2.01.1', '1.01.1')).toBe(true);
+    expect(isRecommendedVersionNewer('1.02.1', '1.01.1')).toBe(true);
+    expect(isRecommendedVersionNewer('1.01.2', '1.01.1')).toBe(true);
+    expect(isRecommendedVersionNewer('1.02', '1.01')).toBe(true);
+    expect(isRecommendedVersionNewer('2', '1')).toBe(true);
+  });
+
+  it('should return false when recommended version is not higher than current', () => {
+    expect(isRecommendedVersionNewer('1.01.1', '1.01.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.01.1', '2.01.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.01.1', '1.02.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.01.1', '1.01.2')).toBe(false);
+    expect(isRecommendedVersionNewer(undefined, '1.01.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.01.1', undefined)).toBe(false);
+    expect(isRecommendedVersionNewer(undefined, undefined)).toBe(false);
+    expect(isRecommendedVersionNewer('xxx', '1.01.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.1', '1.01.1')).toBe(false);
+    expect(isRecommendedVersionNewer('1.01', '1.02')).toBe(false);
+    expect(isRecommendedVersionNewer('1', '2')).toBe(false);
+  });
+});

--- a/src/lib/utilities/version-check.ts
+++ b/src/lib/utilities/version-check.ts
@@ -1,0 +1,19 @@
+export const isRecommendedVersionNewer = (
+  recommendedVersion: string,
+  currentVersion: string,
+) => {
+  if (!recommendedVersion || !currentVersion) {
+    return false;
+  }
+
+  const [major1, minor1, patch1] = recommendedVersion.split('.').map(Number);
+  const [major2, minor2, patch2] = currentVersion.split('.').map(Number);
+
+  if (major1 !== major2) {
+    return major1 > major2;
+  } else if (minor1 !== minor2) {
+    return minor1 > minor2;
+  } else {
+    return patch1 > patch2;
+  }
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

added sanity checks before showing banner about new Temporal version

## Why?
<!-- Tell your future self why have you made these changes -->

removing reliance on Temporal service and Version info tool to recommend only newer versions

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Tried on Temporal versions `1.14.2`, `1.15.2` and `1.16.0` and verified that banner is shown accordingly

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
