### PR TITLE
Add handleError on workflows service to handle bad namespaces in url

### DIFF
--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -48,12 +48,18 @@ export const fetchAllWorkflows = async (
       `Error fetching workflows: ${err.status}: ${err.statusText}`;
   };
 
+  const handleError = (err: unknown) => {
+    // Handle when bad namespace is entered in URL and no status code is returned
+    error = 'Failed to fetch workflows';
+  };
+
   const { executions, nextPageToken } =
     (await requestFromAPI<ListWorkflowExecutionsResponse>(
       routeForApi(endpoint, { namespace }),
       {
         params: { query },
         onError,
+        handleError,
         request,
       },
     )) ?? { executions: [], nextPageToken: '' };


### PR DESCRIPTION
## What was changed
Add handleError generic error if onError is skipped due to request failing and no response is returned

<img width="1726" alt="Screen Shot 2022-08-29 at 2 09 33 PM" src="https://user-images.githubusercontent.com/7967403/187280257-caacc0ef-ba31-4151-bcc5-f8be8141de2d.png">
