### PR TITLE
scaffold fiction and add a few chapters

### DIFF
--- a/src/lib/stores/fiction-store.ts
+++ b/src/lib/stores/fiction-store.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const currentProps = writable<{ [index: string]: unknown }>({});

--- a/src/routes/fiction/__layout.svelte
+++ b/src/routes/fiction/__layout.svelte
@@ -1,0 +1,64 @@
+<script context="module" lang="ts">
+  import type { Load } from '@sveltejs/kit';
+
+  export const load: Load = async ({ fetch }) => {
+    const res = await fetch('/fiction/chapters');
+    if (res.ok) {
+      const json = await res.json();
+
+      return {
+        props: {
+          chapters: json.chapters,
+        },
+      };
+    }
+    return {
+      props: {
+        chapters: [],
+      },
+    };
+  };
+</script>
+
+<script lang="ts">
+  import '../../app.css';
+  import { currentProps } from '$lib/stores/fiction-store';
+  import CodeBlock from '$lib/components/code-block.svelte';
+
+  export let chapters: string[];
+</script>
+
+<svelte:head>
+  <title>Temporal - Fiction</title>
+
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+
+  <meta property="og:title" content="Temporal - Fiction" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://temporal.io" />
+  <meta property="og:image" content="/banner.png" />
+</svelte:head>
+
+<main class="flex h-screen w-screen">
+  <nav class="h-full w-96 border-r-2 p-4">
+    <h1>Fiction 📚</h1>
+    <ul class="ml-4">
+      {#each chapters as chapter}
+        <li>
+          <a href="/fiction/chapters/{chapter}">{chapter}</a>
+        </li>
+      {/each}
+    </ul>
+  </nav>
+  <article class="flex h-full w-full flex-col justify-between">
+    <div class="flex flex-col p-8">
+      <slot />
+    </div>
+    <div class="h-96">
+      {#key $currentProps}
+        <CodeBlock content={$currentProps} />
+      {/key}
+    </div>
+  </article>
+</main>

--- a/src/routes/fiction/_chapter.svelte
+++ b/src/routes/fiction/_chapter.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { currentProps } from '$lib/stores/fiction-store';
+  import type { SvelteComponentTyped } from 'svelte/internal';
+
+  type ComponentProps<T> = T extends new (
+    ...args: any[]
+  ) => SvelteComponentTyped<infer Props>
+    ? Props
+    : unknown;
+
+  type T = $$Generic;
+
+  interface $$Props {
+    description: string;
+    component: T;
+    props?: ComponentProps<T>;
+  }
+
+  export let description;
+  export let props = {};
+  let Component;
+  export { Component as component };
+
+  function handleClick() {
+    currentProps.set({ ...props });
+  }
+</script>
+
+<div
+  on:click={handleClick}
+  class="mt-4 cursor-pointer border-2 p-4 hover:bg-gray-50"
+>
+  <h2 class="mb-4">{description}</h2>
+  <svelte:component this={Component} {...props}>
+    <slot />
+  </svelte:component>
+</div>

--- a/src/routes/fiction/chapters.ts
+++ b/src/routes/fiction/chapters.ts
@@ -1,0 +1,15 @@
+import { join } from 'path';
+import { readdirSync } from 'fs';
+
+export async function get() {
+  const files = readdirSync(join('src', 'routes', 'fiction', 'chapters'));
+
+  return {
+    status: 200,
+    body: {
+      chapters: files
+        .filter((file) => file.includes('.svelte'))
+        .map((file) => file.split('.svelte')[0]),
+    },
+  };
+}

--- a/src/routes/fiction/chapters/button.svelte
+++ b/src/routes/fiction/chapters/button.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import Chapter from '../_chapter.svelte';
+  import Button from '$lib/components/button.svelte';
+</script>
+
+<Chapter description="A primary button" component={Button}>Click Me</Chapter>
+
+<Chapter
+  description="A dangerous button"
+  component={Button}
+  props={{ destroy: true }}>Danger</Chapter
+>
+
+<Chapter
+  description="A button as an anchor"
+  component={Button}
+  props={{ href: 'https://temporal.io', as: 'anchor' }}>Link</Chapter
+>
+
+<Chapter
+  description="A button with an Icon"
+  component={Button}
+  props={{ icon: 'refresh' }}
+>
+  Reload
+</Chapter>

--- a/src/routes/fiction/chapters/link.svelte
+++ b/src/routes/fiction/chapters/link.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import Link from '$lib/components/link.svelte';
+  import Chapter from '../_chapter.svelte';
+</script>
+
+<Chapter
+  description="A link"
+  component={Link}
+  props={{ href: 'https://temporal.io' }}>Link</Chapter
+>
+
+<Chapter
+  description="An active link"
+  component={Link}
+  props={{ href: 'https://temporal.io', active: true }}>Active Link</Chapter
+>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,8 +2,12 @@ import path from 'path';
 import preprocess from 'svelte-preprocess';
 import adapter from '@sveltejs/adapter-static';
 
-const buildTarget = process.env.VITE_TEMPORAL_UI_BUILD_TARGET || 'local';
+// Workaround until SvelteKit uses Vite 2.3.8 (and it's confirmed to fix the Tailwind JIT problem)
+const mode = process.env.NODE_ENV;
+const dev = mode === 'development';
+process.env.TAILWIND_MODE = dev ? 'watch' : 'build';
 
+const buildTarget = process.env.VITE_TEMPORAL_UI_BUILD_TARGET || 'local';
 let outputDirectory = `build-${buildTarget}`;
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -32,7 +36,9 @@ const config = {
       },
       files: (filepath) => /^(?!.*(?:test)).*\.ts$/.test(filepath),
     },
+   ...(!dev && {
     routes: (filepath) =>/^(?!.*(?:fiction)).*$/.test(filepath),
+   }),
     vite: {
       resolve: {
         alias: {
@@ -44,7 +50,3 @@ const config = {
 };
 
 export default config;
-// Workaround until SvelteKit uses Vite 2.3.8 (and it's confirmed to fix the Tailwind JIT problem)
-const mode = process.env.NODE_ENV;
-const dev = mode === 'development';
-process.env.TAILWIND_MODE = dev ? 'watch' : 'build';

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -36,9 +36,9 @@ const config = {
       },
       files: (filepath) => /^(?!.*(?:test)).*\.ts$/.test(filepath),
     },
-   ...(!dev && {
-    routes: (filepath) =>/^(?!.*(?:fiction)).*$/.test(filepath),
-   }),
+    ...(!dev && {
+      routes: (filepath) => /^(?!.*(?:fiction)).*$/.test(filepath),
+    }),
     vite: {
       resolve: {
         alias: {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -32,6 +32,7 @@ const config = {
       },
       files: (filepath) => /^(?!.*(?:test)).*\.ts$/.test(filepath),
     },
+    routes: (filepath) =>/^(?!.*(?:fiction)).*$/.test(filepath),
     vite: {
       resolve: {
         alias: {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Scaffolds out "fiction" aka "storybook lite™" and adds a couple of "chapters" aka "stories".
![localhost_3000_fiction_chapters_button](https://user-images.githubusercontent.com/11775628/173392089-4a0c5a19-b81e-4031-b596-0c23a9afd966.png)

## Why?
vastly improves developer experience, allows us to get ahead by building components we know we'll need on pages that don't exist yet.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
Ran locally and went to the /fiction route to verify intended behavior.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
