### PR TITLE
Add isCloud check for supportsReverseOrder

### DIFF
--- a/src/lib/services/cluster-service.ts
+++ b/src/lib/services/cluster-service.ts
@@ -7,10 +7,7 @@ export const fetchCluster = async (
   settings: Settings,
   request = fetch,
 ): Promise<GetClusterInfoResponse> => {
-  if (settings.runtimeEnvironment.isCloud) {
-    cluster.set({ serverVersion: '1.17.0' });
-    return;
-  }
+  if (settings.runtimeEnvironment.isCloud) return;
 
   return await requestFromAPI(routeForApi('cluster'), {
     request,

--- a/src/lib/services/cluster-service.ts
+++ b/src/lib/services/cluster-service.ts
@@ -7,7 +7,10 @@ export const fetchCluster = async (
   settings: Settings,
   request = fetch,
 ): Promise<GetClusterInfoResponse> => {
-  if (settings.runtimeEnvironment.isCloud) return;
+  if (settings.runtimeEnvironment.isCloud) {
+    cluster.set({ serverVersion: '1.17.0' });
+    return;
+  }
 
   return await requestFromAPI(routeForApi('cluster'), {
     request,

--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -1,6 +1,7 @@
 import { derived } from 'svelte/store';
 import { page } from '$app/stores';
 import { persistStore } from '$lib/stores/persist-store';
+import { settings } from '$lib/stores/settings';
 import { temporalVersion } from './versions';
 import { isVersionNewer } from '$lib/utilities/version-check';
 
@@ -33,8 +34,10 @@ export const eventSortParam = derived([page], ([$page]) =>
 );
 
 export const supportsReverseOrder = derived(
-  [temporalVersion],
-  ([$temporalVersion]) => {
+  [temporalVersion, settings],
+  ([$temporalVersion, $settings]) => {
+    if ($settings.runtimeEnvironment.isCloud) return true;
+
     console.log('supports reverse', isVersionNewer($temporalVersion, '1.16.0'));
     return isVersionNewer($temporalVersion, '1.16.0');
   },


### PR DESCRIPTION
## What was changed
With the added temporalVersion check for the reverse call, cloud will always have reverse disabled since the cluster store is never set. I hard coded in 1.17.0 but definitely looking for suggestions here. Is it safe to assume cloud will always be above 1.16? Should I just do a isCloud check here?

## Why?
Add reverse events call for cloud
