### PR TITLE
Fix error parsing queries from the Java SDK

### DIFF
--- a/src/lib/utilities/get-query-types-from-error.test.ts
+++ b/src/lib/utilities/get-query-types-from-error.test.ts
@@ -13,6 +13,19 @@ const error = {
   ],
 };
 
+const javaSDKError = {
+  code: 3,
+  message:
+    'java.lang.IllegalArgumentException: Unknown query type: @@temporal-internal__list, knownTypes=[getLoan, getNextPaymentDue, getPaymentObligations, getNextPaymentObligation]\n\tat io.temporal.internal.sync.QueryDispatcher.handleQuery(QueryDispatcher.java:79)\n\tat io.temporal.internal.sync.SyncWorkflowContext.handleQuery(SyncWorkflowContext.java:277)\n\tat io.temporal.internal.sync.WorkflowExecuteRunnable.handleQuery(WorkflowExecuteRunnable.java:118)\n\tat io.temporal.internal.sync.SyncWorkflow.query(SyncWorkflow.java:187)\n\tat io.temporal.internal.replay.ReplayWorkflowExecutor.query(ReplayWorkflowExecutor.java:136)\n\tat io.temporal.internal.replay.ReplayWorkflowRunTaskHandler.handleQueryWorkflowTask(ReplayWorkflowRunTaskHandler.java:241)\n\tat io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTaskWithQuery(ReplayWorkflowTaskHandler.java:117)\n\tat io.temporal.internal.replay.ReplayWorkflowTaskHandler.handleWorkflowTask(ReplayWorkflowTaskHandler.java:97)\n\tat io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handleTask(WorkflowWorker.java:277)\n\tat io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:231)\n\tat io.temporal.internal.worker.WorkflowWorker$TaskHandlerImpl.handle(WorkflowWorker.java:173)\n\tat io.temporal.internal.worker.PollTaskExecutor.lambda$process$0(PollTaskExecutor.java:93)\n\tat java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)\n\tat java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)\n\tat java.lang.Thread.run(Thread.java:750)\n',
+  details: [
+    {
+      typeUrl:
+        'type.googleapis.com/temporal.api.errordetails.v1.QueryFailedFailure',
+      value: null,
+    },
+  ],
+};
+
 describe(getQueryTypesFromError, () => {
   it('should return an array of query types', () => {
     const queryTypes = ['__open_sessions'];
@@ -23,5 +36,14 @@ describe(getQueryTypesFromError, () => {
     expect(getQueryTypesFromError(error.message)).not.toContain(
       '__stack_trace',
     );
+  });
+
+  it('should work with the Java SDK', () => {
+    expect(getQueryTypesFromError(javaSDKError.message)).toEqual([
+      'getLoan',
+      'getNextPaymentDue',
+      'getPaymentObligations',
+      'getNextPaymentObligation',
+    ]);
   });
 });

--- a/src/lib/utilities/get-query-types-from-error.ts
+++ b/src/lib/utilities/get-query-types-from-error.ts
@@ -1,9 +1,17 @@
 export const getQueryTypesFromError = (message: string): string[] => {
+  console.log(message);
   const indexOfOpeningBracket = message.indexOf('[');
   const indexOfClosingBracket = message.indexOf(']');
 
   return message
     .slice(indexOfOpeningBracket + 1, indexOfClosingBracket)
     .split(' ')
-    .filter((query) => query !== '__stack_trace');
+    .filter((query: string) => query !== '__stack_trace')
+    .map((query: string) => {
+      if (query.endsWith(',')) {
+        return query.slice(0, query.length - 1);
+      } else {
+        return query;
+      }
+    });
 };


### PR DESCRIPTION
The Java SDK uses commas between the queries. This change solves for that.