### PR TITLE
Add Marker event category filter, add parent id, fix input/results on category filter

### DIFF
--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -5,7 +5,7 @@
   import { routeForWorkflow, routeForWorkers } from '$lib/utilities/route-for';
   import {
     getCodeBlockValue,
-    shouldDisplayAsWorkflowLink,
+    shouldDisplayAsExecutionLink,
     shouldDisplayAsWorkersLink,
     shouldDisplayAsPlainText,
   } from '$lib/utilities/get-single-attribute-for-event';
@@ -16,6 +16,7 @@
 
   export let key: string;
   export let value: string | Record<string, unknown>;
+
   export let inline = false;
 
   const { workflow, namespace, run } = $page.params;
@@ -33,7 +34,7 @@
         {inline}
       />
     </div>
-  {:else if shouldDisplayAsWorkflowLink(key)}
+  {:else if shouldDisplayAsExecutionLink(key)}
     <div class="detail-row">
       <h2 class="text-sm">{format(key)}</h2>
       <div class="text-sm">

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -4,7 +4,7 @@
   import { format } from '$lib/utilities/format-camel-case';
   import { routeForWorkflow, routeForWorkers } from '$lib/utilities/route-for';
   import {
-    shouldDisplayAsWorkflowLink,
+    shouldDisplayAsExecutionLink,
     shouldDisplayAsWorkersLink,
     shouldDisplayAsPlainText,
     getCodeBlockValue,
@@ -29,7 +29,7 @@
       {format(key)}
     </h2>
     <CodeBlock content={getCodeBlockValue(value)} class="w-full" {inline} />
-  {:else if shouldDisplayAsWorkflowLink(key)}
+  {:else if shouldDisplayAsExecutionLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
       <h2 class="mr-3 text-sm">{format(key)}</h2>
       <div class="text-sm">

--- a/src/lib/models/event-history/get-event-categorization.ts
+++ b/src/lib/models/event-history/get-event-categorization.ts
@@ -18,6 +18,8 @@ export const eventTypeCategorizations: Readonly<
   StartChildWorkflowExecutionFailed: 'child-workflow',
   StartChildWorkflowExecutionInitiated: 'child-workflow',
 
+  MarkerRecorded: 'marker',
+
   SignalExternalWorkflowExecutionFailed: 'signal',
   SignalExternalWorkflowExecutionInitiated: 'signal',
   WorkflowExecutionSignaled: 'signal',
@@ -44,7 +46,6 @@ export const eventTypeCategorizations: Readonly<
   RequestCancelExternalWorkflowExecutionFailed: 'workflow',
   RequestCancelExternalWorkflowExecutionInitiated: 'workflow',
 
-  MarkerRecorded: 'command',
   UpsertWorkflowSearchAttributes: 'command',
 };
 
@@ -52,10 +53,11 @@ export type EventTypeCategory = typeof categories[number];
 const categories = [
   'activity',
   'child-workflow',
+  'command',
+  'marker',
   'signal',
   'timer',
   'workflow',
-  'command',
 ] as const;
 
 type EventTypeOption = {
@@ -68,6 +70,7 @@ export const allEventTypeOptions: EventTypeOption[] = [
   { label: 'Activity', option: 'activity' },
   { label: 'Child Workflow', option: 'child-workflow' },
   { label: 'Command', option: 'command' },
+  { label: 'Marker', option: 'marker' },
   { label: 'Signal', option: 'signal' },
   { label: 'Timer', option: 'timer' },
   { label: 'Workflow', option: 'workflow' },

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -1,6 +1,6 @@
 import {
   getSingleAttributeForEvent,
-  shouldDisplayAsWorkflowLink,
+  shouldDisplayAsExecutionLink,
 } from './get-single-attribute-for-event';
 
 describe(getSingleAttributeForEvent, () => {
@@ -143,17 +143,17 @@ describe(getSingleAttributeForEvent, () => {
   });
 });
 
-describe(shouldDisplayAsWorkflowLink, () => {
+describe(shouldDisplayAsExecutionLink, () => {
   it('should return true for event keys that end with RunId', () => {
-    expect(shouldDisplayAsWorkflowLink('originalExecutionRunId')).toBe(true);
-    expect(shouldDisplayAsWorkflowLink('firstExecutionRunId')).toBe(true);
-    expect(shouldDisplayAsWorkflowLink('continuedExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsExecutionLink('originalExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsExecutionLink('firstExecutionRunId')).toBe(true);
+    expect(shouldDisplayAsExecutionLink('continuedExecutionRunId')).toBe(true);
   });
 
   it('should return false for event keys that do not end with RunId', () => {
-    expect(shouldDisplayAsWorkflowLink('')).toBe(false);
-    expect(shouldDisplayAsWorkflowLink('workflowType.name')).toBe(false);
-    expect(shouldDisplayAsWorkflowLink('parentInitiatedEventId')).toBe(false);
-    expect(shouldDisplayAsWorkflowLink('inlineRunIdSample')).toBe(false);
+    expect(shouldDisplayAsExecutionLink('')).toBe(false);
+    expect(shouldDisplayAsExecutionLink('workflowType.name')).toBe(false);
+    expect(shouldDisplayAsExecutionLink('parentInitiatedEventId')).toBe(false);
+    expect(shouldDisplayAsExecutionLink('inlineRunIdSample')).toBe(false);
   });
 });

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -55,7 +55,7 @@ export const getCodeBlockValue: Parameters<typeof JSON.stringify>[0] = (
   return value?.payloads ?? value?.indexedFields ?? value?.points ?? value;
 };
 
-const keysWithWorkflowLinks = [
+const keysWithExecutionLinks = [
   'baseRunId',
   'continuedExecutionRunId',
   'firstExecutionRunId',
@@ -64,17 +64,18 @@ const keysWithWorkflowLinks = [
   'originalExecutionRunId',
 ] as const;
 
-const keysWithWorkerLinks = ['taskQueueName'] as const;
-
-export const shouldDisplayAsWorkflowLink = (
+// For linking to same workflow but different execution
+export const shouldDisplayAsExecutionLink = (
   key: string,
-): key is typeof keysWithWorkflowLinks[number] => {
-  for (const workflowKey of keysWithWorkflowLinks) {
+): key is typeof keysWithExecutionLinks[number] => {
+  for (const workflowKey of keysWithExecutionLinks) {
     if (key === workflowKey) return true;
   }
 
   return false;
 };
+
+const keysWithWorkerLinks = ['taskQueueName'] as const;
 
 export const shouldDisplayAsWorkersLink = (
   key: string,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -76,15 +76,26 @@
       href={routeForWorkers(workflowRoute)}
     />
     {#if workflow?.parent}
-      <WorkflowDetail
-        title="Parent"
-        content={workflow.parent?.workflowId}
-        href={routeForWorkflow({
-          namespace,
-          workflow: workflow.parent?.workflowId,
-          run: workflow.parent?.runId,
-        })}
-      />
+      <div class="gap-2 xl:flex">
+        <WorkflowDetail
+          title="Parent"
+          content={workflow.parent?.workflowId}
+          href={routeForWorkflow({
+            namespace,
+            workflow: workflow.parent?.workflowId,
+            run: workflow.parent?.runId,
+          })}
+        />
+        <WorkflowDetail
+          title="Parent ID"
+          content={workflow.parent?.runId}
+          href={routeForWorkflow({
+            namespace,
+            workflow: workflow.parent?.workflowId,
+            run: workflow.parent?.runId,
+          })}
+        />
+      </div>
     {/if}
     <WorkflowDetail
       title="State Transitions"

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/_input-and-results.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Icon from '$lib/holocene/icon/index.svelte';
 
-  import { events, updating } from '$lib/stores/events';
+  import { eventHistory, updating } from '$lib/stores/events';
 
   import { getWorkflowStartedAndCompletedEvents } from '$lib/utilities/get-started-and-completed-events';
   import { capitalize } from '$lib/utilities/format-camel-case';
@@ -11,7 +11,9 @@
   export let type: 'input' | 'results';
 
   $: title = capitalize(type);
-  $: content = getWorkflowStartedAndCompletedEvents($events)[type];
+  $: content = getWorkflowStartedAndCompletedEvents(
+    $eventHistory?.events ?? [],
+  )[type];
 </script>
 
 <article


### PR DESCRIPTION
## What was changed
Added Marker filter

<img width="1725" alt="Screen Shot 2022-06-22 at 11 32 45 AM" src="https://user-images.githubusercontent.com/7967403/175106712-103bd196-0d1a-4eeb-804f-06edfb116143.png">

Added Parent Id to header of workflow

<img width="1727" alt="Screen Shot 2022-06-22 at 1 09 35 PM" src="https://user-images.githubusercontent.com/7967403/175107073-674c9a56-ab59-4192-beab-bde7118099a2.png">


Fixed issue when filtering by event category that made input/results spin and refactored name of utility
