### PR TITLE
Rework Code Blocks in Pending Activities

### DIFF
--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -55,7 +55,7 @@
       class="w-full overflow-x-scroll rounded-lg p-4"
       class:h-full={!inline}><code
         bind:this={root}
-        class={`language-${language}`}
+        class="language-{language}"
         data-cy={$$props['data-cy']}
       /></pre>
 

--- a/src/lib/components/workflow/pending-activties.svelte
+++ b/src/lib/components/workflow/pending-activties.svelte
@@ -34,19 +34,17 @@
             <a class="flex w-full items-center hover:bg-gray-50" {href}>
               <div class="pending-activity-inner-row">
                 <div class="pending-activity-detail">
-                  <h4>Activity Type</h4>
+                  <h4 class="pending-activity-detail-header">Activity Type</h4>
                   <Badge type={failed ? 'warning' : 'default'}>
                     {pendingActivity.activityType}
                   </Badge>
                 </div>
-                <h4 class="pending-activity-detail">
-                  Last Heartbeat {formatDate(
-                    pendingActivity.lastHeartbeatTime,
-                    'relative',
-                  )}
-                </h4>
                 <div class="pending-activity-detail">
-                  <h4>Attempt</h4>
+                  <h4 class="pending-activity-detail-header">Last Heartbeat</h4>
+                  {formatDate(pendingActivity.lastHeartbeatTime, 'relative')}
+                </div>
+                <div class="pending-activity-detail">
+                  <h4 class="pending-activity-detail-header">Attempt</h4>
                   <Badge type={failed ? 'warning' : 'default'}>
                     {#if failed}
                       <Icon
@@ -60,19 +58,20 @@
                   </Badge>
                 </div>
                 <div class="pending-activity-detail">
-                  <h4>Attempts Left</h4>
+                  <h4 class="pending-activity-detail-header">Attempts Left</h4>
                   <Badge type={failed ? 'warning' : 'default'}>
                     {pendingActivity.maximumAttempts - pendingActivity.attempt}
                   </Badge>
                 </div>
                 <div class="pending-activity-detail">
-                  <h4>Next Retry</h4>
+                  <h4 class="pending-activity-detail-header">Next Retry</h4>
                   <Badge type={failed ? 'warning' : 'default'}>
                     {defaultWorkflowTaskTimeout}
                   </Badge>
                 </div>
                 <h4 class="pending-activity-detail">
-                  Expiration {formatDuration(
+                  <h4 class="pending-activity-detail-header">Expiration</h4>
+                  {formatDuration(
                     getDuration({
                       start: Date.now(),
                       end: pendingActivity.expirationTime,
@@ -83,24 +82,26 @@
             </a>
             {#if failed}
               <div class="pending-activity-failure-details">
-                <div class="hidden lg:inline-block">
-                  {#if pendingActivity.heartbeatDetails}
-                    <h4>Heartbeat Details</h4>
+                {#if pendingActivity.heartbeatDetails}
+                  <div class="w-full">
+                    <h4 class="pending-activity-detail-header">
+                      Heartbeat Details
+                    </h4>
                     <CodeBlock
                       class="max-h-32"
                       content={pendingActivity.heartbeatDetails}
                     />
-                  {/if}
-                </div>
-                <div class="hidden lg:inline-block">
-                  {#if pendingActivity.lastFailure}
-                    <h4>Last Failure</h4>
+                  </div>
+                {/if}
+                {#if pendingActivity.lastFailure}
+                  <div class="w-full">
+                    <h4 class="pending-activity-detail-header">Last Failure</h4>
                     <CodeBlock
                       class="max-h-32"
                       content={pendingActivity.lastFailure}
                     />
-                  {/if}
-                </div>
+                  </div>
+                {/if}
               </div>
             {/if}
           </div>
@@ -115,11 +116,11 @@
 
 <style lang="postcss">
   .pending-activity-row {
-    @apply mb-2 flex w-full flex-row items-center;
+    @apply mb-2 flex gap-2 w-full flex-row items-center;
   }
 
   .pending-activity-summary {
-    @apply w-full border-b-2 border-gray-300 text-sm;
+    @apply w-full overflow-x-scroll border-b-2 border-gray-300 text-sm;
   }
 
   .pending-activity-row:last-child .pending-activity-summary {
@@ -127,21 +128,18 @@
   }
 
   .pending-activity-inner-row {
-    width: 100%;
-    display: grid;
-    grid-template-columns: 20% 20% repeat(3, 1fr) 20%;
-    column-gap: 1rem;
+    @apply w-full flex flex-row gap-6 content-between;
   }
 
   .pending-activity-detail {
-    @apply xl:flex xl:flex-row xl:items-center xl:gap-2;
+    @apply xl:flex xl:flex-row xl:items-center xl:gap-2 w-full whitespace-nowrap;
+  }
+
+  .pending-activity-detail-header {
+    @apply font-medium after:content-[':'];
   }
 
   .pending-activity-failure-details {
-    width: 100%;
-    margin-bottom: 0.5rem;
-    display: grid;
-    grid-template-columns: 40% 1fr;
-    column-gap: 2rem;
+    @apply w-full gap-4 flex flex-row;
   }
 </style>


### PR DESCRIPTION
Addresses an edge case where if a failure had long message, it would exceed the width of the container.

Before:

<img width="1704" alt="image" src="https://user-images.githubusercontent.com/251000/178295140-28fd7bb5-81fc-4d0c-9365-fc37a2a73ec4.png">

After:

<img width="1671" alt="Screen Shot 2022-07-11 at 11 00 54 AM" src="https://user-images.githubusercontent.com/251000/178295188-4ed20455-1f0f-44c5-94f9-5c84f176227b.png">

