### PR TITLE
Fix is unauthorized

### DIFF
--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -52,10 +52,10 @@ export const handleUnauthorizedOrForbiddenError = (
   }
 };
 
-const isUnauthorized = (error: any): error is NetworkError => {
+const isUnauthorized = (error: any): boolean => {
   return error?.statusCode === 401;
 };
 
-const isForbidden = (error: any): error is NetworkError => {
+const isForbidden = (error: any): boolean => {
   return error?.statusCode === 403;
 };

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -52,18 +52,10 @@ export const handleUnauthorizedOrForbiddenError = (
   }
 };
 
-const isUnauthorized = (error: unknown): error is NetworkError => {
-  if (isNetworkError(error)) {
-    return error.statusCode === 401;
-  }
-
-  return false;
+const isUnauthorized = (error: any): error is NetworkError => {
+  return error?.statusCode === 401;
 };
 
-const isForbidden = (error: unknown): error is NetworkError => {
-  if (isNetworkError(error)) {
-    return error.statusCode === 403;
-  }
-
-  return false;
+const isForbidden = (error: any): error is NetworkError => {
+  return error?.statusCode === 403;
 };


### PR DESCRIPTION
## What was changed
Check only for statusCode on response for isUnauthorized and isForbidden.

## Why?
The isNetworkError was returning false because some response bodys are undefined:

```
    networkErr?.statusCode !== undefined &&
    networkErr?.statusText !== undefined &&
    networkErr?.response !== undefined

```



## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
