### PR TITLE
Add tmprl-test as cloud domain

### DIFF
--- a/src/lib/services/settings-service.test.ts
+++ b/src/lib/services/settings-service.test.ts
@@ -1,0 +1,17 @@
+import { isCloudMatch } from './settings-service';
+
+describe('isCloudMatch', () => {
+  it('should return true for tmprl.cloud', () => {
+    expect(isCloudMatch.test('tmprl.cloud')).toBe(true);
+  });
+
+  it('should return true for tmprl-test.cloud', () => {
+    expect(isCloudMatch.test('tmprl.cloud')).toBe(true);
+  });
+
+  it('should return false for non Temporal domains', () => {
+    expect(isCloudMatch.test(undefined)).toBe(false);
+    expect(isCloudMatch.test('xxx.xxx')).toBe(false);
+    expect(isCloudMatch.test('localhost:3000')).toBe(false);
+  });
+});

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -4,7 +4,7 @@ import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 import type { SettingsResponse } from '$types';
 
-const isCloudMatch = /tmprl\.cloud$/;
+export const isCloudMatch = /(tmprl\.cloud|tmprl-test\.cloud)$/;
 
 export const fetchSettings = async (request = fetch): Promise<Settings> => {
   const settings: SettingsResponse = await requestFromAPI(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added `tmprl-test.cloud` as a cloud domain in `isCloud` check

This is a temporary approach until supporting plugins in UI Frontend

## Why?
<!-- Tell your future self why have you made these changes -->

infra team testing

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Added unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
