### PR TITLE
Handle errors that have status prop instead of statusCode

### DIFF
--- a/src/lib/utilities/handle-error.test.ts
+++ b/src/lib/utilities/handle-error.test.ts
@@ -19,7 +19,19 @@ describe('handleError', () => {
     vi.clearAllMocks();
   });
 
-  it('should redirect if it is an unauthorized error', () => {
+  it('should redirect if it is an unauthorized error with status', () => {
+    const error = {
+      status: 401,
+      statusText: 'Unauthorized',
+      response: null as unknown as Response,
+    };
+
+    handleError(error);
+
+    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+  });
+
+  it('should redirect if it is an unauthorized error with statusCode', () => {
     const error = {
       statusCode: 401,
       statusText: 'Unauthorized',
@@ -31,7 +43,7 @@ describe('handleError', () => {
     expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
   });
 
-  it('should redirect if it is an forbidden error', () => {
+  it('should redirect if it is a forbidden error with status', () => {
     const error = {
       statusCode: 403,
       statusText: 'Forbidden',
@@ -41,6 +53,29 @@ describe('handleError', () => {
     handleError(error);
 
     expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+  });
+
+  it('should redirect if it is a forbidden error with statusCode', () => {
+    const error = {
+      status: 403,
+      statusText: 'Forbidden',
+      response: null as unknown as Response,
+    };
+
+    handleError(error);
+
+    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+  });
+
+  it('should not redirect if not 401/403', () => {
+    const error = {
+      statusText: 'Forbidden',
+      response: null as unknown as Response,
+    };
+
+    handleError(error);
+
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   it('should add notification if it is a NetworkError', () => {

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -53,9 +53,9 @@ export const handleUnauthorizedOrForbiddenError = (
 };
 
 const isUnauthorized = (error: any): boolean => {
-  return error?.statusCode === 401;
+  return error?.statusCode === 401 || error?.status === 401;
 };
 
 const isForbidden = (error: any): boolean => {
-  return error?.statusCode === 403;
+  return error?.statusCode === 403 || error?.status === 403;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Added `error.status` handling in addition to `error.statusCode`

## Why?
<!-- Tell your future self why have you made these changes -->

backends may fill out `status` instead of `statusCode`

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

unit tests +
manually throwing 401 in ui-server

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
