### PR TITLE
Create indented block from Workflow Task Started to last Command event

### DIFF
--- a/cypress/integration/event-history-empty-states.spec.js
+++ b/cypress/integration/event-history-empty-states.spec.js
@@ -18,6 +18,12 @@ describe('Workflow Executions List', () => {
 
     cy.intercept(
       Cypress.env('VITE_API_HOST') +
+        `/api/v1/namespaces/default/workflows/*/runs/*/query*`,
+      { fixture: 'query.json' },
+    ).as('query-api');
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
         `/api/v1/namespaces/default/workflows/*/runs/*?`,
       { fixture: 'workflow.json' },
     ).as('workflow-api');
@@ -44,6 +50,7 @@ describe('Workflow Executions List', () => {
 
       cy.wait('@workflow-api');
       cy.wait('@event-history-api');
+      cy.wait('@query-api');
 
       cy.contains('No Events Match');
     });

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -23,7 +23,11 @@
     <h2 class="w-full items-center xl:items-start xl:w-1/4 text-sm">
       {format(key)}
     </h2>
-    <CodeBlock content={value} class="w-full xl:w-3/4" {inline} />
+    <CodeBlock
+      content={value}
+      class="w-full w-96 md:w-auto xl:w-3/4"
+      {inline}
+    />
   {:else if shouldDisplayAsWorkflowLink(key)}
     <div class="flex items-center xl:items-start w-full xl:3/4">
       <h2 class="w-full xl:w-1/4 text-sm">{format(key)}</h2>

--- a/src/lib/components/event/event-group-details.svelte
+++ b/src/lib/components/event/event-group-details.svelte
@@ -14,9 +14,8 @@
             }}
           >
             <span class="event-type" class:active={id === selectedId}
-              >{eventInGroup.eventType}</span
+              >{eventInGroup.eventType} (#{id})</span
             >
-            (#{id})
           </li>
         {/each}
       </ul>

--- a/src/lib/components/event/event-group-details.svelte
+++ b/src/lib/components/event/event-group-details.svelte
@@ -26,7 +26,7 @@
 
 <style lang="postcss">
   li {
-    @apply my-2 cursor-pointer;
+    @apply my-6 cursor-pointer;
   }
   .event-type:hover {
     @apply text-blue-700 border-b-2 border-blue-700;

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -11,6 +11,7 @@
   import EventDetails from './event-details.svelte';
   import EventGroupDetails from './event-group-details.svelte';
   import { isSubrowActivity } from '$lib/utilities/is-subrow-activity';
+  import { eventViewType } from '$lib/stores/event-view-type';
 
   export let event: IterableEvent;
   export let groups: CompactEventGroups;
@@ -51,7 +52,7 @@
     }
   };
 
-  $: subRow = isSubrowActivity(event);
+  $: subRow = isSubrowActivity(event) && $eventViewType === 'summary';
 </script>
 
 <article class="row" id={event.id}>
@@ -61,11 +62,12 @@
       class:subRow
       href="#{event.id}">{event.id}</a
     >
+  </div>
+  <div class="cell text-left">
     <a
       href="#{event.id}"
-      class="md:mx-2 text-sm md:text-base font-semibold {subRow
-        ? 'md:text-sm md:mx-0'
-        : ''}"
+      class="md:mx-2 text-sm md:text-base font-semibold"
+      class:subRow
       class:link={!expandAll}
       on:click|stopPropagation={onLinkClick}
     >
@@ -98,12 +100,12 @@
 
 <style lang="postcss">
   .cell {
-    @apply xl:table-cell xl:border-b-2 border-gray-700 py-1 px-3 leading-4;
+    @apply xl:table-cell xl:border-b-2 border-gray-300 py-1 px-3 leading-4;
     flex: 40%;
   }
 
   .row {
-    @apply no-underline py-3 text-sm border-b-2 border-gray-700 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
+    @apply no-underline py-3 text-sm border-b-2 border-gray-300 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
   }
 
   .row:hover {
@@ -123,6 +125,6 @@
   }
 
   .subRow {
-    @apply ml-8 text-sm;
+    @apply md:ml-6 text-sm;
   }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -131,10 +131,7 @@
     @apply text-blue-700 underline decoration-blue-700;
   }
 
-  .row:last-of-type .cell {
-    @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
-  }
-
+  .row:last-of-type .cell,
   .row:last-of-type .id-cell {
     @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
   }
@@ -143,10 +140,7 @@
     @apply ml-2 md:ml-4 xl:ml-6 text-sm;
   }
 
-  .expanded {
-    @apply bg-blue-50;
-  }
-
+  .expanded,
   .expanded:hover {
     @apply bg-blue-50;
   }

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -10,6 +10,7 @@
 
   import EventDetails from './event-details.svelte';
   import EventGroupDetails from './event-group-details.svelte';
