### PR TITLE
Use props for export history url fetch, not params

### DIFF
--- a/src/lib/components/export-history.svelte
+++ b/src/lib/components/export-history.svelte
@@ -5,7 +5,11 @@
   import { faDownload } from '@fortawesome/free-solid-svg-icons';
   import Button from './button.svelte';
 
-  const { workflow: workflowId, run: runId, namespace } = $page.params;
+  export let namespace: string;
+  export let workflowId: string;
+  export let runId: string;
+
+  // const { workflow: workflowId, run: runId, namespace } = $page.params;
 
   const exportHistory = async () => {
     const events = await fetchRawEvents({

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -44,7 +44,11 @@
         <span class="font-medium select-all">{workflow.id}</span>
       </h1>
       <div class="ml-8 flex justify-end items-center gap-4">
-        <ExportHistory />
+        <ExportHistory
+          {namespace}
+          workflowId={workflow.id}
+          runId={workflow.runId}
+        />
         <TerminateWorkflow {workflow} {namespace} />
       </div>
     </div>


### PR DESCRIPTION
## What was changed
Because we are double encoding urls on the client side, the export history download is failing due it the wrong path. Use the props of namespace/workflowId/runId instead of $page.params to get the correct path.

## Why?
Fixes export history