### PR TITLE
Use window.location.assign instead of goto on redirect to login

### DIFF
--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -1,5 +1,4 @@
 import { browser } from '$app/env';
-import { goto } from '$app/navigation';
 import { networkError } from '$lib/stores/error';
 import { notifications } from '../stores/notifications';
 import { isNetworkError } from './is-network-error';
@@ -8,9 +7,10 @@ import { routeForLoginPage } from './route-for';
 // This will eventually be expanded on.
 export const handleError = (error: unknown): void => {
   if (isUnauthorized(error) && browser) {
-    goto(routeForLoginPage());
+    window.location.href = routeForLoginPage();
     return;
   }
+
   if (isForbidden(error)) {
     notifications.add('error', `${error.statusCode} ${error.statusText}`);
     return;

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -7,7 +7,7 @@ import { routeForLoginPage } from './route-for';
 // This will eventually be expanded on.
 export const handleError = (error: unknown): void => {
   if (isUnauthorized(error) && browser) {
-    window.location.href = routeForLoginPage();
+    window.location.assign(routeForLoginPage());
     return;
   }
 


### PR DESCRIPTION
## What was changed
goto(loginPage) causes an infinite redirect loop

## Why?
Allow users to view login page to log back in
