### PR TITLE
Address edge case in ordering hash and search parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 /.svelte-kit
 /package
+/cypress/screenshots
 /cypress/videos
 /build-local
 /build-cloud

--- a/cypress/integration/events-in-ascending-order-in-json-view.spec.js
+++ b/cypress/integration/events-in-ascending-order-in-json-view.spec.js
@@ -1,0 +1,41 @@
+/// <reference types="cypress" />
+
+const visitWorkflow = (suffix = '') => {
+  cy.visit(
+    `/namespaces/default/workflows/workflowId/runId/history/json${suffix}`,
+  );
+};
+
+describe('Fallback to Ascending Ordering of Event History on Older Versions of Temporal Server', () => {
+  beforeEach(() => {
+    cy.interceptNamespacesApi();
+    cy.interceptUserApi();
+    cy.interceptGithubReleasesApi();
+    cy.interceptQueryApi();
+    cy.interceptTaskQueuesApi();
+    cy.interceptSettingsApi();
+    cy.interceptWorkflowApi();
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
+        '/api/v1/namespaces/default/workflows/workflowId/runs/runId/events?',
+      { fixture: 'event-history-completed.json' },
+    ).as('events-ascending-api');
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
+        '/api/v1/namespaces/default/workflows/workflowId/runs/runId/events/reverse?',
+      { fixture: 'event-history-completed-reverse.json' },
+    ).as('events-descending-api');
+  });
+
+  it('should show the events in ascending order in the JSON view', () => {
+    visitWorkflow();
+    cy.wait('@events-ascending-api');
+  });
+
+  it('should ignore parameters for sort order in JSON view', () => {
+    visitWorkflow('?sort=descending');
+    cy.wait('@events-ascending-api');
+  });
+});

--- a/src/lib/components/export-history.svelte
+++ b/src/lib/components/export-history.svelte
@@ -11,6 +11,7 @@
       namespace,
       workflowId,
       runId,
+      sort: 'ascending',
     });
 
     const content = JSON.stringify({ events }, null, 2);

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -1,6 +1,22 @@
 <script lang="ts">
+  import { page } from '$app/stores';
+
   import CodeBlock from '$lib/components/code-block.svelte';
-  import { events } from '$lib/stores/events';
+  import Loading from '$lib/components/loading.svelte';
+  import { fetchRawEvents } from '$lib/services/events-service';
+  import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
+
+  const { namespace, workflow: workflowId, run: runId } = $page.params;
+  const events = fetchRawEvents({
+    namespace: decodeURIForSvelte(namespace),
+    workflowId: decodeURIForSvelte(workflowId),
+    runId: decodeURIForSvelte(runId),
+    sort: 'ascending',
+  });
 </script>
 
-<CodeBlock content={$events} data-cy="event-history-json" />
+{#await events}
+  <Loading />
+{:then events}
+  <CodeBlock content={events} data-cy="event-history-json" />
+{/await}

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -5,26 +5,23 @@ import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 import { toEventHistory } from '$lib/models/event-history';
 import type { EventSortOrder } from '$lib/stores/event-view';
+import { isSortOrder } from '$lib/utilities/is';
 
 export type FetchEventsParameters = NamespaceScopedRequest &
   PaginationCallbacks<GetWorkflowExecutionHistoryResponse> & {
     workflowId: string;
     runId: string;
     rawPayloads?: boolean;
-    sort?: string;
+    sort?: EventSortOrder;
   };
 
 export type FetchEventsParametersWithSettings = FetchEventsParameters & {
   settings: Settings;
 };
 
-const isSortOrder = (sortOrder: string): sortOrder is EventSortOrder => {
-  if (sortOrder === 'ascending') return true;
-  if (sortOrder === 'descending') return true;
-  return false;
-};
-
-const getEndpointForSortOrder = (sortOrder: string): WorkflowAPIRoutePath => {
+const getEndpointForSortOrder = (
+  sortOrder: EventSortOrder,
+): WorkflowAPIRoutePath => {
   if (!isSortOrder(sortOrder)) return 'events.descending';
   if (sortOrder === 'descending') return 'events.descending';
   if (sortOrder === 'ascending') return 'events.ascending';

--- a/src/lib/stores/versions.ts
+++ b/src/lib/stores/versions.ts
@@ -3,9 +3,9 @@ import { cluster } from './cluster';
 import { settings } from './settings';
 
 export const temporalVersion = derived([cluster], ([$cluster]) => {
-  return $cluster.serverVersion;
+  return $cluster?.serverVersion;
 });
 
 export const uiVersion = derived([settings], ([$settings]) => {
-  return $settings.version;
+  return $settings?.version;
 });

--- a/src/lib/utilities/is.ts
+++ b/src/lib/utilities/is.ts
@@ -1,3 +1,5 @@
+import type { EventSortOrder } from '$lib/stores/event-view';
+
 type Space = ' ';
 type Quote = "'" | '"';
 type Operator = typeof operators[number];
@@ -69,5 +71,11 @@ export const isOperator = (x: unknown): x is Operator => {
     if (x === operator) return true;
   }
 
+  return false;
+};
+
+export const isSortOrder = (sortOrder: string): sortOrder is EventSortOrder => {
+  if (sortOrder === 'ascending') return true;
+  if (sortOrder === 'descending') return true;
   return false;
 };

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -69,7 +69,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/#?parameter=value',
+      'https://temporal.io/?parameter=value',
       gotoOptions,
     );
   });
