### PR TITLE
Format Max Retries from 0 to Unlimited, consolidate event groupings

### DIFF
--- a/src/lib/utilities/format-event-attributes.test.ts
+++ b/src/lib/utilities/format-event-attributes.test.ts
@@ -133,8 +133,9 @@ describe(attributeGroups, () => {
       'identity',
       'firstExecutionRunId',
       'attempt',
+      'parentInitiatedEventId',
     ]);
-    expect(groups.parent).toEqual(['parentInitiatedEventId']);
+    expect(groups.parent).toEqual([]);
     expect(groups.activity).toEqual([]);
     expect(groups.taskQueue).toEqual(['taskQueueKind', 'taskQueueName']);
     expect(groups.schedule).toEqual([]);

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -18,6 +18,15 @@ const keysToExpand: Readonly<Set<string>> = new Set([
   'workflowExecution',
 ]);
 
+const keysToFormat: Readonly<Set<string>> = new Set(['maximumAttempts']);
+
+const formatValue = (key: string, value: unknown) => {
+  if (key === 'maximumAttempts' && value === 0) {
+    return 'Unlimited';
+  }
+  return value;
+};
+
 const formatNestedAttributes = (
   attributes: CombinedAttributes,
   key: string,
@@ -26,7 +35,14 @@ const formatNestedAttributes = (
     for (const [nestedKey, nestedValue] of Object.entries(attributes[key])) {
       const shouldDisplayNested = shouldDisplayNestedAttribute(nestedValue);
       if (shouldDisplayNested) {
-        attributes[`${key}${capitalize(nestedKey)}`] = nestedValue;
+        if (keysToFormat.has(nestedKey)) {
+          attributes[`${key}${capitalize(nestedKey)}`] = formatValue(
+            nestedKey,
+            nestedValue,
+          );
+        } else {
+          attributes[`${key}${capitalize(nestedKey)}`] = nestedValue;
+        }
       }
     }
     delete attributes[key];
@@ -93,6 +109,42 @@ export type AttributeGrouping = Partial<
   Record<AttributeGroup, EventAttributeKey[]>
 >;
 
+const consolidateActivityGroups = (
+  event: IterableEvent,
+  groupedAttributes: AttributeGrouping,
+) => {
+  // Move activity group into summary if activity
+  if (event.category === 'activity' && groupedAttributes?.activity?.length) {
+    groupedAttributes.summary = [
+      ...groupedAttributes?.activity,
+      ...groupedAttributes.summary,
+    ];
+    groupedAttributes.activity = [];
+  }
+
+  // Move workflow group into summary if activity
+  if (event.category === 'activity' && groupedAttributes?.workflow?.length) {
+    groupedAttributes.summary = [
+      ...groupedAttributes.summary,
+      ...groupedAttributes?.workflow,
+    ];
+    groupedAttributes.workflow = [];
+  }
+};
+
+const consolidateSingleItemGroups = (groupedAttributes: AttributeGrouping) => {
+  const keysToIgnore: Readonly<Set<string>> = new Set([
+    'summary',
+    'searchAttributes',
+  ]);
+  for (const [key, value] of Object.entries(groupedAttributes)) {
+    if (value.length === 1 && !keysToIgnore.has(key)) {
+      groupedAttributes.summary = [...groupedAttributes.summary, ...value];
+      groupedAttributes[key] = [];
+    }
+  }
+};
+
 export const attributeGroups = (
   event: IterableEvent,
   attributes: CombinedAttributes,
@@ -121,13 +173,8 @@ export const attributeGroups = (
     }
   }
 
-  if (event.category === 'activity' && groupedAttributes?.workflow?.length) {
-    groupedAttributes.summary = [
-      ...groupedAttributes.summary,
-      ...groupedAttributes?.workflow,
-    ];
-    groupedAttributes.workflow = [];
-  }
+  consolidateActivityGroups(event, groupedAttributes);
+  consolidateSingleItemGroups(groupedAttributes);
 
   return groupedAttributes;
 };


### PR DESCRIPTION
## What was changed
If Retry Policy Maximum Attempts equals 0, rename to 'Unlimited' to be more accurate. Move activity grouping into summary grouping if activity category, move single item groupings into summary grouping.

<img width="1672" alt="Screen Shot 2022-05-16 at 9 22 58 AM" src="https://user-images.githubusercontent.com/7967403/168614824-eaedf6b2-7946-432c-97b2-5d20ee30cc8a.png">

## Why?
More informative tagging, less click actions to view event history details