### PR TITLE
Make namespace name 12px, truncate and show tooltip above on open nav

### DIFF
--- a/src/lib/holocene/navigation/full-nav.svelte
+++ b/src/lib/holocene/navigation/full-nav.svelte
@@ -55,12 +55,16 @@
         class="relative flex cursor-pointer items-center"
         on:click={toggleNamespaceSelector}
       >
-        <Tooltip right hide={$navOpen} text={activeNamespace ?? 'Namespaces'}>
+        <Tooltip
+          right={!$navOpen}
+          topRight={$navOpen}
+          text={activeNamespace ?? 'Namespaces'}
+        >
           <div class="nav-icon">
             <Icon name="namespaceSelect" scale={1.6} />
           </div>
         </Tooltip>
-        <div class="nav-title namespace">
+        <div class="nav-title namespace truncate" style="font-size: 12px;">
           {activeNamespace ?? 'Namespaces'}
         </div>
       </div>

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -6,6 +6,7 @@
   export let text: string = '';
   export let icon: IconName | undefined = undefined;
   export let top = false;
+  export let topRight = false;
   export let right = false;
   export let bottom = false;
   export let left = false;
@@ -18,7 +19,14 @@
 {:else}
   <div class="wrapper relative inline-block">
     <slot />
-    <div class="tooltip" class:left class:right class:bottom class:top>
+    <div
+      class="tooltip"
+      class:left
+      class:right
+      class:bottom
+      class:top
+      class:topRight
+    >
       <div class="inline-block rounded-lg bg-gray-800 px-2 py-2">
         {#if copyable}
           <Copyable clickAllToCopy content={text} color="white">
@@ -60,6 +68,10 @@
   }
   .tooltip.right {
     @apply right-0 -mr-4 translate-x-full;
+  }
+
+  .tooltip.topRight {
+    @apply right-1/2 -mt-4 mr-4 -translate-x-1/2 -translate-y-full;
   }
 
   .wrapper:hover .tooltip {


### PR DESCRIPTION
## What was changed
Make namespace name in nav truncated, 12px and show tooltip on hover when nav open.

<img width="1728" alt="Screen Shot 2022-06-24 at 10 11 25 AM" src="https://user-images.githubusercontent.com/7967403/175564659-68494d6e-e494-4fd1-8059-6427ea6b7b09.png">

## Why?
Better UI