### PR TITLE
Move show-data-encoder store to it's own file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.45",
+  "version": "2.1.46",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/holocene/data-encoder-status.svelte
+++ b/src/lib/holocene/data-encoder-status.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import Icon from '$holocene/icon/icon.svelte';
 
-  import {
-    dataEncoder,
-    showDataEncoderSettings,
-  } from '$lib/stores/data-encoder';
+  import { dataEncoder } from '$lib/stores/data-encoder';
+  import { showDataEncoderSettings } from '$lib/stores/show-data-encoder';
 
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import DataEncoderSettings from './data-encoder-settings.svelte';

--- a/src/lib/stores/data-encoder.ts
+++ b/src/lib/stores/data-encoder.ts
@@ -9,8 +9,6 @@ import {
   lastDataEncoderStatus,
 } from './data-encoder-config';
 
-export const showDataEncoderSettings = writable(false);
-
 export const dataEncoder = derived(
   [
     page,

--- a/src/lib/stores/show-data-encoder.ts
+++ b/src/lib/stores/show-data-encoder.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const showDataEncoderSettings = writable(false);

--- a/src/routes/_header.svelte
+++ b/src/routes/_header.svelte
@@ -14,7 +14,7 @@
   import DataEncoderStatus from '$lib/holocene/data-encoder-status.svelte';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
   import { getApiOrigin } from '$lib/utilities/get-api-origin';
-  import { showDataEncoderSettings } from '$lib/stores/data-encoder';
+  import { showDataEncoderSettings } from '$lib/stores/show-data-encoder';
 
   export let user: User;
 


### PR DESCRIPTION
## What was changed
Because of reasons, can't keep that store in a file that uses $app imports. So moving to it's own file

1.00-next-.428 version will fix this

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
