### PR TITLE
Remove data-encoder status on login page, add login page test

### DIFF
--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -15,11 +15,16 @@ describe('Login page', () => {
 
     cy.wait('@settings-api');
     cy.wait('@user-api');
+
+    cy.get('[data-cy="navigation-header"]').as('header');
   });
 
   it('have the correct login title', () => {
     cy.get('[data-cy="login-title"]').contains('Welcome back.');
     cy.get('[data-cy="login-info"]').contains(`Let's get you signed in.`);
     cy.get('[data-cy="login-button"]').contains('Continue to SSO');
+    cy.get('@header')
+      .find('[data-cy="data-encoder-status-configured"]')
+      .should('not.exist');
   });
 });

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -1,0 +1,25 @@
+describe('Login page', () => {
+  beforeEach(() => {
+    cy.interceptApi();
+
+    cy.visit('/namespaces/default/workflows');
+
+    cy.intercept(Cypress.env('VITE_API_HOST') + '/api/v1/settings*', {
+      Auth: { Enabled: true, Options: null },
+      DefaultNamespace: 'default',
+      ShowTemporalSystemNamespace: false,
+      FeedbackURL: '',
+      NotifyOnNewVersion: true,
+      Codec: { Endpoint: '', AccessToken: '' },
+    }).as('settings-api');
+
+    cy.wait('@settings-api');
+    cy.wait('@user-api');
+  });
+
+  it('have the correct login title', () => {
+    cy.get('[data-cy="login-title"]').contains('Welcome back.');
+    cy.get('[data-cy="login-info"]').contains(`Let's get you signed in.`);
+    cy.get('[data-cy="login-button"]').contains('Continue to SSO');
+  });
+});

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -2,8 +2,6 @@ describe('Login page', () => {
   beforeEach(() => {
     cy.interceptApi();
 
-    cy.visit('/namespaces/default/workflows');
-
     cy.intercept(Cypress.env('VITE_API_HOST') + '/api/v1/settings*', {
       Auth: { Enabled: true, Options: null },
       DefaultNamespace: 'default',
@@ -12,14 +10,19 @@ describe('Login page', () => {
       NotifyOnNewVersion: true,
       Codec: { Endpoint: '', AccessToken: '' },
     }).as('settings-api');
-
-    cy.wait('@settings-api');
-    cy.wait('@user-api');
-
-    cy.get('[data-cy="navigation-header"]').as('header');
   });
 
   it('have the correct login title', () => {
+    cy.visit('/namespaces/default/workflows');
+
+    cy.wait('@settings-api');
+    cy.wait('@user-api');
+    cy.wait('@settings-api');
+
+    cy.url().should('include', `/login`);
+
+    cy.get('[data-cy="navigation-header"]').as('header');
+
     cy.get('[data-cy="login-title"]').contains('Welcome back.');
     cy.get('[data-cy="login-info"]').contains(`Let's get you signed in.`);
     cy.get('[data-cy="login-button"]').contains('Continue to SSO');

--- a/src/lib/components/hamburger-header.svelte
+++ b/src/lib/components/hamburger-header.svelte
@@ -8,6 +8,7 @@
   import FeedbackButton from '$lib/components/feedback-button.svelte';
 
   export let href: string;
+  export let user: User;
 
   $: open = false;
 </script>
@@ -28,7 +29,9 @@
     </a>
   </div>
   <div class="flex gap-4 col-span-4 justify-end items-center">
-    <DataEncoderStatus />
+    {#if user}
+      <DataEncoderStatus />
+    {/if}
   </div>
 </header>
 {#if open}

--- a/src/lib/components/navigation-header.svelte
+++ b/src/lib/components/navigation-header.svelte
@@ -3,6 +3,7 @@
   import FeedbackButton from '$lib/components/feedback-button.svelte';
 
   export let href: string;
+  export let user: User;
 </script>
 
 <header class="navigation-header" data-cy="navigation-header">
@@ -16,7 +17,9 @@
     <slot name="links" />
   </div>
   <div class="flex justify-end gap-4 col-span-5 col-end-13 items-center">
-    <DataEncoderStatus />
+    {#if user}
+      <DataEncoderStatus />
+    {/if}
     <FeedbackButton />
     <slot name="user" />
   </div>

--- a/src/routes/_header-responsive.svelte
+++ b/src/routes/_header-responsive.svelte
@@ -18,7 +18,7 @@
     $page.params.namespace || $page.stuff?.settings?.defaultNamespace;
 </script>
 
-<HamburgerHeader href={routeForWorkflows({ namespace })}>
+<HamburgerHeader href={routeForWorkflows({ namespace })} {user}>
   <svelte:fragment slot="action">
     <NamespaceSelect />
   </svelte:fragment>

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -18,7 +18,7 @@
   export let user: User;
 </script>
 
-<NavigationHeader href={routeForWorkflows({ namespace })}>
+<NavigationHeader href={routeForWorkflows({ namespace })} {user}>
   <svelte:fragment slot="logo">
     <NamespaceSelect />
   </svelte:fragment>

--- a/src/routes/import/_import-header-responsive.svelte
+++ b/src/routes/import/_import-header-responsive.svelte
@@ -8,7 +8,7 @@
   export let user: User;
 </script>
 
-<HamburgerHeader href="/">
+<HamburgerHeader href="/" {user}>
   <svelte:fragment slot="links">
     <NavigationLink href={routeForImport({ importType: 'events' })}>
       Import

--- a/src/routes/import/_import-header.svelte
+++ b/src/routes/import/_import-header.svelte
@@ -7,7 +7,7 @@
   export let user: User;
 </script>
 
-<NavigationHeader href="/">
+<NavigationHeader href="/" {user}>
   <svelte:fragment slot="links">
     <NavigationLink href={routeForImport({ importType: 'events' })}>
       Import

--- a/src/routes/login/index@login.svelte
+++ b/src/routes/login/index@login.svelte
@@ -28,17 +28,19 @@
 
 <script lang="ts">
   import NavigationHeader from '$lib/components/navigation-header.svelte';
+  import HamburgerHeader from '$lib/components/hamburger-header.svelte';
 
   export let settings: Settings;
 </script>
 
-<NavigationHeader href="/" />
+<NavigationHeader href="/" user={undefined} />
+<HamburgerHeader href="/" user={undefined} />
 <section class="text-center my-[20vh]">
-  <h1 class="text-8xl font-semibold">Welcome back.</h1>
-  <p class="my-7">Let's get you signed in.</p>
+  <h1 class="text-8xl font-semibold" data-cy="login-title">Welcome back.</h1>
+  <p class="my-7" data-cy="login-info">Let's get you signed in.</p>
   <div class="mx-auto">
     <Button
-      classes=""
+      dataCy="login-button"
       login
       icon={faLock}
       on:click={() => {

--- a/src/routes/signin/index@signin.svelte
+++ b/src/routes/signin/index@signin.svelte
@@ -28,11 +28,13 @@
 
 <script lang="ts">
   import NavigationHeader from '$lib/components/navigation-header.svelte';
+  import HamburgerHeader from '$lib/components/hamburger-header.svelte';
 
   export let settings: Settings;
 </script>
 
-<NavigationHeader href="/" />
+<NavigationHeader href="/" user={undefined} />
+<HamburgerHeader href="/" user={undefined} />
 <section class="text-center my-[20vh]">
   <h1 class="text-8xl font-semibold">Welcome back.</h1>
   <p class="my-7">Let's get you signed in.</p>


### PR DESCRIPTION
## What was changed
Don't show data-encoder status button in header if a user is on the login page since they cannot use it until they are signed in. Add cypress test for login page.

## Why?
Prevent users from having access to feature they can't use until logged in.
