### PR TITLE
Show search attributes on the namespace settings page, fix CodeBlock

### DIFF
--- a/cypress/fixtures/search-attributes.json
+++ b/cypress/fixtures/search-attributes.json
@@ -1,0 +1,26 @@
+{
+  "keys": {
+    "BatcherNamespace": "Keyword",
+    "BatcherUser": "Keyword",
+    "BinaryChecksums": "Keyword",
+    "CloseTime": "Datetime",
+    "CustomBoolField": "Bool",
+    "CustomDatetimeField": "Datetime",
+    "CustomDoubleField": "Double",
+    "CustomIntField": "Int",
+    "CustomKeywordField": "Keyword",
+    "CustomStringField": "Text",
+    "CustomTextField": "Text",
+    "ExecutionDuration": "Int",
+    "ExecutionStatus": "Keyword",
+    "ExecutionTime": "Datetime",
+    "HistoryLength": "Int",
+    "RunId": "Keyword",
+    "StartTime": "Datetime",
+    "StateTransitionCount": "Int",
+    "TaskQueue": "Keyword",
+    "TemporalChangeVersion": "Keyword",
+    "WorkflowId": "Keyword",
+    "WorkflowType": "Keyword"
+  }
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -32,6 +32,12 @@ Cypress.Commands.add('interceptNamespacesApi', () => {
   }).as('namespaces-api');
 });
 
+Cypress.Commands.add('interceptSearchAttributesApi', () => {
+  cy.intercept(Cypress.env('VITE_API_HOST') + '/api/v1/search-attributes*', {
+    fixture: 'search-attributes.json',
+  }).as('search-attributes-api');
+});
+
 Cypress.Commands.add('interceptWorkflowsApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') + `/api/v1/namespaces/*/workflows?query=*`,
@@ -112,5 +118,6 @@ Cypress.Commands.add(
     cy.interceptQueryApi();
     cy.interceptTaskQueuesApi();
     cy.interceptSettingsApi();
+    cy.interceptSearchAttributesApi();
   },
 );

--- a/src/api.d.ts
+++ b/src/api.d.ts
@@ -12,15 +12,17 @@ type TaskQueueAPIRoutePath = 'task-queue';
 type ParameterlessAPIRoutePath = 'cluster' | 'settings' | 'user' | 'namespaces';
 type SchedulesAPIRoutePath = 'schedules';
 type ScheduleAPIRoutePath = 'schedule' | 'schedule.delete';
+type SearchAttributesRoutePath = 'search-attributes';
 
 type APIRoutePath =
-  | WorkflowsAPIRoutePath
-  | WorkflowAPIRoutePath
   | ParameterlessAPIRoutePath
-  | TaskQueueAPIRoutePath
-  | WorkflowsAPIArchivalRoutePath
+  | ScheduleAPIRoutePath
   | SchedulesAPIRoutePath
-  | ScheduleAPIRoutePath;
+  | SearchAttributesRoutePath
+  | TaskQueueAPIRoutePath
+  | WorkflowAPIRoutePath
+  | WorkflowsAPIArchivalRoutePath
+  | WorkflowsAPIRoutePath;
 
 type APIRouteParameters = {
   namespace: string;

--- a/src/lib/components/code-block.svelte
+++ b/src/lib/components/code-block.svelte
@@ -22,7 +22,7 @@
     return JSON.stringify(parsedData, undefined, inline ? 0 : 2);
   };
 
