### PR TITLE
Truncate height of code block; remove framing logic

### DIFF
--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -4,10 +4,8 @@
   import Icon from 'svelte-fa';
   import { faCheck, faCopy } from '@fortawesome/free-solid-svg-icons';
 
-  export let heading = '';
   export let content: Parameters<typeof JSON.stringify>[0];
   export let copied = false;
-  export let framed = false;
   export let language = 'json';
 
   const isJSON = language === 'json';
@@ -42,32 +40,15 @@
 </script>
 
 {#if content || content === null}
-  <div class="relative w-full" class:framed>
-    <div id="clipboard" />
-
-    {#if heading}
-      <h3 class="text-lg mb-2 w-full">{heading}</h3>
-    {/if}
-
+  <div class="relative w-full h-full">
     <!-- The spacing for this if statement is like this because PRE's honor all whitespace and 
       line breaks so we have this peculiar formatting to preserve this components output -->
     <pre
-      class="p-4 rounded-lg"
-      class:h-full={framed}><code class="language-{language}"
+      class="p-4 rounded-lg overflow-y-scroll h-full max-h-96"><code class="language-{language}"
       >{#if isJSON}{formatJSON(content)}{:else}{@html content}{/if}</code></pre>
 
-    <button on:click={copy} class="absolute top-4 right-4 block">
-      {#if copied}
-        <Icon icon={faCheck} color="white" />
-      {:else}
-        <Icon icon={faCopy} color="white" />
-      {/if}
+    <button on:click={copy} class="absolute top-4 right-4">
+      <Icon icon={copied ? faCheck : faCopy} color="white" />
     </button>
   </div>
 {/if}
-
-<style lang="postcss">
-  .framed {
-    @apply border-2 border-gray-300 rounded-lg p-4 flex flex-col;
-  }
-</style>

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -44,7 +44,7 @@
     <!-- The spacing for this if statement is like this because PRE's honor all whitespace and 
       line breaks so we have this peculiar formatting to preserve this components output -->
     <pre
-      class="p-4 rounded-lg overflow-y-scroll h-full max-h-96"><code class="language-{language}"
+      class="p-4 rounded-lg overflow-scroll h-full max-h-96"><code class="language-{language}"
       >{#if isJSON}{formatJSON(content)}{:else}{@html content}{/if}</code></pre>
 
     <button on:click={copy} class="absolute top-4 right-4">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -62,10 +62,16 @@
 </script>
 
 <section class="flex flex-col gap-4">
-  <div class="flex gap-4">
-    <CodeBlock heading="Input" content={input} framed />
-    <CodeBlock heading="Result" content={result} framed />
-  </div>
+  <section class="flex gap-4 w-full">
+    <article class="border-2 border-gray-300 p-4 rounded-lg w-full">
+      <h3 class="text-lg">Input</h3>
+      <CodeBlock content={input} />
+    </article>
+    <article class="border-2 border-gray-300 p-4 rounded-lg w-full">
+      <h3 class="text-lg">Results</h3>
+      <CodeBlock content={result} />
+    </article>
+  </section>
   <PendingActivties />
   <section id="event-history">
     <nav class="flex gap-4 justify-between items-end pb-4">


### PR DESCRIPTION
- Sets an upper limit for code blocks
- Makes code block scrollable
- Removes extra logic around having a frame from the code block itself
- Fixes issues where the copy icon was outside the code block in framed code blocks