### PR TITLE
Update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-Temporal must be running in development. ([See our documentation](https://docs.temporal.io/docs/server/quick-install) for details.)
+Temporal must be running in development. (For details, see [Run a dev Cluster](https://docs.temporal.io/application-development-guide#run-a-dev-cluster) in the documentation.)
 
 ## Trying it out
 

--- a/src/routes/namespaces/[namespace]/archival/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/archival/index@root.svelte
@@ -103,10 +103,10 @@
     inline
   />
   <p>
-    For more details please check out <a
+    For more details, please check out <a
       class="text-blue-700 underline"
-      href="https://docs.temporal.io/docs/server/archive-data/"
-      target="_blank">Archival Docs</a
+      href="https://docs.temporal.io/server/archive-data/"
+      target="_blank">Archival documentation</a
     >.
   </p>
 {:else}
@@ -128,10 +128,10 @@
     />
   {/if}
   <p>
-    For more details please check out <a
+    For more details, please check out <a
       class="text-blue-700 underline"
-      href="https://docs.temporal.io/docs/server/archive-data/"
-      target="_blank">Archival Docs</a
+      href="https://docs.temporal.io/server/archive-data/"
+      target="_blank">Archival documentation</a
     >.
   </p>
 {/if}


### PR DESCRIPTION
## What was changed?

- README.md: Updated documentation link in Prerequisites section
- index@root.svelte: Updated two documentation links

## Why?

- README.md: The previous URL was 404 because the content was moved into a larger guide
- index@root.svelte: The `/docs` portion of the URL was removed 5/23/2022

## Checklist

1. How was this tested?

   - README.md: Checked link in GitHub
   - index@root.svelte: _Not_ tested; approach with skepticism

3. Any docs updates needed?

   - Nope.