### PR TITLE
Use pagination helper for namespaces

### DIFF
--- a/src/lib/services/namespaces-service.ts
+++ b/src/lib/services/namespaces-service.ts
@@ -1,4 +1,5 @@
 import { notifications } from '$lib/stores/notifications';
+import { paginated } from '$lib/utilities/paginated';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
@@ -16,12 +17,12 @@ export async function fetchNamespaces(
     return emptyNamespace;
   }
 
-  const results = await requestFromAPI<ListNamespacesResponse>(
-    routeForApi('namespaces'),
-    {
+  const results = await paginated(async (token: string) =>
+    requestFromAPI<ListNamespacesResponse>(routeForApi('namespaces'), {
       request,
+      token,
       onError: () => notifications.add('error', 'Unable to fetch namespaces'),
-    },
+    }),
   );
 
   return results ?? emptyNamespace;


### PR DESCRIPTION
Uses `paginated` to collect all of the namespaces if there are more than 100 namespaces.