+  import { isSubrowActivity } from '$lib/utilities/is-subrow-activity';
 
   export let event: IterableEvent;
   export let groups: CompactEventGroups;
@@ -49,16 +50,22 @@
       expanded = !expanded;
     }
   };
+
+  $: subRow = isSubrowActivity(event);
 </script>
 
 <article class="row" id={event.id}>
   <div class="cell text-left">
-    <a class="text-gray-500 mx-1 text-sm md:text-base" href="#{event.id}"
-      >{event.id}</a
+    <a
+      class="text-gray-500 mx-1 text-sm md:text-base"
+      class:subRow
+      href="#{event.id}">{event.id}</a
     >
     <a
       href="#{event.id}"
-      class="md:mx-2 text-sm md:text-base font-semibold"
+      class="md:mx-2 text-sm md:text-base font-semibold {subRow
+        ? 'md:text-sm md:mx-0'
+        : ''}"
       class:link={!expandAll}
       on:click|stopPropagation={onLinkClick}
     >
@@ -108,10 +115,14 @@
   }
 
   .row:hover .link {
-    @apply text-blue-700 border-b-2 border-blue-700;
+    @apply text-blue-700 underline decoration-blue-700;
   }
 
   .row:last-of-type .cell {
     @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
+  }
+
+  .subRow {
+    @apply ml-8 text-sm;
   }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -55,24 +55,28 @@
   $: subRow = isSubrowActivity(event) && $eventViewType === 'summary';
 </script>
 
-<article class="row" id={event.id}>
-  <div class="cell text-left">
+<article class="row" id={event.id} class:expanded={expanded && !expandAll}>
+  <div class="id-cell text-left">
     <a
       class="text-gray-500 mx-1 text-sm md:text-base"
       class:subRow
       href="#{event.id}">{event.id}</a
     >
   </div>
-  <div class="cell text-left">
+  <div class="cell flex text-left">
     <a
-      href="#{event.id}"
+      class="text-gray-500 mx-1 text-sm md:text-base xl:hidden"
+      class:subRow
+      href="#{event.id}">{event.id}</a
+    >
+    <p
       class="md:mx-2 text-sm md:text-base font-semibold"
       class:subRow
       class:link={!expandAll}
       on:click|stopPropagation={onLinkClick}
     >
       {event.name}
-    </a>
+    </p>
     {#if expanded && compact}
       <EventGroupDetails {eventGroup} bind:selectedId />
     {/if}
@@ -100,12 +104,16 @@
 
 <style lang="postcss">
   .cell {
-    @apply xl:table-cell xl:border-b-2 border-gray-300 py-1 px-3 leading-4;
+    @apply xl:table-cell xl:border-b-2 border-gray-200 py-1 px-3 leading-4;
     flex: 40%;
   }
 
+  .id-cell {
+    @apply hidden xl:table-cell xl:border-b-2 border-gray-200 py-1 px-3 leading-4;
+  }
+
   .row {
-    @apply no-underline py-3 text-sm border-b-2 border-gray-300 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
+    @apply no-underline py-3 text-sm border-b-2 border-gray-200 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
   }
 
   .row:hover {
@@ -124,7 +132,19 @@
     @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
   }
 
+  .row:last-of-type .id-cell {
+    @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
+  }
+
   .subRow {
-    @apply md:ml-6 text-sm;
+    @apply ml-2 xl:ml-6 text-sm;
+  }
+
+  .expanded {
+    @apply bg-blue-50;
+  }
+
+  .expanded:hover {
+    @apply bg-blue-50;
   }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getGroupForEvent, isEventGroup } from '$lib/models/group-events';