-  const parsedContent = isJSON ? formatJSON(content) : content;
+  $: parsedContent = isJSON ? formatJSON(content) : content;
   const { copy, copied } = copyToClipboard(parsedContent);
 
   function highlight(root: HTMLElement, language: string, source: string) {

--- a/src/lib/models/event-groups/get-event-in-group.test.ts
+++ b/src/lib/models/event-groups/get-event-in-group.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { groupEvents } from '.';
-import { createEventGroup } from './create-event-group';
 import {
   eventIsCanceled,
   eventIsFailureOrTimedOut,

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -2,15 +2,13 @@ import { searchAttributes } from '$lib/stores/search-attributes';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
-import type { GetSearchAttributesResponse } from '$types';
-
 export const fetchSearchAttributes = async (
   settings: Settings,
   request = fetch,
-): Promise<GetSearchAttributesResponse> => {
+): Promise<SearchAttributesResponse> => {
   if (settings.runtimeEnvironment.isCloud) return;
 
-  return await requestFromAPI<GetSearchAttributesResponse>(
+  return await requestFromAPI<SearchAttributesResponse>(
     routeForApi('search-attributes'),
     {
       request,

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -1,0 +1,23 @@
+import { searchAttributes } from '$lib/stores/search-attributes';
+import { requestFromAPI } from '$lib/utilities/request-from-api';
+import { routeForApi } from '$lib/utilities/route-for-api';
+
+import type { GetSearchAttributesResponse } from '$types';
+
+export const fetchSearchAttributes = async (
+  request = fetch,
+): Promise<GetSearchAttributesResponse> => {
+  return await requestFromAPI<GetSearchAttributesResponse>(
+    routeForApi('search-attributes'),
+    {
+      request,
+    },
+  ).then((searchAttributesResponse) => {
+    console.log({ searchAttributesResponse });
+    if (searchAttributesResponse.keys) {
+      searchAttributes.set(searchAttributesResponse.keys);
+    }
+
+    return searchAttributesResponse;
+  });
+};

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -5,16 +5,18 @@ import { routeForApi } from '$lib/utilities/route-for-api';
 import type { GetSearchAttributesResponse } from '$types';
 
 export const fetchSearchAttributes = async (
+  settings: Settings,
   request = fetch,
 ): Promise<GetSearchAttributesResponse> => {
+  if (settings.runtimeEnvironment.isCloud) return;
+
   return await requestFromAPI<GetSearchAttributesResponse>(
     routeForApi('search-attributes'),
     {
       request,
     },
   ).then((searchAttributesResponse) => {
-    console.log({ searchAttributesResponse });
-    if (searchAttributesResponse.keys) {
+    if (searchAttributesResponse?.keys) {
       searchAttributes.set(searchAttributesResponse.keys);
     }
 

--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -45,7 +45,6 @@ export const supportsReverseOrder = derived(
   ([$temporalVersion, $settings]) => {
     if ($settings.runtimeEnvironment.isCloud) return true;
 
-    console.log('supports reverse', isVersionNewer($temporalVersion, '1.16.0'));
     return isVersionNewer($temporalVersion, '1.16.0');
   },
 );

--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -1,0 +1,6 @@
+import type { GetSearchAttributesResponse } from '$types';
+import { writable } from 'svelte/store';
+
+export const searchAttributes = writable<GetSearchAttributesResponse['keys']>(
+  {},
+);

--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -1,4 +1,3 @@
-import type { GetSearchAttributesResponse } from '$types';
 import { writable } from 'svelte/store';
 
-export const searchAttributes = writable<GetSearchAttributesResponse['keys']>();
+export const searchAttributes = writable<SearchAttributes>();

--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -1,6 +1,4 @@
 import type { GetSearchAttributesResponse } from '$types';
 import { writable } from 'svelte/store';
 
-export const searchAttributes = writable<GetSearchAttributesResponse['keys']>(
-  {},
-);
+export const searchAttributes = writable<GetSearchAttributesResponse['keys']>();

--- a/src/lib/utilities/is.test.ts
+++ b/src/lib/utilities/is.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { isString, isNull, isObject, isNumber } from './is';
+import {
+  isString,
+  isNull,
+  isObject,
+  isNumber,
+  isSortOrder,
+  isOperator,
+  isExecutionStatus,
+  isSpace,
+  isQuote,
+} from './is';
 
 describe('isString', () => {
   it('should return true if given a string', () => {
@@ -114,5 +124,215 @@ describe('isNumber', () => {
 
   it('should return false if given an array', () => {
     expect(isNumber([])).toBe(false);
+  });
+});
+
+describe('isOperator', () => {
+  it('should return true for "="', () => {
+    expect(isOperator('=')).toBe(true);
+  });
+
+  it('should return true for ">"', () => {
+    expect(isOperator('>')).toBe(true);
+  });
+
+  it('should return true for "<"', () => {
+    expect(isOperator('<')).toBe(true);
+  });
+
+  it('should return true for "!"', () => {
+    expect(isOperator('!')).toBe(true);
+  });
+
+  it('should return true for ">="', () => {
+    expect(isOperator('>=')).toBe(true);
+  });
+
+  it('should return true for "<="', () => {
+    expect(isOperator('<=')).toBe(true);
+  });
+
+  it('should return true for "=="', () => {
+    expect(isOperator('==')).toBe(true);
+  });
+
+  it('should return true for "!="', () => {
+    expect(isOperator('!=')).toBe(true);
+  });
+
+  it('should return true for "==="', () => {
+    expect(isOperator('===')).toBe(true);
+  });
+
+  it('should return true for "!=="', () => {
+    expect(isOperator('!==')).toBe(true);
+  });
+
+  it('should return true for "and"', () => {
+    expect(isOperator('and')).toBe(true);
+  });
+
+  it('should return true for "or"', () => {
+    expect(isOperator('or')).toBe(true);
+  });
+
+  it('should return true for "between"', () => {
+    expect(isOperator('between')).toBe(true);
+  });
+
+  it('should return true for "order by"', () => {
+    expect(isOperator('order by')).toBe(true);
+  });
+
+  it('should return true for "in"', () => {
+    expect(isOperator('in')).toBe(true);
+  });
+
+  it('should return true for "("', () => {
+    expect(isOperator('(')).toBe(true);
+  });
+
+  it('should return true for ")"', () => {
+    expect(isOperator(')')).toBe(true);
+  });
+
+  it('should return false for "bogus"', () => {
+    expect(isOperator('bogus')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isOperator(null as unknown as string)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isOperator(undefined as unknown as string)).toBe(false);
+  });
+
+  it('should return false for {}', () => {
+    expect(isOperator({} as unknown as string)).toBe(false);
+  });
+});
+
+describe('isSortOrder', () => {
+  it('should return true for "ascending"', () => {
+    expect(isSortOrder('ascending')).toBe(true);
+  });
+
+  it('should return true for "descending"', () => {
+    expect(isSortOrder('descending')).toBe(true);
+  });
+
+  it('should return false for "a random string"', () => {
+    expect(isSortOrder('a random string')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isSortOrder(null as unknown as string)).toBe(false);
+  });
+});
+
+describe('isExecutionStatus', () => {
+  it('should return true for "Running"', () => {
+    expect(isExecutionStatus('Running')).toBe(true);
+  });
+
+  it('should return true for "TimedOut"', () => {
+    expect(isExecutionStatus('TimedOut')).toBe(true);
+  });
+
+  it('should return true for "Completed"', () => {
+    expect(isExecutionStatus('Completed')).toBe(true);
+  });
+
+  it('should return true for "Failed"', () => {
+    expect(isExecutionStatus('Failed')).toBe(true);
+  });
+
+  it('should return true for "Completed"', () => {
+    expect(isExecutionStatus('Completed')).toBe(true);
+  });
+
+  it('should return true for "ContinuedAsNew"', () => {
+    expect(isExecutionStatus('ContinuedAsNew')).toBe(true);
+  });
+
+  it('should return true for "Canceled"', () => {
+    expect(isExecutionStatus('Canceled')).toBe(true);
+  });
+
+  it('should return true for "Terminated"', () => {
+    expect(isExecutionStatus('Terminated')).toBe(true);
+  });
+
+  it('should return false for "Invalid"', () => {
+    expect(isExecutionStatus('Invalid')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isExecutionStatus(null as unknown as string)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isExecutionStatus(undefined as unknown as string)).toBe(false);
+  });
+
+  it('should return false for {}', () => {
+    expect(isExecutionStatus({})).toBe(false);
+  });
+
+  it('should return false for []', () => {
+    expect(isExecutionStatus([])).toBe(false);
+  });
+
+  it('should return false for a boolean', () => {
+    expect(isExecutionStatus(true)).toBe(false);
+  });
+});
+
+describe('isSpace', () => {
+  it('should return true for a space', () => {
+    expect(isSpace(' ')).toBe(true);
+  });
+
+  it('should return false for a letter', () => {
+    expect(isSpace('a')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isSpace(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isSpace(undefined)).toBe(false);
+  });
+
+  it('should return false for []', () => {
+    expect(isSpace([])).toBe(false);
+  });
+
+  it('should return false for {}', () => {
+    expect(isSpace({})).toBe(false);
+  });
+});
+
+describe('isQuote', () => {
+  it('should return true for a single quote', () => {
+    expect(isQuote(`'`)).toBe(true);
+  });
+
+  it('should return true for a single quote', () => {
+    expect(isQuote(`"`)).toBe(true);
+  });
+
+  it('should return false for a letter', () => {
+    expect(isQuote(`a`)).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isQuote(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isQuote(undefined)).toBe(false);
   });
 });

--- a/src/lib/utilities/is.ts
+++ b/src/lib/utilities/is.ts
@@ -26,6 +26,13 @@ const operators = [
   '!=',
   '===',
   '!==',
+  'and',
+  'or',
+  'between',
+  'order by',
+  'in',
+  '(',
+  ')',
 ] as const;
 
 export const isString = (x: unknown): x is string => typeof x === 'string';
@@ -66,6 +73,7 @@ export const isQuote = (x: unknown): x is Quote => {
 
 export const isOperator = (x: unknown): x is Operator => {
   if (!isString(x)) return false;
+  x = x.toLocaleLowerCase();
 
   for (const operator of operators) {
     if (x === operator) return true;
@@ -74,7 +82,9 @@ export const isOperator = (x: unknown): x is Operator => {
   return false;
 };
 
-export const isSortOrder = (sortOrder: string): sortOrder is EventSortOrder => {
+export const isSortOrder = (
+  sortOrder: string | EventSortOrder,
+): sortOrder is EventSortOrder => {
   if (sortOrder === 'ascending') return true;
   if (sortOrder === 'descending') return true;
   return false;

--- a/src/lib/utilities/query/is-search-attribute.test.ts
+++ b/src/lib/utilities/query/is-search-attribute.test.ts
@@ -1,0 +1,37 @@
+import { writable } from 'svelte/store';
+import { describe, expect, it } from 'vitest';
+import { isSearchAttribute } from './is-search-attribute';
+
+const searchAttributes = writable<SearchAttributes>({
+  WorkflowType: 'Keyword',
+});
+
+describe('isSearchAttribute', () => {
+  it('should return true if the attribute is a key in the search attributes', () => {
+    expect(isSearchAttribute('WorkflowType', { WorkflowType: 'Keyword' })).toBe(
+      true,
+    );
+  });
+
+  it('should return false if the attribute is not a key in the search attributes', () => {
+    expect(isSearchAttribute('NotAKey', { WorkflowType: 'Keyword' })).toBe(
+      false,
+    );
+  });
+
+  it('should return false if the attribute is null', () => {
+    expect(
+      isSearchAttribute(null as unknown as string, { WorkflowType: 'Keyword' }),
+    ).toBe(false);
+  });
+
+  it('should return false if the attribute is undefined', () => {
+    expect(
+      isSearchAttribute(undefined as unknown as string, {
+        WorkflowType: 'Keyword',
+      }),
+    ).toBe(false);
+  });
+
+  describe('with store', () => {});
+});

--- a/src/lib/utilities/query/is-search-attribute.test.ts
+++ b/src/lib/utilities/query/is-search-attribute.test.ts
@@ -8,21 +8,17 @@ const searchAttributes = writable<SearchAttributes>({
 
 describe('isSearchAttribute', () => {
   it('should return true if the attribute is a key in the search attributes', () => {
-    expect(isSearchAttribute('WorkflowType', { WorkflowType: 'Keyword' })).toBe(
-      true,
-    );
+    expect(isSearchAttribute('WorkflowType', searchAttributes)).toBe(true);
   });
 
   it('should return false if the attribute is not a key in the search attributes', () => {
-    expect(isSearchAttribute('NotAKey', { WorkflowType: 'Keyword' })).toBe(
-      false,
-    );
+    expect(isSearchAttribute('NotAKey', searchAttributes)).toBe(false);
   });
 
   it('should return false if the attribute is null', () => {
-    expect(
-      isSearchAttribute(null as unknown as string, { WorkflowType: 'Keyword' }),
-    ).toBe(false);
+    expect(isSearchAttribute(null as unknown as string, searchAttributes)).toBe(
+      false,
+    );
   });
 
   it('should return false if the attribute is undefined', () => {

--- a/src/lib/utilities/query/is-search-attribute.test.ts
+++ b/src/lib/utilities/query/is-search-attribute.test.ts
@@ -1,33 +1,59 @@
 import { writable } from 'svelte/store';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isSearchAttribute } from './is-search-attribute';
 
-const searchAttributes = writable<SearchAttributes>({
+const store = writable<SearchAttributes>({
   WorkflowType: 'Keyword',
 });
 
 describe('isSearchAttribute', () => {
   it('should return true if the attribute is a key in the search attributes', () => {
-    expect(isSearchAttribute('WorkflowType', searchAttributes)).toBe(true);
+    expect(isSearchAttribute('WorkflowType', store)).toBe(true);
   });
 
   it('should return false if the attribute is not a key in the search attributes', () => {
-    expect(isSearchAttribute('NotAKey', searchAttributes)).toBe(false);
+    expect(isSearchAttribute('NotAKey', store)).toBe(false);
   });
 
   it('should return false if the attribute is null', () => {
-    expect(isSearchAttribute(null as unknown as string, searchAttributes)).toBe(
+    expect(isSearchAttribute(null as unknown as string, store)).toBe(false);
+  });
+
+  it('should return false if the attribute is undefined', () => {
+    expect(isSearchAttribute(undefined as unknown as string, store)).toBe(
       false,
     );
   });
 
-  it('should return false if the attribute is undefined', () => {
-    expect(
-      isSearchAttribute(undefined as unknown as string, {
-        WorkflowType: 'Keyword',
-      }),
-    ).toBe(false);
-  });
+  describe('with store', () => {
+    beforeEach(() => {
+      vi.mock('$lib/stores/search-attributes', () => {
+        return {
+          searchAttributes: writable<SearchAttributes>({
+            WorkflowType: 'Keyword',
+          }),
+        };
+      });
+    });
 
-  describe('with store', () => {});
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('should return true if the attribute is a key in the search attributes', () => {
+      expect(isSearchAttribute('WorkflowType')).toBe(true);
+    });
+
+    it('should return false if the attribute is not a key in the search attributes', () => {
+      expect(isSearchAttribute('NotAKey')).toBe(false);
+    });
+
+    it('should return false if the attribute is null', () => {
+      expect(isSearchAttribute(null as unknown as string)).toBe(false);
+    });
+
+    it('should return false if the attribute is undefined', () => {
+      expect(isSearchAttribute(undefined as unknown as string)).toBe(false);
+    });
+  });
 });

--- a/src/lib/utilities/query/is-search-attribute.ts
+++ b/src/lib/utilities/query/is-search-attribute.ts
@@ -1,0 +1,11 @@
+import { get } from 'svelte/store';
+import { searchAttributes } from '$lib/stores/search-attributes';
+import { isString } from '../is';
+
+export const isSearchAttribute = (
+  attribute: string,
+  attributes = searchAttributes,
+): attribute is string => {
+  if (!isString(attribute)) return false;
+  return !!get(attributes)[attribute];
+};

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -63,7 +63,9 @@ export function routeForApi(
   parameters: TaskQueueRouteParameters,
   shouldEncode?: boolean,
 ): string;
-export function routeForApi(route: ParameterlessAPIRoutePath): string;
+export function routeForApi(
+  route: ParameterlessAPIRoutePath | SearchAttributesRoutePath,
+): string;
 export function routeForApi(
   route: APIRoutePath,
   parameters?: APIRouteParameters,
@@ -77,6 +79,7 @@ export function routeForApi(
     user: '/me',
     namespaces: '/namespaces',
     'task-queue': `/namespaces/${parameters?.namespace}/task-queues/${parameters?.queue}`,
+    'search-attributes': '/search-attributes',
     workflows: `/namespaces/${parameters?.namespace}/workflows`,
     'workflows.archived': `/namespaces/${parameters?.namespace}/workflows/archived`,
     workflow: `/namespaces/${parameters?.namespace}/workflows/${parameters?.workflowId}/runs/${parameters?.runId}`,

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -37,7 +37,7 @@
 
     const cluster: GetClusterInfoResponse = await fetchCluster(settings, fetch);
 
-    fetchSearchAttributes();
+    fetchSearchAttributes(settings);
 
     const uiVersionInfo: UiVersionInfo = {
       current: settings.version,

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -1,6 +1,6 @@
 <script context="module" lang="ts">
   import type { Load } from '@sveltejs/kit';
-  import type { ListNamespacesResponse } from '$types';
+  import type { ListNamespacesResponse, GetClusterInfoResponse } from '$types';
 
   import '../app.css';
 
@@ -9,9 +9,10 @@
   import { fetchCluster } from '$lib/services/cluster-service';
   import { fetchNamespaces } from '$lib/services/namespaces-service';
   import { fetchLatestUiVersion } from '$lib/services/github-service';
+  import { fetchSearchAttributes } from '$lib/services/search-attributes-service';
+
   import { getDefaultNamespace } from '$lib/utilities/get-namespace';
   import { isAuthorized } from '$lib/utilities/is-authorized';
-  import type { GetClusterInfoResponse } from '$types';
 
   export const load: Load = async function ({ fetch }) {
     const settings: Settings = await fetchSettings(fetch);
@@ -28,11 +29,15 @@
       settings,
       fetch,
     );
+
     const defaultNamespace: string = getDefaultNamespace({
       namespaces: namespacesResp?.namespaces,
       settings,
     });
+
     const cluster: GetClusterInfoResponse = await fetchCluster(settings, fetch);
+
+    fetchSearchAttributes();
 
     const uiVersionInfo: UiVersionInfo = {
       current: settings.version,

--- a/src/routes/namespaces/[namespace]/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/index@root.svelte
@@ -16,7 +16,7 @@
 
     if (!currentNamespace) {
       return {
-        error: `Namespace ${namespace} does not exist`,
+        error: `The namespace "${namespace}" does not exist.`,
         status: 404,
       };
     }
@@ -124,18 +124,20 @@
   </article>
 </div>
 
-<section>
-  <h1 class="my-4 text-lg font-medium">Search Attributes</h1>
-  <Table class="w-full">
-    <TableHeaderRow slot="headers">
-      <th>Key</th>
-      <th>Type</th>
-    </TableHeaderRow>
-    {#each Object.entries($searchAttributes) as [key, type]}
-      <TableRow>
-        <td>{key}</td>
-        <td>{type}</td>
-      </TableRow>
-    {/each}
-  </Table>
-</section>
+{#if $searchAttributes}
+  <section>
+    <h1 class="my-4 text-lg font-medium">Search Attributes</h1>
+    <Table class="w-full">
+      <TableHeaderRow slot="headers">
+        <th>Key</th>
+        <th>Type</th>
+      </TableHeaderRow>
+      {#each Object.entries($searchAttributes) as [key, type]}
+        <TableRow>
+          <td>{key}</td>
+          <td>{type}</td>
+        </TableRow>
+      {/each}
+    </Table>
+  </section>
+{/if}

--- a/src/routes/namespaces/[namespace]/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/index@root.svelte
@@ -8,7 +8,6 @@
     if (searchParams.has('time-range')) searchParams.delete('time-range');
 
     const namespace = params.namespace;
-
     const namespaces: DescribeNamespaceResponse[] = stuff.namespaces;
 
     const currentNamespace = namespaces.find(
@@ -34,17 +33,23 @@
 </script>
 
 <script lang="ts">
-  import { dev } from '$app/env';
   import { onMount } from 'svelte';
+  import { dev } from '$app/env';
+  import { page } from '$app/stores';
 
   import { temporalVersion, uiVersion } from '$lib/stores/versions';
   import { supportsReverseOrder } from '$lib/stores/event-view';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
+  import { searchAttributes } from '$lib/stores/search-attributes';
 
   import { fromSecondsToDaysOrHours } from '$lib/utilities/format-date';
   import { getClusters } from '$lib/utilities/get-clusters';
+
   import PageTitle from '$lib/holocene/page-title.svelte';
-  import { page } from '$app/stores';
+  import Table from '$lib/holocene/table/table.svelte';
+  import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';
+  import TableRow from '$lib/holocene/table/table-row.svelte';
+  import { getEnabledCategories } from 'trace_events';
 
   export let currentNamespace: DescribeNamespaceResponse;
   export let clusters: string;
@@ -99,6 +104,7 @@
       {clusters}
     </p>
   </article>
+
   <article class="namespace-info w-full p-4">
     <h1 class="my-4 text-lg font-medium">Versions</h1>
     <p data-cy="server-version">
@@ -117,3 +123,19 @@
     {/if}
   </article>
 </div>
+
+<section>
+  <h1 class="my-4 text-lg font-medium">Search Attributes</h1>
+  <Table class="w-full">
+    <TableHeaderRow slot="headers">
+      <th>Key</th>
+      <th>Type</th>
+    </TableHeaderRow>
+    {#each Object.entries($searchAttributes) as [key, type]}
+      <TableRow>
+        <td>{key}</td>
+        <td>{type}</td>
+      </TableRow>
+    {/each}
+  </Table>
+</section>

--- a/src/search-attributes.d.ts
+++ b/src/search-attributes.d.ts
@@ -1,0 +1,15 @@
+type SearchAttributesValue =
+  | 'Bool'
+  | 'Datetime'
+  | 'Double'
+  | 'Int'
+  | 'Keyword'
+  | 'Text';
+
+type SearchAttributes = {
+  [k: string]: SearchAttributesValue;
+};
+
+type SearchAttributesResponse = {
+  keys: SearchAttributes;
+};


### PR DESCRIPTION
- Adds support for displaying search attributes in the namespace settings page.
- Fixes a bug in the `CodeBlock` component where it might show stale data.
- Adds support for all operators in the tokenizer.
- Increases test coverage for `is.ts`.