### PR TITLE
Collapse Input & Result by default

### DIFF
--- a/cypress/integration/namespaces.spec.js
+++ b/cypress/integration/namespaces.spec.js
@@ -46,6 +46,6 @@ describe('Namespace Select', () => {
 
   it('have the correct namespaces in the dropdown when using navigation header', () => {
     cy.get('@namespace-select-button').click({ wait: 1000 });
-    cy.get('[data-cy="namespace-list"]').children().should('have.length', 2);
+    cy.get('.prose > .text-2xl').contains('Select a namespace');
   });
 });

--- a/cypress/integration/namespaces.spec.js
+++ b/cypress/integration/namespaces.spec.js
@@ -45,7 +45,6 @@ describe('Namespace Select', () => {
   });
 
   it('have the correct namespaces in the dropdown when using navigation header', () => {
-    cy.viewport(1500, 600);
     cy.get('@namespace-select-button').click({ wait: 1000 });
     cy.get('[data-cy="namespace-list"]').children().should('have.length', 2);
   });

--- a/cypress/integration/workflow-input-and-results.spec.js
+++ b/cypress/integration/workflow-input-and-results.spec.js
@@ -38,6 +38,7 @@ describe('Workflow Input and Results', () => {
     cy.visit(`/namespaces/default/workflows/${workflowId}/${runId}`);
 
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsCompletedFixture.history.events[0];
     const input = Buffer.from(
@@ -55,6 +56,7 @@ describe('Workflow Input and Results', () => {
         .data,
       'base64',
     ).toString();
+
     cy.get('[data-cy="workflow-results"]').contains(results);
   });
 
@@ -69,6 +71,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsCompletedNullFixture.history.events[0];
     const input = Buffer.from(
@@ -103,6 +106,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsRunningFixture.history.events[0];
     const input = Buffer.from(
@@ -110,7 +114,7 @@ describe('Workflow Input and Results', () => {
       'base64',
     ).toString();
     cy.get('[data-cy="workflow-input"]').contains(input);
-    cy.get('[data-cy="workflow-results"]').contains('In progress');
+    cy.get('[data-cy="result-code-block"]').should('not.exist');
   });
 
   it('should show the input and results for failed workflow', () => {
@@ -124,6 +128,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsFailedFixture.history.events[0];
     const input = Buffer.from(
@@ -153,6 +158,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsCanceledFixture.history.events[0];
     const input = Buffer.from(
@@ -174,6 +180,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsTimedOutFixture.history.events[0];
     const input = Buffer.from(
@@ -195,6 +202,7 @@ describe('Workflow Input and Results', () => {
 
     cy.wait('@workflow-api');
     cy.wait('@event-history-api');
+    cy.get('[data-cy="workflow-input-results-toggle"]').click();
 
     const firstEvent = eventsContinuedAsNewFixture.history.events[0];
     const input = Buffer.from(

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -55,7 +55,7 @@
         >{#if isJSON}{formatJSON(content)}{:else}{@html content}{/if}</code
       ></pre>
 
-    <button on:click={copy} class="absolute top-4 right-4">
+    <button on:click|stopPropagation={copy} class="absolute top-4 right-4">
       <Icon icon={copied ? faCheck : faCopy} color="white" />
     </button>
   </div>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -99,8 +99,7 @@
   </section>
   <WorkflowStackTraceError {workflow} {workers} />
   <section class="flex gap-4 w-full flex-col lg:flex-row">
-    <InputAndResults type="input" />
-    <InputAndResults type="results" />
+    <InputAndResults running={workflow.isRunning} />
   </section>
   <PendingActivties />
   <section id="event-history">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -43,7 +43,11 @@
           <div class="w-full">
             {#if resultsContent}
               <h3 class="text-base text-gray-900">Result</h3>
-              <CodeBlock content={resultsContent} class="mb-2 max-h-96" />
+              <CodeBlock
+                content={resultsContent}
+                data-cy="result-code-block"
+                class="mb-2 max-h-96"
+              />
             {/if}
           </div>
         </article>
@@ -51,7 +55,11 @@
     {/if}
   </div>
   <div class="h-8 w-8">
-    <div class="expand-icon" on:click={() => (showContent = !showContent)}>
+    <div
+      class="expand-icon"
+      on:click={() => (showContent = !showContent)}
+      data-cy="workflow-input-results-toggle"
+    >
       {showContent ? '-' : '+'}
     </div>
   </div>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -1,39 +1,73 @@
 <script lang="ts">
   import Icon from 'svelte-fa';
   import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+  import { fade } from 'svelte/transition';
 
   import { events } from '$lib/stores/events';
 
   import { getWorkflowStartedAndCompletedEvents } from '$lib/utilities/get-started-and-completed-events';
-  import { capitalize } from '$lib/utilities/format-camel-case';
 
   import CodeBlock from '$lib/components/code-block.svelte';
 
-  export let type: 'input' | 'results';
+  export let running: boolean;
 
-  $: title = capitalize(type);
-  $: content = getWorkflowStartedAndCompletedEvents($events)[type];
+  $: inputContent = getWorkflowStartedAndCompletedEvents($events)['input'];
+  $: resultsContent = getWorkflowStartedAndCompletedEvents($events)['results'];
+
+  let showContent = false;
 </script>
 
 <article
-  class="flex flex-col border-2 border-gray-300 p-4 rounded-lg w-full lg:w-1/2"
-  data-cy="workflow-{type}"
+  class="flex flex-row justify-between border-2 border-gray-300 p-4 rounded-lg w-full"
+  class:expanded={showContent}
+  data-cy="input-and-results"
 >
-  <h3 class="text-lg">{title}</h3>
-  {#if content}
-    <CodeBlock {content} class="mb-2 max-h-96" />
-  {:else}
-    <div class="my-12 flex flex-col justify-start items-center gap-2">
-      <div
-        class="flex rounded-full items-center justify-center w-16 h-16 bg-gray-200"
-      >
-        <Icon
-          icon={faSpinner}
-          scale={1.2}
-          class="block w-full h-full animate-spin"
-        />
+  <div class="w-full">
+    <h3 class="text-lg">
+      Input & Result
+      {#if running}
+        <Icon icon={faSpinner} scale={0.8} class="inline animate-spin" />
+      {/if}
+    </h3>
+    {#if showContent}
+      <div class="flex flex-col lg:flex-row gap-4">
+        <article class="flex flex-col py-4 w-full" data-cy="workflow-input">
+          <div class="w-full">
+            <h3 class="text-base text-gray-900">Input</h3>
+            {#if inputContent}
+              <CodeBlock content={inputContent} class="mb-2 max-h-96" />
+            {/if}
+          </div>
+        </article>
+        <article class="flex flex-col py-4 w-full" data-cy="workflow-results">
+          <div class="w-full">
+            {#if resultsContent}
+              <h3 class="text-base text-gray-900">Result</h3>
+              <CodeBlock content={resultsContent} class="mb-2 max-h-96" />
+            {/if}
+          </div>
+        </article>
       </div>
-      <h2 class="text-xl font-medium">In progress…</h2>
+    {/if}
+  </div>
+  <div class="h-8 w-8">
+    <div class="expand-icon" on:click={() => (showContent = !showContent)}>
+      {showContent ? '-' : '+'}
     </div>
-  {/if}
+  </div>
 </article>
+
+<style lang="postcss">
+  .expanded {
+    @apply pb-8;
+  }
+
+  .expand-icon {
+    @apply text-center text-3xl px-1 pt-2 pb-2 leading-4 text-gray-900 rounded-full cursor-pointer select-none;
+  }
+  .expand-icon:hover {
+    @apply bg-gray-100;
+    transition: background-color 0.3s linear;
+    -webkit-transition: background-color 0.3s linear;
+  }
+</style>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -18,9 +18,10 @@
 </script>
 
 <article
-  class="flex flex-row justify-between border-2 border-gray-300 p-4 rounded-lg w-full"
+  class="input-and-results"
   class:expanded={showContent}
-  data-cy="input-and-results"
+  data-cy="workflow-input-results-toggle"
+  on:click={() => (showContent = !showContent)}
 >
   <div class="w-full">
     <h3 class="text-lg">
@@ -54,28 +55,30 @@
       </div>
     {/if}
   </div>
-  <div class="h-8 w-8">
-    <div
-      class="expand-icon"
-      on:click={() => (showContent = !showContent)}
-      data-cy="workflow-input-results-toggle"
-    >
+  <div class="h-8 w-8 text-center">
+    <div class="expand-icon">
       {showContent ? '-' : '+'}
     </div>
   </div>
 </article>
 
 <style lang="postcss">
-  .expanded {
-    @apply pb-8;
+  .input-and-results {
+    @apply flex flex-row justify-between border-2 border-gray-300 p-4 rounded-lg w-full cursor-pointer;
+  }
+  .expand-icon {
+    @apply text-2xl rounded-full select-none;
   }
 
   .expand-icon {
-    @apply text-center text-3xl px-1 pt-2 pb-2 leading-4 text-gray-900 rounded-full cursor-pointer select-none;
+    transition: all 0.5s ease-in-out;
   }
-  .expand-icon:hover {
-    @apply bg-gray-100;
-    transition: background-color 0.3s linear;
-    -webkit-transition: background-color 0.3s linear;
+
+  .input-and-results:hover .expand-icon {
+    @apply bg-gray-200;
+    transform: scale(1.2);
+  }
+  .expanded {
+    @apply pb-8;
   }
 </style>


### PR DESCRIPTION
## What was changed
Do not show Input and Result of workflow by default, make them expandable:

<img width="1728" alt="Screen Shot 2022-05-26 at 10 16 24 AM" src="https://user-images.githubusercontent.com/7967403/170521254-d41dc724-b417-4cba-9445-6299c6ae902e.png">
<img width="1728" alt="Screen Shot 2022-05-26 at 10 19 29 AM" src="https://user-images.githubusercontent.com/7967403/170521273-dd3f8376-5de6-436f-906c-f3799c513c76.png">
<img width="1728" alt="Screen Shot 2022-05-26 at 10 17 13 AM" src="https://user-images.githubusercontent.com/7967403/170521264-c206deec-4885-4542-95e4-6fdec6871b5e.png">

## Why?
Feedback showed that it wasn't necessary to show input/result by default and it took up a lot of real estate on the screen when they just want to scroll to events.

