### PR TITLE
Add action locations to Pagination 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.46",
+  "version": "2.1.47",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.47",
+  "version": "2.1.48",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -43,13 +43,16 @@
 <svelte:window bind:innerWidth={screenWidth} />
 
 <div class="pagination relative mb-8 flex flex-col gap-4">
-  <div class="flex justify-between">
-    <div class="flex items-center">
-      {#if updating}
-        <p class="mr-6 text-gray-600">Updating…</p>
-      {/if}
+  <div
+    class={`flex items-center ${
+      updating || $$slots['action-top-left'] ? 'justify-between' : 'justify-end'
+    }`}
+  >
+    {#if updating}
+      <p class="mr-6 text-gray-600">Updating…</p>
+    {:else}
       <slot name="action-top-left" />
-    </div>
+    {/if}
     <nav
       style={floatStyle}
       bind:clientHeight={height}

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -44,11 +44,12 @@
 
 <div class="pagination relative mb-8 flex flex-col gap-4">
   <div class="flex justify-between">
-    <p class="mr-6 flex items-center text-gray-600">
+    <div class="flex items-center">
       {#if updating}
-        Updating…
+        <p class="mr-6 text-gray-600">Updating…</p>
       {/if}
-    </p>
+      <slot name="action-top-left" />
+    </div>
     <nav
       style={floatStyle}
       bind:clientHeight={height}

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -82,38 +82,46 @@
           <Icon name="chevron-right" />
         </button>
       </div>
-      <slot name="action" />
+      <slot name="action-top-right" />
     </nav>
   </div>
   <slot visibleItems={$store.items} initialItem={$store.initialItem} />
-  <nav class="flex justify-end gap-8">
-    <div class="flex items-center justify-center gap-2">
-      <p class="w-fit text-right">Per Page</p>
-      <FilterSelect
-        label="Per Page"
-        parameter={key}
-        value={String(perPage)}
-        options={perPageOptions(perPage)}
-      />
-    </div>
-    <div class="flex items-center justify-center gap-6">
-      <button
-        class="caret"
-        disabled={!$store.hasPrevious}
-        on:click={() => store.previous()}
-      >
-        <Icon name="chevron-left" />
-      </button>
-      <p>
-        {$store.startingIndex + 1}–{$store.endingIndex + 1} of {$store.length}
-      </p>
-      <button
-        class="caret"
-        disabled={!$store.hasNext}
-        on:click={() => store.next()}
-      >
-        <Icon name="chevron-right" />
-      </button>
+  <nav
+    class={`flex ${
+      $$slots['action-bottom-left'] ? 'justify-between' : 'justify-end'
+    }`}
+  >
+    <slot name="action-bottom-left" />
+    <div class="flex gap-8">
+      <div class="flex items-center justify-center gap-2">
+        <p class="w-fit text-right">Per Page</p>
+        <FilterSelect
+          label="Per Page"
+          parameter={key}
+          value={String(perPage)}
+          options={perPageOptions(perPage)}
+        />
+      </div>
+      <div class="flex items-center justify-center gap-6">
+        <button
+          class="caret"
+          disabled={!$store.hasPrevious}
+          on:click={() => store.previous()}
+        >
+          <Icon name="chevron-left" />
+        </button>
+        <p>
+          {$store.startingIndex + 1}–{$store.endingIndex + 1} of {$store.length}
+        </p>
+        <button
+          class="caret"
+          disabled={!$store.hasNext}
+          on:click={() => store.next()}
+        >
+          <Icon name="chevron-right" />
+        </button>
+      </div>
+      <slot name="action-bottom-right" />
     </div>
   </nav>
 </div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds two additional locations for the `action` slot in the Holocene `Pagination` component, as well as updates existing location name.

| `action` is now `action-top-right` |   `action-bottom-right` |  `action-bottom-left` |
| --- | --- | --- |
|<img width="1008" alt="Screen Shot 2022-09-08 at 1 14 04 PM" src="https://user-images.githubusercontent.com/15069288/189212200-0b248488-faec-4a83-b2c4-293efb2d28c9.png">|<img width="1013" alt="Screen Shot 2022-09-08 at 1 13 33 PM" src="https://user-images.githubusercontent.com/15069288/189212201-097027a2-7409-41fa-8dc8-a3063b706a17.png">|<img width="1047" alt="Screen Shot 2022-09-08 at 1 13 15 PM" src="https://user-images.githubusercontent.com/15069288/189212203-5872ed98-cbb8-40b1-9a93-7727b3b6284a.png">|


## Why?
<!-- Tell your future self why have you made these changes -->
For use in designs.

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: n/a
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
