### PR TITLE
Add new task-queues route and link to it on event history

### DIFF
--- a/cypress/integration/task-queues.spec.js
+++ b/cypress/integration/task-queues.spec.js
@@ -1,0 +1,31 @@
+/// <reference types="cypress" />
+
+import * as dateTz from 'date-fns-tz';
+
+import tq from '../fixtures/task-queues.json';
+
+describe('Task Queues Page', () => {
+  beforeEach(() => {
+    cy.interceptApi();
+
+    cy.visit(`/namespaces/default/task-queues/a-task-queue`);
+
+    cy.wait('@namespaces-api');
+  });
+
+  it('default to last viewed event view when visiting a workflow', () => {
+    cy.wait('@task-queues-api');
+
+    cy.get('[data-cy="pollers-title"]').contains('Pollers');
+    cy.get('.text-lg').contains('Task Queue: a-task-queue');
+    cy.get('[data-cy=worker-row]').should('have.length', 1);
+    cy.get('[data-cy=worker-identity]').contains(tq.pollers[0].identity);
+    cy.get('[data-cy=worker-last-access-time]').contains(
+      dateTz.formatInTimeZone(
+        new Date(tq.pollers[0].lastAccessTime),
+        'UTC',
+        'yyyy-MM-dd z HH:mm:ss.SS',
+      ),
+    );
+  });
+});

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -2,11 +2,15 @@
   import { page } from '$app/stores';
 
   import { format } from '$lib/utilities/format-camel-case';
-  import { routeForWorkflow, routeForWorkers } from '$lib/utilities/route-for';
+  import {
+    routeForWorkflow,
+    routeForWorkers,
+    routeForTaskQueue,
+  } from '$lib/utilities/route-for';
   import {
     getCodeBlockValue,
     shouldDisplayAsExecutionLink,
-    shouldDisplayAsWorkersLink,
+    shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
   } from '$lib/utilities/get-single-attribute-for-event';
 
@@ -48,12 +52,12 @@
         </Copyable>
       </div>
     </div>
-  {:else if shouldDisplayAsWorkersLink(key)}
+  {:else if shouldDisplayAsTaskQueueLink(key)}
     <div class="detail-row">
       <h2 class="text-sm">{format(key)}</h2>
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
-          <Link href={routeForWorkers({ namespace, workflow, run })}>
+          <Link href={routeForTaskQueue({ namespace, queue: value })}>
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -2,10 +2,13 @@
   import { page } from '$app/stores';
 
   import { format } from '$lib/utilities/format-camel-case';
-  import { routeForWorkflow, routeForWorkers } from '$lib/utilities/route-for';
+  import {
+    routeForWorkflow,
+    routeForTaskQueue,
+  } from '$lib/utilities/route-for';
   import {
     shouldDisplayAsExecutionLink,
-    shouldDisplayAsWorkersLink,
+    shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
     getCodeBlockValue,
   } from '$lib/utilities/get-single-attribute-for-event';
@@ -43,7 +46,7 @@
         </Copyable>
       </div>
     </div>
