### PR TITLE
Workflow Type click filter

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VITE_API="http://localhost:8080"
+VITE_API="http://localhost:8081"
 VITE_MODE="development"

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-VITE_API="http://localhost:8081"
+VITE_API="http://localhost:8080"
 VITE_MODE="development"

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -18,6 +18,7 @@
   import Icon from '$lib/holocene/icon/index.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
+  import FilterOrCopyTooltip from '$lib/holocene/filter-or-copy-tooltip.svelte';
   export let namespace: string;
   export let workflow: WorkflowExecution;
   export let timeFormat: TimeFormat | string;
@@ -32,7 +33,10 @@
     const defaultQuery = toListWorkflowQuery({ timeRange: 'All' });
     const query = $page.url.searchParams.get('query');
     const parameters = toListWorkflowParameters(query ?? defaultQuery);
-    const value = toListWorkflowQuery({ ...parameters, workflowType });
+    const value = toListWorkflowQuery({
+      ...parameters,
+      workflowType: parameters?.workflowType ? '' : workflowType,
+    });
     updateQueryParameters({
       url: $page.url,
       parameter: 'query',
@@ -67,7 +71,12 @@
   </div>
   <div class="cell links flex gap-2 font-medium md:font-normal">
     <h3 class="md:hidden">Workflow Name:</h3>
-    <Tooltip bottom text={workflow.name} copyable icon="filter">
+    <FilterOrCopyTooltip
+      bottom
+      content={workflow.name}
+      onFilter={() => onTypeClick(workflow.name)}
+      filtered={$page.url.searchParams.get('query').includes(workflow.name)}
+    >
       <span
         class="table-link"
         on:click|preventDefault|stopPropagation={() =>
@@ -77,7 +86,7 @@
           $workflowTypeColumnWidth || $workflowSummaryColumnWidth,
         )}</span
       >
-    </Tooltip>
+    </FilterOrCopyTooltip>
     <p class="time-cell-inline">
       {formatDate(workflow.endTime, timeFormat)}
     </p>

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -7,6 +7,9 @@
     workflowTypeColumnWidth,
     workflowSummaryColumnWidth,
   } from '$lib/stores/column-width';
+  import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
 
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
@@ -46,7 +49,16 @@
   <div class="cell links flex gap-2 font-medium md:font-normal">
     <h3 class="md:hidden">Workflow Name:</h3>
     <Tooltip bottom copyable text={workflow.name}>
-      <span class="table-link"
+      <span
+        class="table-link"
+        on:click|preventDefault|stopPropagation={() =>
+          updateQueryParameters({
+            url: $page.url,
+            parameter: 'query',
+            value: `WorkflowType="${workflow.name}"`,
+            allowEmpty: true,
+            goto,
+          })}
         >{getTruncatedWord(
           workflow.name,
           $workflowTypeColumnWidth || $workflowSummaryColumnWidth,

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -1,16 +1,21 @@
 <script lang="ts">
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+
   import { formatDate, getMilliseconds } from '$lib/utilities/format-date';
   import { routeForWorkflow } from '$lib/utilities/route-for';
   import { getTruncatedWord } from '$lib/utilities/get-truncated-word';
+  import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
+  import { toListWorkflowParameters } from '$lib/utilities/query/to-list-workflow-parameters';
+  import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
+
   import {
     workflowIdColumnWidth,
     workflowTypeColumnWidth,
     workflowSummaryColumnWidth,
   } from '$lib/stores/column-width';
-  import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
-  import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
 
+  import Icon from '$lib/holocene/icon/index.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   export let namespace: string;
@@ -22,6 +27,20 @@
     workflow: workflow.id,
     run: workflow.runId,
   });
+
+  const onTypeClick = (workflowType) => {
+    const defaultQuery = toListWorkflowQuery({ timeRange: 'All' });
+    const query = $page.url.searchParams.get('query');
+    const parameters = toListWorkflowParameters(query ?? defaultQuery);
+    const value = toListWorkflowQuery({ ...parameters, workflowType });
+    updateQueryParameters({
+      url: $page.url,
+      parameter: 'query',
+      value,
+      allowEmpty: true,
+      goto,
+    });
+  };
 </script>
 
 <a {href} class="row group">
@@ -48,17 +67,11 @@
   </div>
   <div class="cell links flex gap-2 font-medium md:font-normal">
     <h3 class="md:hidden">Workflow Name:</h3>
