### PR TITLE
Improve event details table layout and styling

### DIFF
--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -31,7 +31,7 @@
     <CodeBlock content={getCodeBlockValue(value)} class="w-full" {inline} />
   {:else if shouldDisplayAsWorkflowLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <h2 class="mr-3 text-sm">{format(key)}</h2>
       <div class="text-sm">
         <Copyable
           content={value}
@@ -46,7 +46,7 @@
     </div>
   {:else if shouldDisplayAsWorkersLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <h2 class="mr-3 text-sm">{format(key)}</h2>
       <div class="text-sm">
         <Copyable
           content={value}
@@ -61,7 +61,7 @@
     </div>
   {:else}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <h2 class="mr-3 text-sm">{format(key)}</h2>
       <p class="text-right text-sm xl:text-left">
         <span
           class="select-all px-2 text-gray-700"

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -25,18 +25,14 @@
   class="flex flex-row gap-2 border-b-2 border-gray-200 py-2 first:pt-0 last:border-b-0 xl:gap-4 {$$props.class}"
 >
   {#if typeof value === 'object'}
-    <h2 class="w-full items-center text-sm xl:w-1/3 xl:items-start">
+    <h2 class="min-w-fit items-center text-sm xl:items-start">
       {format(key)}
     </h2>
-    <CodeBlock
-      content={getCodeBlockValue(value)}
-      class="w-full w-96 md:w-auto xl:w-2/3"
-      {inline}
-    />
+    <CodeBlock content={getCodeBlockValue(value)} class="w-full" {inline} />
   {:else if shouldDisplayAsWorkflowLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="w-full text-sm xl:w-1/3">{format(key)}</h2>
-      <div class="w-full text-sm xl:w-2/3">
+      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <div class="text-sm">
         <Copyable
           content={value}
           container-class="flex-row-reverse xl:flex-row"
@@ -50,8 +46,8 @@
     </div>
   {:else if shouldDisplayAsWorkersLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="w-full text-sm xl:w-1/3">{format(key)}</h2>
-      <div class="w-full text-sm xl:w-2/3">
+      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <div class="text-sm">
         <Copyable
           content={value}
           container-class="flex-row-reverse xl:flex-row"
@@ -65,8 +61,8 @@
     </div>
   {:else}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="w-full text-sm xl:w-1/3">{format(key)}</h2>
-      <p class="w-full text-right text-sm xl:w-2/3 xl:text-left">
+      <h2 class="text-sm mr-3">{format(key)}</h2>
+      <p class="text-right text-sm xl:text-left">
         <span
           class="select-all px-2 text-gray-700"
           class:badge={!shouldDisplayAsPlainText(key)}>{value}</span

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -75,21 +75,32 @@
   class:canceled
   class:terminated
   data-cy="event-summary-row"
+  on:click|stopPropagation={onLinkClick}
 >
   <td class="id-cell text-left">
     <a class="mx-1 text-sm text-gray-500 md:text-base" href="#{event.id}"
       >{event.id}</a
     >
   </td>
-  <td class="cell flex text-left">
+  <td class="cell flex text-left w-1/4">
     <a
       class="mx-1 text-sm text-gray-500 md:text-base xl:hidden"
       href="#{event.id}">{event.id}</a
     >
-    <p
-      class="link event-name text-sm font-semibold md:mx-2 md:text-base"
-      on:click|stopPropagation={onLinkClick}
-    >
+    <p class="m-0 text-sm md:text-base">
+      {#if showElapsed && event.id !== initialItem.id}
+        {formatDistanceAbbreviated({
+          start: initialItem.eventTime,
+          end: currentEvent.eventTime,
+        })}
+        {timeDiffChange}
+      {:else}
+        {formatDate(event?.eventTime, $timeFormat)}
+      {/if}
+    </p>
+  </td>
+  <td class="cell text-sm font-normal text-right xl:text-left w-10">
+    <p tabindex="0" class="event-name font-semibold text-sm md:text-base">
       {#if compact && failure}
         <Icon class="inline text-red-700" icon={faClock} />
       {/if}
@@ -100,29 +111,20 @@
         <Icon class="inline text-pink-700" icon={faClock} />
       {/if}
       {event.name}
-      <Icon class="inline" icon={expanded ? faAngleUp : faAngleDown} />
     </p>
-  </td>
-  <td class="cell links text-right text-sm font-normal xl:text-left">
-    {#if showElapsed && event.id !== initialItem.id}
-      {formatDistanceAbbreviated({
-        start: initialItem.eventTime,
-        end: currentEvent.eventTime,
-      })}
-      {timeDiffChange}
-    {:else}
-      {formatDate(event?.eventTime, $timeFormat)}
-    {/if}
   </td>
   <td class="cell links">
     {#if !expanded}
       <EventDetailsRow {...getSingleAttributeForEvent(currentEvent)} inline />
     {/if}
   </td>
+  <td class="cell text-right">
+    <Icon class="inline" icon={expanded ? faAngleUp : faAngleDown} />
+  </td>
 </tr>
 {#if expanded}
   <tr class="expanded-row">
-    <td class="expanded-cell" colspan="4">
+    <td class="expanded-cell" colspan="5">
       <EventDetailsFull
         event={currentEvent}
         {compact}
@@ -139,12 +141,13 @@
   }
 
   .row:hover {
-    @apply bg-gray-50;
+    @apply bg-gray-50 cursor-pointer;
   }
 
   .expanded.row {
     @apply border-b-0;
   }
+
   .failure,
   .failure:hover {
     @apply bg-red-50;
@@ -184,14 +187,6 @@
   .expanded .cell,
   .expanded .id-cell {
     @apply border-b-0;
-  }
-
-  .link {
-    @apply cursor-pointer text-gray-900;
-  }
-
-  .row:hover .link {
-    @apply text-blue-700 underline decoration-blue-700;
   }
 
   .row:last-of-type .cell,

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -82,7 +82,7 @@
       >{event.id}</a
     >
   </td>
-  <td class="cell flex text-left w-1/4">
+  <td class="cell flex w-1/4 text-left">
     <a
       class="mx-1 text-sm text-gray-500 md:text-base xl:hidden"
       href="#{event.id}">{event.id}</a
@@ -99,8 +99,8 @@
       {/if}
     </p>
   </td>
-  <td class="cell text-sm font-normal text-right xl:text-left w-10">
-    <p tabindex="0" class="event-name font-semibold text-sm md:text-base">
+  <td class="cell w-10 text-right text-sm font-normal xl:text-left">
+    <p tabindex="0" class="event-name text-sm font-semibold md:text-base">
       {#if compact && failure}
         <Icon class="inline text-red-700" icon={faClock} />
       {/if}
@@ -141,7 +141,7 @@
   }
 
   .row:hover {
-    @apply bg-gray-50 cursor-pointer;
+    @apply cursor-pointer bg-gray-50;
   }
 
   .expanded.row {

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -8,6 +8,7 @@
 
   import { eventSortOrder, eventShowElapsed } from '$lib/stores/event-view';
   import { timeFormat } from '$lib/stores/time-format';
+  import { workflowEventsColumnWidth } from '$lib/stores/column-width';
 
   import { getGroupForEvent, isEventGroup } from '$lib/models/event-groups';
   import {
@@ -20,6 +21,7 @@
     formatDistanceAbbreviated,
   } from '$lib/utilities/format-date';
   import { getSingleAttributeForEvent } from '$lib/utilities/get-single-attribute-for-event';
+  import { getTruncatedWord } from '$lib/utilities/get-truncated-word';
 
   import EventDetailsRow from './event-details-row.svelte';
   import EventDetailsFull from './event-details-full.svelte';
@@ -110,7 +112,7 @@
       {#if compact && terminated}
         <Icon class="inline text-pink-700" icon={faClock} />
       {/if}
-      {event.name}
+      {getTruncatedWord(event.name, $workflowEventsColumnWidth)}
     </p>
   </td>
   <td class="cell links">

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
 
+  import { workflowEventsColumnWidth } from '$lib/stores/column-width';
   import EventCategoryFilter from '$lib/components/event/event-category-filter.svelte';
   import EventDateFilter from '$lib/components/event/event-date-filter.svelte';
   import { expandAllEvents } from '$lib/stores/event-view';
@@ -27,12 +28,15 @@
     data-cy="event-summary-table-header-desktop"
   >
     <div class="hidden xl:table-row">
-      <div class="table-header w-8 rounded-tl-md" />
+      <div class="table-header w-12 rounded-tl-md" />
       <div class="table-header w-1/5">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>
-      <div class="table-header relative w-1/5">
+      <div
+        bind:offsetWidth={$workflowEventsColumnWidth}
+        class="table-header relative w-1/5"
+      >
         {title}<EventCategoryFilter />
       </div>
       <div class="table-header w-auto" />
@@ -51,25 +55,26 @@
     </div>
   </div>
   <div class="table-header-row-responsive rounded-t-md">
-    <div class="table-header-responsive">
+    <div class="table-header-responsive w-2/3">
       Date & Time
       {#if !compact}<EventDateFilter />{/if}
     </div>
-    <div class="table-header-responsive">
+    <div
+      bind:offsetWidth={$workflowEventsColumnWidth}
+      class="table-header-responsive w-1/3 justify-end"
+    >
       {title}<EventCategoryFilter />
     </div>
     <div class="table-header-responsive" />
-    <div class="table-header-responsive">
-      <div>
-        <input
-          class="mr-1"
-          type="checkbox"
-          name="expandAll"
-          on:change={handleChange}
-          checked={expandAll}
-        />
-        <label for="expandAll">Expand all</label>
-      </div>
+    <div class="table-header-responsive min-w-fit">
+      <input
+        class="mr-1"
+        type="checkbox"
+        name="expandAll"
+        on:change={handleChange}
+        checked={expandAll}
+      />
+      <label for="expandAll">Expand all</label>
     </div>
   </div>
   <div class="overflow-y-auto xl:table-row-group">
@@ -87,7 +92,7 @@
   }
 
   .table-header-row-responsive {
-    @apply flex justify-end bg-gray-900 px-3 text-gray-100 xl:hidden;
+    @apply flex justify-between bg-gray-900 px-3 text-gray-100 xl:hidden;
   }
 
   .table-header {

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -28,16 +28,16 @@
   >
     <div class="hidden xl:table-row">
       <div class="table-header w-8 rounded-tl-md" />
-      <div class="table-header w-1/4">
-        {title}<EventCategoryFilter />
-      </div>
-      <div class="table-header">
+      <div class="table-header w-1/5">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>
-      <div class="table-header relative w-1/2 rounded-tr-md">
-        Event Details
-        <div class="absolute right-4 top-3">
+      <div class="table-header relative w-1/5">
+        {title}<EventCategoryFilter />
+      </div>
+      <div class="table-header w-auto" />
+      <div class="table-header relative w-32 rounded-tr-md">
+        <div class="absolute right-5 top-3">
           <input
             class="mr-1"
             type="checkbox"
@@ -51,14 +51,18 @@
     </div>
   </div>
   <div class="table-header-row-responsive rounded-t-md">
-    <div class="table-header-responsive">{title}<EventCategoryFilter /></div>
     <div class="table-header-responsive">
       Date & Time
       {#if !compact}<EventDateFilter />{/if}
     </div>
     <div class="table-header-responsive">
+      {title}<EventCategoryFilter />
+    </div>
+    <div class="table-header-responsive" />
+    <div class="table-header-responsive">
       <div>
         <input
+          class="mr-1"
           type="checkbox"
           name="expandAll"
           on:change={handleChange}
@@ -87,7 +91,7 @@
   }
 
   .table-header {
-    @apply flex p-2 text-left xl:table-cell;
+    @apply flex px-3 py-2 text-left xl:table-cell;
   }
 
   .table-header-responsive {

--- a/src/lib/components/link.svelte
+++ b/src/lib/components/link.svelte
@@ -8,7 +8,7 @@
   class:text-blue-900={active}
   {...$$props}
   class="{$$props.class} underline underline-offset-2 hover:text-blue-700"
-  on:click
+  on:click|stopPropagation
 >
   <slot />
 </a>

--- a/src/lib/stores/column-width.ts
+++ b/src/lib/stores/column-width.ts
@@ -4,4 +4,3 @@ export const workflowIdColumnWidth = writable<number>(0);
 export const workflowTypeColumnWidth = writable<number>(0);
 export const workflowSummaryColumnWidth = writable<number>(0);
 export const workflowEventsColumnWidth = writable<number>(0);
-

--- a/src/lib/stores/column-width.ts
+++ b/src/lib/stores/column-width.ts
@@ -3,3 +3,5 @@ import { writable } from 'svelte/store';
 export const workflowIdColumnWidth = writable<number>(0);
 export const workflowTypeColumnWidth = writable<number>(0);
 export const workflowSummaryColumnWidth = writable<number>(0);
+export const workflowEventsColumnWidth = writable<number>(0);
+


### PR DESCRIPTION
<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- swap "Date & Time" and "Workflow Events" columns
- move caret to its own cell
- make whole row clickable to expand row
### Before:
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/11775628/171467030-4b58bced-9643-414e-bb56-c013382edb76.png">

### After:
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/11775628/171466929-047cd944-127f-4cf5-a5bd-2aca113a5b4f.png">

## Why?
Improve information architecture and ux of the event details table. Make it easier to parse by users.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Tested by running the app locally and verifying the desired layout/design changes
