### PR TITLE
Remove goto as a required argument for updateQueryParams

### DIFF
--- a/src/lib/components/event/event-category-filter.svelte
+++ b/src/lib/components/event/event-category-filter.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
 
   import Icon from '$lib/holocene/icon/index.svelte';
 
@@ -23,7 +22,6 @@
       parameter: parameter,
       value: _value,
       url: $page.url,
-      goto,
     }).then((v) => (_value = v?.toString()));
   }
 

--- a/src/lib/components/event/event-date-filter.svelte
+++ b/src/lib/components/event/event-date-filter.svelte
@@ -18,7 +18,6 @@
   } from '$lib/stores/event-view';
 
   import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
 
   let sortOptions: EventSortOrderOptions = [
@@ -38,7 +37,6 @@
       parameter: 'sort',
       value: option,
       url: $page.url,
-      goto,
     });
   };
 

--- a/src/lib/components/select/filter-select.svelte
+++ b/src/lib/components/select/filter-select.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
 
@@ -21,7 +20,6 @@
       parameter,
       value: _value,
       url: $page.url,
-      goto,
     }).then((v) => (value = v));
   };
 </script>

--- a/src/lib/components/workflow/workflow-filters.svelte
+++ b/src/lib/components/workflow/workflow-filters.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import debounce from 'just-debounce';
   import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
 
   import { timeFormat } from '$lib/stores/time-format';
 
@@ -40,7 +39,6 @@
         parameter: 'search',
         value: searchType,
         url: $page.url,
-        goto,
       });
     };
 
@@ -53,7 +51,6 @@
       url: $page.url,
       parameter: 'query',
       value: query,
-      goto,
     });
   };
 
@@ -65,7 +62,6 @@
       parameter: 'query',
       value: query,
       allowEmpty: true,
-      goto,
     });
   }, 300);
 </script>

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { goto } from '$app/navigation';
 
   import { formatDate, getMilliseconds } from '$lib/utilities/format-date';
   import { routeForWorkflow } from '$lib/utilities/route-for';
@@ -37,7 +36,6 @@
       parameter: 'query',
       value,
       allowEmpty: true,
