### PR TITLE
Don't fetch stack trace when no workers running, better warning message

### DIFF
--- a/src/lib/components/empty-state.svelte
+++ b/src/lib/components/empty-state.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import Icon from '$lib/holocene/icon/index.svelte';
+  import type { IconName } from '$lib/holocene/icon/paths';
 
   export let title: string;
   export let content: string = '';
   export let error: string = '';
+  export let icon: IconName = 'comet';
 </script>
 
 <div
@@ -13,7 +15,7 @@
   <span
     class="flex h-16 w-16 items-center justify-center rounded-full bg-gray-200"
   >
-    <Icon name="comet" class="block h-full w-full" /></span
+    <Icon name={icon} class="block h-full w-full" /></span
   >
   <h2 class="text-xl font-medium">{title}</h2>
   {#if content}
@@ -26,4 +28,5 @@
       {error}
     </p>
   {/if}
+  <slot />
 </div>

--- a/src/lib/components/workflow/workflow-stack-trace-error.svelte
+++ b/src/lib/components/workflow/workflow-stack-trace-error.svelte
@@ -12,8 +12,9 @@
 {#if runningWithNoWorkers}
   <section class="stack-trace">
     <EmptyState
-      title="An Error Occured"
-      content="Please make sure you have at least one worker running."
+      icon="warning"
+      title="No Workers Running."
+      content="Please make sure you have at least one worker connected to the {workflow.taskQueue} Task Queue."
       class="my-0"
     />
   </section>

--- a/src/lib/components/workflow/workflow-stack-trace-error.svelte
+++ b/src/lib/components/workflow/workflow-stack-trace-error.svelte
@@ -13,7 +13,7 @@
   <section class="stack-trace">
     <EmptyState
       icon="warning"
-      title="No Workers Running."
+      title="No Workers Running"
       content="Please make sure you have at least one worker connected to the {workflow.taskQueue} Task Queue."
       class="my-0"
     />

--- a/src/lib/holocene/icon/paths.ts
+++ b/src/lib/holocene/icon/paths.ts
@@ -367,8 +367,6 @@ const temporalIcon: Icon = {
   ],
 };
 
-// <circle cx="12" cy = "16" r = "1" fill = "currentColor" > </circle>
-
 const warningIcon = {
   paths: [
     {

--- a/src/lib/holocene/icon/paths.ts
+++ b/src/lib/holocene/icon/paths.ts
@@ -367,6 +367,25 @@ const temporalIcon: Icon = {
   ],
 };
 
+// <circle cx="12" cy = "16" r = "1" fill = "currentColor" > </circle>
+
+const warningIcon = {
+  paths: [
+    {
+      d: 'M4.9522 16.3536L10.2152 5.85658C10.9531 4.38481 13.0539 4.3852 13.7913 5.85723L19.0495 16.3543C19.7156 17.6841 18.7487 19.25 17.2613 19.25H6.74007C5.25234 19.25 4.2854 17.6835 4.9522 16.3536Z',
+      stroke: '#111827',
+    },
+    {
+      d: 'M12 10V13',
+      stroke: '#111827',
+    },
+    {
+      d: 'M 12, 16 m -1, 0 a 1,1 0 1,0 2,0 a 1,1 0 1,0 -2,0',
+      fill: '#111827',
+    },
+  ],
+};
+
 const workflowIcon: Icon = {
   paths: [
     {
@@ -414,5 +433,6 @@ export const icons: { [index: string]: Icon } = {
   spinner: spinnerIcon,
   stopwatch: stopwatchIcon,
   temporal: temporalIcon,
+  warning: warningIcon,
   workflow: workflowIcon,
 };

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -9,6 +9,7 @@
   import Select from '$lib/components/select/select.svelte';
   import Button from '$holocene/button.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import Loading from '$lib/holocene/loading.svelte';
 
   const { namespace } = $page.params;
   const { workflow } = $workflowRun;
@@ -44,7 +45,7 @@
 <section>
   {#await queryTypes}
     <div class="text-center">
-      <h2 class="font-bold text-2xl mb-4">Loading…</h2>
+      <Loading />
       <p>(This will fail if you have no workers running.)</p>
     </div>
   {:then types}
@@ -73,10 +74,11 @@
         <CodeBlock content={result} />
       {/await}
     </div>
-  {:catch}
+  {:catch _error}
     <EmptyState
       title="An Error Occurred"
       content="Please make sure you have at least one worker running."
+      error={_error?.message}
     />
   {/await}
 </section>

--- a/src/lib/pages/workflow-stack-trace.svelte
+++ b/src/lib/pages/workflow-stack-trace.svelte
@@ -9,9 +9,11 @@
   import Button from '$holocene/button.svelte';
   import EmptyState from '$lib/components/empty-state.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import Loading from '$lib/holocene/loading.svelte';
+  import Link from '$lib/components/link.svelte';
 
   const { namespace } = $page.params;
-  const { workflow } = $workflowRun;
+  const { workflow, workers } = $workflowRun;
 
   let currentdate = new Date();
   let isLoading = false;
@@ -44,10 +46,10 @@
   url={$page.url.href}
 />
 <section>
-  {#if workflow.isRunning}
+  {#if workflow.isRunning && workers?.pollers?.length > 0}
     {#await stackTrace}
       <div class="text-center">
-        <h2 class="font-bold text-2xl mb-4">Loading…</h2>
+        <Loading />
         <p>(This will fail if you have no workers running.)</p>
       </div>
     {:then result}
@@ -76,9 +78,15 @@
       />
     {/await}
   {:else}
-    <EmptyState
-      title="No Stack Traces Found"
-      dataCy="query-stack-trace-empty"
-    />
+    <EmptyState title="No Stack Traces Found" dataCy="query-stack-trace-empty">
+      {#if workflow.isRunning && workers?.pollers?.length === 0}
+        <p>
+          To enable <Link
+            href="https://docs.temporal.io/concepts/what-is-a-query/#stack-trace-query"
+            >stack traces</Link
+          >, run a Worker on the {workflow?.taskQueue} Task Queue.
+        </p>
+      {/if}
+    </EmptyState>
   {/if}
 </section>


### PR DESCRIPTION
## What was changed

If no workers are running on a running workflow, don't query stack trace. Show link instead.

<img width="1722" alt="Screen Shot 2022-07-11 at 3 59 11 PM" src="https://user-images.githubusercontent.com/7967403/178361079-0d921e99-4503-4684-b31a-6760ba6cf29e.png">

Better warning icon and text
<img width="1719" alt="Screen Shot 2022-07-11 at 4 21 49 PM" src="https://user-images.githubusercontent.com/7967403/178361050-4d332958-cca1-4ca0-82e9-338ffd54eb77.png">

Also, show query error if error occurs

## Why?
Better UX around error states of querying / no workers

Closes #604, #607, 