### PR TITLE
Show single cloud namespace in drawer

### DIFF
--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -33,7 +33,7 @@
   });
 
   // To show single namespace on cloud
-  if (isCloud && $page.params.namespace && !namespace.length) {
+  if (isCloud && $page.params.namespace && !namespaces.length) {
     const href = routeForWorkflows({ namespace: $page.params.namespace });
     namespaceList.push({
       namespace: $page.params.namespace,

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -32,6 +32,16 @@
     return { namespace, href, onClick: () => goto(href) };
   });
 
+  // To show single namespace on cloud
+  if (isCloud && $page.params.namespace && !namespaceList.length) {
+    const href = routeForWorkflows({ namespace: $page.params.namespace });
+    namespaceList.push({
+      namespace: $page.params.namespace,
+      href,
+      onClick: () => goto(href),
+    });
+  }
+
   $: linkList = {
     home: routeForWorkflows({ namespace }),
     archive: routeForArchivalWorkfows({ namespace }),

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -33,7 +33,7 @@
   });
 
   // To show single namespace on cloud
-  if (isCloud && $page.params.namespace && !namespaceList.length) {
+  if (isCloud && $page.params.namespace && !namespace.length) {
     const href = routeForWorkflows({ namespace: $page.params.namespace });
     namespaceList.push({
       namespace: $page.params.namespace,


### PR DESCRIPTION
## What was changed
Show the single namespace in cloud in drawer so it's not empty.

<img width="1727" alt="Screen Shot 2022-06-10 at 8 03 06 AM" src="https://user-images.githubusercontent.com/7967403/173070718-77376b55-7787-4f5c-9f42-10d6e28bb27a.png">

