### PR TITLE
Load workflows onMount and update loadingRow

### DIFF
--- a/src/lib/components/loading-row.svelte
+++ b/src/lib/components/loading-row.svelte
@@ -1,7 +1,3 @@
-<script lang="ts">
-  import WorkflowStatus from '$lib/components/workflow-status.svelte';
-</script>
-
 <article class="row">
   <div class="cell">
     <p />

--- a/src/lib/components/loading-row.svelte
+++ b/src/lib/components/loading-row.svelte
@@ -1,5 +1,36 @@
-<tr>
-  <td colspan="5" class="m-auto p-12 text-center font-extralight text-2xl">
-    Loading
-  </td>
-</tr>
+<script lang="ts">
+  import WorkflowStatus from '$lib/components/workflow-status.svelte';
+</script>
+
+<article class="row">
+  <div class="cell">
+    <p />
+  </div>
+  <div class="cell w-1/2">
+    <p>Loading</p>
+  </div>
+  <div class="cell">
+    <p />
+  </div>
+  <div class="cell">
+    <p />
+  </div>
+  <span class=" md:hidden"> - </span>
+  <div class="cell">
+    <p />
+  </div>
+</article>
+
+<style lang="postcss">
+  .row {
+    @apply no-underline p-2 text-sm border-b-2 items-center md:text-base md:table-row last-of-type:border-b-0;
+  }
+
+  .cell {
+    @apply md:table-cell md:border-b-2 text-left p-2;
+  }
+
+  .row:last-of-type .cell {
+    @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
+  }
+</style>

--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -1,6 +1,5 @@
 <script context="module" lang="ts">
   import type { Load } from '@sveltejs/kit';
-  import type { CombinedWorkflowExecutionsResponse } from '$lib/services/workflow-service';
 
   import { fetchAllWorkflows } from '$lib/services/workflow-service';
 
@@ -26,7 +25,6 @@
   import Pagination from '$lib/components/pagination.svelte';
   import Badge from '$lib/components/badge.svelte';
   import LoadingRow from '$lib/components/loading-row.svelte';
-  import { onMount } from 'svelte';
   import { page } from '$app/stores';
 
   export let namespace: string;

--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -48,13 +48,7 @@
     query,
   };
 
-  let workflows: Promise<CombinedWorkflowExecutionsResponse> = new Promise(
-    () => [],
-  );
-
-  $: {
-    workflows = fetchAllWorkflows(namespace, parameters, fetch);
-  }
+  $: workflows = fetchAllWorkflows(namespace, parameters, fetch);
 
   const errorMessage = isAdvancedSearch
     ? 'Please check your syntax and try again.'


### PR DESCRIPTION
## What was changed
The biggest bottleneck in our first meaningful paint once logged in is waiting for the workflows api response. This moves the workflows call to onMount instead of the load function. We are also not putting workflows in page.stuff so there is no risk of moving into onMount.

<img width="1728" alt="Screen Shot 2022-04-15 at 4 35 47 PM" src="https://user-images.githubusercontent.com/7967403/163635335-589cfc89-e064-4c41-ab13-0d8da6d97701.png">

## Why?
More responsive experience for the user, removes duplicate worfklows api call on load (server and ui). Since this is potentially a large response (1+MB), it doesn't make sense to wait for it on the server before rendering anything.
