### PR TITLE
Add middleware for access token

### DIFF
--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -116,7 +116,6 @@ export const requestFromAPI = async <T>(
 const withSecurityOptions = (options: RequestInit): RequestInit => {
   const opts: RequestInit = { credentials: 'include', ...options };
   opts.headers = withCsrf(options?.headers);
-
   return opts;
 };
 


### PR DESCRIPTION
## What was changed
Check for accessToken promise and fetch token and add to Authorization header if it exists.

## Why?
Support for access token auth.

