### PR TITLE
Add `npm install` to 'Trying it out instruction'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Starting the UI API server will give you a somewhat recent version on `localhost
 Once you have the prerequisites going, run the following:
 
 ```bash
+npm install
 npm run build:local
 npm run preview:local
 ```


### PR DESCRIPTION
Otherwise you will get
```bash
sh: 1: svelte-kit: not found
```

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
