### PR TITLE
use our colors for code block syntax highlighting

### DIFF
--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -13,7 +13,7 @@
 
   const copy = () =>
     navigator.clipboard
-      .writeText(isJSON ? formatJSON(JSON.stringify(content)) : content)
+      .writeText(isJSON ? formatJSON(content) : content)
       .then(() => {
         copied = !copied;
         setTimeout(() => (copied = false), 2000);

--- a/static/prism/prism.css
+++ b/static/prism/prism.css
@@ -1,10 +1,5 @@
 /* PrismJS 1.25.0
-https://prismjs.com/download.html#themes=prism-tomorrow&languages=json */
-/**
- * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
- * Based on https://github.com/chriskempson/tomorrow-theme
- * @author Rose Pritchard
- */
+https://prismjs.com/download.html#languages=json */
 
 code[class*="language-"],
 pre[class*="language-"] {
@@ -38,13 +33,14 @@ pre[class*="language-"] {
 	overflow: auto;
 }
 
-:not(pre) > code[class*="language-"],
+:not(pre)>code[class*="language-"],
 pre[class*="language-"] {
-	background: #2d2d2d;
+	/* gray-900 */
+	background: #18181b;
 }
 
 /* Inline code */
-:not(pre) > code[class*="language-"] {
+:not(pre)>code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
 	white-space: normal;
@@ -55,35 +51,41 @@ pre[class*="language-"] {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-	color: #999;
+	/* gray-400 */
+	color: #a1a1aa;
 }
 
 .token.punctuation {
-	color: #ccc;
+	/* gray-200 */
+	color: #e4e4e7;
 }
 
 .token.tag,
 .token.attr-name,
 .token.namespace,
 .token.deleted {
-	color: #e2777a;
+	/* red-400 */
+	color: #f87171;
 }
 
 .token.function-name {
-	color: #6196cc;
+	/* blue-200 */
+	color: #bfdbfe;
 }
 
 .token.boolean,
 .token.number,
 .token.function {
-	color: #f08d49;
+	/* purple-200 */
+	color: #c7d2fe;
 }
 
 .token.property,
 .token.class-name,
 .token.constant,
 .token.symbol {
-	color: #f8c555;
+	/* purple-200 */
+	color: #e9d5ff;
 }
 
 .token.selector,
@@ -91,7 +93,8 @@ pre[class*="language-"] {
 .token.atrule,
 .token.keyword,
 .token.builtin {
-	color: #cc99cd;
+	/* pink-200 */
+	color: #fbcfe8;
 }
 
 .token.string,
@@ -99,19 +102,22 @@ pre[class*="language-"] {
 .token.attr-value,
 .token.regex,
 .token.variable {
-	color: #7ec699;
+	/* green-200 */
+	color: #bbf7d0;
 }
 
 .token.operator,
 .token.entity,
 .token.url {
-	color: #67cdcc;
+	/* purple-400 */
+	color: #c084fc;
 }
 
 .token.important,
 .token.bold {
 	font-weight: bold;
 }
+
 .token.italic {
 	font-style: italic;
 }


### PR DESCRIPTION
## What was changed
Use our colors for code block syntax higlighting

### Before:
<img width="850" alt="Screen Shot 2022-06-02 at 8 33 02 AM" src="https://user-images.githubusercontent.com/11775628/171654301-3f6aa0bb-599d-470d-bf55-18e54b773b0a.png">

### After:
<img width="850" alt="Screen Shot 2022-06-02 at 8 34 33 AM" src="https://user-images.githubusercontent.com/11775628/171654338-9b8a4ca0-aa8a-456c-af5a-cc2312e4ca06.png">

## Why?
Having a consistent brand identity is important

## Checklist
1. How was this tested:
Running the app locally and visually verifying the intended changes