-  {:else if shouldDisplayAsWorkersLink(key)}
+  {:else if shouldDisplayAsTaskQueueLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
       <h2 class="mr-3 text-sm">{format(key)}</h2>
       <div class="text-sm">
@@ -51,7 +54,7 @@
           content={value}
           container-class="flex-row-reverse xl:flex-row"
         >
-          <Link href={routeForWorkers({ namespace, workflow, run })}>
+          <Link href={routeForTaskQueue({ namespace, queue: value })}>
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/workers-list.svelte
+++ b/src/lib/components/workers-list.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import Icon from '$lib/holocene/icon/index.svelte';
+
+  import { timeFormat } from '$lib/stores/time-format';
+  import { formatDate } from '$lib/utilities/format-date';
+
+  import EmptyState from '$lib/components/empty-state.svelte';
+  import type { GetPollersResponse } from '$lib/services/pollers-service';
+
+  export let taskQueue: string;
+  export let workers: GetPollersResponse;
+</script>
+
+<section class="flex flex-col gap-4">
+  <h3 class="text-lg font-medium">
+    Task Queue: <span class="select-all font-normal">{taskQueue}</span>
+  </h3>
+  <section class="flex w-full flex-col rounded-lg border-2 border-gray-900">
+    <div class="flex flex-row bg-gray-900 p-2 text-white">
+      <div class="w-3/12 text-left">ID</div>
+      <div class="w-3/12 text-left">Last Accessed</div>
+      <div class="w-3/12 text-left">Workflow Task Handler</div>
+      <div class="w-2/12 text-left">Activity Handler</div>
+    </div>
+    {#each workers.pollers as poller (poller.identity)}
+      <article
+        class="flex h-full w-full flex-row border-b-2 p-2 no-underline last:border-b-0"
+        data-cy="worker-row"
+      >
+        <div class="links w-3/12 text-left" data-cy="worker-identity">
+          <p class="select-all">{poller.identity}</p>
+        </div>
+        <div class="links w-3/12 text-left" data-cy="worker-last-access-time">
+          <h3>
+            <p class="select-all">
+              {formatDate(poller.lastAccessTime, $timeFormat)}
+            </p>
+          </h3>
+        </div>
+        <div class="w-3/12 text-left">
+          {#if poller.taskQueueTypes.includes('WORKFLOW')}
+            <Icon name="checkMark" stroke="blue" />
+          {:else}
+            <Icon name="close" stroke="black" />
+          {/if}
+        </div>
+        <div class="w-3/12 text-left">
+          {#if poller.taskQueueTypes.includes('ACTIVITY')}
+            <Icon name="checkMark" stroke="blue" />
+          {:else}
+            <Icon name="close" stroke="black" />
+          {/if}
+        </div>
+      </article>
+    {:else}
+      <EmptyState title={'No Workers Found'} />
+    {/each}
+  </section>
+</section>

--- a/src/lib/pages/task-queue-workers.svelte
+++ b/src/lib/pages/task-queue-workers.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+
+  import PageTitle from '$lib/holocene/page-title.svelte';
+  import WorkersList from '$lib/components/workers-list.svelte';
+  import { getPollers } from '$lib/services/pollers-service';
+
+  let { queue, namespace } = $page.params;
+
+  let workers = getPollers({ queue, namespace }, { returnAllPollers: true });
+</script>
+
+<PageTitle title={`Task Queue | ${queue}`} url={$page.url.href} />
+{#await workers then workers}
+  <WorkersList taskQueue={queue} {workers} />
+{/await}

--- a/src/lib/pages/workflow-workers.svelte
+++ b/src/lib/pages/workflow-workers.svelte
@@ -1,62 +1,12 @@
 <script lang="ts">
   import { page } from '$app/stores';
-
-  import Icon from '$lib/holocene/icon/index.svelte';
   import { workflowRun } from '$lib/stores/workflow-run';
 
-  import { timeFormat } from '$lib/stores/time-format';
-  import { formatDate } from '$lib/utilities/format-date';
-
-  import EmptyState from '$lib/components/empty-state.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import WorkersList from '$lib/components/workers-list.svelte';
 
   const { workers, workflow } = $workflowRun;
 </script>
 
 <PageTitle title={`Workers | ${workflow.id}`} url={$page.url.href} />
-<section class="flex flex-col gap-4">
-  <h3 class="text-lg font-medium">
-    Task Queue: <span class="select-all font-normal">{workflow.taskQueue}</span>
-  </h3>
-  <section class="flex w-full flex-col rounded-lg border-2 border-gray-900">
-    <div class="flex flex-row bg-gray-900 p-2 text-white">
-      <div class="w-3/12 text-left">ID</div>
-      <div class="w-3/12 text-left">Last Accessed</div>
-      <div class="w-3/12 text-left">Workflow Task Handler</div>
-      <div class="w-2/12 text-left">Activity Handler</div>
-    </div>
-    {#each workers.pollers as poller (poller.identity)}
-      <article
-        class="flex h-full w-full flex-row border-b-2 p-2 no-underline last:border-b-0"
-        data-cy="worker-row"
-      >
-        <div class="links w-3/12 text-left" data-cy="worker-identity">
-          <p class="select-all">{poller.identity}</p>
-        </div>
-        <div class="links w-3/12 text-left" data-cy="worker-last-access-time">
-          <h3>
-            <p class="select-all">
-              {formatDate(poller.lastAccessTime, $timeFormat)}
-            </p>
-          </h3>
-        </div>
-        <div class="w-3/12 text-left">
-          {#if poller.taskQueueTypes.includes('WORKFLOW')}
-            <Icon name="checkMark" stroke="blue" />
-          {:else}
-            <Icon name="close" stroke="black" />
-          {/if}
-        </div>
-        <div class="w-3/12 text-left">
-          {#if poller.taskQueueTypes.includes('ACTIVITY')}
-            <Icon name="checkMark" stroke="blue" />
-          {:else}
-            <Icon name="close" stroke="black" />
-          {/if}
-        </div>
-      </article>
-    {:else}
-      <EmptyState title={'No Workers Found'} />
-    {/each}
-  </section>
-</section>
+<WorkersList taskQueue={workflow.taskQueue} {workers} />

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -26,6 +26,7 @@ export type PollerWithTaskQueueTypes = PollerInfo & {
 
 export async function getPollers(
   parameters: GetAllPollersRequest,
+  options = { returnAllPollers: false },
   request = fetch,
 ): Promise<GetPollersResponse> {
   const workflowPollers = await requestFromAPI<GetPollersResponse>(
@@ -82,8 +83,16 @@ export async function getPollers(
     workflowPollers.pollers.reduce(r('WORKFLOW'), {}),
   );
 
+  const pollers =
+    options?.returnAllPollers && !activityPollers.pollers.length
+      ? workflowPollers.pollers
+      : activityPollers.pollers;
+  const taskQueueStatus =
+    options?.returnAllPollers && !activityPollers.pollers.length
+      ? workflowPollers.taskQueueStatus
+      : activityPollers.taskQueueStatus;
   return {
-    pollers: activityPollers.pollers,
-    taskQueueStatus: activityPollers.taskQueueStatus,
+    pollers,
+    taskQueueStatus,
   };
 }

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -74,13 +74,13 @@ export const shouldDisplayAsExecutionLink = (
   return false;
 };
 
-const keysWithWorkerLinks = ['taskQueueName'] as const;
+const keysWithTaskQueueLinks = ['taskQueueName'] as const;
 
-export const shouldDisplayAsWorkersLink = (
+export const shouldDisplayAsTaskQueueLink = (
   key: string,
-): key is typeof keysWithWorkerLinks[number] => {
-  for (const workerKey of keysWithWorkerLinks) {
-    if (key === workerKey) return true;
+): key is typeof keysWithTaskQueueLinks[number] => {
+  for (const taskQueueKey of keysWithTaskQueueLinks) {
+    if (key === taskQueueKey) return true;
   }
 
   return false;

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -22,6 +22,7 @@ export const isEventView = (view: string): view is EventView => {
 };
 
 export type NamespaceParameter = Pick<RouteParameters, 'namespace'>;
+export type TaskQueueParameters = Pick<RouteParameters, 'namespace' | 'queue'>;
 export type WorkflowParameters = Pick<
   RouteParameters,
   'namespace' | 'workflow' | 'run'
@@ -105,6 +106,12 @@ export const routeForEventHistory = ({
 
 export const routeForWorkers = (parameters: WorkflowParameters): string => {
   return `${routeForWorkflow(parameters)}/workers`;
+};
+
+export const routeForTaskQueue = (parameters: TaskQueueParameters): string => {
+  return `${routeForNamespace({
+    namespace: parameters.namespace,
+  })}/task-queues/${parameters.queue}`;
 };
 
 export const routeForStackTrace = (parameters: WorkflowParameters): string => {

--- a/src/routes/namespaces/[namespace]/task-queues/[queue].svelte
+++ b/src/routes/namespaces/[namespace]/task-queues/[queue].svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import TaskQueueWorkers from '$lib/pages/task-queue-workers.svelte';
+</script>
+
+<TaskQueueWorkers />

--- a/src/routes/namespaces/[namespace]/task-queues/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/task-queues/__layout@root.svelte
@@ -1,0 +1,4 @@
+<h1 class="relative flex items-center gap-4 text-2xl" data-cy="pollers-title">
+  Pollers
+</h1>
+<slot />


### PR DESCRIPTION
## What was changed
Add a new task-queues page that allows you to view a specific task queue. Events with task queue names in the event history will link to this page. The Worker tab will keep it's existing functionality and show the Workflow task queue.

https://user-images.githubusercontent.com/7967403/180294696-3db7c108-1850-4ec0-be87-0d4296698c75.mov

<img width="1722" alt="Screen Shot 2022-07-21 at 1 50 03 PM" src="https://user-images.githubusercontent.com/7967403/180294759-bfccbbc1-f2af-4dc0-a23f-83acad17414c.png">


## Why?
Allow users to see specific task queues instead of only the workflow task queue.

Closes #659 

cc @tsurdilo 