### PR TITLE
Only call updateQueryParams in filter select on change of value

### DIFF
--- a/src/lib/components/select/filter-select.svelte
+++ b/src/lib/components/select/filter-select.svelte
@@ -16,17 +16,17 @@
 
   let _value = parameterValue || (value && value.toString());
 
-  $: {
+  const onChange = () => {
     updateQueryParameters({
       parameter,
       value: _value,
       url: $page.url,
       goto,
     }).then((v) => (value = v));
-  }
+  };
 </script>
 
-<Select {id} bind:value={_value} {...$$props}>
+<Select on:change={onChange} {id} bind:value={_value} {...$$props}>
   <slot>
     {#each options as option}
       <Option value={option} />


### PR DESCRIPTION
## What was changed
Only update query params from the filter select on change instead of listening for query param changes. It can cause infinite loops with pagination.

## Why?
Fix bug with pagination, only trigger updates onChange to have more predictable behavior.

