### PR TITLE
Support serving UI from sub path

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,16 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/css/normalize.css" />
-    <link rel="stylesheet" href="/css/override.css" />
-    <link rel="stylesheet" href="/prism/prism.css" />
+    <link rel="stylesheet" href="%sveltekit.assets%/css/normalize.css" />
+    <link rel="stylesheet" href="%sveltekit.assets%/css/override.css" />
+    <link rel="stylesheet" href="%sveltekit.assets%/prism/prism.css" />
     %sveltekit.head%
   </head>
 
   <body>
     <div id="svelte">%sveltekit.body%</div>
-    <script src="/prism/prism.js"></script>
+    <script src="%sveltekit.assets%/prism/prism.js"></script>
   </body>
 </html>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,6 +4,7 @@ type Vitest = import('vitest');
 
 interface ImportMetaEnv {
   readonly VITE_TEMPORAL_UI_BUILD_TARGET: string;
+  readonly VITE_PUBLIC_PATH: string;
   readonly VITE_API: string;
 }
 

--- a/src/lib/components/hamburger-header.svelte
+++ b/src/lib/components/hamburger-header.svelte
@@ -4,6 +4,7 @@
   import { fly } from 'svelte/transition';
 
   import { hasKeys } from '$lib/utilities/has';
+  import { publicPath } from '$lib/utilities/get-public-path';
 
   import DataEncoderStatus from '$lib/components/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
@@ -25,7 +26,7 @@
   </div>
   <div class="col-span-4 flex justify-center gap-4">
     <a {href} class="block">
-      <img src="/logo.svg" alt="Temporal Logo" class="max-h-10" />
+      <img src="{publicPath}/logo.svg" alt="Temporal Logo" class="max-h-10" />
     </a>
   </div>
   <div class="col-span-4 flex items-center justify-end gap-4">

--- a/src/lib/components/navigation-header.svelte
+++ b/src/lib/components/navigation-header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { hasKeys } from '$lib/utilities/has';
+  import { publicPath } from '$lib/utilities/get-public-path';
   import DataEncoderStatus from '$lib/components/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
 
@@ -10,7 +11,7 @@
 <header class="navigation-header" data-cy="navigation-header">
   <div class="col-span-3 flex items-center gap-4">
     <a {href} class="block">
-      <img src="/logo.svg" alt="Temporal Logo" class="max-h-10" />
+      <img src="{publicPath}/logo.svg" alt="Temporal Logo" class="max-h-10" />
     </a>
     <slot name="logo" />
   </div>

--- a/src/lib/holocene/loading.svelte
+++ b/src/lib/holocene/loading.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
+  import { publicPath } from '$lib/utilities/get-public-path';
   export let title: string = 'Loading…';
-
-  const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
 </script>
 
 <div class="my-12 flex flex-col items-center justify-start {$$props.class}">

--- a/src/lib/holocene/loading.svelte
+++ b/src/lib/holocene/loading.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   export let title: string = 'Loading…';
+
+  const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
 </script>
 
 <div class="my-12 flex flex-col items-center justify-start {$$props.class}">
   <img
-    src="/Temporal_Logo_Animation.gif"
+    src="{publicPath}/Temporal_Logo_Animation.gif"
     style="margin-top: -40px;"
     alt="Temporal Logo"
     width="200px"

--- a/src/lib/holocene/page-title.svelte
+++ b/src/lib/holocene/page-title.svelte
@@ -1,13 +1,16 @@
 <script>
   export let title = 'Temporal';
   export let url = 'https://temporal.io';
-  export let image = '/banner.png';
+
+  const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
+
+  export let image = `${publicPath}/banner.png`;
 </script>
 
 <svelte:head>
   <title>{title}</title>
 
-  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="manifest" href="{publicPath}/site.webmanifest" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
   <meta property="og:title" content={title} />

--- a/src/lib/holocene/page-title.svelte
+++ b/src/lib/holocene/page-title.svelte
@@ -1,8 +1,8 @@
 <script>
+  import { publicPath } from '$lib/utilities/get-public-path';
+
   export let title = 'Temporal';
   export let url = 'https://temporal.io';
-
-  const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
 
   export let image = `${publicPath}/banner.png`;
 </script>

--- a/src/lib/utilities/get-public-path.ts
+++ b/src/lib/utilities/get-public-path.ts
@@ -1,0 +1,1 @@
+export const publicPath: string = import.meta.env.VITE_PUBLIC_PATH || '';

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,5 +1,7 @@
 import { getApiOrigin } from './get-api-origin';
 
