### PR TITLE
Add scroll to top button

### DIFF
--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -63,6 +63,7 @@
   import Banners from '$lib/components/banner/banners.svelte';
   import { ErrorBoundary } from '$lib/components/error-boundary';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import ScrollToTop from '$lib/holocene/scroll-to-top.svelte';
 
   export let user: User;
   export let uiVersionInfo: UiVersionInfo;
@@ -81,5 +82,6 @@
         <slot />
       </ErrorBoundary>
     </div>
+    <ScrollToTop />
   </section>
 </div>

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -69,14 +69,14 @@
 </script>
 
 <PageTitle />
-<div class="flex h-screen w-screen flex-row">
+<div class="flex w-screen flex-row">
   <Notifications />
   <div class="sticky top-0 z-20 h-screen w-auto">
     <Header {user} />
   </div>
-  <section id="content" class="h-screen w-max flex-auto overflow-auto">
+  <section id="content" class="min-h-screen w-max flex-auto overflow-auto">
     <Banners {uiVersionInfo} />
-    <div class="z-10 flex h-full flex-col gap-4 px-10 pb-10 pt-8">
+    <div class="z-10 flex flex-col gap-4 px-10 pb-10 pt-8">
       <ErrorBoundary onError={() => {}}>
         <slot />
       </ErrorBoundary>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This adds a button that appears on scroll for **all** pages to take the user back to the top of the page.

## Why?
<!-- Tell your future self why have you made these changes -->
It was requested.

## Checklist
<!--- add/delete as needed --->

1. Closes: Back to Top / Back to Bottom <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify button shows up on scroll down
- [ ] Verify button does not show up when user is at the top of the page
- [ ] Verify, when clicked, page is taken back to the top
- [ ] Verify button shows up on all pages that can scroll
- [ ] Verify layout for all pages looks as expected
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
