### PR TITLE
add bottom border to Tab

### DIFF
--- a/src/lib/components/tab.svelte
+++ b/src/lib/components/tab.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <a
-  class="block text-sm md:text-base whitespace-nowrap"
+  class="block text-sm md:text-base border-b-2 whitespace-nowrap"
   class:active
   {href}
   data-cy={$$props.dataCy}


### PR DESCRIPTION
## What was changed
Adds a bottom border from the Tab component
Before
![image](https://user-images.githubusercontent.com/4372470/170108935-51a7f4ba-7736-4f35-baaa-8689bd115ca9.png)

After
![image](https://user-images.githubusercontent.com/4372470/170108906-131ce231-bad5-4f49-a57b-efbf60b60450.png)

## Why?
This change was suggested by me

## Checklist
1. How was this tested:
Ran ui locally and visually verified the intended change was made

2. Any docs updates needed?
No