+const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
+
 const replaceNamespaceInApiUrl = (
   apiUrl: string,
   namespace: string,
@@ -17,6 +19,8 @@ const base = (namespace?: string): string => {
   }
 
   if (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+
+  baseUrl = `${baseUrl}${publicPath}`;
   return baseUrl;
 };
 

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,6 +1,5 @@
 import { getApiOrigin } from './get-api-origin';
-
-const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
+import { publicPath } from './get-public-path';
 
 const replaceNamespaceInApiUrl = (
   apiUrl: string,

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -2,6 +2,8 @@ import { browser } from '$app/env';
 import { toURL } from '$lib/utilities/to-url';
 import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
 
+const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
+
 type RouteParameters = {
   namespace: string;
   workflow: string;
@@ -46,13 +48,13 @@ export type AuthenticationParameters = {
 };
 
 export const routeForNamespaces = (): string => {
-  return `/namespaces`;
+  return `${publicPath}/namespaces`;
 };
 
 export const routeForNamespace = ({
   namespace,
 }: NamespaceParameter): string => {
-  return `/namespaces/${namespace}`;
+  return `${publicPath}/namespaces/${namespace}`;
 };
 
 export const routeForWorkflows = (parameters: NamespaceParameter): string => {
@@ -135,7 +137,7 @@ export const routeForAuthentication = (
 ): string => {
   const { settings, searchParams: currentSearchParams, originUrl } = parameters;
 
-  const login = new URL('/auth/sso', settings.baseUrl);
+  const login = new URL(`${publicPath}/auth/sso`, settings.baseUrl);
   let opts = settings.auth.options ?? [];
 
   opts = [...opts, 'returnUrl'];
@@ -161,7 +163,7 @@ export const routeForLoginPage = (isBrowser = browser): string => {
     return login.toString();
   }
 
-  return '/login';
+  return `${publicPath}/login`;
 };
 
 type ImportParameters = {
@@ -174,9 +176,9 @@ export const routeForImport = ({
   view,
 }: ImportParameters): string => {
   if (importType === 'events' && view) {
-    return `/import/${importType}/namespace/workflow/run/history/${view}`;
+    return `${publicPath}/import/${importType}/namespace/workflow/run/history/${view}`;
   }
-  return `/import/${importType}`;
+  return `${publicPath}/import/${importType}`;
 };
 
 export const hasParameters =

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -1,8 +1,7 @@
 import { browser } from '$app/env';
 import { toURL } from '$lib/utilities/to-url';
+import { publicPath } from '$lib/utilities/get-public-path';
 import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
-
-const publicPath = import.meta.env.VITE_PUBLIC_PATH || '';
 
 type RouteParameters = {
   namespace: string;

--- a/src/routes/login/index@login.svelte
+++ b/src/routes/login/index@login.svelte
@@ -28,12 +28,13 @@
 <script lang="ts">
   import NavigationHeader from '$lib/components/navigation-header.svelte';
   import HamburgerHeader from '$lib/components/hamburger-header.svelte';
+  import { publicPath } from '$lib/utilities/get-public-path';
 
   export let settings: Settings;
 </script>
 
-<NavigationHeader href="/" user={undefined} />
-<HamburgerHeader href="/" user={undefined} />
+<NavigationHeader href="{publicPath}/" user={undefined} />
+<HamburgerHeader href="{publicPath}/" user={undefined} />
 <section class="my-[20vh] text-center">
   <h1 class="text-8xl font-semibold" data-cy="login-title">Welcome back.</h1>
   <p class="my-7" data-cy="login-info">Let's get you signed in.</p>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,6 +9,8 @@ process.env.TAILWIND_MODE = dev ? 'watch' : 'build';
 const buildTarget = process.env.VITE_TEMPORAL_UI_BUILD_TARGET || 'local';
 let outputDirectory = `build-${buildTarget}`;
 
+const publicPath = process.env.VITE_PUBLIC_PATH || '';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
   // Consult https://github.com/sveltejs/svelte-preprocess
@@ -24,6 +26,9 @@ const config = {
       assets: outputDirectory,
       fallback: 'index.html',
     }),
+    paths: {
+      base: publicPath,
+    },
     package: {
       dir: 'package',
       emitTypes: true,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Allowed changing the public path under which the UI is served

## Why?
<!-- Tell your future self why have you made these changes -->

community requests
resolves #576 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

tested manually by setting the env variable to ``, `/subpath` and `/subpath1/subpath2`
adding unit tests for `route-for` and `route-for-api`

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
