### PR TITLE
Truncate workflow id and type and add copyable tooltip

### DIFF
--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import Icon from 'svelte-fa';
   import { faCheck, faCopy } from '@fortawesome/free-solid-svg-icons';
+  import { noop } from 'svelte/internal';
 
   export let content: string;
   export let visible = false;
@@ -35,37 +36,21 @@
   };
 </script>
 
-{#if clickAllToCopy}
-  <div
-    class="flex gap-2 items-center group {$$props['container-class']}"
-    on:click|preventDefault|stopPropagation={copy}
-  >
-    <slot>
-      <span class={$$props.class} class:select-all={!$$slots.default}
-        >{content}</span
-      >
-    </slot>
+<div
+  class="flex gap-2 items-center group {$$props['container-class']}"
+  on:click|preventDefault|stopPropagation={clickAllToCopy ? copy : noop}
+>
+  <slot>
+    <span class={$$props.class} class:select-all={!$$slots.default}
+      >{content}</span
+    >
+  </slot>
+  <button on:click|preventDefault|stopPropagation={copy}>
     <Icon
       icon={copied ? faCheck : faCopy}
       {color}
       class={visible ? 'visible' : 'invisible group-hover:visible'}
       {size}
     />
-  </div>
-{:else}
-  <div class="flex gap-2 items-center group {$$props['container-class']}">
-    <slot>
-      <span class={$$props.class} class:select-all={!$$slots.default}
-        >{content}</span
-      >
-    </slot>
-    <button on:click|preventDefault|stopPropagation={copy}>
-      <Icon
-        icon={copied ? faCheck : faCopy}
-        {color}
-        class={visible ? 'visible' : 'invisible group-hover:visible'}
-        {size}
-      />
-    </button>
-  </div>
-{/if}
+  </button>
+</div>

--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -4,6 +4,7 @@
 
   export let content: string;
   export let visible = false;
+  export let color = 'black';
 
   export let size:
     | 'xs'
@@ -42,6 +43,7 @@
   <button on:click|preventDefault|stopPropagation={copy}>
     <Icon
       icon={copied ? faCheck : faCopy}
+      {color}
       class={visible ? 'visible' : 'invisible group-hover:visible'}
       {size}
     />

--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -5,6 +5,7 @@
   export let content: string;
   export let visible = false;
   export let color = 'black';
+  export let clickAllToCopy = false;
 
   export let size:
     | 'xs'
@@ -34,18 +35,37 @@
   };
 </script>
 