@@ -82,7 +82,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/#?parameter=newvalue',
+      'https://temporal.io/?parameter=newvalue',
       gotoOptions,
     );
   });
@@ -94,7 +94,7 @@ describe('updateQueryParameters', () => {
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    expect(goto).toHaveBeenCalledWith('https://temporal.io/#', gotoOptions);
+    expect(goto).toHaveBeenCalledWith('https://temporal.io/', gotoOptions);
   });
 
   it('should set the parameter to an empty string if allowEmpty is set', () => {
@@ -105,7 +105,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto, allowEmpty: true });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/#?parameter=',
+      'https://temporal.io/?parameter=',
       gotoOptions,
     );
   });

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -134,7 +134,7 @@ describe('a sanity test for how URLs work in JavaScript', () => {
 
   it('should not be able to parse the hash if it comes before the search parameters', () => {
     const url = new URL('https://temporal.io/#hash?parameter=value');
-    expect(url.hash).not.toBe('hash');
+    expect(url.hash).not.toBe('#hash');
   });
 
   it('should not be able to parse the search parameters if they come after the hash', () => {

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { updateQueryParameters } from './update-query-parameters';
+import { addHashToURL, updateQueryParameters } from './update-query-parameters';
 
 const gotoOptions = { replaceState: true, keepfocus: true, noscroll: true };
 const url = new URL('https://temporal.io');
@@ -50,7 +50,7 @@ describe('updateQueryParameters', () => {
 
   it('should call the delete method on the query when null is provided', () => {
     const parameter = 'parameter';
-    const value = null;
+    const value = null as unknown as string;
     const goto = () => Promise.resolve();
 
     const spy = vi.spyOn(url.searchParams, 'delete');
@@ -68,7 +68,10 @@ describe('updateQueryParameters', () => {
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    expect(goto).toHaveBeenCalledWith(url.toString(), gotoOptions);
+    expect(goto).toHaveBeenCalledWith(
+      'https://temporal.io/#?parameter=value',
+      gotoOptions,
+    );
   });
 
   it('should call `goto` with the correct path when query parameters already exist', () => {
@@ -79,18 +82,73 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/?parameter=newvalue#',
+      'https://temporal.io/#?parameter=newvalue',
       gotoOptions,
     );
   });
 
   it('should call `goto` with without the "?" if the query params are empty', () => {
     const parameter = 'parameter';
-    const value = null;
+    const value = null as unknown as string;
     const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith('https://temporal.io/#', gotoOptions);
+  });
+
+  it('should set the parameter to an empty string if allowEmpty is set', () => {
+    const parameter = 'parameter';
+    const value = '';
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto, allowEmpty: true });
+
+    expect(goto).toHaveBeenCalledWith(
+      'https://temporal.io/#?parameter=',
+      gotoOptions,
+    );
+  });
+});
+
+describe('addHashToURL', () => {
+  it('should add a hash to a URL', () => {
+    const url = new URL('https://temporal.io/');
+    expect(addHashToURL(url)).toBe('https://temporal.io/#');
+  });
+
+  it('should not add a duplicate hash to a URL', () => {
+    const url = new URL('https://temporal.io/#');
+    expect(addHashToURL(url)).toBe('https://temporal.io/#');
+  });
+
+  it('should put the hash before the search parameters', () => {
+    const url = new URL('https://temporal.io/?parameter=value');
+    expect(addHashToURL(url)).toBe('https://temporal.io/#?parameter=value');
+  });
+});
+
+describe('a sanity test for how URLs work in JavaScript', () => {
+  // This is primarily meant to serve as documentation for some of the of the
+  // decisions made above.
+
+  it('should not be able to parse the hash if it comes before the search parameters', () => {
+    const url = new URL('https://temporal.io/#hash?parameter=value');
+    expect(url.hash).not.toBe('hash');
+  });
+
+  it('should not be able to parse the search parameters if they come after the hash', () => {
+    const url = new URL('https://temporal.io/#hash?parameter=value');
+    expect(url.search).not.toBe('?parameter=value');
+  });
+
+  it('should be able to parse the search parameters if it comes after the hash', () => {
+    const url = new URL('https://temporal.io/?parameter=value#hash');
+    expect(url.search).toBe('?parameter=value');
+  });
+
+  it('should be able to parse hash if it comes after the search parameters ', () => {
+    const url = new URL('https://temporal.io/?parameter=value#hash');
+    expect(url.hash).toBe('#hash');
   });
 });

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -129,7 +129,7 @@ describe('addHashToURL', () => {
 });
 
 describe('a sanity test for how URLs work in JavaScript', () => {
-  // This is primarily meant to serve as documentation for some of the of the
+  // This is primarily meant to serve as documentation for some of the
   // decisions made above.
 
   it('should not be able to parse the hash if it comes before the search parameters', () => {

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -35,7 +35,7 @@ export const updateQueryParameters = async ({
   }
 
   if (browser && url.href !== window.location.href) {
-    goto(url.href, gotoOptions);
+    goto(String(url), gotoOptions);
   }
 
   return value;

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -35,8 +35,7 @@ export const updateQueryParameters = async ({
   }
 
   if (browser && url.href !== window.location.href) {
-    // This is to trigger store updates when used as npm package.
-    goto(addHashToURL(url), gotoOptions);
+    goto(url.href, gotoOptions);
   }
 
   return value;

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -11,7 +11,7 @@ type UpdateQueryParams = {
   invalidate?: typeof invalidate;
 };
 
-export const gotoOptions = {
+const gotoOptions = {
   replaceState: true,
   keepfocus: true,
   noscroll: true,

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -35,12 +35,22 @@ export const updateQueryParameters = async ({
   }
 
   if (browser && url.href !== window.location.href) {
-    // Needed to trigger store updates when used as npm package
-    if (!url.href.endsWith('#')) {
-      url.href = url.href + '#';
-    }
-    goto(String(url), gotoOptions);
+    // This is to trigger store updates when used as npm package.
+    goto(addHashToURL(url), gotoOptions);
   }
 
   return value;
+};
+
+export const addHashToURL = (url: URL): string => {
+  const { href } = url;
+
+  if (href.includes('#')) return href;
+
+  if (href.includes('?')) {
+    const [before, after] = href.split('?');
+    return `${before}#?${after}`;
+  }
+
+  return href + '#';
 };


### PR DESCRIPTION
The hash should come after the search parameters. This addresses an edge case when using `updateQueryParameters` that could render both the search parameters and the hash unreadable in JavaScript.

- Current behavior: `https://temporal.io/?parameter=#` and `https://temporal.io/?parameter=value#`
- Desired behavior:  `https://temporal.io/#?parameter=` and `https://temporal.io/#?parameter=value`

Included are a set of tests that outline this behavior.

```js
describe('a sanity test for how URLs work in JavaScript', () => {
  it('should not be able to parse the hash if it comes before the search parameters', () => {
    const url = new URL('https://temporal.io/#hash?parameter=value');
    expect(url.hash).not.toBe('hash');
  });

  it('should not be able to parse the search parameters if they come after the hash', () => {
    const url = new URL('https://temporal.io/#hash?parameter=value');
    expect(url.search).not.toBe('?parameter=value');
  });

  it('should be able to parse the search parameters if it comes after the hash', () => {
    const url = new URL('https://temporal.io/?parameter=value#hash');
    expect(url.search).toBe('?parameter=value');
  });

  it('should be able to parse hash if it comes after the search parameters ', () => {
    const url = new URL('https://temporal.io/?parameter=value#hash');
    expect(url.hash).toBe('#hash');
  });
```