### PR TITLE
add onError handler for fetchAllWorkflows, show error in empty state

### DIFF
--- a/src/lib/components/empty-state.svelte
+++ b/src/lib/components/empty-state.svelte
@@ -3,6 +3,7 @@
 
   export let title: string;
   export let content: string = '';
+  export let error: string = '';
 </script>
 
 <div
@@ -17,5 +18,12 @@
   <h2 class="text-xl font-medium">{title}</h2>
   {#if content}
     <p class="text-center">{content}</p>
+  {/if}
+  {#if error}
+    <p
+      class="rounded-md border-2 border-orange-500 bg-orange-100 p-5 text-center"
+    >
+      {error}
+    </p>
   {/if}
 </div>

--- a/src/lib/pages/workflows.svelte
+++ b/src/lib/pages/workflows.svelte
@@ -2,7 +2,12 @@
   import { page } from '$app/stores';
   import { timeFormat } from '$lib/stores/time-format';
   import { workflowsSearch } from '$lib/stores/workflows';
-  import { workflows, loading, updating } from '$lib/stores/workflows';
+  import {
+    workflows,
+    loading,
+    updating,
+    workflowError,
+  } from '$lib/stores/workflows';
   import { namespaceSelectorOpen } from '$lib/stores/nav-open';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
   import { viewFeature } from '$lib/stores/new-feature-tags';
@@ -77,5 +82,9 @@
     </WorkflowsSummaryTable>
   </Pagination>
 {:else}
-  <EmptyState title={'No Workflows Found'} content={errorMessage} />
+  <EmptyState
+    title={'No Workflows Found'}
+    content={errorMessage}
+    error={$workflowError}
+  />
 {/if}

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -38,8 +38,11 @@ export const fetchAllWorkflows = async (
     ? 'workflows.archived'
     : 'workflows';
 
-  let onError: ErrorCallback;
-  let error: string;
+  let error = '';
+  const onError: ErrorCallback = (err) =>
+    (error =
+      err?.body?.message ??
+      `Error fetching workflows: ${err.status}: ${err.statusText}`);
 
   const { executions, nextPageToken } =
     (await requestFromAPI<ListWorkflowExecutionsResponse>(

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -18,8 +18,15 @@ const parameters = derived([namespace, query], ([$namespace, $query]) => {
 const updateWorkflows: StartStopNotifier<WorkflowExecution[]> = (set) => {
   return parameters.subscribe(({ namespace, query }) => {
     withLoading(loading, updating, async () => {
-      const { workflows } = await fetchAllWorkflows(namespace, { query });
+      const { workflows, error } = await fetchAllWorkflows(namespace, {
+        query,
+      });
       set(workflows);
+      if (error) {
+        workflowError.set(error);
+      } else {
+        workflowError.set('');
+      }
     });
   });
 };
@@ -34,4 +41,5 @@ export const workflowsSearch = writable<WorkflowsSearch>({
 });
 export const updating = writable(true);
 export const loading = writable(true);
+export const workflowError = writable('');
 export const workflows = readable<WorkflowExecution[]>([], updateWorkflows);


### PR DESCRIPTION
## What was changed
Instead of hitting ErrorBoundary on fetchAllWorkflows, catch it with onError and display error in empty state. 

## Why?
Doesn't crash page, shows error and lets users jump back into fixing search.