### PR TITLE
Show 404 for non-existent namespace, show API error message on error page

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -45,6 +45,7 @@ interface NetworkError {
   statusCode: number;
   statusText: string;
   response: Response;
+  message?: string;
 }
 
 type Settings = {

--- a/src/lib/components/error.svelte
+++ b/src/lib/components/error.svelte
@@ -10,6 +10,7 @@
 
   export let error: globalThis.Error = null;
   export let status = 500;
+  let message = error?.message || '';
 
   if (isNetworkError(error)) {
     status = error.statusCode;
@@ -27,6 +28,10 @@
 <section aria-roledescription="error" class="text-center align-middle mt-32">
   <h1 class="text-[12rem] font-semibold ">{status}</h1>
   <p class="-mt-6 mb-5 text-lg">Uh oh. There's an error.</p>
+  <p class="my-4 text-2xl text-red-700 w-auto font-extrabold">
+    {message}
+  </p>
+
   <p class="text-lg">
     <Link
       href={currentLocation}

--- a/src/lib/utilities/get-namespace.ts
+++ b/src/lib/utilities/get-namespace.ts
@@ -15,13 +15,12 @@ export const getNamespace = ({
   namespace,
   defaultNamespace,
   namespaces,
-}: GetNamespaceParameters): string => {
-  if (
-    namespace &&
-    namespaces &&
-    namespaces.find((ns) => ns.namespaceInfo.name === namespace)
-  ) {
-    return namespace;
+}: GetNamespaceParameters): string | undefined => {
+  if (namespace && namespaces) {
+    if (namespaces.find((ns) => ns.namespaceInfo.name === namespace)) {
+      return namespace;
+    }
+    return;
   }
 
   return defaultNamespace;

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -83,6 +83,7 @@ export const requestFromAPI = async <T>(
           statusCode: response.status,
           statusText: response.statusText,
           response,
+          message: body?.message ?? response.statusText,
         } as NetworkError;
       }
     }

--- a/src/lib/utilities/stores/with-loading.ts
+++ b/src/lib/utilities/stores/with-loading.ts
@@ -8,7 +8,11 @@ export const withLoading = async (
   fn: () => Promise<void>,
 ): Promise<void> => {
   updating.set(true);
-  await fn();
+  try {
+    await fn();
+  } catch (error) {
+    console.error(error);
+  }
   loading.set(false);
   setTimeout(() => {
     updating.set(false);

--- a/src/routes/namespaces/[namespace]/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/index@root.svelte
@@ -4,18 +4,30 @@
   import { routeForWorkflows } from '$lib/utilities/route-for';
   import { getNamespace } from '$lib/utilities/get-namespace';
 
-  export const load: Load = async ({ stuff }) => {
+  export const load: Load = async ({ stuff, params }) => {
     const namespaces = stuff.namespaces;
     const defaultNamespace = stuff?.settings?.defaultNamespace;
 
-    const namespace = getNamespace({ namespaces, defaultNamespace });
-    const redirect = routeForWorkflows({
-      namespace,
+    const namespace = getNamespace({
+      namespace: params.namespace,
+      namespaces,
+      defaultNamespace,
     });
 
+    if (namespace) {
+      const redirect = routeForWorkflows({
+        namespace,
+      });
+
+      return {
+        status: 302,
+        redirect,
+      };
+    }
+
     return {
-      status: 302,
-      redirect,
+      error: `Namespace ${params.namespace} does not exist`,
+      status: 404,
     };
   };
 </script>

--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -20,7 +20,6 @@
 </script>
 
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { timeFormat } from '$lib/stores/time-format';
   import { workflows, loading, updating } from '$lib/stores/workflows';
 


### PR DESCRIPTION
## What was changed
1. Show api error message on error page.
2. We redirect to defaultNamespace if a non-existent namespace is entered in URL. This now shows a 404 page with error message for better error handling. 


<img width="1721" alt="Screen Shot 2022-05-17 at 3 17 03 PM" src="https://user-images.githubusercontent.com/7967403/168902412-673cd7b6-17c9-4d1a-aea9-46efbe7786b9.png">

<img width="1717" alt="Screen Shot 2022-05-17 at 3 16 26 PM" src="https://user-images.githubusercontent.com/7967403/168902315-c0fa5cad-add2-45e6-b6da-81828461be11.png">


## Why?
More information to user to understand errors

## Todo

- [ ] Change style of error message?