### PR TITLE
Increase status column width to prevent wrapping of Timed Out status.

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/_workflows-summary-table.svelte
@@ -10,7 +10,7 @@
 <section class="workflow-table">
   <div class="table-header-row md:table-header-group">
     <div class="md:table-row hidden">
-      <div class="table-header table-cell rounded-tl-md w-24">Status</div>
+      <div class="table-header table-cell rounded-tl-md w-28">Status</div>
       <div
         bind:offsetWidth={$workflowIdColumnWidth}
         class="table-header table-cell md:w-60 xl:w-auto"


### PR DESCRIPTION
## What was changed
Increase status width by 8 px to prevent wrapping Timed Out status.

## Why?
Consistent layout