### PR TITLE
Set lastUsedNamespace on namespace page mount

### DIFF
--- a/src/routes/namespaces/[namespace]/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/index@root.svelte
@@ -35,14 +35,21 @@
 
 <script lang="ts">
   import { dev } from '$app/env';
+  import { onMount } from 'svelte';
+
   import { temporalVersion, uiVersion } from '$lib/stores/versions';
   import { supportsReverseOrder } from '$lib/stores/event-view';
+  import { lastUsedNamespace } from '$lib/stores/namespaces';
 
   import { fromSecondsToDaysOrHours } from '$lib/utilities/format-date';
   import { getClusters } from '$lib/utilities/get-clusters';
 
   export let currentNamespace: DescribeNamespaceResponse;
   export let clusters: string;
+
+  onMount(() => {
+    $lastUsedNamespace = currentNamespace?.namespaceInfo?.name;
+  });
 </script>
 
 <h2 class="text-2xl" data-cy="namespace-title">


### PR DESCRIPTION
## What was changed
Set lastUsedNamespace on namespace page mount so when Workflows button is clicked it goes to that namespace's workflow

## Why?
Better UI
