### PR TITLE
Wait on event store update to render CodeBlock for InputResults

### DIFF
--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -2,26 +2,17 @@
   import Icon from 'svelte-fa';
   import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
-  import { events } from '$lib/stores/events';
+  import { events, updating } from '$lib/stores/events';
 
   import { getWorkflowStartedAndCompletedEvents } from '$lib/utilities/get-started-and-completed-events';
   import { capitalize } from '$lib/utilities/format-camel-case';
 
   import CodeBlock from '$lib/components/code-block.svelte';
-  import { onMount } from 'svelte';
 
   export let type: 'input' | 'results';
 
   $: title = capitalize(type);
   $: content = getWorkflowStartedAndCompletedEvents($events)[type];
-
-  let open = false;
-
-  onMount(() => {
-    setTimeout(() => {
-      open = true;
-    }, 250);
-  });
 </script>
 
 <article
@@ -30,7 +21,7 @@
 >
   <h3 class="text-lg">{title}</h3>
   {#if content}
-    {#if open}
+    {#if !$updating}
       <CodeBlock {content} class="mb-2 max-h-96" />
     {:else}
       <div class="my-12 flex flex-col items-center justify-start gap-2">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -8,11 +8,20 @@
   import { capitalize } from '$lib/utilities/format-camel-case';
 
   import CodeBlock from '$lib/components/code-block.svelte';
+  import { onMount } from 'svelte';
 
   export let type: 'input' | 'results';
 
   $: title = capitalize(type);
   $: content = getWorkflowStartedAndCompletedEvents($events)[type];
+
+  let open = false;
+
+  onMount(() => {
+    setTimeout(() => {
+      open = true;
+    }, 250);
+  });
 </script>
 
 <article
@@ -21,7 +30,21 @@
 >
   <h3 class="text-lg">{title}</h3>
   {#if content}
-    <CodeBlock {content} class="mb-2 max-h-96" />
+    {#if open}
+      <CodeBlock {content} class="mb-2 max-h-96" />
+    {:else}
+      <div class="my-12 flex flex-col items-center justify-start gap-2">
+        <div
+          class="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200"
+        >
+          <Icon
+            icon={faSpinner}
+            scale={1.2}
+            class="block h-full w-full animate-spin"
+          />
+        </div>
+      </div>
+    {/if}
   {:else}
     <div class="my-12 flex flex-col items-center justify-start gap-2">
       <div

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -21,9 +21,7 @@
 >
   <h3 class="text-lg">{title}</h3>
   {#if content}
-    {#if !$updating}
-      <CodeBlock {content} class="mb-2 max-h-96" />
-    {:else}
+    {#if $updating}
       <div class="my-12 flex flex-col items-center justify-start gap-2">
         <div
           class="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200"
@@ -35,6 +33,8 @@
           />
         </div>
       </div>
+    {:else}
+      <CodeBlock {content} class="mb-2 max-h-96" />
     {/if}
   {:else}
     <div class="my-12 flex flex-col items-center justify-start gap-2">


### PR DESCRIPTION
## What was changed
Do not immediately render CodeBlock in InputAndResults. Wait for updating of event store to complete before rendering.

https://user-images.githubusercontent.com/7967403/171919030-8fbccb5e-a075-456a-b90c-a0fe734d5dc8.mov


## Why?
Currently there is a bug where if you switch between non-running workflows the input and results are stale from previous workflow. This fixes it.
