### PR TITLE
Create reusable Copyable Component; use in workflow list

### DIFF
--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Icon from 'svelte-fa';
+  import { faCheck, faCopy } from '@fortawesome/free-solid-svg-icons';
+
+  export let content: string;
+  export let visible = false;
+
+  let copied = false;
+
+  const copy = (event: Event) => {
+    navigator.clipboard
+      .writeText(content)
+      .then(() => {
+        copied = !copied;
+        setTimeout(() => (copied = false), 500);
+      })
+      .catch((error) => console.error(error));
+  };
+</script>
+
+<div class="flex gap-2 items-center">
+  <slot>{content}</slot>
+  <button on:click|preventDefault|stopPropagation={copy}>
+    <Icon
+      icon={copied ? faCheck : faCopy}
+      class={visible ? 'visible' : 'invisible group-hover:visible'}
+    />
+  </button>
+</div>

--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -18,7 +18,7 @@
   };
 </script>
 
-<div class="flex gap-2 items-center">
+<div class="flex gap-2 items-center group">
   <slot>{content}</slot>
   <button on:click|preventDefault|stopPropagation={copy}>
     <Icon

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -6,7 +6,6 @@
   import { shouldDisplayAsWorkflowLink } from '$lib/utilities/get-single-attribute-for-event';
 
   import CodeBlock from '../code-block.svelte';
-  import TableLink from '$lib/components/table-link.svelte';
 
   export let key: string;
   export let value: string | Record<string, unknown>;
@@ -22,9 +21,12 @@
     {#if typeof value === 'object'}
       <CodeBlock content={value} />
     {:else if shouldDisplayAsWorkflowLink(key)}
-      <TableLink href={routeForWorkflow({ namespace, workflow, run: value })}
-        >{value}</TableLink
+      <a
+        href={routeForWorkflow({ namespace, workflow, run: value })}
+        class="border-b-2 hover:text-blue-700 hover:border-blue-700"
       >
+        {value}
+      </a>
     {:else}
       <p><span class="bg-gray-300 text-gray-700 px-2">{value}</span></p>
     {/if}

--- a/src/lib/components/table-link.svelte
+++ b/src/lib/components/table-link.svelte
@@ -1,7 +1,0 @@
-<script lang="ts">
-  export let href: string;
-</script>
-
-<a {href} {...$$props} class="table-link {$$props.class ?? ''}">
-  <slot />
-</a>

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { formatDate, getMilliseconds } from '$lib/utilities/format-date';
-
-  import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import { routeForWorkflow } from '$lib/utilities/route-for';
 
-  import TableLink from '$lib/components/table-link.svelte';
+  import WorkflowStatus from '$lib/components/workflow-status.svelte';
+  import Copyable from '$lib/components/copyable.svelte';
 
   export let namespace: string;
   export let workflow: WorkflowExecution;
@@ -17,7 +16,7 @@
   });
 </script>
 
-<article class="row">
+<a {href} class="row group">
   <div class="cell">
     <div>
       <WorkflowStatus
@@ -27,14 +26,14 @@
     </div>
   </div>
   <div class="cell links font-medium md:font-normal">
-    <p>
-      <TableLink {href} data-test="workflow-link">{workflow.id}</TableLink>
-    </p>
+    <Copyable content={workflow.id}>
+      <span class="table-link">{workflow.id}</span>
+    </Copyable>
   </div>
   <div class="cell links font-medium md:font-normal">
-    <p>
-      <TableLink {href} data-test="workflow-link">{workflow.name}</TableLink>
-    </p>
+    <Copyable content={workflow.name}>
+      <span class="table-link">{workflow.name}</span>
+    </Copyable>
   </div>
   <div class="inline-block cell font-normal">
     <p>
@@ -47,11 +46,11 @@
       {formatDate(workflow.endTime, timeFormat)}
     </p>
   </div>
-</article>
+</a>
 
 <style lang="postcss">
   .row {
-    @apply no-underline p-2 text-sm border-b-2 items-center md:text-base md:table-row last-of-type:border-b-0;
+    @apply block no-underline p-2 text-sm border-b-2 items-center md:text-base md:table-row last-of-type:border-b-0;
   }
 
   .cell {
@@ -62,8 +61,8 @@
     @apply bg-gray-50;
   }
 
-  .row:hover :global(.table-link) {
-    @apply text-blue-700 border-b-2 border-blue-700;
+  .table-link {
+    @apply border-b-2 group-hover:text-blue-700 group-hover:border-blue-700;
   }
 
   .row:last-of-type .cell {


### PR DESCRIPTION
- Adds a copy icon to the workflow name and id when the row is hovered.
- Makes the entire row clickable (as per a request from @Spikhalskiy)
- Removes `TableLink` component