### PR TITLE
Add namespace switcher to schedules

### DIFF
--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -34,7 +34,10 @@
   );
 
   const namespaceList = namespaces.map((namespace: string) => {
-    const href = routeForWorkflows({ namespace });
+    const onSchedulesPage = $page.url.pathname.endsWith('schedules');
+    const href = onSchedulesPage
+      ? routeForSchedules({ namespace })
+      : routeForWorkflows({ namespace });
     return {
       namespace,
       href,

--- a/src/routes/namespaces/[namespace]/schedules/index.svelte
+++ b/src/routes/namespaces/[namespace]/schedules/index.svelte
@@ -16,6 +16,7 @@
   import { fetchAllSchedules } from '$lib/services/schedule-service';
   import type { ScheduleListEntry } from '$types';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import NamespaceSelector from '$lib/holocene/namespace-selector.svelte';
 
   let { namespace } = $page.params;
 
@@ -38,6 +39,7 @@
 <div class="flex flex-row justify-between">
   <h2 class="flex items-center gap-2 text-2xl">
     Schedules<Badge type="alpha">Alpha</Badge>
+    <NamespaceSelector />
   </h2>
   <Button
     class="h-10"


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->

## Why?
<img width="1725" alt="Screen Shot 2022-08-31 at 3 46 14 PM" src="https://user-images.githubusercontent.com/7967403/187778812-5c0c0c55-7f9c-437c-961e-e12d3e8d345d.png">

Allow switching of namespaces while remaining on schedules page

Closes #800 