### PR TITLE
Show pending activities error message

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
@@ -6,7 +6,7 @@
   import { routeForPendingActivities } from '$lib/utilities/route-for';
   import Link from '$lib/components/link.svelte';
 
-  const { pendingActivities } = $page.stuff.workflow;
+  const { pendingActivities, endTime } = $page.stuff.workflow;
   const { namespace, workflow, run } = $page.params;
 
   const href = routeForPendingActivities({ namespace, workflow, run });
@@ -22,13 +22,15 @@
     <section class="w-full table-auto space-x-4">
       {#each pendingActivities as { id, ...pendingActivity } (id)}
         <a
-          class="flex content-between w-full border-b-2 border-gray-300 p-2 last-of-type:border-b-0 hover:bg-gray-50"
+          class="block md:flex content-between w-full border-b-2 border-gray-300 p-2 last-of-type:border-b-0 hover:bg-gray-50"
           {href}
         >
-          <div class="text-left font-normal text-gray-500 w-40">
+          <div
+            class="w-full md:w-1/12 text-left font-normal text-gray-500 w-40"
+          >
             {pendingActivity.activityId}
           </div>
-          <div class="w-full">
+          <div class="w-full md:w-1/4">
             <div class="flex gap-2">
               <h4>Activity Name</h4>
               <p>
@@ -38,15 +40,16 @@
               </p>
             </div>
           </div>
-          <div class="w-full">
+          <div class="w-full md:w-5/12">
             <div class="flex gap-2">
               <h3>Last Failure</h3>
+            </div>
+            <div>
               <pre
-                style="padding: 0 1em; margin: 0"
-                class="rounded-lg"><code class="language-json">{pendingActivity.lastFailure}</code></pre>
+                class="rounded-lg break-words"><code class="language-json">{pendingActivity.lastFailure?.message ?? ''}</code></pre>
             </div>
           </div>
-          <div class="w-full">
+          <div class="w-full md:w-1/4">
             <div class="flex gap-2">
               <h4>Last Heartbeat Time</h4>
               <p>{formatDate(pendingActivity.lastHeartbeatTime)}</p>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_pending-activties.svelte
@@ -6,7 +6,7 @@
   import { routeForPendingActivities } from '$lib/utilities/route-for';
   import Link from '$lib/components/link.svelte';
 
-  const { pendingActivities, endTime } = $page.stuff.workflow;
+  const { pendingActivities } = $page.stuff.workflow;
   const { namespace, workflow, run } = $page.params;
 
   const href = routeForPendingActivities({ namespace, workflow, run });
@@ -46,7 +46,7 @@
             </div>
             <div>
               <pre
-                class="rounded-lg break-words"><code class="language-json">{pendingActivity.lastFailure?.message ?? ''}</code></pre>
+                class="rounded-lg"><code class="language-json">{pendingActivity.lastFailure?.message ?? ''}</code></pre>
             </div>
           </div>
           <div class="w-full md:w-1/4">


### PR DESCRIPTION
## What was changed
Show pending activities last failure message instead of [object object]
<img width="1670" alt="Screen Shot 2022-04-13 at 9 54 22 AM" src="https://user-images.githubusercontent.com/7967403/163210025-0ddc3432-37bc-43ab-9a35-ba5f9125d607.png">

