### PR TITLE
Fix pending activity id overflow

### DIFF
--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -31,87 +31,97 @@
     <section>
       {#each pendingActivities as { id, ...pendingActivity } (id)}
         {@const failed = pendingActivity.attempt > 1}
-        <div class="pending-activity-row">
-          <h3 class="w-6 self-start p-1 font-normal text-gray-500">
+        <div class="pending-activity-row-container">
+          <h3 class="w-full self-start text-sm font-normal text-gray-500">
             {pendingActivity.activityId}
           </h3>
-          <div class="pending-activity-summary">
-            <a class="flex w-full items-center hover:bg-gray-50" {href}>
-              <div class="pending-activity-inner-row">
-                <div class="pending-activity-detail">
-                  <h4 class="pending-activity-detail-header">Activity Type</h4>
-                  <Badge type={failed ? 'error' : 'default'}>
-                    {pendingActivity.activityType}
-                  </Badge>
-                </div>
-                <div class="pending-activity-detail">
-                  <h4 class="pending-activity-detail-header">Last Heartbeat</h4>
-                  {formatDate(pendingActivity.lastHeartbeatTime, 'relative')}
-                </div>
-                <div class="pending-activity-detail">
-                  <h4 class="pending-activity-detail-header">Attempt</h4>
-                  <Badge type={failed ? 'error' : 'default'}>
-                    {#if failed}
-                      <Icon name="retry" />
-                    {/if}
-                    {pendingActivity.attempt}
-                  </Badge>
-                </div>
-                <div class="pending-activity-detail">
-                  <h4 class="pending-activity-detail-header">Attempts Left</h4>
-                  <Badge type={failed ? 'error' : 'default'}>
-                    {formatAttemptsLeft(
-                      pendingActivity.maximumAttempts,
-                      pendingActivity.attempt,
-                    )}
-                  </Badge>
-                </div>
-                {#if failed && pendingActivity.scheduledTime}
+          <div class="pending-activity-row">
+            <div class="pending-activity-summary">
+              <a class="flex w-full items-center hover:bg-gray-50" {href}>
+                <div class="pending-activity-inner-row">
                   <div class="pending-activity-detail">
-                    <h4 class="pending-activity-detail-header">Next Retry</h4>
+                    <h4 class="pending-activity-detail-header">
+                      Activity Type
+                    </h4>
                     <Badge type={failed ? 'error' : 'default'}>
-                      {toTimeDifference(pendingActivity.scheduledTime)}
+                      {pendingActivity.activityType}
                     </Badge>
                   </div>
-                {/if}
-                <div class="pending-activity-detail">
-                  <h4 class="pending-activity-detail-header">Expiration</h4>
-                  {formatRetryExpiration(
-                    pendingActivity.maximumAttempts,
-                    formatDuration(
-                      getDuration({
-                        start: Date.now(),
-                        end: pendingActivity.expirationTime,
-                      }),
-                    ),
-                  )}
-                </div>
-              </div>
-            </a>
-            {#if failed}
-              <div class="pending-activity-failure-details">
-                {#if pendingActivity.heartbeatDetails}
-                  <div class="w-full">
+                  <div class="pending-activity-detail">
                     <h4 class="pending-activity-detail-header">
-                      Heartbeat Details
+                      Last Heartbeat
                     </h4>
-                    <CodeBlock
-                      class="max-h-32"
-                      content={pendingActivity.heartbeatDetails}
-                    />
+                    {formatDate(pendingActivity.lastHeartbeatTime, 'relative')}
                   </div>
-                {/if}
-                {#if pendingActivity.lastFailure}
-                  <div class="w-full">
-                    <h4 class="pending-activity-detail-header">Last Failure</h4>
-                    <CodeBlock
-                      class="max-h-32"
-                      content={pendingActivity.lastFailure}
-                    />
+                  <div class="pending-activity-detail">
+                    <h4 class="pending-activity-detail-header">Attempt</h4>
+                    <Badge type={failed ? 'error' : 'default'}>
+                      {#if failed}
+                        <Icon name="retry" />
+                      {/if}
+                      {pendingActivity.attempt}
+                    </Badge>
                   </div>
-                {/if}
-              </div>
-            {/if}
+                  <div class="pending-activity-detail">
+                    <h4 class="pending-activity-detail-header">
+                      Attempts Left
+                    </h4>
+                    <Badge type={failed ? 'error' : 'default'}>
+                      {formatAttemptsLeft(
+                        pendingActivity.maximumAttempts,
+                        pendingActivity.attempt,
+                      )}
+                    </Badge>
+                  </div>
+                  {#if failed && pendingActivity.scheduledTime}
+                    <div class="pending-activity-detail">
+                      <h4 class="pending-activity-detail-header">Next Retry</h4>
+                      <Badge type={failed ? 'error' : 'default'}>
+                        {toTimeDifference(pendingActivity.scheduledTime)}
+                      </Badge>
+                    </div>
+                  {/if}
+                  <div class="pending-activity-detail">
+                    <h4 class="pending-activity-detail-header">Expiration</h4>
+                    {formatRetryExpiration(
+                      pendingActivity.maximumAttempts,
+                      formatDuration(
+                        getDuration({
+                          start: Date.now(),
+                          end: pendingActivity.expirationTime,
+                        }),
+                      ),
+                    )}
+                  </div>
+                </div>
+              </a>
+              {#if failed}
+                <div class="pending-activity-failure-details">
+                  {#if pendingActivity.heartbeatDetails}
+                    <div class="w-full">
+                      <h4 class="pending-activity-detail-header">
+                        Heartbeat Details
+                      </h4>
+                      <CodeBlock
+                        class="max-h-32"
+                        content={pendingActivity.heartbeatDetails}
+                      />
+                    </div>
+                  {/if}
+                  {#if pendingActivity.lastFailure}
+                    <div class="w-full">
+                      <h4 class="pending-activity-detail-header">
+                        Last Failure
+                      </h4>
+                      <CodeBlock
+                        class="max-h-32"
+                        content={pendingActivity.lastFailure}
+                      />
+                    </div>
+                  {/if}
+                </div>
+              {/if}
+            </div>
           </div>
         </div>
       {/each}
@@ -123,6 +133,10 @@
 {/if}
 
 <style lang="postcss">
+  .pending-activity-row-container {
+    @apply mt-4;
+  }
+
   .pending-activity-row {
     @apply flex w-full flex-row items-center gap-2;
   }

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -35,7 +35,7 @@
     {#each pendingActivities as { id, activityId, ...details } (id)}
       {@const failed = details.attempt > 1}
       <div class="event-table-body">
-        <div class="flex w-8 items-start p-5">
+        <div class="flex w-24 items-start break-all py-5 pl-5 pr-2">
           <Link href="#{id}">{activityId}</Link>
         </div>
         <div class="w-full py-4 px-5">


### PR DESCRIPTION
## What was changed
Move pending activity id above pending activity details in Event History page, make the pending activity id column wider and break the word on the Pending Activities page.

<img width="1597" alt="Screen Shot 2022-09-20 at 8 38 57 AM" src="https://user-images.githubusercontent.com/7967403/191275293-0f8dbfd2-b670-4c35-952a-979b4ab77b9f.png">

<img width="1697" alt="Screen Shot 2022-09-20 at 8 43 40 AM" src="https://user-images.githubusercontent.com/7967403/191275265-dd36f723-9492-4a99-97fe-1a82ce4ae119.png">


Fixes #843, #798 
