### PR TITLE
Fix auth redirection to VITE_API address

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -15,12 +15,6 @@ interface Window {
   };
 }
 
-interface ImportMeta {
-  env: {
-    VITE_API: string;
-  };
-}
-
 type Eventual<T> = T | PromiseLike<T>;
 
 type NamespaceScopedRequest = { namespace: string };

--- a/src/lib/components/logout-button.svelte
+++ b/src/lib/components/logout-button.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
+  import { getApiOrigin } from '$lib/utilities/get-api-origin';
 
   export let user: User;
 </script>
@@ -7,7 +8,7 @@
 {#if user?.email}
   <button
     class="logout-button min-w-min"
-    on:click={() => goto(import.meta.env.VITE_API + '/auth/logout')}
+    on:click={() => goto(getApiOrigin() + '/auth/logout')}
   >
     <img
       src={user.picture}

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -1,5 +1,6 @@
 import { browser } from '$app/env';
 import { settings } from '$lib/stores/settings';
+import { getApiOrigin } from '$lib/utilities/get-api-origin';
 import { getEnvironment } from '$lib/utilities/get-environment';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
@@ -20,8 +21,7 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
       enabled: !!settingsResponse?.Auth?.Enabled,
       options: settingsResponse?.Auth?.Options,
     },
-    baseUrl:
-      import.meta?.env?.VITE_API ?? browser ? window.location.origin : '',
+    baseUrl: getApiOrigin(),
     codec: {
       endpoint: settingsResponse?.Codec?.Endpoint,
       accessToken: settingsResponse?.Codec?.AccessToken,

--- a/src/lib/utilities/get-api-origin.test.ts
+++ b/src/lib/utilities/get-api-origin.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getApiOrigin } from './get-api-origin';
+
+describe('getApiOrigin', () => {
+  it('should return VITE_API if it is set to absolute URL', () => {
+    import.meta.env.VITE_API = 'http://localhost:8080';
+
+    const url = getApiOrigin();
+    expect(url).toEqual('http://localhost:8080');
+  });
+
+  it('should return URL with no trail slash', () => {
+    import.meta.env.VITE_API = 'http://localhost:8080/';
+
+    const url = getApiOrigin();
+    expect(url).toEqual('http://localhost:8080');
+  });
+
+  it('should replace relative path with window location origin', () => {
+    import.meta.env.VITE_API = '';
+    let url = getApiOrigin();
+    expect(url).toEqual('http://localhost:3000');
+
+    import.meta.env.VITE_API = '/';
+    url = getApiOrigin();
+    expect(url).toEqual('http://localhost:3000');
+  });
+});

--- a/src/lib/utilities/get-api-origin.ts
+++ b/src/lib/utilities/get-api-origin.ts
@@ -1,0 +1,17 @@
+import { browser } from '$app/env';
+
+export function getApiOrigin(): string | null {
+  const isRelative = !import.meta.env.VITE_API.startsWith('http');
+
+  let origin = '';
+
+  if (isRelative) {
+    origin = browser ? window.location.origin : '';
+  } else {
+    origin = import.meta.env.VITE_API;
+  }
+
+  if (origin.endsWith('/')) origin = origin.slice(0, -1);
+
+  return origin;
+}

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,3 +1,5 @@
+import { getApiOrigin } from './get-api-origin';
+
 const replaceNamespaceInApiUrl = (
   apiUrl: string,
   namespace: string,
@@ -11,7 +13,7 @@ const base = (namespace?: string): string => {
   if (globalThis?.AppConfig?.apiUrl && namespace) {
     baseUrl = replaceNamespaceInApiUrl(globalThis.AppConfig.apiUrl, namespace);
   } else {
-    baseUrl = import.meta.env.VITE_API;
+    baseUrl = getApiOrigin();
   }
 
   if (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -13,6 +13,7 @@
   import Navigation from '$lib/holocene/navigation/full-nav.svelte';
   import DataEncoderStatus from '$lib/components/data-encoder-status.svelte';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
+  import { getApiOrigin } from '$lib/utilities/get-api-origin';
 
   export let user: User;
 
@@ -68,7 +69,7 @@
       'https://github.com/temporalio/ui/issues/new/choose',
   };
 
-  const logout = () => goto(import.meta.env.VITE_API + '/auth/logout');
+  const logout = () => goto(getApiOrigin() + '/auth/logout');
 </script>
 
 <Navigation


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixed auth redirection when VITE_API is set to a different origin

## Why?
<!-- Tell your future self why have you made these changes -->

Auth would always redirect to `window.location.origin` when authenticating instead of VITE_API

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

ui-server running under http://localhost:8088/ and ui under http://localhost:3000/
Verified that UI redirects to http://localhost:8088/auth/sso

added unit tests

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
