### PR TITLE
Remove url from layout load function to prevent refetching on every page change

### DIFF
--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -6,14 +6,7 @@ import type { SettingsResponse } from '$types';
 
 const isCloudMatch = /tmprl\.cloud$/;
 
-interface FetchSettingsInterface {
-  url: URL;
-}
-
-export const fetchSettings = async (
-  { url }: FetchSettingsInterface,
-  request = fetch,
-): Promise<Settings> => {
+export const fetchSettings = async (request = fetch): Promise<Settings> => {
   const settings: SettingsResponse = await requestFromAPI(
     routeForApi('settings'),
     { request },
@@ -42,14 +35,14 @@ export const fetchSettings = async (
           return EnvironmentOverride === 'cloud';
         }
 
-        return isCloudMatch.test(url.hostname);
+        return isCloudMatch.test(browser ? window.location.hostname : '');
       },
       get isLocal() {
         if (EnvironmentOverride) {
           return EnvironmentOverride === 'local';
         }
 
-        return isCloudMatch.test(url.hostname);
+        return isCloudMatch.test(browser ? window.location.hostname : '');
       },
       envOverride: Boolean(EnvironmentOverride),
     },

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -13,8 +13,8 @@
   import { isAuthorized } from '$lib/utilities/is-authorized';
   import type { GetClusterInfoResponse } from '$types';
 
-  export const load: Load = async function ({ url, fetch }) {
-    const settings: Settings = await fetchSettings({ url }, fetch);
+  export const load: Load = async function ({ fetch }) {
+    const settings: Settings = await fetchSettings(fetch);
     const user = await fetchUser(fetch);
 
     if (!isAuthorized(settings, user)) {

--- a/src/routes/import/__layout-import.svelte
+++ b/src/routes/import/__layout-import.svelte
@@ -7,8 +7,8 @@
   import { fetchUser } from '$lib/services/user-service';
   import { fetchCluster } from '$lib/services/cluster-service';
 
-  export const load: Load = async function ({ url, fetch }) {
-    const settings: Settings = await fetchSettings({ url }, fetch);
+  export const load: Load = async function ({ fetch }) {
+    const settings: Settings = await fetchSettings(fetch);
 
     const user = await fetchUser(fetch);
     const cluster = await fetchCluster(settings, fetch);

--- a/src/routes/login/index@login.svelte
+++ b/src/routes/login/index@login.svelte
@@ -10,8 +10,8 @@
 
   import type { Load } from '@sveltejs/kit';
 
-  export const load: Load = async function ({ url }) {
-    const settings: Settings = await fetchSettings({ url });
+  export const load: Load = async function ({ fetch }) {
+    const settings: Settings = await fetchSettings(fetch);
 
     if (!settings.auth.enabled) {
       return {

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/compact/index.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/compact/index.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import EventSummary from '$lib/components/event/event-summary.svelte';
   import { ascendingEventGroups } from '$lib/stores/events';
-  import { eventGroups } from '$lib/stores/events';
 </script>
 
 <EventSummary

--- a/src/routes/signin/index@signin.svelte
+++ b/src/routes/signin/index@signin.svelte
@@ -10,8 +10,8 @@
 
   import type { Load } from '@sveltejs/kit';
 
-  export const load: Load = async function ({ url }) {
-    const settings: Settings = await fetchSettings({ url });
+  export const load: Load = async function ({ fetch }) {
+    const settings: Settings = await fetchSettings(fetch);
 
     if (!settings.auth.enabled) {
       return {


### PR DESCRIPTION
## What was changed
Removed { url } parameter from the root layout load function to prevent our app from refetching the following endpoints on every url change. 

- settings
- user
- namespaces
- cluster
- version

The url parameter was only used in the settings service, which can use the window.location.pathname instead of url.hostname. 


<!-- Describe what has changed in this PR -->

## Why?
Better performance, less api calls.

## Checklist

- [ ] Any reason to not do this? Do we need/want to refetch user/settings/namespaces more frequently?

