### PR TITLE
fix conflicting column widths from responsive and non-responsive col headers

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -123,7 +123,7 @@
       {#if compact && terminated}
         <Icon class="inline text-pink-700" icon={faClock} />
       {/if}
-      {getTruncatedWord(event.name, truncateWidth)}
+      {getTruncatedWord(event.name, truncateWidth - 30)}
     </p>
   </td>
   <td class="cell links">

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -8,7 +8,10 @@
 
   import { eventSortOrder, eventShowElapsed } from '$lib/stores/event-view';
   import { timeFormat } from '$lib/stores/time-format';
-  import { workflowEventsColumnWidth } from '$lib/stores/column-width';
+  import {
+    workflowEventsColumnWidth,
+    workflowEventsResponsiveColumnWidth,
+  } from '$lib/stores/column-width';
 
   import { getGroupForEvent, isEventGroup } from '$lib/models/event-groups';
   import {
@@ -67,6 +70,14 @@
   const failure = eventOrGroupIsFailureOrTimedOut(compact ? eventGroup : event);
   const canceled = eventOrGroupIsCanceled(compact ? eventGroup : event);
   const terminated = eventOrGroupIsTerminated(compact ? eventGroup : event);
+
+  let truncateWidth;
+  workflowEventsColumnWidth.subscribe((value) => {
+    if (value !== 0) truncateWidth = value;
+  });
+  workflowEventsResponsiveColumnWidth.subscribe((value) => {
+    if (value !== 0) truncateWidth = value;
+  });
 </script>
 
 <tr
@@ -112,7 +123,7 @@
       {#if compact && terminated}
         <Icon class="inline text-pink-700" icon={faClock} />
       {/if}
-      {getTruncatedWord(event.name, $workflowEventsColumnWidth)}
+      {getTruncatedWord(event.name, truncateWidth)}
     </p>
   </td>
   <td class="cell links">

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -38,7 +38,7 @@
       </div>
       <div
         bind:offsetWidth={$workflowEventsColumnWidth}
-        class="table-header relative"
+        class="table-header relative w-1/5"
       >
         {title}<EventCategoryFilter />
       </div>

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
 
-  import { workflowEventsColumnWidth } from '$lib/stores/column-width';
+  import {
+    workflowEventsColumnWidth,
+    workflowEventsResponsiveColumnWidth,
+  } from '$lib/stores/column-width';
   import EventCategoryFilter from '$lib/components/event/event-category-filter.svelte';
   import EventDateFilter from '$lib/components/event/event-date-filter.svelte';
   import { expandAllEvents } from '$lib/stores/event-view';
@@ -29,13 +32,13 @@
   >
     <div class="hidden xl:table-row">
       <div class="table-header w-12 rounded-tl-md" />
-      <div class="table-header w-1/5">
+      <div class="table-header w-80">
         Date & Time
         {#if !compact}<EventDateFilter />{/if}
       </div>
       <div
         bind:offsetWidth={$workflowEventsColumnWidth}
-        class="table-header relative w-1/5"
+        class="table-header relative"
       >
         {title}<EventCategoryFilter />
       </div>
@@ -60,7 +63,7 @@
       {#if !compact}<EventDateFilter />{/if}
     </div>
     <div
-      bind:offsetWidth={$workflowEventsColumnWidth}
+      bind:offsetWidth={$workflowEventsResponsiveColumnWidth}
       class="table-header-responsive w-1/3 justify-end"
     >
       {title}<EventCategoryFilter />

--- a/src/lib/stores/column-width.ts
+++ b/src/lib/stores/column-width.ts
@@ -4,3 +4,4 @@ export const workflowIdColumnWidth = writable<number>(0);
 export const workflowTypeColumnWidth = writable<number>(0);
 export const workflowSummaryColumnWidth = writable<number>(0);
 export const workflowEventsColumnWidth = writable<number>(0);
+export const workflowEventsResponsiveColumnWidth = writable<number>(0);


### PR DESCRIPTION
## What was changed
Bindings from 2 different table header elements were sharing a reference to the same store value, which caused an issue in some browsers. I made a unique store for each element (which displays conditionally based on the 1280px breakpoint), and wrote some logic to determine which store value to use based on which value has changed last and isn't 0.

## Why?
to fix a visual bug

## Checklist
1. How was this tested:
Running the ui locally and verifying the expected results.
