### PR TITLE
add disabled state to autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.28",
+  "version": "2.1.29",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/holocene/autocomplete.svelte
+++ b/src/lib/holocene/autocomplete.svelte
@@ -15,6 +15,7 @@
   export let theme: 'dark' | 'light' = 'light';
   export let options: string[];
   export let onOptionClick: (option: string) => void;
+  export let disabled = false;
 
   let show = false;
   $: filteredOptions = !value
@@ -24,11 +25,7 @@
       );
 </script>
 
-<div
-  class="autocomplete-container"
-  use:clickOutside
-  on:click-outside={() => (show = false)}
->
+<div class="relative" use:clickOutside on:click-outside={() => (show = false)}>
   <Input
     {id}
     bind:value
@@ -37,6 +34,7 @@
     {placeholder}
     {theme}
     {copyable}
+    {disabled}
     on:input
     on:change
     on:focus={() => (show = true)}
@@ -58,9 +56,3 @@
     </Menu>
   {/if}
 </div>
-
-<style lang="postcss">
-  .autocomplete-container {
-    @apply relative;
-  }
-</style>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- add disabled state to Autocomplete component which renders our default disabled state with lock icon
<img width="907" alt="Screen Shot 2022-08-17 at 3 10 01 PM" src="https://user-images.githubusercontent.com/11775628/185243730-8dbd9f2f-f442-4a44-ab79-24fd7134bf55.png">

## Why?
<!-- Tell your future self why have you made these changes -->
Need for cloud-ui user roles on Namespace edit page
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