-    <Tooltip bottom copyable text={workflow.name}>
+    <Tooltip bottom text={workflow.name} icon="filter">
       <span
         class="table-link"
         on:click|preventDefault|stopPropagation={() =>
-          updateQueryParameters({
-            url: $page.url,
-            parameter: 'query',
-            value: `WorkflowType="${workflow.name}"`,
-            allowEmpty: true,
-            goto,
-          })}
+          onTypeClick(workflow.name)}
         >{getTruncatedWord(
           workflow.name,
           $workflowTypeColumnWidth || $workflowSummaryColumnWidth,

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -15,7 +15,6 @@
     workflowSummaryColumnWidth,
   } from '$lib/stores/column-width';
 
-  import Icon from '$lib/holocene/icon/index.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import FilterOrCopyTooltip from '$lib/holocene/filter-or-copy-tooltip.svelte';
@@ -29,13 +28,14 @@
     run: workflow.runId,
   });
 
-  const onTypeClick = (workflowType: string) => {
+  const onTypeClick = (type: string) => {
     const defaultQuery = toListWorkflowQuery({ timeRange: 'All' });
     const query = $page.url.searchParams.get('query');
     const parameters = toListWorkflowParameters(query ?? defaultQuery);
+    const workflowType = parameters?.workflowType === type ? '' : type;
     const value = toListWorkflowQuery({
       ...parameters,
-      workflowType: parameters?.workflowType ? '' : workflowType,
+      workflowType,
     });
     updateQueryParameters({
       url: $page.url,
@@ -75,7 +75,7 @@
       bottom
       content={workflow.name}
       onFilter={() => onTypeClick(workflow.name)}
-      filtered={$page.url.searchParams.get('query').includes(workflow.name)}
+      filtered={$page.url?.searchParams?.get('query')?.includes(workflow.name)}
     >
       <span
         class="table-link"

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -28,7 +28,7 @@
     run: workflow.runId,
   });
 
-  const onTypeClick = (workflowType) => {
+  const onTypeClick = (workflowType: string) => {
     const defaultQuery = toListWorkflowQuery({ timeRange: 'All' });
     const query = $page.url.searchParams.get('query');
     const parameters = toListWorkflowParameters(query ?? defaultQuery);
@@ -67,7 +67,7 @@
   </div>
   <div class="cell links flex gap-2 font-medium md:font-normal">
     <h3 class="md:hidden">Workflow Name:</h3>
-    <Tooltip bottom text={workflow.name} icon="filter">
+    <Tooltip bottom text={workflow.name} copyable icon="filter">
       <span
         class="table-link"
         on:click|preventDefault|stopPropagation={() =>

--- a/src/lib/holocene/filter-or-copy-tooltip.svelte
+++ b/src/lib/holocene/filter-or-copy-tooltip.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import Icon from '$lib/holocene/icon/index.svelte';
+  import { noop } from 'svelte/internal';
+
+  export let content: string;
+  export let top = false;
+  export let right = false;
+  export let bottom = false;
+  export let left = false;
+  export let hide: boolean | null = false;
+  export let onFilter: () => void;
+  export let filtered: boolean;
+
+  let copied = false;
+
+  const copy = () => {
+    navigator.clipboard
+      .writeText(content)
+      .then(() => {
+        copied = !copied;
+        setTimeout(() => (copied = false), 500);
+      })
+      .catch((error) => console.error(error));
+  };
+</script>
+
+{#if hide}
+  <slot />
+{:else}
+  <div
+    class="wrapper relative inline-block"
+    on:click|preventDefault|stopPropagation={noop}
+  >
+    <slot />
+    <div class="tooltip" class:left class:right class:bottom class:top>
+      <div class="inline-block rounded-lg bg-gray-800 px-2 py-2 text-gray-100">
+        <button on:click|preventDefault|stopPropagation={onFilter} class="mr-1">
+          {#key filtered}
+            <Icon
+              name="filter"
+              stroke="#fff"
+              fill={filtered ? '#fff' : ''}
+              class="inline h-4"
+            />
+          {/key}
+          Filter
+        </button>
+        <span>|</span>
+        <button on:click|preventDefault|stopPropagation={copy}>
+          <Icon
+            name={copied ? 'checkMark' : 'copy'}
+            stroke="#fff"
+            class="inline h-4"
+          />
+          Copy
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style lang="postcss">
+  .tooltip {
+    @apply invisible absolute left-0 top-0 z-50 inline-block translate-x-12 whitespace-nowrap text-xs opacity-0 shadow-md transition-all;
+  }
+
+  .tooltip.top {
+    @apply left-1/2 -mt-4 -translate-x-1/2 -translate-y-full;
+  }
+  .tooltip.bottom {
+    @apply left-1/2 bottom-0 -mb-1 -translate-x-1/2 translate-y-full;
+  }
+  .tooltip.left {
+    @apply left-0 -ml-4 -translate-x-full;
+  }
+  .tooltip.right {
+    @apply right-0 -mr-4 translate-x-full;
+  }
+
+  .wrapper:hover .tooltip {
+    @apply visible opacity-90;
+  }
+</style>

--- a/src/lib/holocene/icon/paths.ts
+++ b/src/lib/holocene/icon/paths.ts
@@ -199,6 +199,15 @@ const fileUploadIcon = {
   ],
 };
 
+const filterIcon = {
+  paths: [
+    {
+      d: 'M3.99961 3H19.9997C20.552 3 20.9997 3.44764 20.9997 3.99987L20.9999 5.58569C21 5.85097 20.8946 6.10538 20.707 6.29295L14.2925 12.7071C14.105 12.8946 13.9996 13.149 13.9996 13.4142L13.9996 19.7192C13.9996 20.3698 13.3882 20.8472 12.7571 20.6894L10.7571 20.1894C10.3119 20.0781 9.99961 19.6781 9.99961 19.2192L9.99961 13.4142C9.99961 13.149 9.89425 12.8946 9.70672 12.7071L3.2925 6.29289C3.10496 6.10536 2.99961 5.851 2.99961 5.58579V4C2.99961 3.44772 3.44732 3 3.99961 3Z',
+      stroke: '#111827',
+    },
+  ],
+};
+
 const jsonIcon = {
   paths: [
     {
@@ -366,6 +375,7 @@ export const icons: { [index: string]: Icon } = {
   feed: feedIcon,
   feedback: feedbackIcon,
   fileUpload: fileUploadIcon,
+  filter: filterIcon,
   json: jsonIcon,
   lock: lockIcon,
   logout: logoutIcon,

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -22,7 +22,13 @@
       <div class="inline-block rounded-lg bg-gray-800 px-2 py-2">
         {#if copyable}
           <Copyable clickAllToCopy content={text} color="white">
-            <span class="text-gray-100">{text}</span>
+            <span class="text-gray-100"
+              >{#if icon}<Icon
+                  name={icon}
+                  class="inline h-4"
+                  stroke="#fff"
+                />{/if}{text}</span
+            >
           </Copyable>
         {:else}
           <span class="flex gap-2 text-gray-100"

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import Copyable from '$lib/components/copyable.svelte';
+  import Icon from '$lib/holocene/icon/index.svelte';
+  import type { IconName } from '$lib/holocene/icon/paths';
+  import { fade } from 'svelte/transition';
 
   export let text: string = '';
+  export let icon: IconName | undefined = undefined;
   export let top = false;
   export let right = false;
   export let bottom = false;
@@ -22,7 +26,13 @@
             <span class="text-gray-100">{text}</span>
           </Copyable>
         {:else}
-          <span class="text-gray-100">{text}</span>
+          <span class="flex gap-2 text-gray-100"
+            >{#if icon}<Icon
+                name={icon}
+                class="inline h-4"
+                stroke="#fff"
+              />{/if}{text}</span
+          >
         {/if}
       </div>
     </div>

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -2,7 +2,6 @@
   import Copyable from '$lib/components/copyable.svelte';
   import Icon from '$lib/holocene/icon/index.svelte';
   import type { IconName } from '$lib/holocene/icon/paths';
-  import { fade } from 'svelte/transition';
 
   export let text: string = '';
   export let icon: IconName | undefined = undefined;


### PR DESCRIPTION
## What was changed
In the workflows list, the workflow type was a link to the individual workflow page. This PR changes that behavior to now set the workflow type filter on the link click. If other filters are already applied, it will preserve those in addition to include the type. The rest of the row is still a link to navigate to individual workflow page. A new filter icon is added to the tooltip for the Workflow Type.


<img width="1700" alt="Screen Shot 2022-06-15 at 12 30 35 PM" src="https://user-images.githubusercontent.com/7967403/173889753-e9293ea8-cd75-4c66-9b22-568e68f7fb95.png">
<img width="1700" alt="Screen Shot 2022-06-15 at 12 30 26 PM" src="https://user-images.githubusercontent.com/7967403/173889757-9af5c4ac-2e8e-4ff4-a481-35c00d87ace9.png">

https://user-images.githubusercontent.com/7967403/173889951-a94cbede-c0ef-4e92-9766-84c01d7ca1db.mov


## Why?
Much quicker for users to filter by type by clicking instead of typing.
