### PR TITLE
Fix lint warning

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,4 +37,13 @@ module.exports = {
       extends: ['plugin:cypress/recommended'],
     },
   ],
+  rules: {
+    '@typescript-eslint/no-unused-vars': [
+      1,
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
+  },
 };

--- a/cypress/plugins/index.cjs
+++ b/cypress/plugins/index.cjs
@@ -15,8 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-// eslint-disable-next-line no-unused-vars
-module.exports = (on, config) => {
+module.exports = (_on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   return config;

--- a/src/lib/components/event/event-details-full.svelte
+++ b/src/lib/components/event/event-details-full.svelte
@@ -23,7 +23,7 @@
     activePill = event.detail.key;
   };
 
-  const handleGroupClick = (id) => (selectedId = id);
+  const handleGroupClick = (id: string) => (selectedId = id);
 </script>
 
 {#if compact && eventGroup}

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -56,8 +56,7 @@ const createGroupFor = <K extends keyof StartingEvents>(
       return getLastEvent(this)?.attributes;
     },
     get eventList() {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      return Array.from(this.events, ([key, value]) => value);
+      return Array.from(this.events, ([_key, value]) => value);
     },
     get isFailureOrTimedOut() {
       return Boolean(this.eventList.find(eventIsFailureOrTimedOut));

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -108,7 +108,7 @@ export const updateEventHistory: StartStopNotifier<FetchEventsResponse> = (
   set,
 ) => {
   return parametersWithSettings.subscribe(async (params) => {
-    const { settings, ...rest } = params;
+    const { settings: _, ...rest } = params;
     if (isNewRequest(rest, previous)) {
       withLoading(loading, updating, async () => {
         const events = await fetchEvents(params);


### PR DESCRIPTION
## Description

<!-- Add a brief description of your change here. -->

Fixes this warning:

<img width="1077" alt="image" src="https://user-images.githubusercontent.com/251288/169702232-20a01cf1-7337-4257-a0f0-ab1b4f2bb97b.png">

Also, if we don't like warnings passing CI, we could do `eslint --ignore-path .gitignore --max-warnings 0 .`