### PR TITLE
Events Service retry

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "stylelint-config-recommended"
-  ],
+  "extends": ["stylelint-config-recommended"],
   "processors": [],
   "rules": {
     "at-rule-no-unknown": [
@@ -26,9 +24,7 @@
     "no-descending-specificity": [
       true,
       {
-        "ignore": [
-          "selectors-within-list"
-        ]
+        "ignore": ["selectors-within-list"]
       }
     ],
     "no-invalid-double-slash-comments": true,

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -1,6 +1,6 @@
 import type { GetWorkflowExecutionHistoryResponse } from '$types';
 
-import { paginatedWithBackOff } from '$lib/utilities/paginated';
+import { paginated } from '$lib/utilities/paginated';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 import { toEventHistory } from '$lib/models/event-history';
@@ -39,13 +39,15 @@ export const fetchRawEvents = async ({
 }: FetchEventsParameters): Promise<HistoryEvent[]> => {
   const endpoint = getEndpointForSortOrder(sort);
 
-  const response = await paginatedWithBackOff(
-    async (token: string) => {
+  const response = await paginated(
+    async (token: string, page?: number) => {
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
         routeForApi(endpoint, { namespace, workflowId, runId }),
         {
-          params: { maximumPageSize: '5' },
           token,
+          shouldRetry: true,
+          retryInterval: 500,
+          handleError: (error) => console.error(error),
           request: fetch,
         },
       );

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -1,6 +1,6 @@
 import type { GetWorkflowExecutionHistoryResponse } from '$types';
 
-import { paginated } from '$lib/utilities/paginated';
+import { paginatedWithBackOff } from '$lib/utilities/paginated';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 import { toEventHistory } from '$lib/models/event-history';
@@ -39,11 +39,12 @@ export const fetchRawEvents = async ({
 }: FetchEventsParameters): Promise<HistoryEvent[]> => {
   const endpoint = getEndpointForSortOrder(sort);
 
-  const response = await paginated(
+  const response = await paginatedWithBackOff(
     async (token: string) => {
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
         routeForApi(endpoint, { namespace, workflowId, runId }),
         {
+          params: { maximumPageSize: '5' },
           token,
           request: fetch,
         },

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -40,7 +40,7 @@ export const fetchRawEvents = async ({
   const endpoint = getEndpointForSortOrder(sort);
 
   const response = await paginated(
-    async (token: string, page?: number) => {
+    async (token: string) => {
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
         routeForApi(endpoint, { namespace, workflowId, runId }),
         {

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -5,7 +5,6 @@ import { merge } from './merge';
 type PaginatedOptions<T> = PaginationCallbacks<T> & {
   token?: NextPageToken;
   previousProps?: WithoutNextPageToken<T>;
-  delay?: number;
 };
 
 /**

--- a/src/lib/utilities/paginated.ts
+++ b/src/lib/utilities/paginated.ts
@@ -89,6 +89,11 @@ export const paginatedWithBackOff = async <T extends WithNextPageToken>(
       previousProps: mergedProps,
     });
   } catch (error: unknown) {
+    if (error?.response?.data?.error) {
+      console.error(
+        `Received error: ${JSON.stringify(error?.response?.data?.error)}`
+      );
+    }
     onError(error);
   }
 };


### PR DESCRIPTION
## What was changed
Allow up to 10 retries (default amount) for events-service with 500 ms delay.

## Why?
To prevent overloading server and getting 429s. Back off the events service call with pagination on a failed call and retry.