+  import Icon from 'svelte-fa';
 
   import {
     formatDate,
@@ -12,6 +13,7 @@
   import EventGroupDetails from './event-group-details.svelte';
   import { isSubrowActivity } from '$lib/utilities/is-subrow-activity';
   import { eventViewType } from '$lib/stores/event-view-type';
+  import { faAngleDown, faAngleUp } from '@fortawesome/free-solid-svg-icons';
 
   export let event: IterableEvent;
   export let groups: CompactEventGroups;
@@ -76,6 +78,7 @@
       on:click|stopPropagation={onLinkClick}
     >
       {event.name}
+      <Icon class="inline" icon={expanded ? faAngleUp : faAngleDown} />
     </p>
     {#if expanded && compact}
       <EventGroupDetails {eventGroup} bind:selectedId />
@@ -104,16 +107,16 @@
 
 <style lang="postcss">
   .cell {
-    @apply xl:table-cell xl:border-b-2 border-gray-200 py-1 px-3 leading-4;
+    @apply xl:table-cell xl:border-b-2 border-gray-700 py-1 px-3 leading-4;
     flex: 40%;
   }
 
   .id-cell {
-    @apply hidden xl:table-cell xl:border-b-2 border-gray-200 py-1 px-3 leading-4;
+    @apply hidden xl:table-cell xl:border-b-2 border-gray-700 py-1 px-3 leading-4;
   }
 
   .row {
-    @apply no-underline py-3 text-sm border-b-2 border-gray-200 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
+    @apply no-underline xl:py-3 text-sm border-b-2 border-gray-700 items-center xl:text-base flex flex-wrap xl:table-row last-of-type:border-b-0;
   }
 
   .row:hover {
@@ -137,7 +140,7 @@
   }
 
   .subRow {
-    @apply ml-2 xl:ml-6 text-sm;
+    @apply ml-2 md:ml-4 xl:ml-6 text-sm;
   }
 
   .expanded {

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,7 +10,7 @@
 <section class="event-table">
   <div class="table-header-row xl:table-header-group">
     <div class="xl:table-row hidden">
-      <div class="table-header w-8 rounded-tl-md" />
+      <div class="table-header w-4 rounded-tl-md" />
       <div class="table-header w-1/4">
         {title}<EventCategoryFilter />
       </div>

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,10 +10,10 @@
 <section class="event-table">
   <div class="table-header-row xl:table-header-group">
     <div class="xl:table-row hidden">
-      <div class="table-header w-1/4 rounded-tl-md">
+      <div class="table-header w-1/3 rounded-tl-md">
         {title}<EventCategoryFilter />
       </div>
-      <div class="table-header w-1/4">
+      <div class="table-header w-1/6">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,10 +10,11 @@
 <section class="event-table">
   <div class="table-header-row xl:table-header-group">
     <div class="xl:table-row hidden">
-      <div class="table-header w-1/3 rounded-tl-md">
+      <div class="table-header w-8 rounded-tl-md" />
+      <div class="table-header w-1/4">
         {title}<EventCategoryFilter />
       </div>
-      <div class="table-header w-1/6">
+      <div class="table-header">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>

--- a/src/lib/utilities/get-truncated-word.ts
+++ b/src/lib/utilities/get-truncated-word.ts
@@ -1,6 +1,6 @@
 export const getTruncatedWord = (word: string, width: number): string => {
-  if (word.length * 8 > width) {
-    const truncLength = Math.floor(width / 8) - 4;
+  if (word.length * 8.15 > width) {
+    const truncLength = Math.floor(width / 8.15) - 4;
     if (truncLength > 0) {
       const trunc = word.slice(0, truncLength);
       return `${trunc}...`;

--- a/src/lib/utilities/is-subrow-activity.ts
+++ b/src/lib/utilities/is-subrow-activity.ts
@@ -1,7 +1,3 @@
-export const isSubrowActivity = (event: IterableEvent): boolean => {
-  return (
-    (event.category === 'command' &&
-      event?.attributes?.workflowTaskCompletedEventId) ||
-    (event.category === 'workflow' && event?.attributes?.startedEventId)
-  );
+export const isSubrowActivity = (event: CommonHistoryEvent): boolean => {
+  return Boolean((event?.attributes as any)?.workflowTaskCompletedEventId);
 };

--- a/src/lib/utilities/is-subrow-activity.ts
+++ b/src/lib/utilities/is-subrow-activity.ts
@@ -1,0 +1,7 @@
+export const isSubrowActivity = (event: IterableEvent): boolean => {
+  return (
+    (event.category === 'command' &&
+      event?.attributes?.workflowTaskCompletedEventId) ||
+    (event.category === 'workflow' && event?.attributes?.startedEventId)
+  );
+};

--- a/src/lib/utilities/is-subrow-activity.ts
+++ b/src/lib/utilities/is-subrow-activity.ts
@@ -1,3 +1,3 @@
-export const isSubrowActivity = (event: CommonHistoryEvent): boolean => {
+export const isSubrowActivity = (event: IterableEvent): boolean => {
   return Boolean((event?.attributes as any)?.workflowTaskCompletedEventId);
 };


### PR DESCRIPTION
## What was changed
Indent command events under the workflow task started event to visually see the grouped events. Also add blue background to expanded rows and a caret icon.

<img width="1659" alt="Screen Shot 2022-04-21 at 3 27 52 PM" src="https://user-images.githubusercontent.com/7967403/164547562-3bf3561d-2bae-440c-9548-1c9279d66212.png">

## Why?
Easier to visually see hierarchy of events and what rows are open.
