### PR TITLE
Add workflow run and events refresh

### DIFF
--- a/src/lib/components/event/event-history-group-timeline.svelte
+++ b/src/lib/components/event/event-history-group-timeline.svelte
@@ -41,15 +41,16 @@
   }
 
   $: startDate = events[0]?.eventTime;
-  $: currentDate = new Date(
-    Date.parse(startDate as string) +
-      (mouseX - xBuffer) * (totalDistance / (width - xBuffer)),
-  );
-  $: endDate = events[events.length - 1]?.eventTime;
-
+  $: endDate = isRunning
+    ? new Date(Date.now())
+    : events[events.length - 1]?.eventTime;
   $: totalDistance = getTimestampDifference(
     startDate as string,
     endDate as string,
+  );
+  $: currentDate = new Date(
+    Date.parse(startDate as string) +
+      (mouseX - xBuffer) * (totalDistance / (width - xBuffer)),
   );
 
   $: getDistance = (date): number => {
@@ -96,7 +97,7 @@
 
 {#if eventGroups.length}
   <div
-    class="min-h-40 relative max-h-96 w-full cursor-crosshair overflow-auto rounded-lg border-2 bg-white"
+    class="min-h-40 relative max-h-96 w-full cursor-crosshair overflow-auto rounded-lg border border-gray-900 bg-blueGray-50 bg-white"
     bind:clientWidth={width}
     on:mousemove={handleMouseMove}
   >
@@ -130,7 +131,7 @@
             1}px; background: {color};"
         />
         <button
-          class="absolute truncate pl-2 text-left text-sm font-medium hover:bg-blueGray-200"
+          class="absolute truncate border-r border-gray-900 pl-2 text-left text-sm font-medium hover:bg-blueGray-200"
           class:event-group-active={$timelineEvents?.length &&
             activeGroup === item.id}
           class:failure
@@ -182,7 +183,7 @@
 
 <style lang="postcss">
   .event-group {
-    @apply absolute rounded-sm text-center;
+    @apply absolute rounded-sm text-center drop-shadow-md;
   }
   .event-group-active {
     @apply bg-blueGray-200;

--- a/src/lib/components/event/event-history-timeline-container.svelte
+++ b/src/lib/components/event/event-history-timeline-container.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { ascendingEventGroups, ascendingEvents } from '$lib/stores/events';
-  import { workflowRun } from '$lib/stores/workflow-run';
+  import { workflowRun, refresh } from '$lib/stores/workflow-run';
   import { timelineEvents } from '$lib/stores/events';
 
   import Accordion from '$lib/holocene/accordion.svelte';
@@ -15,8 +15,7 @@
   import Autocomplete from '$lib/holocene/autocomplete.svelte';
   import Badge from '$lib/holocene/badge.svelte';
 
-  let { workflow } = $workflowRun;
-  let isRunning = workflow.isRunning;
+  $: isRunning = $workflowRun.workflow.isRunning;
 
   let showEventTypeFilter = false;
   let eventTypeValue = '';
@@ -119,7 +118,7 @@
         <Button
           variant="secondary"
           disabled={!isRunning}
-          on:click={() => window.location.reload()}
+          on:click={() => ($refresh = Date.now())}
           ><Icon name="refresh" stroke="currentcolor" scale={0.8} /></Button
         >
       </div>

--- a/src/lib/components/terminate-workflow.svelte
+++ b/src/lib/components/terminate-workflow.svelte
@@ -5,6 +5,8 @@
 
   import Button from '$holocene/button.svelte';
   import Modal from '$lib/components/modal.svelte';
+  import { refresh } from '$lib/stores/workflow-run';
+  import { tick } from 'svelte';
 
   export let workflow: WorkflowExecution;
   export let namespace: string;
@@ -18,11 +20,12 @@
   const isEligibleForTermination = (workflow: WorkflowExecution) =>
     String(workflow.status) === 'Running';
 
-  const handleSuccessfulTermination = () => {
+  const handleSuccessfulTermination = async () => {
     showConfirmation = false;
     reason = '';
+    $refresh = Date.now();
+    await tick();
     notifications.add('success', 'Workflow Terminated');
-    window.location.reload();
   };
 
   const terminate = () => {

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -20,6 +20,7 @@ import { eventCategoryParam, eventSortOrder } from './event-view';
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { withLoading, delay } from '$lib/utilities/stores/with-loading';
 import { groupEvents } from '$lib/models/event-groups';
+import { refresh } from '$lib/stores/workflow-run';
 
 const emptyEvents: FetchEventsResponse = {
   events: [],
@@ -100,12 +101,17 @@ export const parameters: Readable<FetchEventsParameters> = derived(
 );
 
 export const parametersWithSettings: Readable<FetchEventsParametersWithSettings> =
-  derived([parameters, settings], ([$parameters, $settings]) => {
-    return {
-      ...$parameters,
-      settings: $settings,
-    };
-  });
+  derived(
+    [parameters, settings, refresh],
+    ([$parameters, $settings, $refresh]) => {
+      return {
+        ...$parameters,
+        settings: $settings,
+        refresh,
+        $refresh,
+      };
+    },
+  );
 
 export const updateEventHistory: StartStopNotifier<FetchEventsResponse> = (
   set,

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -8,17 +8,19 @@ import { getPollers } from '$lib/services/pollers-service';
 import type { GetPollersResponse } from '$lib/services/pollers-service';
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 
+export const refresh = writable(0);
 const namespace = derived([page], ([$page]) => $page.params.namespace);
 const workflowId = derived([page], ([$page]) => $page.params.workflow);
 const runId = derived([page], ([$page]) => $page.params.run);
 
 const parameters = derived(
-  [namespace, workflowId, runId],
-  ([$namespace, $workflowId, $runId]) => {
+  [namespace, workflowId, runId, refresh],
+  ([$namespace, $workflowId, $runId, $refresh]) => {
     return {
       namespace: $namespace,
       workflowId: decodeURIForSvelte($workflowId ?? ''),
       runId: $runId,
+      refresh: $refresh,
     };
   },
 );
@@ -33,7 +35,7 @@ const updateWorkflowRun: StartStopNotifier<{
   workflow: WorkflowExecution;
   workers: GetPollersResponse;
 }> = (set) => {
-  return parameters.subscribe(({ namespace, workflowId, runId }) => {
+  return parameters.subscribe(({ namespace, workflowId, runId, refresh }) => {
     if (namespace && workflowId && runId) {
       withLoading(loading, updating, async () => {
         const workflow = await fetchWorkflow({ namespace, workflowId, runId });

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import WorkflowHistoryLayout from '$lib/layouts/workflow-history-layout.svelte';
+  import EventHistoryTimelineContainer from '$lib/components/event/event-history-timeline-container.svelte';
 </script>
 
 <WorkflowHistoryLayout>
+  <svelte:fragment slot="timeline">
+    <!-- <EventHistoryTimelineContainer /> -->
+  </svelte:fragment>
   <slot />
 </WorkflowHistoryLayout>


### PR DESCRIPTION
## What was changed
Allow refreshing the workflow and it's events without a page refresh from the Timeline. Also removes the need for a page refresh when terminating workflow. Includes small style updates to Timeline. Leaving the TimelineContainer commented out on layout so if we want to add it, simply uncomment it.

https://user-images.githubusercontent.com/7967403/180488705-61526edd-aed9-4294-ac55-3154fdf4fc19.mov


