### PR TITLE
Move query and searchType out of load

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -7,17 +7,14 @@
   const defaultQuery = toListWorkflowQuery({ timeRange: '1 day' });
 
   export const load: Load = async function ({ params, url }) {
-    const searchType = getSearchType(url);
-
     if (!url.searchParams.has('query')) {
       url.searchParams.set('query', defaultQuery);
     }
 
-    const query = url.searchParams.get('query');
     const { namespace } = params;
 
     return {
-      props: { namespace, searchType, query },
+      props: { namespace },
     };
   };
 </script>
@@ -39,10 +36,12 @@
   import WorkflowsSummaryRow from './_workflows-summary-row.svelte';
   import WorkflowFilters from './_workflow-filters.svelte';
   import WorkflowsLoading from './_workflows-loading.svelte';
+  import { page } from '$app/stores';
 
   export let namespace: string;
-  export let searchType: 'basic' | 'advanced';
-  export let query: string;
+
+  let searchType: 'basic' | 'advanced' = getSearchType($page.url);
+  let query = $page.url.searchParams.get('query');
 
   const errorMessage =
     searchType === 'advanced'


### PR DESCRIPTION
## What was changed
When there are no workflows found for a query and you try to toggle between basic and advanced search, it gets stuck. This fixes that issue by moving the query and searchType out of the load function.

https://user-images.githubusercontent.com/7967403/168147041-9ba0e43a-8436-4384-aa3a-cdf30d8d8a4f.mov