-      goto,
     });
   };
 </script>

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -1,0 +1,175 @@
+import { readable } from 'svelte/store';
+
+interface Page<Params extends Record<string, string> = Record<string, string>> {
+  url: URL;
+  params: Params;
+  routeId: string | null;
+  stuff: App.Stuff;
+  status: number;
+  error: Error | null;
+}
+
+const settings: Settings = {
+  auth: {
+    enabled: false,
+    options: null,
+  },
+  baseUrl: 'http://localhost:3000',
+  codec: {
+    endpoint: '',
+    accessToken: '',
+  },
+  defaultNamespace: 'default',
+  showTemporalSystemNamespace: false,
+  notifyOnNewVersion: true,
+  feedbackURL: '',
+  runtimeEnvironment: {
+    isCloud: false,
+    isLocal: true,
+    envOverride: true,
+  },
+  version: '2.0.0',
+};
+
+const stuff: App.Stuff = {
+  namespaces: [
+    {
+      namespaceInfo: {
+        name: 'my-namespace-name',
+        state: 'Registered',
+        description: '',
+        ownerEmail: '',
+        data: {},
+        id: '2f3e9cc5-13e0-43fb-805f-adc817fe8b7c',
+      },
+      config: {
+        workflowExecutionRetentionTtl: '259200s',
+        badBinaries: {
+          binaries: {},
+        },
+        historyArchivalState: 'Disabled',
+        historyArchivalUri: '',
+        visibilityArchivalState: 'Disabled',
+        visibilityArchivalUri: '',
+      },
+      replicationConfig: {
+        activeClusterName: 'active',
+        clusters: [
+          {
+            clusterName: 'active',
+          },
+        ],
+        state: 'Unspecified',
+      },
+      failoverVersion: '0',
+      isGlobalNamespace: false,
+    },
+    {
+      namespaceInfo: {
+        name: 'temporal-system',
+        state: 'Registered',
+        description: 'Temporal internal system namespace',
+        ownerEmail: 'temporal-core@temporal.io',
+        data: {},
+        id: '32049b68-7872-4094-8e63-d0dd59896a83',
+      },
+      config: {
+        workflowExecutionRetentionTtl: '604800s',
+        badBinaries: {
+          binaries: {},
+        },
+        historyArchivalState: 'Disabled',
+        historyArchivalUri: '',
+        visibilityArchivalState: 'Disabled',
+        visibilityArchivalUri: '',
+      },
+      replicationConfig: {
+        activeClusterName: 'active',
+        clusters: [
+          {
+            clusterName: 'active',
+          },
+        ],
+        state: 'Unspecified',
+      },
+      failoverVersion: '0',
+      isGlobalNamespace: false,
+    },
+    {
+      namespaceInfo: {
+        name: 'default',
+        state: 'Registered',
+        description: 'Default namespace for Temporal Server.',
+        ownerEmail: '',
+        data: {},
+        id: 'a0f1d023-7f0f-4189-a8a5-510f603569c8',
+      },
+      config: {
+        workflowExecutionRetentionTtl: '86400s',
+        badBinaries: {
+          binaries: {},
+        },
+        historyArchivalState: 'Disabled',
+        historyArchivalUri: '',
+        visibilityArchivalState: 'Disabled',
+        visibilityArchivalUri: '',
+      },
+      replicationConfig: {
+        activeClusterName: 'active',
+        clusters: [
+          {
+            clusterName: 'active',
+          },
+        ],
+        state: 'Unspecified',
+      },
+      failoverVersion: '0',
+      isGlobalNamespace: false,
+    },
+    {
+      namespaceInfo: {
+        name: 'canary',
+        state: 'Registered',
+        description: 'Namespace for running temporal canary workflows',
+        ownerEmail: 'canary',
+        data: {},
+        id: 'c3e6ec56-8059-4bdf-99ac-d50d3fa1616c',
+      },
+      config: {
+        workflowExecutionRetentionTtl: '864000s',
+        badBinaries: {
+          binaries: {},
+        },
+        historyArchivalState: 'Disabled',
+        historyArchivalUri: '',
+        visibilityArchivalState: 'Disabled',
+        visibilityArchivalUri: '',
+      },
+      replicationConfig: {
+        activeClusterName: 'active',
+        clusters: [
+          {
+            clusterName: 'active',
+          },
+        ],
+        state: 'Unspecified',
+      },
+      failoverVersion: '0',
+      isGlobalNamespace: false,
+    },
+  ],
+  settings,
+};
+
+export const page = readable<Page>({
+  error: null,
+  params: {
+    namespace: 'default',
+  },
+  routeId: 'namespaces/[namespace]/workflows@root',
+  status: 200,
+  stuff,
+  url: new URL(
+    'http://localhost:3000/namespaces/default/workflows?search=basic&query=WorkflowType%3D%22testing%22',
+  ),
+});

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { updateQueryParameters } from './update-query-parameters';
 

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -1,11 +1,12 @@
 import { browser } from '$app/env';
-import type { goto, invalidate } from '$app/navigation';
+import { goto as navigateTo } from '$app/navigation';
+import type { invalidate } from '$app/navigation';
 
 type UpdateQueryParams = {
   parameter: string;
   value?: string | number | boolean;
   url: URL;
-  goto: typeof goto;
+  goto?: typeof navigateTo;
   allowEmpty?: boolean;
   invalidate?: typeof invalidate;
 };
@@ -20,7 +21,7 @@ export const updateQueryParameters = async ({
   parameter,
   value,
   url,
-  goto,
+  goto = navigateTo,
   allowEmpty = false,
 }: UpdateQueryParams): Promise<typeof value> => {
   const next = String(value);

--- a/src/routes/namespaces/[namespace]/archival/_filter-input.svelte
+++ b/src/routes/namespaces/[namespace]/archival/_filter-input.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
   import debounce from 'just-debounce';
@@ -19,7 +18,6 @@
       parameter,
       value: _value,
       url: $page.url,
-      goto,
     });
   }
 </script>


### PR DESCRIPTION
Now that we can better mock out SveliteKit internals in unit tests, `updateQueryParams` can import `goto` directly and no longer needs to have the dependency injected.

This also adds a mock for `pages` in `$app/stores`.