-<div class="flex gap-2 items-center group {$$props['container-class']}">
-  <slot>
-    <span class={$$props.class} class:select-all={!$$slots.default}
-      >{content}</span
-    >
-  </slot>
-  <button on:click|preventDefault|stopPropagation={copy}>
+{#if clickAllToCopy}
+  <div
+    class="flex gap-2 items-center group {$$props['container-class']}"
+    on:click|preventDefault|stopPropagation={copy}
+  >
+    <slot>
+      <span class={$$props.class} class:select-all={!$$slots.default}
+        >{content}</span
+      >
+    </slot>
     <Icon
       icon={copied ? faCheck : faCopy}
       {color}
       class={visible ? 'visible' : 'invisible group-hover:visible'}
       {size}
     />
-  </button>
-</div>
+  </div>
+{:else}
+  <div class="flex gap-2 items-center group {$$props['container-class']}">
+    <slot>
+      <span class={$$props.class} class:select-all={!$$slots.default}
+        >{content}</span
+      >
+    </slot>
+    <button on:click|preventDefault|stopPropagation={copy}>
+      <Icon
+        icon={copied ? faCheck : faCopy}
+        {color}
+        class={visible ? 'visible' : 'invisible group-hover:visible'}
+        {size}
+      />
+    </button>
+  </div>
+{/if}

--- a/src/lib/components/tooltip.svelte
+++ b/src/lib/components/tooltip.svelte
@@ -1,30 +1,39 @@
 <script lang="ts">
+  import Copyable from './copyable.svelte';
+
   export let text: string = '';
   export let top = false;
   export let right = false;
   export let bottom = false;
   export let left = false;
+  export let copyable = false;
 </script>
 
 <div class="wrapper relative inline-block">
   <slot />
   <div class="tooltip" class:left class:right class:bottom class:top>
     <div class="bg-gray-800 inline-block px-2 py-2 rounded-lg">
-      <span class="text-gray-100">{text}</span>
+      {#if copyable}
+        <Copyable content={text} color="white">
+          <span class="text-gray-100">{text}</span>
+        </Copyable>
+      {:else}
+        <span class="text-gray-100">{text}</span>
+      {/if}
     </div>
   </div>
 </div>
 
 <style lang="postcss">
   .tooltip {
-    @apply inline-block left-0 top-0 opacity-0 whitespace-nowrap absolute z-10 translate-x-12 text-xs shadow-md transition-all invisible;
+    @apply inline-block left-0 top-0 opacity-0 whitespace-nowrap absolute z-50 translate-x-12 text-xs shadow-md transition-all invisible;
   }
 
   .tooltip.top {
     @apply left-1/2 -mt-4 -translate-x-1/2 -translate-y-full;
   }
   .tooltip.bottom {
-    @apply left-1/2 bottom-0 -mb-4 -translate-x-1/2 translate-y-full;
+    @apply left-1/2 bottom-0 -mb-2 -translate-x-1/2 translate-y-full;
   }
   .tooltip.left {
     @apply left-0 -ml-4 -translate-x-full;
@@ -33,6 +42,9 @@
     @apply right-0 -mr-4 translate-x-full;
   }
 
+  .wrapper {
+    /* @apply absolute; */
+  }
   .wrapper:hover .tooltip {
     @apply opacity-90 visible;
   }

--- a/src/lib/components/tooltip.svelte
+++ b/src/lib/components/tooltip.svelte
@@ -14,7 +14,7 @@
   <div class="tooltip" class:left class:right class:bottom class:top>
     <div class="bg-gray-800 inline-block px-2 py-2 rounded-lg">
       {#if copyable}
-        <Copyable content={text} color="white">
+        <Copyable clickAllToCopy content={text} color="white">
           <span class="text-gray-100">{text}</span>
         </Copyable>
       {:else}
@@ -33,7 +33,7 @@
     @apply left-1/2 -mt-4 -translate-x-1/2 -translate-y-full;
   }
   .tooltip.bottom {
-    @apply left-1/2 bottom-0 -mb-2 -translate-x-1/2 translate-y-full;
+    @apply left-1/2 bottom-0 -mb-1 -translate-x-1/2 translate-y-full;
   }
   .tooltip.left {
     @apply left-0 -ml-4 -translate-x-full;
@@ -42,9 +42,6 @@
     @apply right-0 -mr-4 translate-x-full;
   }
 
-  .wrapper {
-    /* @apply absolute; */
-  }
   .wrapper:hover .tooltip {
     @apply opacity-90 visible;
   }

--- a/src/lib/stores/column-width-store.ts
+++ b/src/lib/stores/column-width-store.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+export const workflowIdColumnWidth = writable<number>(0);
+export const workflowTypeColumnWidth = writable<number>(0);

--- a/src/lib/utilities/get-truncated-word.test.ts
+++ b/src/lib/utilities/get-truncated-word.test.ts
@@ -1,0 +1,13 @@
+import { getTruncatedWord } from './get-truncated-word';
+
+describe(getTruncatedWord, () => {
+  it('should return same word if the width is wider than word', () => {
+    expect(getTruncatedWord('Running', 100)).toBe('Running');
+  });
+  it('should return truncated word if the width is shorter than word', () => {
+    expect(getTruncatedWord('Running', 50)).toBe('Ru...');
+  });
+  it('should return "..." if the width is zero', () => {
+    expect(getTruncatedWord('Running', 0)).toBe('...');
+  });
+});

--- a/src/lib/utilities/get-truncated-word.ts
+++ b/src/lib/utilities/get-truncated-word.ts
@@ -1,0 +1,12 @@
+export const getTruncatedWord = (word: string, width: number): string => {
+  if (word.length * 8 > width) {
+    const truncLength = Math.floor(width / 8) - 4;
+    if (truncLength > 0) {
+      const trunc = word.slice(0, truncLength);
+      return `${trunc}...`;
+    } else {
+      return '...';
+    }
+  }
+  return word;
+};

--- a/src/routes/namespaces/[namespace]/workflows/_workflow-loading-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflow-loading-row.svelte
@@ -1,18 +1,17 @@
 <article class="row">
-  <div class="cell">
+  <div class="cell md:table-cell">
     <p />
   </div>
-  <div class="cell w-1/2">
+  <div class="cell md:table-cell w-1/2">
     <p>Loading</p>
   </div>
-  <div class="cell">
+  <div class="cell md:table-cell">
     <p />
   </div>
-  <div class="cell">
+  <div class="cell inline-block md:hidden xl:table-cell">
     <p />
   </div>
-  <span class=" md:hidden"> - </span>
-  <div class="cell">
+  <div class="cell inline-block md:hidden xl:table-cell">
     <p />
   </div>
 </article>
@@ -23,7 +22,7 @@
   }
 
   .cell {
-    @apply md:table-cell md:border-b-2 text-left p-2;
+    @apply md:border-b-2 text-left p-2;
   }
 
   .row:last-of-type .cell {

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
@@ -4,6 +4,7 @@
 
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import Copyable from '$lib/components/copyable.svelte';
+  import Tooltip from '$lib/components/tooltip.svelte';
 
   export let namespace: string;
   export let workflow: WorkflowExecution;
@@ -25,11 +26,10 @@
       />
     </div>
   </div>
-  <div class="cell links font-medium md:font-normal flex gap-2">
-    <h3 class="md:hidden">Workflow ID:</h3>
-    <Copyable content={workflow.id} size="xs">
+  <div class="cell overflow-cell links font-medium md:font-normal">
+    <Tooltip bottom copyable text={workflow.id}>
       <span class="table-link">{workflow.id}</span>
-    </Copyable>
+    </Tooltip>
   </div>
   <div class="cell links font-medium md:font-normal flex gap-2">
     <h3 class="md:hidden">Workflow Name:</h3>
@@ -56,7 +56,11 @@
   }
 
   .cell {
-    @apply md:table-cell md:border-b-2 text-left p-2 overflow-hidden whitespace-nowrap text-ellipsis;
+    @apply md:table-cell md:border-b-2 text-left p-2;
+  }
+
+  .overflow-cell {
+    @apply whitespace-nowrap text-ellipsis;
   }
 
   .row:hover {

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
@@ -56,7 +56,7 @@
   }
 
   .cell {
-    @apply md:table-cell md:border-b-2 text-left p-2;
+    @apply md:table-cell md:border-b-2 text-left p-2 overflow-hidden whitespace-nowrap text-ellipsis;
   }
 
   .row:hover {

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-row.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { formatDate, getMilliseconds } from '$lib/utilities/format-date';
   import { routeForWorkflow } from '$lib/utilities/route-for';
+  import { getTruncatedWord } from '$lib/utilities/get-truncated-word';
+  import {
+    workflowIdColumnWidth,
+    workflowTypeColumnWidth,
+  } from '$lib/stores/column-width-store';
 
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
-  import Copyable from '$lib/components/copyable.svelte';
   import Tooltip from '$lib/components/tooltip.svelte';
-
   export let namespace: string;
   export let workflow: WorkflowExecution;
   export let timeFormat: TimeFormat;
@@ -28,22 +31,32 @@
   </div>
   <div class="cell overflow-cell links font-medium md:font-normal">
     <Tooltip bottom copyable text={workflow.id}>
-      <span class="table-link">{workflow.id}</span>
+      <span class="table-link"
+        >{getTruncatedWord(workflow.id, $workflowIdColumnWidth)}</span
+      >
     </Tooltip>
+    <p class="time-cell-inline">
+      {formatDate(workflow.startTime, timeFormat)}
+    </p>
   </div>
   <div class="cell links font-medium md:font-normal flex gap-2">
     <h3 class="md:hidden">Workflow Name:</h3>
-    <Copyable content={workflow.name} size="xs">
-      <span class="table-link">{workflow.name}</span>
-    </Copyable>
+    <Tooltip bottom copyable text={workflow.name}>
+      <span class="table-link"
+        >{getTruncatedWord(workflow.name, $workflowTypeColumnWidth)}</span
+      >
+    </Tooltip>
+    <p class="time-cell-inline">
+      {formatDate(workflow.endTime, timeFormat)}
+    </p>
   </div>
-  <div class="inline-block cell font-normal">
+  <div class="time-cell font-normal">
     <p>
       {formatDate(workflow.startTime, timeFormat)}
     </p>
   </div>
   <span class="md:hidden"> - </span>
-  <div class="inline-block cell font-normal">
+  <div class="time-cell font-medium md:font-normal">
     <p>
       {formatDate(workflow.endTime, timeFormat)}
     </p>
@@ -53,6 +66,14 @@
 <style lang="postcss">
   .row {
     @apply block no-underline p-2 text-sm border-b-2 items-center md:text-base md:table-row last-of-type:border-b-0;
+  }
+
+  .time-cell {
+    @apply inline-block md:hidden xl:table-cell md:border-b-2 text-left p-2;
+  }
+
+  .time-cell-inline {
+    @apply hidden md:block xl:hidden mt-2;
   }
 
   .cell {
@@ -68,7 +89,7 @@
   }
 
   .table-link {
-    @apply border-b-2 group-hover:text-blue-700 group-hover:border-blue-700;
+    @apply group-hover:text-blue-700 group-hover:underline group-hover:decoration-blue-700;
   }
 
   .row:last-of-type .cell {

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -1,13 +1,46 @@
+<script lang="ts">
+  import {
+    workflowIdColumnWidth,
+    workflowTypeColumnWidth,
+  } from '$lib/stores/column-width-store';
+
+  // Need to measure column width since we can't use a tooltip and use overflow-hidden for text overflow
+  let workflowIdWidth: number = 0;
+  let workflowTypeWidth: number = 0;
+
+  $: {
+    workflowIdColumnWidth.set(workflowIdWidth);
+  }
+
+  $: {
+    workflowTypeColumnWidth.set(workflowTypeWidth);
+  }
+</script>
+
 <section class="workflow-table">
   <div class="table-header-row md:table-header-group">
     <div class="md:table-row hidden">
-      <div class="table-header rounded-tl-md w-24">Status</div>
-      <div class="table-header">Workflow ID</div>
-      <div class="table-header w-44 lg:w-60 xl:w-80">Type</div>
-      <div class="table-header w-32 lg:w-40 xl:w-64 text-sm lg:text-base">
+      <div class="table-header table-cell rounded-tl-md w-24">Status</div>
+      <div
+        bind:offsetWidth={workflowIdWidth}
+        class="table-header table-cell md:w-60 xl:w-auto"
+      >
+        Workflow ID
+      </div>
+      <div
+        bind:offsetWidth={workflowTypeWidth}
+        class="table-header table-cell md:w-60 xl:w-80"
+      >
+        Type
+      </div>
+      <div
+        class="table-header hidden xl:table-cell xl:w-64 text-sm xl:text-base"
+      >
         Start
       </div>
-      <div class="table-header rounded-tr-md w-32 lg:w-40 xl:w-64">End</div>
+      <div class="table-header rounded-tr-md hidden xl:table-cell xl:w-64">
+        End
+      </div>
     </div>
   </div>
   <div class="table-header-row md:hidden">
@@ -24,10 +57,10 @@
   }
 
   .table-header-row {
-    @apply bg-gray-900 text-white rounded-t-lg;
+    @apply bg-gray-900 text-white rounded-t-sm md:rounded-t-lg;
   }
 
   .table-header {
-    @apply table-cell text-left p-2;
+    @apply text-left p-2;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -1,11 +1,11 @@
 <section class="workflow-table">
   <div class="table-header-row md:table-header-group">
     <div class="md:table-row hidden">
-      <div class="table-header rounded-tl-md">Status</div>
+      <div class="table-header rounded-tl-md w-24">Status</div>
       <div class="table-header">Workflow ID</div>
-      <div class="table-header">Type</div>
-      <div class="table-header">Start</div>
-      <div class="table-header rounded-tr-md">End</div>
+      <div class="table-header w-60">Type</div>
+      <div class="table-header w-60">Start</div>
+      <div class="table-header rounded-tr-md w-60">End</div>
     </div>
   </div>
   <div class="table-header-row md:hidden">
@@ -18,7 +18,7 @@
 
 <style lang="postcss">
   .workflow-table {
-    @apply md:table border-gray-900 border-2 rounded-lg w-full mb-6;
+    @apply md:table md:table-fixed border-gray-900 border-2 rounded-lg w-full mb-6;
   }
 
   .table-header-row {

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -3,7 +3,7 @@
     <div class="md:table-row hidden">
       <div class="table-header rounded-tl-md w-24">Status</div>
       <div class="table-header">Workflow ID</div>
-      <div class="table-header w-60">Type</div>
+      <div class="table-header w-72">Type</div>
       <div class="table-header w-60">Start</div>
       <div class="table-header rounded-tr-md w-60">End</div>
     </div>

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -5,16 +5,6 @@
   } from '$lib/stores/column-width-store';
 
   // Need to measure column width since we can't use a tooltip and use overflow-hidden for text overflow
-  let workflowIdWidth: number = 0;
-  let workflowTypeWidth: number = 0;
-
-  $: {
-    workflowIdColumnWidth.set(workflowIdWidth);
-  }
-
-  $: {
-    workflowTypeColumnWidth.set(workflowTypeWidth);
-  }
 </script>
 
 <section class="workflow-table">
@@ -22,13 +12,13 @@
     <div class="md:table-row hidden">
       <div class="table-header table-cell rounded-tl-md w-24">Status</div>
       <div
-        bind:offsetWidth={workflowIdWidth}
+        bind:offsetWidth={$workflowIdColumnWidth}
         class="table-header table-cell md:w-60 xl:w-auto"
       >
         Workflow ID
       </div>
       <div
-        bind:offsetWidth={workflowTypeWidth}
+        bind:offsetWidth={$workflowTypeColumnWidth}
         class="table-header table-cell md:w-60 xl:w-80"
       >
         Type

--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -3,9 +3,11 @@
     <div class="md:table-row hidden">
       <div class="table-header rounded-tl-md w-24">Status</div>
       <div class="table-header">Workflow ID</div>
-      <div class="table-header w-72">Type</div>
-      <div class="table-header w-60">Start</div>
-      <div class="table-header rounded-tr-md w-60">End</div>
+      <div class="table-header w-44 lg:w-60 xl:w-80">Type</div>
+      <div class="table-header w-32 lg:w-40 xl:w-64 text-sm lg:text-base">
+        Start
+      </div>
+      <div class="table-header rounded-tr-md w-32 lg:w-40 xl:w-64">End</div>
     </div>
   </div>
   <div class="table-header-row md:hidden">

--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -24,7 +24,7 @@
   import EmptyState from '$lib/components/empty-state.svelte';
   import Pagination from '$lib/components/pagination.svelte';
   import Badge from '$lib/components/badge.svelte';
-  import LoadingRow from '$lib/components/loading-row.svelte';
+  import WorkflowLoadingRow from './_workflow-loading-row.svelte';
   import { page } from '$app/stores';
 
   export let namespace: string;
@@ -58,7 +58,7 @@
 {#await workflows}
   <Pagination items={[]} let:visibleItems>
     <WorkflowsSummaryTable>
-      <LoadingRow />
+      <WorkflowLoadingRow />
     </WorkflowsSummaryTable>
   </Pagination>
 {:then { workflows }}


### PR DESCRIPTION
## What was changed
The workflow table can have different heights for rows based on the length of the workflow id and type. To make the table more consistent, this PR truncates the id and type based on the column width as well as adds a tooltip with the full id and type. You can click on the tooltip to quickly copy the id or type.

<img width="1721" alt="Screen Shot 2022-04-19 at 2 31 10 PM" src="https://user-images.githubusercontent.com/7967403/164081245-f6f8bd95-74b4-411e-b2a6-3bf5d05ffe08.png">
<img width="1016" alt="Screen Shot 2022-04-19 at 2 31 30 PM" src="https://user-images.githubusercontent.com/7967403/164081287-a57d12b0-08bc-4afb-af91-f267d6bd28f0.png">


## Why?
Easier to view the table when all rows are the same height, but can also view full information and copy quickly if needed.

