### PR TITLE
Remove onError in workflow-service and redirect to login on 403

### DIFF
--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -41,12 +41,6 @@ export const fetchAllWorkflows = async (
   let onError: ErrorCallback;
   let error: string;
 
-  if (parameters.query) {
-    onError = (response) => {
-      error = response.body.message;
-    };
-  }
-
   const { executions, nextPageToken } =
     (await requestFromAPI<ListWorkflowExecutionsResponse>(
       routeForApi(endpoint, { namespace }),

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -11,8 +11,8 @@ export const handleError = (error: unknown): void => {
     return;
   }
 
-  if (isForbidden(error)) {
-    notifications.add('error', `${error.statusCode} ${error.statusText}`);
+  if (isForbidden(error) && browser) {
+    window.location.assign(routeForLoginPage());
     return;
   }
 


### PR DESCRIPTION
## What was changed
The workflow service prevented us from reaching the handleError logic with it's own onError handler that wasn't being used. This PR removes that onError handler and updates the handleError function to redirect to /login when a 403 is returned from the api.

## Why?
Prevent users who are unauthorized or have an expired token from seeing empty workflow page and instead redirect back to login page.

