### PR TITLE
Add Cypress test to make sure that terminate API request fires when the button has been hit

### DIFF
--- a/cypress/integration/workflow-termination.spec.js
+++ b/cypress/integration/workflow-termination.spec.js
@@ -51,4 +51,20 @@ describe('Terminate Button is Shown', () => {
 
     cy.get('[data-cy="terminate-button"]').should('not.exist');
   });
+
+  it.only('should send a request to terminate workflows when write actions are enabled', () => {
+    cy.intercept(Cypress.env('VITE_API_HOST') + `/api/v1/settings?`, {
+      fixture: 'settings.json',
+    }).as('settings-api');
+
+    cy.visit(
+      `/namespaces/default/workflows/${workflowId}/${runId}/history/feed?sort=descending`,
+    );
+
+    cy.wait('@settings-api');
+    cy.wait('@workflow-api');
+
+    cy.get('[data-cy="terminate-button"]').click();
+    cy.get('[data-cy="modal-confirmation"]').click();
+  });
 });

--- a/cypress/integration/workflow-termination.spec.js
+++ b/cypress/integration/workflow-termination.spec.js
@@ -52,10 +52,16 @@ describe('Terminate Button is Shown', () => {
     cy.get('[data-cy="terminate-button"]').should('not.exist');
   });
 
-  it.only('should send a request to terminate workflows when write actions are enabled', () => {
+  it('should send a request to terminate workflows when write actions are enabled', () => {
     cy.intercept(Cypress.env('VITE_API_HOST') + `/api/v1/settings?`, {
       fixture: 'settings.json',
     }).as('settings-api');
+
+    cy.intercept(
+      'POST',
+      Cypress.env('VITE_API_HOST') +
+        `/api/v1/namespaces/default/workflows/${workflowId}/runs/${runId}/terminate?*`,
+    ).as('terminate-api');
 
     cy.visit(
       `/namespaces/default/workflows/${workflowId}/${runId}/history/feed?sort=descending`,
@@ -66,5 +72,6 @@ describe('Terminate Button is Shown', () => {
 
     cy.get('[data-cy="terminate-button"]').click();
     cy.get('[data-cy="modal-confirmation"]').click();
+    cy.wait('@terminate-api');
   });
 });

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -41,6 +41,7 @@
           <Button
             variant={confirmType}
             disabled={confirmDisabled}
+            dataCy="modal-confirmation"
             on:click={() => dispatch('confirmModal', {})}>{confirmText}</Button
           >
         {/if}


### PR DESCRIPTION
Related to #738.