### PR TITLE
fix click handler on menu item

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.33",
+  "version": "2.1.34",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/holocene/primitives/menu/menu-item.svelte
+++ b/src/lib/holocene/primitives/menu/menu-item.svelte
@@ -17,13 +17,13 @@
     class:active
     class:disabled
     {disabled}
-    class="menu-item inline-block whitespace-nowrap {$$props.class}"
+    class="menu-item {$$props.class}"
   >
     <slot />
   </a>
 {:else}
   <li
-    on:click
+    on:click|preventDefault
     role="menuitem"
     class:dark
     class:destructive


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
add `preventDefault` modifier on Menu Item click events for when they are children of other elements with click listeners. Can't use `stopPropagation` here because we still need the event to bubble up to the menu trigger so that the menu can close. 

Also remove some unnecessary styling
## Why?
<!-- Tell your future self why have you made these changes -->
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
