### PR TITLE
Persist workflow details view choice

### DIFF
--- a/cypress/fixtures/query.json
+++ b/cypress/fixtures/query.json
@@ -1,0 +1,6 @@
+{
+  "queryRejected": null,
+  "queryResult": {
+    "payloads": []
+  }
+}

--- a/cypress/integration/view-event-history.spec.js
+++ b/cypress/integration/view-event-history.spec.js
@@ -17,6 +17,12 @@ describe('Workflow Executions List', () => {
 
     cy.intercept(
       Cypress.env('VITE_API_HOST') +
+        `/api/v1/namespaces/default/workflows/*/runs/*/query*`,
+      { fixture: 'query.json' },
+    ).as('query-api');
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
         `/api/v1/namespaces/default/workflows/${workflowId}/runs/${runId}?`,
       { fixture: 'workflow.json' },
     ).as('workflow-api');
@@ -47,7 +53,28 @@ describe('Workflow Executions List', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.wait('@query-api');
 
     cy.url().should('contain', '/summary');
+  });
+
+  it('default to last viewed event view when visiting a workflow', () => {
+    cy.visit(`/namespaces/default/workflows/${workflowId}/${runId}`);
+
+    cy.wait('@workflow-api');
+    cy.wait('@event-history-api');
+    cy.wait('@query-api');
+
+    cy.url().should('contain', '/summary');
+
+    cy.get(
+      '[href="/namespaces/default/workflows/b12453_Completed/db7b0929-24bc-424c-a935-a1f8da69755e/history/full?per-page=100"]',
+    ).click();
+    cy.url().should('contain', '/full');
+
+    cy.visit('/namespaces/default/workflows');
+
+    cy.visit(`/namespaces/default/workflows/${workflowId}/${runId}`);
+    cy.url().should('contain', '/full');
   });
 });

--- a/src/events.d.ts
+++ b/src/events.d.ts
@@ -159,7 +159,7 @@ type ChildEvent = StartChildWorkflowExecutionInitiatedEvent &
   ChildWorkflowExecutionTimedOutEvent &
   ChildWorkflowExecutionTerminatedEvent;
 
