### PR TITLE
Add reverse query param to event history route

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -4,10 +4,8 @@
 
   import { eventFilterSort, eventShowElapsed } from '$lib/stores/event-filters';
   import { timeFormat } from '$lib/stores/time-format';
-  import { eventViewType } from '$lib/stores/event-view-type';
 
   import { getGroupForEvent, isEventGroup } from '$lib/models/event-groups';
-  import { isSubrowActivity } from '$lib/utilities/is-subrow-activity';
   import {
     formatDate,
     formatDistanceAbbreviated,
@@ -53,27 +51,21 @@
   const onLinkClick = () => {
     expanded = !expanded;
   };
-
-  $: subRow = isSubrowActivity(event) && $eventViewType === 'feed';
 </script>
 
 <article class="row" id={event.id} class:expanded={expanded && !expandAll}>
   <div class="id-cell text-left">
-    <a
-      class="text-gray-500 mx-1 text-sm md:text-base"
-      class:subRow
-      href="#{event.id}">{event.id}</a
+    <a class="text-gray-500 mx-1 text-sm md:text-base" href="#{event.id}"
+      >{event.id}</a
     >
   </div>
   <div class="cell flex text-left">
     <a
       class="text-gray-500 mx-1 text-sm md:text-base xl:hidden"
-      class:subRow
       href="#{event.id}">{event.id}</a
     >
     <p
       class="md:mx-2 text-sm md:text-base font-semibold link"
-      class:subRow
       on:click|stopPropagation={onLinkClick}
     >
       {event.name}
@@ -133,10 +125,6 @@
   .row:last-of-type .cell,
   .row:last-of-type .id-cell {
     @apply border-b-0 first-of-type:rounded-bl-lg  last-of-type:rounded-br-lg;
-  }
-
-  .subRow {
-    @apply ml-2 md:ml-4 xl:ml-6 text-sm;
   }
 
   .expanded,

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -6,7 +6,7 @@ type RouteParameters = {
   workflow: string;
   run: string;
   view?: EventView | string;
-  queryParams?: URLSearchParams | Record<string, string>;
+  queryParams?: Record<string, string>;
   eventId: string;
   queue: string;
 };
@@ -154,8 +154,12 @@ export const routeForImport = ({
 };
 
 const hasParameters =
-  <T extends Record<string, string>>(...required: string[]) =>
-  (parameters: Record<string, string>): parameters is T => {
+  <T extends Record<string, string | Record<string, string>>>(
+    ...required: string[]
+  ) =>
+  (
+    parameters: Record<string, string | Record<string, string>>,
+  ): parameters is T => {
     for (const parameter of required) {
       if (!parameters[parameter]) return false;
     }
@@ -176,6 +180,7 @@ export const isEventHistoryParameters = hasParameters<EventHistoryParameters>(
   'workflow',
   'run',
   'view',
+  'queryParams',
 );
 
 export const isEventParameters = hasParameters<EventParameters>(

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -1,10 +1,12 @@
 import { browser } from '$app/env';
+import { toURL } from '$lib/utilities/to-url';
 
 type RouteParameters = {
   namespace: string;
   workflow: string;
   run: string;
   view?: EventView | string;
+  queryParams?: URLSearchParams | Record<string, string>;
   eventId: string;
   queue: string;
 };
@@ -23,7 +25,7 @@ export type WorkflowParameters = Pick<
 >;
 export type EventHistoryParameters = Pick<
   RouteParameters,
-  'namespace' | 'workflow' | 'run' | 'view'
+  'namespace' | 'workflow' | 'run' | 'view' | 'queryParams'
 >;
 export type EventParameters = Required<
   Pick<RouteParameters, 'namespace' | 'workflow' | 'run' | 'view' | 'eventId'>
@@ -67,11 +69,12 @@ export const routeForWorkflow = ({
 
 export const routeForEventHistory = ({
   view,
+  queryParams,
   ...parameters
 }: EventHistoryParameters): string => {
   const eventHistoryPath = `${routeForWorkflow(parameters)}/history`;
   if (!view || !isEventView(view)) return `${eventHistoryPath}/feed`;
-  return `${eventHistoryPath}/${view}`;
+  return toURL(`${eventHistoryPath}/${view}`, queryParams);
 };
 
 export const routeForEventHistoryItem = (

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -7,7 +7,6 @@
   export const load: Load = async function ({ params, url, stuff, fetch }) {
     const { workflow } = stuff;
     const { namespace } = params;
-
     const parameters = {
       namespace,
       workflowId: workflow.id,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -7,6 +7,7 @@
   export const load: Load = async function ({ params, url, stuff, fetch }) {
     const { workflow } = stuff;
     const { namespace } = params;
+
     const parameters = {
       namespace,
       workflowId: workflow.id,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/index.svelte
@@ -4,13 +4,17 @@
   import { onMount } from 'svelte';
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import { page } from '$app/stores';
+  import { eventFilterSort } from '$lib/stores/event-filters';
 
   const { namespace, workflow, run } = $page.params;
 
   onMount(async () => {
+    const queryParams =
+      $eventFilterSort === 'reverse' ? { sort: 'reverse' } : undefined;
     goto(
       routeForEventHistory({
         view: $eventViewType,
+        queryParams,
         namespace,
         workflow,
         run,


### PR DESCRIPTION
## What was changed
Persist reverse sorting of event history to each subsequent workflow you visit. Also remove indenting of subrow events.

