### PR TITLE
Badge overflow fix

### DIFF
--- a/src/lib/holocene/badge.svelte
+++ b/src/lib/holocene/badge.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <div
-  class="{type} flex w-fit flex-row items-center justify-center rounded-sm p-1 text-sm font-medium transition-colors {$$props.class}"
+  class="{type} flex w-fit flex-row items-center justify-center break-all rounded-sm p-1 text-sm font-medium transition-colors {$$props.class}"
 >
   <slot />
 </div>

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -165,7 +165,7 @@
   }
 
   .event-table-row {
-    @apply grid grid-cols-2 border-b border-gray-300 py-1;
+    @apply grid grid-cols-2 break-all border-b border-gray-300 py-1;
   }
 
   .event-table-row:last-child {

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -165,7 +165,7 @@
   }
 
   .event-table-row {
-    @apply grid grid-cols-2 break-all border-b border-gray-300 py-1;
+    @apply grid grid-cols-2 border-b border-gray-300 py-1;
   }
 
   .event-table-row:last-child {


### PR DESCRIPTION
## What was changed
Add break-all to Badge to prevent overflow of text

<img width="514" alt="Screen Shot 2022-08-29 at 2 43 44 PM" src="https://user-images.githubusercontent.com/7967403/187285986-46597c27-0a23-4223-8c85-774408144b1a.png">

