### PR TITLE
remove bottom border from Tab

### DIFF
--- a/src/lib/components/tab.svelte
+++ b/src/lib/components/tab.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <a
-  class="block text-sm md:text-base border-b-2 whitespace-nowrap"
+  class="block text-sm md:text-base whitespace-nowrap"
   class:active
   {href}
   data-cy={$$props.dataCy}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Removes the bottom border from the `Tab` component
Before
<img width="1460" alt="Screen Shot 2022-05-24 at 9 29 50 AM" src="https://user-images.githubusercontent.com/11775628/170098708-515c1279-7b1b-49d3-8c8d-37a253451f4e.png">

After
<img width="1460" alt="Screen Shot 2022-05-24 at 9 30 08 AM" src="https://user-images.githubusercontent.com/11775628/170098723-f947bcb4-f7f8-421b-b87f-74721b338529.png">

## Why?
This change was suggested by design

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Ran ui locally and visually verified the intended change was made

1. Any docs updates needed?
No
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
