### PR TITLE
Persisted query parameter store

### DIFF
--- a/src/lib/stores/persisted-search-parameter.ts
+++ b/src/lib/stores/persisted-search-parameter.ts
@@ -1,5 +1,4 @@
 import { browser } from '$app/env';
-import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 import { writable, get, type Writable } from 'svelte/store';
 

--- a/src/lib/stores/persisted-search-parameter.ts
+++ b/src/lib/stores/persisted-search-parameter.ts
@@ -1,0 +1,98 @@
+import { browser } from '$app/env';
+import { goto } from '$app/navigation';
+import { page } from '$app/stores';
+import { writable, get, type Writable } from 'svelte/store';
+
+type SearchParameterValue = string | number | boolean | null;
+
+const isBoolean = (value: SearchParameterValue): value is boolean => typeof value === 'boolean';
+const isNumber = (value: SearchParameterValue): value is number => typeof value === 'number';
+
+const toNumber = (value: string): number => parseInt(value);
+const toBoolean = (value: string, defaultValue: boolean): boolean => {
+	if (value === 'true') return true;
+	if (value === 'false') return false;
+	return defaultValue;
+};
+
+const getFromSearchParameters = (parameter: string): string | undefined => {
+	const value = get(page).url.searchParams.get(parameter);
+	if (value) return value;
+};
+
+const saveToSearchParameters = (parameter: string, value: SearchParameterValue) => {
+	if (browser) {
+		const url = new URL(window?.location?.href);
+		url.searchParams.set(parameter, String(value));
+
+		goto(url.href, {
+			replaceState: true,
+			keepfocus: true,
+			noscroll: true
+		});
+	}
+};
+
+const getFromLocalStorage = (parameter: string): string | undefined => {
+	if (browser) {
+		const value = window?.localStorage?.getItem(parameter);
+		if (value) return value;
+	}
+};
+
+const saveToLocalStorage = (parameter: string, value: SearchParameterValue) => {
+	if (browser) {
+		window?.localStorage?.setItem(parameter, String(value));
+	}
+};
+
+const getValue = (parameter: string, defaultValue: SearchParameterValue): SearchParameterValue => {
+	let value: string | undefined = undefined;
+
+	let searchParameterValue = getFromSearchParameters(parameter);
+	let localStorageValue = getFromLocalStorage(parameter);
+
+	if (searchParameterValue !== undefined) {
+		saveToLocalStorage(parameter, searchParameterValue);
+		value = searchParameterValue;
+	} else if (localStorageValue !== undefined) {
+		saveToSearchParameters(parameter, localStorageValue);
+		value = localStorageValue;
+	}
+
+	if (value !== undefined) {
+		if (isBoolean(defaultValue)) return toBoolean(value, defaultValue);
+		if (isNumber(defaultValue)) return toNumber(value);
+	}
+
+	return defaultValue;
+};
+
+const setValue = (parameter: string, value: SearchParameterValue) => {
+	saveToLocalStorage(parameter, value);
+	saveToSearchParameters(parameter, value);
+};
+
+export const searchParameter = (
+	parameter: string,
+	defaultValue: SearchParameterValue
+): Writable<SearchParameterValue> => {
+	const value = getValue(parameter, defaultValue);
+	const store = writable(value);
+
+	const set: typeof store.set = (value: SearchParameterValue) => {
+		store.set(value);
+		setValue(parameter, value);
+	};
+
+	const update: typeof store.update = (updater) => {
+		store.update(updater);
+		setValue(parameter, value);
+	};
+
+	return {
+		subscribe: store.subscribe,
+		set,
+		update
+	};
+};

--- a/src/lib/stores/persisted-search-parameter.ts
+++ b/src/lib/stores/persisted-search-parameter.ts
@@ -1,96 +1,116 @@
 import { browser } from '$app/env';
 import { page } from '$app/stores';
-import { writable, get, type Writable } from 'svelte/store';
+import { writable, get, Writable } from 'svelte/store';
 
 type SearchParameterValue = string | number | boolean | null;
 
-const isBoolean = (value: SearchParameterValue): value is boolean => typeof value === 'boolean';
-const isNumber = (value: SearchParameterValue): value is number => typeof value === 'number';
+const isBoolean = (value: SearchParameterValue): value is boolean =>
+  typeof value === 'boolean';
+const isNumber = (value: SearchParameterValue): value is number =>
+  typeof value === 'number';
 
 const toNumber = (value: string): number => parseInt(value);
 const toBoolean = (value: string, defaultValue: boolean): boolean => {
-	if (value === 'true') return true;
-	if (value === 'false') return false;
-	return defaultValue;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return defaultValue;
 };
 
 const getFromSearchParameters = (parameter: string): string | undefined => {
-	const value = get(page).url.searchParams.get(parameter);
-	if (value) return value;
+  const value = get(page).url.searchParams.get(parameter);
+  if (value) return value;
 };
 
