### PR TITLE
Add error state to Textarea

### DIFF
--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -3,12 +3,34 @@
   export let disabled: boolean = false;
   export let placeholder: string = '';
   export let rows: number = 5;
+  export let error: string = null;
+  let hasError = error || $$slots.error;
 </script>
 
 <textarea
   class="font-mono min-h-fit w-full rounded border border-gray-900 p-5 text-sm"
+  class:error={hasError}
   bind:value
   {disabled}
   {placeholder}
   {rows}
 />
+{#if hasError}
+  <div class="error-msg">
+    {#if $$slots.error}
+      <slot name="error" />
+    {:else}
+      <p>{error}</p>
+    {/if}
+  </div>
+{/if}
+
+<style lang="postcss">
+  .error {
+    @apply border-danger;
+  }
+
+  .error-msg {
+    @apply border-danger font-primary text-sm font-normal text-danger;
+  }
+</style>

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -1,29 +1,31 @@
 <script lang="ts">
-  export let value: string = '';
+  import { noop } from 'svelte/internal';
   export let disabled: boolean = false;
+  export let error: string = '';
+  export let isValid: boolean = true;
   export let placeholder: string = '';
   export let rows: number = 5;
-  export let error: string = null;
-  let hasError = error || $$slots.error;
+  export let value: string;
+  export let onBlur: (e: Event) => void = noop;
 </script>
 
 <textarea
   class="font-mono min-h-fit w-full rounded border border-gray-900 p-5 text-sm"
-  class:error={hasError}
+  class:error={!isValid}
   bind:value
+  on:blur={onBlur}
   {disabled}
   {placeholder}
   {rows}
 />
-{#if hasError}
-  <div class="error-msg">
-    {#if $$slots.error}
-      <slot name="error" />
-    {:else}
+<div class="error-msg">
+  {#if !isValid}
+    {#if error}
       <p>{error}</p>
     {/if}
-  </div>
-{/if}
+    <slot name="error" />
+  {/if}
+</div>
 
 <style lang="postcss">
   .error {

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -18,7 +18,7 @@
   {placeholder}
   {rows}
 />
-<div class="error-msg">
+<div class="error-msg" aria-live={isValid ? 'off' : 'assertive'}>
   {#if !isValid}
     {#if error}
       <p>{error}</p>

--- a/src/routes/fiction/chapters/textarea.svelte
+++ b/src/routes/fiction/chapters/textarea.svelte
@@ -16,11 +16,11 @@
 <Chapter
   description="A textarea with an error"
   component={Textarea}
-  props={{ value, error: 'There was an error.' }}
+  props={{ value, isValid: false, error: 'There was an error.' }}
 />
 
 <Chapter
   description="A textarea with a placeholder"
   component={Textarea}
-  props={{ placeholder: 'Add text here...' }}
+  props={{ placeholder: 'Add text here...', value: '' }}
 />

--- a/src/routes/fiction/chapters/textarea.svelte
+++ b/src/routes/fiction/chapters/textarea.svelte
@@ -14,6 +14,12 @@
 />
 
 <Chapter
+  description="A textarea with an error"
+  component={Textarea}
+  props={{ value, error: 'There was an error.' }}
+/>
+
+<Chapter
   description="A textarea with a placeholder"
   component={Textarea}
   props={{ placeholder: 'Add text here...' }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds an error state to the `<Textarea />` holocene component.

<img width="810" alt="Screen Shot 2022-07-28 at 5 22 32 PM" src="https://user-images.githubusercontent.com/15069288/181653206-1fcf19ed-e3bb-444e-8c9b-fe27bcd5dd47.png">

## Why?
<!-- Tell your future self why have you made these changes -->
We'll need the ability to alert a user if there is an error (e.g. if the text is not in the right format).

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a

2. How was this tested: n/a

3. Any docs updates needed? none