-type EventHistoryView = 'full' | 'compact' | 'json';
+type EventView = 'full' | 'compact' | 'summary' | 'json';
 
 type FetchEventsResponse = {
   events: HistoryEventWithId[];

--- a/src/lib/stores/event-view-type.ts
+++ b/src/lib/stores/event-view-type.ts
@@ -1,0 +1,10 @@
+import { persistStore } from '$lib/stores/persist-store';
+import { isEventView } from '$lib/utilities/route-for';
+
+export const eventViewType = persistStore('eventView', 'summary');
+
+export const setEventViewType = (view: string): void => {
+  if (isEventView(view)) {
+    eventViewType.set(view);
+  }
+};

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -1,18 +1,17 @@
 import { browser } from '$app/env';
 
-export type EventView = 'full' | 'compact' | 'summary' | 'json';
-
 type RouteParameters = {
   namespace: string;
   workflow: string;
   run: string;
-  view?: EventView;
+  view?: EventView | string;
   eventId: string;
   queue: string;
 };
 
 export const isEventView = (view: string): view is EventView => {
   if (view === 'summary') return true;
+  if (view === 'full') return true;
   if (view === 'compact') return true;
   if (view === 'json') return true;
   return false;
@@ -72,11 +71,8 @@ export const routeForEventHistory = ({
   ...parameters
 }: EventHistoryParameters): string => {
   const eventHistoryPath = `${routeForWorkflow(parameters)}/history`;
-  if (!view) return eventHistoryPath;
-  if (view === 'summary') return `${eventHistoryPath}/summary`;
-  if (view === 'full') return `${eventHistoryPath}/full`;
-  if (view === 'compact') return `${eventHistoryPath}/compact`;
-  if (view === 'json') return `${eventHistoryPath}/json`;
+  if (!view || !isEventView(view)) return eventHistoryPath;
+  return `${eventHistoryPath}/${view}`;
 };
 
 export const routeForEventHistoryItem = (

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
@@ -20,7 +20,7 @@
 
     return {
       props: { workflow, namespace, workers },
-      stuff: { workflow, namespace, workers },
+      stuff: { workflow, workers },
     };
   };
 </script>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
@@ -20,7 +20,7 @@
 
     return {
       props: { workflow, namespace, workers },
-      stuff: { workflow, workers },
+      stuff: { workflow, namespace, workers },
     };
   };
 </script>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -1,10 +1,6 @@
 <script context="module" lang="ts">
   import type { Load } from '@sveltejs/kit';
-  import {
-    EventView,
-    routeForWorkers,
-    routeForWorkflow,
-  } from '$lib/utilities/route-for';
+  import { routeForWorkers, routeForWorkflow } from '$lib/utilities/route-for';
 
   import { fetchEvents } from '$lib/services/events-service';
 
@@ -46,6 +42,7 @@
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import { getWorkflowStartedAndCompletedEvents } from '$lib/utilities/get-started-and-completed-events';
   import { formatDate } from '$lib/utilities/format-date';
+  import { eventViewType, setEventViewType } from '$lib/stores/event-view-type';
 
   import ToggleButton from '$lib/components/toggle-button.svelte';
   import ToggleButtons from '$lib/components/toggle-buttons.svelte';
@@ -124,22 +121,26 @@
             icon={faTable}
             base={routeForEventHistory(routeParameters('summary'))}
             href={routeForEventHistory(routeParameters('summary'))}
-            >Summary</ToggleButton
+            active={$eventViewType === 'summary'}
+            on:click={() => setEventViewType('summary')}>Summary</ToggleButton
           >
           <ToggleButton
             icon={faBars}
             href={routeForEventHistory(routeParameters('full'))}
-            >Full</ToggleButton
+            active={$eventViewType === 'full'}
+            on:click={() => setEventViewType('full')}>Full</ToggleButton
           >
           <ToggleButton
             icon={faLayerGroup}
             href={routeForEventHistory(routeParameters('compact'))}
-            >Compact</ToggleButton
+            active={$eventViewType === 'compact'}
+            on:click={() => setEventViewType('compact')}>Compact</ToggleButton
           >
           <ToggleButton
             icon={faCode}
             href={routeForEventHistory(routeParameters('json'))}
-            >JSON</ToggleButton
+            active={$eventViewType === 'json'}
+            on:click={() => setEventViewType('json')}>JSON</ToggleButton
           >
         </ToggleButtons>
       </div>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
@@ -8,10 +8,9 @@
   const { namespace, workflow, run } = $page.params;
 
   onMount(async () => {
-    const view = $eventViewType;
     goto(
       routeForEventHistory({
-        view,
+        view: $eventViewType,
         namespace,
         workflow,
         run,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
@@ -1,7 +1,24 @@
-<script context="module" lang="ts">
-  import type { Load } from '@sveltejs/kit';
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { eventViewType } from '$lib/stores/event-view-type';
+  import { onMount } from 'svelte';
+  import { routeForEventHistory } from '$lib/utilities/route-for';
+  import { page } from '$app/stores';
 
-  export const load: Load = async function ({ url }) {
-    return { status: 302, redirect: `${url.pathname}/summary` };
-  };
+  const { namespace, workflow, run } = $page.params;
+
+  onMount(async () => {
+    const view = $eventViewType;
+    goto(
+      routeForEventHistory({
+        view,
+        namespace,
+        workflow,
+        run,
+      }),
+      {
+        replaceState: true,
+      },
+    );
+  });
 </script>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
@@ -10,7 +10,7 @@
   onMount(async () => {
     goto(
       routeForEventHistory({
-        view: $eventViewType,
+        view: $eventViewType ?? 'summary',
         namespace,
         workflow,
         run,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
@@ -10,7 +10,7 @@
   onMount(async () => {
     goto(
       routeForEventHistory({
-        view: $eventViewType ?? 'summary',
+        view: $eventViewType,
         namespace,
         workflow,
         run,


### PR DESCRIPTION
## What was changed
Persist workflow details view in localStorage so when they go back to the workflows page and select new workflow, it automatically goes to the last view.

## Why?
Let's users stay in the view they prefer.
