### PR TITLE
Update link colors

### DIFF
--- a/src/lib/components/link.svelte
+++ b/src/lib/components/link.svelte
@@ -7,13 +7,13 @@
   {href}
   class:active
   {...$$props}
-  class="border-b-2 border-blue-600 {$$props.class} hover:text-blue-900 hover:no-underline"
+  class="border-b-2 border-gray-900 {$$props.class} hover:text-blue-700 hover:border-blue-700"
 >
   <slot />
 </a>
 
 <style lang="postcss">
   .active {
-    @apply text-blue-700 border-b-2 border-blue-600;
+    @apply text-blue-900 border-b-2 border-blue-900;
   }
 </style>


### PR DESCRIPTION
## What was changed
Updated link colors to be blue only on hover and active per @canvanooo 

<img width="863" alt="Screen Shot 2022-04-22 at 10 06 23 AM" src="https://user-images.githubusercontent.com/7967403/164742078-affe8bd9-2657-4726-b234-3914800dab19.png">