-const saveToSearchParameters = (parameter: string, value: SearchParameterValue) => {
-	if (browser) {
-		const url = new URL(window?.location?.href);
-		url.searchParams.set(parameter, String(value));
+const saveToSearchParameters = (
+  parameter: string,
+  value: SearchParameterValue,
+) => {
+  if (browser) {
+    const url = new URL(window?.location?.href);
+    url.searchParams.set(parameter, String(value));
 
-		window?.history.replaceState(null, '', url);
-	}
+    window?.history.replaceState(null, '', url);
+  }
 };
 
-const getFromLocalStorage = (parameter: string, persist: boolean): string | undefined => {
-	if (browser && persist) {
-		const value = window?.localStorage?.getItem(parameter);
-		if (value) return value;
-	}
+const getFromLocalStorage = (
+  parameter: string,
+  persist: boolean,
+): string | undefined => {
+  if (browser && persist) {
+    const value = window?.localStorage?.getItem(parameter);
+    if (value) return value;
+  }
 };
 
-const saveToLocalStorage = (parameter: string, value: SearchParameterValue, persist: boolean) => {
-	if (browser && persist) {
-		window?.localStorage?.setItem(parameter, String(value));
-	}
+const saveToLocalStorage = (
+  parameter: string,
+  value: SearchParameterValue,
+  persist: boolean,
+) => {
+  if (browser && persist) {
+    window?.localStorage?.setItem(parameter, String(value));
+  }
 };
 
-const getValue = (parameter: string, defaultValue: SearchParameterValue, persist: boolean): SearchParameterValue => {
-	let value: string | undefined = undefined;
+const getValue = (
+  parameter: string,
+  defaultValue: SearchParameterValue,
+  persist: boolean,
+): SearchParameterValue => {
+  let value: string | undefined = undefined;
 
-	let searchParameterValue = getFromSearchParameters(parameter);
-	let localStorageValue = getFromLocalStorage(parameter, persist);
+  const searchParameterValue = getFromSearchParameters(parameter);
+  const localStorageValue = getFromLocalStorage(parameter, persist);
 
-	if (searchParameterValue !== undefined) {
-		saveToLocalStorage(parameter, searchParameterValue, persist);
-		value = searchParameterValue;
-	} else if (localStorageValue !== undefined) {
-		saveToSearchParameters(parameter, localStorageValue);
-		value = localStorageValue;
-	}
+  if (searchParameterValue !== undefined) {
+    saveToLocalStorage(parameter, searchParameterValue, persist);
+    value = searchParameterValue;
+  } else if (localStorageValue !== undefined) {
+    saveToSearchParameters(parameter, localStorageValue);
+    value = localStorageValue;
+  }
 
-	if (value !== undefined) {
-		if (isBoolean(defaultValue)) return toBoolean(value, defaultValue);
-		if (isNumber(defaultValue)) return toNumber(value);
-		return value;
-	}
+  if (value !== undefined) {
+    if (isBoolean(defaultValue)) return toBoolean(value, defaultValue);
+    if (isNumber(defaultValue)) return toNumber(value);
+    return value;
+  }
 
   setValue(parameter, value, persist);
-	return defaultValue;
+  return defaultValue;
 };
 
-const setValue = (parameter: string, value: SearchParameterValue, persist: boolean) => {
-	saveToLocalStorage(parameter, value, persist);
-	saveToSearchParameters(parameter, value);
+const setValue = (
+  parameter: string,
+  value: SearchParameterValue,
+  persist: boolean,
+) => {
+  saveToLocalStorage(parameter, value, persist);
+  saveToSearchParameters(parameter, value);
 };
 
 export const searchParameter = (
-	parameter: string,
-	defaultValue: SearchParameterValue,
-  persist = true
+  parameter: string,
+  defaultValue: SearchParameterValue,
+  persist = true,
 ): Writable<SearchParameterValue> => {
-	const value = getValue(parameter, defaultValue, persist);
-	const store = writable(value);
+  const value = getValue(parameter, defaultValue, persist);
+  const store = writable(value);
 
-	const set: typeof store.set = (value: SearchParameterValue) => {
-		store.set(value);
-		setValue(parameter, value, persist);
-	};
+  const set: typeof store.set = (value: SearchParameterValue) => {
+    store.set(value);
+    setValue(parameter, value, persist);
+  };
 
-	const update: typeof store.update = (updater) => {
-		store.update(updater);
-		setValue(parameter, value, persist);
-	};
+  const update: typeof store.update = (updater) => {
+    store.update(updater);
+    setValue(parameter, value, persist);
+  };
 
-	return {
-		subscribe: store.subscribe,
-		set,
-		update
-	};
+  return {
+    subscribe: store.subscribe,
+    set,
+    update,
+  };
 };

--- a/src/lib/stores/persisted-search-parameter.ts
+++ b/src/lib/stores/persisted-search-parameter.ts
@@ -26,12 +26,6 @@ const saveToSearchParameters = (parameter: string, value: SearchParameterValue) 
 		url.searchParams.set(parameter, String(value));
 
 		window?.history.replaceState(null, '', url);
-
-		// goto(url.href, {
-		// 	replaceState: true,
-		// 	keepfocus: true,
-		// 	noscroll: true
-		// });
 	}
 };
 
@@ -68,6 +62,7 @@ const getValue = (parameter: string, defaultValue: SearchParameterValue, persist
 		return value;
 	}
 
+  setValue(parameter, value, persist);
 	return defaultValue;
 };
 


### PR DESCRIPTION
Adds a store that takes a key and a value.

- When this store is loaded, it checks to see if a value has been provided in a search parameter.
- If it has not been provided by a search parameter, check for the key in LocalStorage.
- If it is in LocalStorage, use that value and update the query parameter.
- If it is not in LocalStorage, use the default value and set it in the search params and LocalStorage.
- If the value is updated, update it in the search params and LocalStorage.