### PR TITLE
Add locked state to Input

### DIFF
--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -16,10 +16,9 @@
   export let valid = true;
   export let hintText = '';
   export let maxLength = 0;
-  export let locked: boolean = false;
 
   const { copy, copied } = copyToClipboard(value);
-  $: disabled = disabled || copyable || locked;
+  $: disabled = disabled || copyable;
 </script>
 
 <div class={$$props.class}>
@@ -52,8 +51,7 @@
       <div class="copy-icon-container" on:click={copy}>
         <Icon name={$copied ? 'checkMark' : 'copy'} stroke="currentcolor" />
       </div>
-    {/if}
-    {#if locked}
+    {:else if disabled}
       <div class="flex h-full w-9 items-center justify-center">
         <Icon name="lock" stroke="currentcolor" />
       </div>

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -16,15 +16,17 @@
   export let valid = true;
   export let hintText = '';
   export let maxLength = 0;
+  export let locked: boolean = false;
 
   const { copy, copied } = copyToClipboard(value);
+  $: disabled = disabled || copyable || locked;
 </script>
 
 <div class={$$props.class}>
   {#if label}
     <label for={id}>{label}</label>
   {/if}
-  <div class="input-container {theme}" class:copyable class:invalid={!valid}>
+  <div class="input-container {theme}" class:disabled class:invalid={!valid}>
     {#if icon !== ''}
       <span class="icon-container">
         <Icon name={icon} scale={0.9} stroke="currentcolor" />
@@ -32,8 +34,8 @@
     {/if}
     <input
       class="m-2 block w-full bg-white focus:outline-none"
-      class:copyable
-      disabled={disabled || copyable}
+      class:disabled
+      {disabled}
       data-lpignore="true"
       maxlength={maxLength > 0 ? maxLength : undefined}
       {placeholder}
@@ -49,6 +51,11 @@
     {#if copyable}
       <div class="copy-icon-container" on:click={copy}>
         <Icon name={$copied ? 'checkMark' : 'copy'} stroke="currentcolor" />
+      </div>
+    {/if}
+    {#if locked}
+      <div class="flex h-full w-9 items-center justify-center">
+        <Icon name="lock" stroke="currentcolor" />
       </div>
     {/if}
     {#if maxLength}
@@ -76,7 +83,7 @@
     @apply relative box-border inline-flex h-10 w-full items-center rounded border border-gray-900 text-sm focus-within:border-blue-700;
   }
 
-  .input-container.copyable {
+  .input-container.disabled {
     @apply border;
   }
 
@@ -119,16 +126,16 @@
     @apply text-gray-400;
   }
 
-  .input-container.light.copyable {
-    @apply border-gray-900 bg-gray-50;
+  .input-container.light.disabled {
+    @apply border-gray-600 bg-gray-50  text-gray-600;
   }
 
-  .input-container.light.copyable input {
-    @apply bg-gray-50 text-gray-900;
+  .input-container.light.disabled input {
+    @apply bg-gray-50;
   }
 
-  .input-container.light.copyable .copy-icon-container {
-    @apply border-gray-900 bg-gray-200;
+  .input-container.light.disabled .copy-icon-container {
+    @apply border-gray-600 bg-gray-200;
   }
 
   /* Dark theme styles */
@@ -143,9 +150,9 @@
     @apply placeholder:text-gray-200;
   }
 
-  .input-container.dark.copyable,
-  .input-container.dark.copyable .copy-icon-container,
-  .input-container.dark.copyable input {
+  .input-container.dark.disabled,
+  .input-container.dark.disabled .copy-icon-container,
+  .input-container.dark.disabled input {
     @apply border-gray-900 bg-gray-900;
   }
 </style>

--- a/src/routes/fiction/chapters/input.svelte
+++ b/src/routes/fiction/chapters/input.svelte
@@ -105,11 +105,34 @@
   }}
 />
 
+<Chapter
+  description="A locked input"
+  component={Input}
+  props={{
+    class: 'w-96',
+    id: 'input7',
+    value: 'robin@temporal.io',
+    locked: true,
+  }}
+/>
+
+<Chapter
+  description="A locked dark input"
+  component={Input}
+  props={{
+    class: 'w-96',
+    id: 'input8',
+    value: 'robin@temporal.io',
+    locked: true,
+    theme: 'dark',
+  }}
+/>
+
 <Chapter description="A Tag Input">
   <ChipInput
     bind:chips={emails}
     class="w-96"
-    id="input7"
+    id="input9"
     label="Email Address(es)"
     required
     hintText="Please enter a properly formatted email address."

--- a/src/routes/fiction/chapters/input.svelte
+++ b/src/routes/fiction/chapters/input.svelte
@@ -112,7 +112,7 @@
     class: 'w-96',
     id: 'input7',
     value: 'robin@temporal.io',
-    locked: true,
+    disabled: true,
   }}
 />
 
@@ -123,7 +123,7 @@
     class: 'w-96',
     id: 'input8',
     value: 'robin@temporal.io',
-    locked: true,
+    disabled: true,
     theme: 'dark',
   }}
 />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR adds a `locked` attribute to the holocene `Input` component. It also updates the styling for the `light` theme `copyable` input by merged styles into one `disabled` style.

| Designs | Existing | Final |
| ----- | ----- | ----- |
|![Screen Shot 2022-08-03 at 10 41 24 AM](https://user-images.githubusercontent.com/15069288/182677485-dd8326f8-0b52-4a52-8edf-c26eb8e3bd82.png)|![existing](https://user-images.githubusercontent.com/15069288/182677514-777870cf-b068-4aa3-bd74-4e40350f8b91.png)|![suggested](https://user-images.githubusercontent.com/15069288/182677539-dba4715f-0b80-43f9-a076-fb1840471812.png)|

## Why?
<!-- Tell your future self why have you made these changes -->
We will need a `locked` option for inputs based on designs and both `copyable` and `locked` inputs are `disabled`.

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested:
- [ ] Verify the `copyable` input looks as expected for `light` and `dark` themes
- [ ] Verify the `locked` input looks as expected for `light` and `dark` themes
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
