### PR TITLE
Remove event summary group single Pill

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "stylelint-config-recommended"
-  ],
+  "extends": ["stylelint-config-recommended"],
   "processors": [],
   "rules": {
     "at-rule-no-unknown": [
@@ -26,9 +24,7 @@
     "no-descending-specificity": [
       true,
       {
-        "ignore": [
-          "selectors-within-list"
-        ]
+        "ignore": ["selectors-within-list"]
       }
     ],
     "no-invalid-double-slash-comments": true,

--- a/src/lib/components/event/event-detail-pills.svelte
+++ b/src/lib/components/event/event-detail-pills.svelte
@@ -5,27 +5,37 @@
     AttributeGrouping,
   } from '$lib/utilities/format-event-attributes';
   import Pill from '$lib/components/pill.svelte';
+  import { count } from 'console';
 
   export let attributeGrouping: AttributeGrouping;
   export let activePill: string;
 
   const dispatch = createEventDispatcher();
+
+  $: pillCount = Object.values(attributeGrouping).reduce((count, value) => {
+    if (value.length) {
+      count += 1;
+    }
+    return count;
+  }, 0);
 </script>
 
-<div class="p-2 text-center xl:text-left">
-  <div class="pill-container">
-    {#each Object.entries(attributeGrouping) as [key, value] (key)}
-      {#if value.length}
-        <Pill
-          active={activePill === key}
-          on:click={() => dispatch('pillChange', { key })}
-          color={attributeGroupingProperties[key].color}
-          >{attributeGroupingProperties[key].label}</Pill
-        >
-      {/if}
-    {/each}
+{#if pillCount > 1}
+  <div class="p-2 text-center xl:text-left">
+    <div class="pill-container">
+      {#each Object.entries(attributeGrouping) as [key, value] (key)}
+        {#if value.length}
+          <Pill
+            active={activePill === key}
+            on:click={() => dispatch('pillChange', { key })}
+            color={attributeGroupingProperties[key].color}
+            >{attributeGroupingProperties[key].label}</Pill
+          >
+        {/if}
+      {/each}
+    </div>
   </div>
-</div>
+{/if}
 
 <style lang="postcss">
   .pill-container {


### PR DESCRIPTION
## What was changed
Remove event summary details Pill if it's the only pill.

<img width="1645" alt="Screen Shot 2022-09-14 at 1 57 26 PM" src="https://user-images.githubusercontent.com/7967403/190270739-477c9d44-32ed-474e-942a-8c90ff483ba3.png">

## Why?
Better UX, users expect Pill is a button that does something when clicked. This is true with multiple Pill buts not with single Pill
