### PR TITLE
Add disabled state to Accordion

### DIFF
--- a/src/lib/holocene/accordion.svelte
+++ b/src/lib/holocene/accordion.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
+  import colors from 'tailwindcss/colors';
   import Icon from '$lib/holocene/icon/index.svelte';
   import type { IconName } from './icon/paths';
   export let title: string;
   export let subtitle: string = '';
   export let icon: IconName | undefined = undefined;
-
   export let open: boolean = false;
+  export let disabled: boolean = false;
+
+  $: open = disabled ? true : open;
 </script>
 
 <section
@@ -15,7 +18,11 @@
     <div
       class="accordion-open flex cursor-pointer flex-col"
       class:open
-      on:click={() => (open = !open)}
+      class:disabled
+      on:click={() => {
+        if (disabled) return;
+        open = !open;
+      }}
     >
       <div class="space-between flex flex-row">
         <h2 class="flex w-full items-center gap-2 text-lg font-medium">
@@ -24,7 +31,7 @@
         </h2>
         <Icon
           name={open ? 'caretUp' : 'caretDown'}
-          stroke="currentcolor"
+          stroke={disabled ? colors.gray[500] : 'currentcolor'}
           scale={1.4}
         />
       </div>
@@ -41,5 +48,9 @@
 <style lang="postcss">
   .open {
     @apply mb-8;
+  }
+
+  .disabled {
+    @apply cursor-default;
   }
 </style>

--- a/src/lib/holocene/icon/index.svelte
+++ b/src/lib/holocene/icon/index.svelte
@@ -14,18 +14,26 @@
 
   $: icon = icons[name];
 
-  function getStroke(path: svelte.JSX.SVGProps<SVGPathElement>) {
-    if (path?.stroke === 'none') return '';
-    if (color !== '') return color;
-    if (stroke !== '') return stroke;
-    return path?.stroke ?? '';
+  function getStroke(params: {
+    path: svelte.JSX.SVGProps<SVGPathElement>;
+    stroke: string;
+    color: string;
+  }) {
+    if (params.path?.stroke === 'none') return '';
+    if (color !== '') return params.color;
+    if (stroke !== '') return params.stroke;
+    return params.path?.stroke ?? '';
   }
 
-  function getFill(path: svelte.JSX.SVGProps<SVGPathElement>) {
-    if (path?.fill === 'none') return '';
-    if (color !== '') return color;
-    if (fill !== '') return fill;
-    return path?.fill ?? '';
+  function getFill(params: {
+    path: svelte.JSX.SVGProps<SVGPathElement>;
+    fill: string;
+    color: string;
+  }) {
+    if (params.path?.fill === 'none') return '';
+    if (color !== '') return params.color;
+    if (fill !== '') return params.fill;
+    return params.path?.fill ?? '';
   }
 </script>
 
@@ -51,8 +59,8 @@
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width={strokeWidth}
-            stroke={getStroke(path)}
-            fill={getFill(path)}
+            stroke={getStroke({ path, stroke, color })}
+            fill={getFill({ path, fill, color })}
             transform="translate({_width / -2} {_height / -2})"
           />
         {/each}

--- a/src/routes/fiction/chapters/accordion.svelte
+++ b/src/routes/fiction/chapters/accordion.svelte
@@ -38,3 +38,13 @@
     <CodeBlock content={JSON.stringify({ some: 'thing', blue: 42 })} />
   </Accordion>
 </Chapter>
+
+<Chapter description="A disabled Accordion">
+  <Accordion
+    disabled
+    title="Certificates"
+    subtitle="Expires on Wed Feb 01, 2030"
+  >
+    <p>Accordion content here.</p>
+  </Accordion>
+</Chapter>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->


<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This adds a `disabled` attribute to the holocene `Accordion` component.
![Untitled](https://user-images.githubusercontent.com/15069288/182493309-aa368300-3a2b-4ce1-9347-da06fd98d770.png)
## Why?
<!-- Tell your future self why have you made these changes -->
This allows the accordion to not be closed in cases it should not be navigated away from (e.g. there are errors on inputs within it).

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify there is a default cursor over the accordion row when it is `disabled`
- [ ] Verify the arrow icon is a lighter gray when the accordion is `disabled`
- [ ] Verify the accordion remains open when `disabled`

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
