### PR TITLE
Redirect to login if unauthorized

### DIFF
--- a/src/lib/utilities/is-authorized.test.ts
+++ b/src/lib/utilities/is-authorized.test.ts
@@ -1,0 +1,37 @@
+import { isAuthorized } from './is-authorized';
+
+const user = {
+  name: 'Test',
+  email: 'test@mail.com',
+  picture: 'image@test.com',
+};
+const noUser = { name: undefined, email: undefined, picture: undefined };
+const getSettings = (enabled: boolean) => ({
+  auth: {
+    enabled,
+    options: [],
+  },
+  baseUrl: 'www.base.com',
+  defaultNamespace: 'default',
+  showTemporalSystemNamespace: false,
+  runtimeEnvironment: {
+    isCloud: false,
+    isLocal: true,
+    envOverride: false,
+  },
+});
+
+describe(isAuthorized, () => {
+  it('should return true if auth no enabled and no user', () => {
+    expect(isAuthorized(getSettings(false), noUser)).toBe(true);
+  });
+  it('should return true if auth no enabled and user', () => {
+    expect(isAuthorized(getSettings(false), user)).toBe(true);
+  });
+  it('should return false if auth enabled and no user', () => {
+    expect(isAuthorized(getSettings(true), noUser)).toBe(false);
+  });
+  it('should return true if auth enabled and user', () => {
+    expect(isAuthorized(getSettings(true), user)).toBe(true);
+  });
+});

--- a/src/lib/utilities/is-authorized.ts
+++ b/src/lib/utilities/is-authorized.ts
@@ -1,0 +1,6 @@
+export const isAuthorized = (
+  settings: Settings,
+  user: { name: string; email: string; picture: string },
+): boolean => {
+  return !settings.auth.enabled || Boolean(user?.email);
+};

--- a/src/routes/__error.svelte
+++ b/src/routes/__error.svelte
@@ -1,22 +1,42 @@
 <script context="module" lang="ts">
   import type { ErrorLoad } from '@sveltejs/kit';
+  import { fetchSettings } from '$lib/services/settings-service';
+  import { fetchUser } from '$lib/services/user-service';
 
-  export const load: ErrorLoad = async function ({ error, status }) {
+  import '../app.css';
+
+  export const load: ErrorLoad = async function ({
+    error,
+    status,
+    url,
+    fetch,
+  }) {
+    const settings: Settings = await fetchSettings({ url }, fetch);
+    const user = await fetchUser(fetch);
+
     return {
+      stuff: {
+        settings,
+      },
       props: {
         error,
         status,
+        settings,
+        user,
       },
     };
   };
 </script>
 
 <script lang="ts">
+  import Header from './_header.svelte';
+  import HeaderResponsive from './_header-responsive.svelte';
   import Error from '$lib/components/error.svelte';
   import { isNetworkError } from '$lib/utilities/is-network-error';
 
   export let error: globalThis.Error;
   export let status: number;
+  export let user: User;
 
   let requestFromAPIError: Record<string, any>;
 
@@ -29,4 +49,6 @@
   } catch (e) {}
 </script>
 
+<Header {user} />
+<HeaderResponsive {user} />
 <Error {error} {status} />


### PR DESCRIPTION
## What was changed
In the root layout, check for user. If they exist, continue on, otherwise redirect to login page.

## Why?
Better auth flow, don't allow users to view namespace information if not logged in.
