### PR TITLE
Add url.hash on goto for update-query-params, speed up drawer

### DIFF
--- a/src/lib/holocene/navigation/_drawer.svelte
+++ b/src/lib/holocene/navigation/_drawer.svelte
@@ -71,7 +71,7 @@
 
   .flyin {
     animation-name: flyin;
-    animation-duration: 0.6s;
+    animation-duration: 0.3s;
     animation-iteration-count: 1;
     animation-direction: normal;
     animation-timing-function: ease-in-out;
@@ -79,7 +79,7 @@
   }
   .flyout {
     animation-name: flyout;
-    animation-duration: 0.6s;
+    animation-duration: 0.3s;
     animation-iteration-count: 1;
     animation-direction: normal;
     animation-timing-function: ease-in-out;
@@ -89,7 +89,7 @@
   @media (max-width: 640px) {
     .flyin {
       animation-name: flyinSmall;
-      animation-duration: 0.6s;
+      animation-duration: 0.3s;
       animation-iteration-count: 1;
       animation-direction: normal;
       animation-timing-function: ease-in-out;
@@ -97,7 +97,7 @@
     }
     .flyout {
       animation-name: flyoutSmall;
-      animation-duration: 0.6s;
+      animation-duration: 0.3s;
       animation-iteration-count: 1;
       animation-direction: normal;
       animation-timing-function: ease-in-out;

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -69,7 +69,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/?parameter=value',
+      'https://temporal.io/?parameter=value#',
       gotoOptions,
     );
   });
@@ -82,7 +82,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/?parameter=newvalue',
+      'https://temporal.io/?parameter=newvalue#',
       gotoOptions,
     );
   });
@@ -94,7 +94,7 @@ describe('updateQueryParameters', () => {
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    expect(goto).toHaveBeenCalledWith('https://temporal.io/', gotoOptions);
+    expect(goto).toHaveBeenCalledWith('https://temporal.io/#', gotoOptions);
   });
 
   it('should set the parameter to an empty string if allowEmpty is set', () => {
@@ -105,7 +105,7 @@ describe('updateQueryParameters', () => {
     updateQueryParameters({ parameter, value, url, goto, allowEmpty: true });
 
     expect(goto).toHaveBeenCalledWith(
-      'https://temporal.io/?parameter=',
+      'https://temporal.io/?parameter=#',
       gotoOptions,
     );
   });
@@ -122,9 +122,9 @@ describe('addHashToURL', () => {
     expect(addHashToURL(url)).toBe('https://temporal.io/#');
   });
 
-  it('should put the hash before the search parameters', () => {
+  it('should put the hash after the search parameters', () => {
     const url = new URL('https://temporal.io/?parameter=value');
-    expect(addHashToURL(url)).toBe('https://temporal.io/#?parameter=value');
+    expect(addHashToURL(url)).toBe('https://temporal.io/?parameter=value#');
   });
 });
 

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -35,21 +35,13 @@ export const updateQueryParameters = async ({
   }
 
   if (browser && url.href !== window.location.href) {
-    goto(String(url), gotoOptions);
+    goto(addHashToURL(url), gotoOptions);
   }
 
   return value;
 };
 
 export const addHashToURL = (url: URL): string => {
-  const { href } = url;
-
-  if (href.includes('#')) return href;
-
-  if (href.includes('?')) {
-    const [before, after] = href.split('?');
-    return `${before}#?${after}`;
-  }
-
-  return href + '#';
+  url.hash = '#';
+  return String(url);
 };


### PR DESCRIPTION
## What was changed
No string shenanigans with url hash, just use url.hash. Speed up drawer.

## Why?
Fixes filtering when used as an npm package

1. Closes #655 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually tested all cases of update query params in OSS and as a package, unit tested.
