### PR TITLE
Use static page titles for workflow history pages

### DIFF
--- a/src/lib/pages/workflow-history-compact.svelte
+++ b/src/lib/pages/workflow-history-compact.svelte
@@ -4,12 +4,11 @@
   import EventSummary from '$lib/components/event/event-summary.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
   import { ascendingEventGroups } from '$lib/stores/events';
+
+  const workflow = $page.params?.workflow;
 </script>
 
-<PageTitle
-  title={`Workflow History | ${$page.params?.workflow}`}
-  url={$page.url.href}
-/>
+<PageTitle title={`Workflow History | ${workflow}`} url={$page.url.href} />
 <EventSummary
   items={$ascendingEventGroups}
   groups={$ascendingEventGroups}

--- a/src/lib/pages/workflow-history-feed.svelte
+++ b/src/lib/pages/workflow-history-feed.svelte
@@ -4,10 +4,9 @@
   import EventSummary from '$lib/components/event/event-summary.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
   import { events, eventGroups } from '$lib/stores/events';
+
+  const workflow = $page.params?.workflow;
 </script>
 
-<PageTitle
-  title={`Workflow History | ${$page.params?.workflow}`}
-  url={$page.url.href}
-/>
+<PageTitle title={`Workflow History | ${workflow}`} url={$page.url.href} />
 <EventSummary items={$events} groups={$eventGroups} />

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -16,12 +16,10 @@
 
   const { pendingActivities, defaultWorkflowTaskTimeout } =
     $workflowRun.workflow;
+  const workflow = $page.params?.workflow;
 </script>
 
-<PageTitle
-  title={`Pending Activities | ${$page.params?.workflow}`}
-  url={$page.url.href}
-/>
+<PageTitle title={`Pending Activities | ${workflow}`} url={$page.url.href} />
 {#if pendingActivities.length}
   <section class="event-table">
     <header class="event-table-header">

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -41,7 +41,7 @@
   }
 </script>
 
-<PageTitle title={`Query | ${$page.params?.workflow}`} url={$page.url.href} />
+<PageTitle title={`Query | ${workflow.id}`} url={$page.url.href} />
 <section>
   {#await queryTypes}
     <div class="text-center">

--- a/src/lib/pages/workflow-stack-trace.svelte
+++ b/src/lib/pages/workflow-stack-trace.svelte
@@ -41,10 +41,7 @@
   };
 </script>
 
-<PageTitle
-  title={`Stack Trace | ${$page.params?.workflow}`}
-  url={$page.url.href}
-/>
+<PageTitle title={`Stack Trace | ${workflow.id}`} url={$page.url.href} />
 <section>
   {#if workflow.isRunning && workers?.pollers?.length > 0}
     {#await stackTrace}

--- a/src/lib/pages/workflow-workers.svelte
+++ b/src/lib/pages/workflow-workers.svelte
@@ -13,7 +13,7 @@
   const { workers, workflow } = $workflowRun;
 </script>
 
-<PageTitle title={`Workers | ${$page.params?.workflow}`} url={$page.url.href} />
+<PageTitle title={`Workers | ${workflow.id}`} url={$page.url.href} />
 <section class="flex flex-col gap-4">
   <h3 class="text-lg font-medium">
     Task Queue: <span class="select-all font-normal">{workflow.taskQueue}</span>


### PR DESCRIPTION
## What was changed
Svelte is too smart for its own good and updates page titles even when they aren't rendered if they use dynamic page titles. I.e if you went to a workflow history page, then back to workflow list page, it would change the title to Workflows | {namespace} (which is correct), then instantly change it to Workflow History | undefined. Make all the workflow history pages static.

## Why?
Fix page titles
