### PR TITLE
Make event history table fixed so keep code block within column

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="/prism/prism.css" />
     %svelte.head%
   </head>
+
   <body>
     <div id="svelte">%svelte.body%</div>
     <script src="/prism/prism.js"></script>

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -40,14 +40,14 @@
 
 {#if content || content === null}
   <div
-    class="relative w-full max-h-96 rounded-lg h-auto {$$props.class} {inline
+    class="relative w-full rounded-lg h-auto {$$props.class} {inline
       ? ''
       : 'lg:h-full'}"
   >
     <!-- The spacing for this if statement is like this because PRE's honor all whitespace and 
       line breaks so we have this peculiar formatting to preserve this components output -->
     <pre
-      class="p-4 rounded-lg w-full overflow-x-scroll"
+      class="p-4 rounded-lg w-full overflow-x-scroll whitespace-pre"
       class:h-full={!inline}><code class="language-{language}"
       >{#if isJSON}{formatJSON(content)}{:else}{@html content}{/if}</code></pre>
 
@@ -56,3 +56,6 @@
     </button>
   </div>
 {/if}
+
+<style lang="postcss">
+</style>

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -47,7 +47,7 @@
     <!-- The spacing for this if statement is like this because PRE's honor all whitespace and 
       line breaks so we have this peculiar formatting to preserve this components output -->
     <pre
-      class="p-4 rounded-lg w-full overflow-x-scroll whitespace-pre"
+      class="p-4 rounded-lg w-full overflow-x-scroll"
       class:h-full={!inline}><code class="language-{language}"
       >{#if isJSON}{formatJSON(content)}{:else}{@html content}{/if}</code></pre>
 
@@ -56,6 +56,3 @@
     </button>
   </div>
 {/if}
-
-<style lang="postcss">
-</style>

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -17,7 +17,7 @@
 </script>
 
 <article
-  class="flex flex-col justify-between xl:flex-row xl:gap-4 gap-2 py-2 last:border-b-0 border-gray-200 first:pt-0 {$$props.class}"
+  class="flex flex-col justify-between xl:flex-row xl:gap-4 gap-2 py-2 last:border-b-0 border-b-2 border-gray-200 first:pt-0 {$$props.class}"
 >
   {#if typeof value === 'object'}
     <h2 class="w-full items-center xl:items-start xl:w-1/4 text-sm">

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -41,7 +41,7 @@
   {:else}
     <div class="flex items-center xl:items-start w-full xl:3/4">
       <h2 class="w-full xl:w-1/4 text-sm">{format(key)}</h2>
-      <p class="w-full xl:w-3/4 text-sm text-right">
+      <p class="w-full xl:w-3/4 text-sm text-right xl:text-left">
         <span class="bg-gray-300 text-gray-700 px-2 select-all">{value}</span>
       </p>
     </div>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -91,12 +91,12 @@
 
 <style lang="postcss">
   .cell {
-    @apply xl:table-cell xl:border-b-2 py-1 px-3 leading-4;
+    @apply xl:table-cell xl:border-b-2 border-gray-700 py-1 px-3 leading-4;
     flex: 40%;
   }
 
   .row {
-    @apply no-underline py-3 text-sm border-b-2 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
+    @apply no-underline py-3 text-sm border-b-2 border-gray-700 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
   }
 
   .row:hover {

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,14 +10,14 @@
 <section class="event-table">
   <div class="table-header-row xl:table-header-group">
     <div class="xl:table-row hidden">
-      <div class="table-header w-96 rounded-tl-md">
+      <div class="table-header w-1/4 rounded-tl-md">
         {title}<EventCategoryFilter />
       </div>
-      <div class="table-header w-60">
+      <div class="table-header w-1/4">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>
-      <div class="table-header rounded-tr-md">Event Details</div>
+      <div class="table-header rounded-tr-md w-1/2">Event Details</div>
     </div>
   </div>
   <div class="table-header-row-responsive rounded-t-md">

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,14 +10,14 @@
 <section class="event-table">
   <div class="table-header-row xl:table-header-group">
     <div class="xl:table-row hidden">
-      <div class="table-header w-3/12 rounded-tl-md">
+      <div class="table-header w-96 rounded-tl-md">
         {title}<EventCategoryFilter />
       </div>
-      <div class="table-header w-2/12">
+      <div class="table-header w-60">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>
-      <div class="table-header w-7/12 rounded-tr-md">Event Details</div>
+      <div class="table-header rounded-tr-md">Event Details</div>
     </div>
   </div>
   <div class="table-header-row-responsive rounded-t-md">
@@ -34,7 +34,7 @@
 
 <style lang="postcss">
   .event-table {
-    @apply xl:table border-gray-900 border-2 rounded-lg w-full;
+    @apply xl:table table-fixed border-gray-900 border-2 rounded-lg w-full;
   }
 
   .table-header-row {
@@ -46,6 +46,6 @@
   }
 
   .table-header {
-    @apply xl:table-cell table-cell text-left px-3 py-3;
+    @apply xl:table-cell text-left px-3 py-3;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -10,6 +10,6 @@
     class="flex flex-col border-2 border-gray-300 p-4 rounded-lg w-full lg:w-1/2"
   >
     <h3 class="text-lg">{title}</h3>
-    <CodeBlock {content} class="mb-2" />
+    <CodeBlock {content} class="mb-2 max-h-96" />
   </article>
 {/if}

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/pending-activities.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/pending-activities.svelte
@@ -10,8 +10,8 @@
 </script>
 
 {#if pendingActivities.length}
-  <section class="border-2 border-gray-300 rounded-lg w-full mb-6">
-    <header class="table-header rounded-t-lg">
+  <section class="border-2 border-gray-900 rounded-lg w-full mb-6">
+    <header class="table-header">
       <h3>Pending Activities</h3>
     </header>
     <div>
@@ -52,6 +52,6 @@
 
 <style lang="postcss">
   .table-header {
-    @apply bg-gray-100 text-gray-800 font-semibold p-4 flex justify-between items-center border-b-2;
+    @apply bg-gray-900 text-white p-4 flex justify-between items-center border-b-2 border-gray-900;
   }
 </style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/workers.svelte
@@ -27,8 +27,8 @@
 <section class="flex flex-col gap-4">
   <h3 class="text-lg font-medium">Task Queue: {taskQueue}</h3>
   {#each workers.pollers as poller (poller.identity)}
-    <section class="flex flex-col border-2 border-gray-300 w-full rounded-lg">
-      <div class="bg-gray-200 flex flex-row p-2">
+    <section class="flex flex-col border-2 border-gray-900 w-full rounded-lg">
+      <div class="bg-gray-900 text-white flex flex-row p-2">
         <div class="w-3/12 text-left">ID</div>
         <div class="w-3/12 text-left">Last Accessed</div>
         <div class="w-3/12 text-left">Workflow Task Handler</div>


### PR DESCRIPTION
## What was changed
Made event history table fixed and updated the row/event detail border to make it easier to ready. Also updated pending activities and workers headers to match other tables.

<img width="1676" alt="Screen Shot 2022-04-20 at 4 06 53 PM" src="https://user-images.githubusercontent.com/7967403/164323265-1803e129-c332-4867-99ba-59543028b8f8.png">

## Why?
Easier to read, keeps table consistent width.

