### PR TITLE
Address Strict TypeScript errors with empty User object

### DIFF
--- a/src/lib/components/hamburger-header.svelte
+++ b/src/lib/components/hamburger-header.svelte
@@ -3,6 +3,8 @@
 
   import { fly } from 'svelte/transition';
 
+  import { hasKeys } from '$lib/utilities/has';
+
   import DataEncoderStatus from '$lib/components/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
 
@@ -28,7 +30,7 @@
     </a>
   </div>
   <div class="col-span-4 flex items-center justify-end gap-4">
-    {#if user}
+    {#if hasKeys(user)}
       <DataEncoderStatus />
     {/if}
   </div>

--- a/src/lib/components/navigation-header.svelte
+++ b/src/lib/components/navigation-header.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { hasKeys } from '$lib/utilities/has';
   import DataEncoderStatus from '$lib/components/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
 
@@ -17,7 +18,7 @@
     <slot name="links" />
   </div>
   <div class="col-span-5 col-end-13 flex items-center justify-end gap-4">
-    {#if user}
+    {#if hasKeys(user)}
       <DataEncoderStatus />
     {/if}
     <FeedbackButton />

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -23,4 +23,26 @@ describe('hasKeys', () => {
     const source = {};
     expect(hasKeys(source)).toBe(false);
   });
+
+  it('should return false if given null', () => {
+    expect(hasKeys(null as unknown as Parameters<typeof hasKeys>[0])).toBe(
+      false,
+    );
+  });
+
+  it('should return false if given undefined', () => {
+    expect(hasKeys(undefined as unknown as Parameters<typeof hasKeys>[0])).toBe(
+      false,
+    );
+  });
+
+  it('should return false if given a number', () => {
+    expect(hasKeys(3 as unknown as Parameters<typeof hasKeys>[0])).toBe(false);
+  });
+
+  it('should return false if given a boolean', () => {
+    expect(hasKeys(true as unknown as Parameters<typeof hasKeys>[0])).toBe(
+      false,
+    );
+  });
 });

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { has, hasKeys } from './has';
+
+describe('has', () => {
+  it('returns true if an object has a key', () => {
+    const source = { foo: 123 };
+    expect(has(source, 'foo')).toBe(true);
+  });
+
+  it('returns false if an object does not have key', () => {
+    const source = { foo: 123 };
+    expect(has(source, 'bar')).toBe(false);
+  });
+});
+
+describe('hasKeys', () => {
+  it('returns true if an object has keys', () => {
+    const source = { foo: 123 };
+    expect(hasKeys(source)).toBe(true);
+  });
+
+  it('returns false if an object has no keys', () => {
+    const source = {};
+    expect(hasKeys(source)).toBe(false);
+  });
+});

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -1,3 +1,5 @@
+import { isObject } from './is';
+
 export const has = (target: unknown, property: string): boolean => {
   return Object.prototype.hasOwnProperty.call(target, property);
 };
@@ -5,5 +7,6 @@ export const has = (target: unknown, property: string): boolean => {
 export const hasKeys = (obj: {
   [key: string | number | symbol]: unknown;
 }): boolean => {
+  if (!isObject(obj)) return false;
   return !!Object.keys(obj).length;
 };

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -1,3 +1,9 @@
 export const has = (target: unknown, property: string): boolean => {
   return Object.prototype.hasOwnProperty.call(target, property);
 };
+
+export const hasKeys = (obj: {
+  [key: string | number | symbol]: unknown;
+}): boolean => {
+  return !!Object.keys(obj).length;
+};

--- a/src/routes/signin/index@signin.svelte
+++ b/src/routes/signin/index@signin.svelte
@@ -32,8 +32,8 @@
   export let settings: Settings;
 </script>
 
-<NavigationHeader href="/" user={undefined} />
-<HamburgerHeader href="/" user={undefined} />
+<NavigationHeader href="/" user={{}} />
+<HamburgerHeader href="/" user={{}} />
 <section class="my-[20vh] text-center">
   <h1 class="text-8xl font-semibold">Welcome back.</h1>
   <p class="my-7">Let's get you signed in.</p>


### PR DESCRIPTION
Fixes two out of 394 TypeScript errors when strict mode is turned on.