### PR TITLE
Customize Feedback URL from settings

### DIFF
--- a/cypress/fixtures/settings-feedback-url.json
+++ b/cypress/fixtures/settings-feedback-url.json
@@ -1,0 +1,8 @@
+{
+  "Auth": { "Enabled": false, "Options": null },
+  "DefaultNamespace": "default",
+  "ShowTemporalSystemNamespace": false,
+  "FeedbackURL": "https://support.com/",
+  "NotifyOnNewVersion": true,
+  "Codec": { "Endpoint": "", "AccessToken": "" }
+}

--- a/cypress/fixtures/settings.json
+++ b/cypress/fixtures/settings.json
@@ -1,0 +1,8 @@
+{
+  "Auth": { "Enabled": false, "Options": null },
+  "DefaultNamespace": "default",
+  "ShowTemporalSystemNamespace": false,
+  "FeedbackURL": "",
+  "NotifyOnNewVersion": true,
+  "Codec": { "Endpoint": "", "AccessToken": "" }
+}

--- a/cypress/integration/feedback.spec.js
+++ b/cypress/integration/feedback.spec.js
@@ -1,0 +1,30 @@
+import settingsWithFeedbackUrl from '../fixtures/settings-feedback-url.json';
+
+describe('Give Feedback link', () => {
+  beforeEach(() => {
+    cy.interceptApi();
+
+    cy.visit('/');
+    cy.wait('@settings-api');
+  });
+
+  it('should link to Temporal UI Github issues by default', () => {
+    cy.get('[data-cy="give-feedback"]').should(
+      'have.attr',
+      'href',
+      'https://github.com/temporalio/ui/issues/new/choose',
+    );
+  });
+
+  it('should link to custom link if set in settings', () => {
+    cy.intercept(Cypress.env('VITE_API_HOST') + '/api/v1/settings*', {
+      fixture: 'settings-feedback-url.json',
+    }).as('settings-api');
+
+    cy.visit('/');
+    cy.wait('@settings-api');
+
+    const url = settingsWithFeedbackUrl.FeedbackURL;
+    cy.get('[data-cy="give-feedback"]').should('have.attr', 'href', url);
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,8 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+import settings from '../fixtures/settings.json';
+
 Cypress.Commands.add(
   'interceptApi',
   ({ namespace } = { namespace: 'default' }) => {
@@ -51,7 +53,7 @@ Cypress.Commands.add(
     }).as('user-api');
 
     cy.intercept(Cypress.env('VITE_API_HOST') + '/api/v1/settings*', {
-      Auth: { Enabled: false, Options: null },
+      ...settings,
       DefaultNamespace: namespace,
     }).as('settings-api');
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -59,6 +59,7 @@ type Settings = {
   };
   defaultNamespace: string;
   showTemporalSystemNamespace: boolean;
+  feedbackURL: string;
   runtimeEnvironment: {
     isCloud: boolean;
     isLocal: boolean;

--- a/src/lib/components/feedback-button.svelte
+++ b/src/lib/components/feedback-button.svelte
@@ -8,7 +8,7 @@
     'https://github.com/temporalio/ui/issues/new/choose';
 </script>
 
-<a {href} target="_blank">
+<a {href} target="_blank" data-cy="give-feedback">
   <div class="feedback-button">
     <div class="feedback-icon">
       <Icon class="" icon={faHeart} color="#e9d5ff" scale={0.5} />

--- a/src/lib/components/feedback-button.svelte
+++ b/src/lib/components/feedback-button.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
   import Icon from 'svelte-fa';
   import { faHeart } from '@fortawesome/free-solid-svg-icons';
+  import { page } from '$app/stores';
+
+  const href =
+    $page.stuff.settings.feedbackURL ||
+    'https://github.com/temporalio/ui/issues/new/choose';
 </script>
 
-<a href="https://github.com/temporalio/ui/issues/new/choose" target="_blank">
+<a {href} target="_blank">
   <div class="feedback-button">
     <div class="feedback-icon">
       <Icon class="" icon={faHeart} color="#e9d5ff" scale={0.5} />

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -34,6 +34,7 @@ export const fetchSettings = async (
     },
     defaultNamespace: settings?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
     showTemporalSystemNamespace: settings?.ShowTemporalSystemNamespace,
+    feedbackURL: settings?.FeedbackURL,
     runtimeEnvironment: {
       get isCloud() {
         if (EnvironmentOverride) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,5 +133,6 @@ export type SettingsResponse = {
   Codec: { Endpoint: string; PassAccessToken?: boolean; AccessToken?: string };
   DefaultNamespace: string;
   ShowTemporalSystemNamespace: boolean;
+  FeedbackURL: string;
   Version: string;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

- Sets `Give Feedback` button URL to config value or defaults to https://github.com/temporalio/ui/issues/new/choose otherwise
- Adds cypress tests for the Feedback button

## Why?
<!-- Tell your future self why have you made these changes -->

Allow admins to point their users to internal support forums instead of Temporal github
Resolve #502

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Changed feedbackURL in settings and verified it has changed to the custom value

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
