### PR TITLE
Persist workflow search query on back

### DIFF
--- a/src/lib/components/workflow/workflow-filters.svelte
+++ b/src/lib/components/workflow/workflow-filters.svelte
@@ -2,6 +2,7 @@
   import debounce from 'just-debounce';
   import { page } from '$app/stores';
   import { goto } from '$app/navigation';
+  import { workflowsSearch } from '$lib/stores/workflows';
 
   import { timeFormat } from '$lib/stores/time-format';
 
@@ -16,10 +17,10 @@
   import Search from '$lib/components/search.svelte';
 
   export let searchType: 'basic' | 'advanced';
-  export let query: string;
 
   const defaultQuery = toListWorkflowQuery({ timeRange: 'All' });
-  let parameters = toListWorkflowParameters(query ?? defaultQuery);
+  $: query = $page.url.searchParams.get('query');
+  $: parameters = toListWorkflowParameters(query ?? defaultQuery);
 
   const statuses = {
     All: null,

--- a/src/lib/pages/workflows.svelte
+++ b/src/lib/pages/workflows.svelte
@@ -12,14 +12,13 @@
   import WorkflowsSummaryRow from '$lib/components/workflow/workflows-summary-row.svelte';
   import WorkflowFilters from '$lib/components/workflow/workflow-filters.svelte';
   import WorkflowsLoading from '$lib/components/workflow/workflows-loading.svelte';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
 
   export let workflows: WorkflowExecution[];
   export let loading: boolean;
   export let updating: boolean;
 
   let searchType: 'basic' | 'advanced' = getSearchType($page.url);
-  let query = $page.url.searchParams.get('query');
 
   const errorMessage =
     searchType === 'advanced'
@@ -27,13 +26,14 @@
       : 'If you have filters applied, try adjusting them.';
 
   onDestroy(() => {
+    const query = $page.url.searchParams.get('query');
     const parameters = query ? toListWorkflowParameters(query) : {};
     $workflowsSearch = { parameters, searchType };
   });
 </script>
 
 <h2 class="text-2xl">Recent Workflows</h2>
-<WorkflowFilters bind:searchType bind:query />
+<WorkflowFilters bind:searchType />
 {#if loading}
   <WorkflowsLoading />
 {:else if workflows.length}

--- a/src/lib/pages/workflows.svelte
+++ b/src/lib/pages/workflows.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { timeFormat } from '$lib/stores/time-format';
+  import { workflowsSearch } from '$lib/stores/workflows';
 
   import { getSearchType } from '$lib/utilities/search-type-parameter';
+  import { toListWorkflowParameters } from '$lib/utilities/query/to-list-workflow-parameters';
 
   import EmptyState from '$lib/components/empty-state.svelte';
   import Pagination from '$lib/components/pagination.svelte';
@@ -10,6 +12,7 @@
   import WorkflowsSummaryRow from '$lib/components/workflow/workflows-summary-row.svelte';
   import WorkflowFilters from '$lib/components/workflow/workflow-filters.svelte';
   import WorkflowsLoading from '$lib/components/workflow/workflows-loading.svelte';
+  import { onDestroy, onMount } from 'svelte';
 
   export let workflows: WorkflowExecution[];
   export let loading: boolean;
@@ -22,6 +25,11 @@
     searchType === 'advanced'
       ? 'Please check your syntax and try again.'
       : 'If you have filters applied, try adjusting them.';
+
+  onDestroy(() => {
+    const parameters = query ? toListWorkflowParameters(query) : {};
+    $workflowsSearch = { parameters, searchType };
+  });
 </script>
 
 <h2 class="text-2xl">Recent Workflows</h2>

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -3,7 +3,7 @@ import { page } from '$app/stores';
 
 import { fetchAllWorkflows } from '$lib/services/workflow-service';
 import { withLoading } from '$lib/utilities/stores/with-loading';
-
+import type { ParsedParameters } from '$lib/utilities/query/to-list-workflow-parameters';
 import type { StartStopNotifier } from 'svelte/store';
 
 const namespace = derived([page], ([$page]) => $page.params.namespace);
@@ -24,6 +24,14 @@ const updateWorkflows: StartStopNotifier<WorkflowExecution[]> = (set) => {
   });
 };
 
+type WorkflowsSearch = {
+  parameters: ParsedParameters;
+  searchType: 'basic' | 'advanced';
+};
+export const workflowsSearch = writable<WorkflowsSearch>({
+  parameters: {},
+  searchType: 'basic',
+});
 export const updating = writable(true);
 export const loading = writable(true);
 export const workflows = readable<WorkflowExecution[]>([], updateWorkflows);

--- a/src/lib/utilities/query/to-list-workflow-parameters.ts
+++ b/src/lib/utilities/query/to-list-workflow-parameters.ts
@@ -4,7 +4,7 @@ import { durationKeys, fromDate } from '../to-duration';
 import { tokenize } from './tokenize';
 
 type Tokens = string[];
-type ParsedParameters = FilterParameters & { timeRange?: string };
+export type ParsedParameters = FilterParameters & { timeRange?: string };
 
 const is =
   (identifier: string) =>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -42,6 +42,7 @@
         href={`/namespaces/${namespace}/workflows?query=${encodeURIForSvelte(
           query,
         )}&search=${searchType}`}
+        data-cy="back-to-workflows"
         class="back-to-workflows"
       >
         <Icon name="caretLeft" class="inline" />Back to Workflows

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/_header.svelte
@@ -2,6 +2,8 @@
   import Icon from 'holocene/components/icon/index.svelte';
 
   import { eventViewType } from '$lib/stores/event-view';
+  import { workflowsSearch } from '$lib/stores/workflows';
+  import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
 
   import {
     routeForEventHistory,
@@ -17,6 +19,7 @@
   import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
   import ExportHistory from '$lib/components/export-history.svelte';
   import Tab from '$lib/components/tab.svelte';
+  import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
 
   export let namespace: string;
   export let workflow: WorkflowExecution;
@@ -27,12 +30,20 @@
     workflow: workflow.id,
     run: workflow.runId,
   };
+
+  const { parameters, searchType } = $workflowsSearch;
+  const query = toListWorkflowQuery(parameters);
 </script>
 
 <header class="flex flex-col gap-4">
   <main class="relative flex flex-col gap-1">
     <div class="-mt-3 -ml-2 block">
-      <a href="/namespaces/{namespace}/workflows" class="back-to-workflows">
+      <a
+        href={`/namespaces/${namespace}/workflows?query=${encodeURIForSvelte(
+          query,
+        )}&search=${searchType}`}
+        class="back-to-workflows"
+      >
         <Icon name="caretLeft" class="inline" />Back to Workflows
       </a>
     </div>


### PR DESCRIPTION
## What was changed
If a user selects filters on the workflows page and navigates to a specific workflow, if they click 'Back to Workflows' it will persist the filters they had applied.

https://user-images.githubusercontent.com/7967403/172928373-4bf22d25-07c1-4267-b5f6-117411586e24.mov


## Why?
Keeps users in the same context when navigating between workflows
