### PR TITLE
Disable version banner based on configuration

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -59,6 +59,7 @@ type Settings = {
   };
   defaultNamespace: string;
   showTemporalSystemNamespace: boolean;
+  notifyOnNewVersion: boolean;
   feedbackURL: string;
   runtimeEnvironment: {
     isCloud: boolean;

--- a/src/lib/components/banner/banners.svelte
+++ b/src/lib/components/banner/banners.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import { BannersState } from '$lib/models/banner-state';
   import BannerTemporalVersion from './banner-temporal-version.svelte';
   import BannerUIVersion from './banner-ui-version.svelte';
@@ -6,10 +7,13 @@
   export let uiVersionInfo: UiVersionInfo;
 
   let shownBanner = BannersState.TemporalVersion;
+  const notifyOnNewVersion = $page.stuff.settings.notifyOnNewVersion;
 </script>
 
-{#if shownBanner === BannersState.TemporalVersion}
-  <BannerTemporalVersion bind:shownBanner />
-{:else if shownBanner === BannersState.UIVersion}
-  <BannerUIVersion {uiVersionInfo} bind:shownBanner />
+{#if notifyOnNewVersion}
+  {#if shownBanner === BannersState.TemporalVersion}
+    <BannerTemporalVersion bind:shownBanner />
+  {:else if shownBanner === BannersState.UIVersion}
+    <BannerUIVersion {uiVersionInfo} bind:shownBanner />
+  {/if}
 {/if}

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -34,6 +34,7 @@ export const fetchSettings = async (
     },
     defaultNamespace: settings?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
     showTemporalSystemNamespace: settings?.ShowTemporalSystemNamespace,
+    notifyOnNewVersion: settings?.NotifyOnNewVersion,
     feedbackURL: settings?.FeedbackURL,
     runtimeEnvironment: {
       get isCloud() {

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -16,11 +16,6 @@
   export const load: Load = async function ({ url, fetch }) {
     const settings: Settings = await fetchSettings({ url }, fetch);
     const user = await fetchUser(fetch);
-    const recommended = await fetchLatestUiVersion(fetch);
-    const uiVersionInfo: UiVersionInfo = {
-      current: settings.version,
-      recommended,
-    };
 
     if (!isAuthorized(settings, user)) {
       return {
@@ -38,6 +33,13 @@
       settings,
     });
     const cluster: GetClusterInfoResponse = await fetchCluster(settings, fetch);
+
+    const uiVersionInfo: UiVersionInfo = {
+      current: settings.version,
+      recommended: settings.notifyOnNewVersion
+        ? await fetchLatestUiVersion(fetch)
+        : undefined,
+    };
 
     return {
       props: { user, uiVersionInfo },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -133,6 +133,7 @@ export type SettingsResponse = {
   Codec: { Endpoint: string; PassAccessToken?: boolean; AccessToken?: string };
   DefaultNamespace: string;
   ShowTemporalSystemNamespace: boolean;
+  NotifyOnNewVersion: boolean;
   FeedbackURL: string;
   Version: string;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Stops showing Version Info banners (Temporal version and UI version) depending on configuration param

## Why?
<!-- Tell your future self why have you made these changes -->

In some use cases people prefer to not show the banner

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Disabled and enabled the banner from settings, verifying that the network requests occur/do not occur + banner is shown/disabled

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
