### PR TITLE
Link to child workflows from parent workflow histories

### DIFF
--- a/src/lib/components/event/event-details-full.svelte
+++ b/src/lib/components/event/event-details-full.svelte
@@ -41,7 +41,7 @@
       />
       {#each Object.entries(attributes) as [key, value] (key)}
         {#if attributeGrouping[activePill]?.includes(key)}
-          <EventDetailsRowExpanded {key} {value} class="w-full" />
+          <EventDetailsRowExpanded {key} {value} {attributes} class="w-full" />
         {/if}
       {/each}
     </div>
@@ -55,7 +55,7 @@
     />
     {#each Object.entries(attributes) as [key, value] (key)}
       {#if attributeGrouping[activePill]?.includes(key)}
-        <EventDetailsRowExpanded {key} {value} class="w-full" />
+        <EventDetailsRowExpanded {key} {value} {attributes} class="w-full" />
       {/if}
     {/each}
   </div>

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -10,6 +10,7 @@
   import {
     getCodeBlockValue,
     shouldDisplayAsExecutionLink,
+    shouldDisplayChildWorkflowLink,
     shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
   } from '$lib/utilities/get-single-attribute-for-event';
@@ -20,6 +21,7 @@
 
   export let key: string;
   export let value: string | Record<string, unknown>;
+  export let attributes: object;
 
   export let inline = false;
 
@@ -58,6 +60,17 @@
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link href={routeForTaskQueue({ namespace, queue: value })}>
+            {value}
+          </Link>
+        </Copyable>
+      </div>
+    </div>
+  {:else if shouldDisplayChildWorkflowLink(key)}
+    <div class="detail-row">
+      <h2 class="text-sm">{format(key)}</h2>
+      <div class="text-sm">
+        <Copyable content={value} container-class="xl:flex-row">
+          <Link href={routeForWorkflow({ namespace, workflow: attributes.workflowExecutionWorkflowId, run: attributes.workflowExecutionRunId})}>
             {value}
           </Link>
         </Copyable>

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -74,6 +74,22 @@ export const shouldDisplayAsExecutionLink = (
   return false;
 };
 
+const keysWithChildExecutionLinks = [
+  'workflowExecutionWorkflowId',
+  'workflowExecutionRunId',
+] as const;
+
+// For linking to a child workflow
+export const shouldDisplayChildWorkflowLink = (
+  key: string,
+): key is typeof keysWithChildExecutionLinks[number] => {
+  for (const workflowKey of keysWithChildExecutionLinks) {
+    if (key === workflowKey) return true;
+  }
+
+  return false;
+};
+
 const keysWithTaskQueueLinks = ['taskQueueName'] as const;
 
 export const shouldDisplayAsTaskQueueLink = (


### PR DESCRIPTION
Attempt to partially solve #845.

<!--- For ALL Contributors 👇 -->

## What was changed

The PR wraps child workflow IDs and Run IDs displayed in workflow histories with links to the corresponding workflow pages. 

## Why?

This is very useful when debugging workflows in the UI as you don't have to go back to the workflow list view and filter by workflow ID. 

Ideally, we could jump to a child workflow in one click as highlighted in #845 instead of having to click on the `Workflow` pill, but his might need more design decision on how to render that out, so I haven't tried to implement it. 

## Checklist
<!--- add/delete as needed --->

1. This only partially implements #845 

2. How was this tested:

Only locally, running the UI with a demo workflow

![image](https://user-images.githubusercontent.com/406923/192262634-af2f6fb1-4ddc-41b5-af84-08ef6925fb75.png)

![image](https://user-images.githubusercontent.com/406923/192262682-a91b07cc-5eb0-4cc6-a7fd-8a149131ea3e.png)


3. Any docs updates needed?

No

--- 

My frontend, typescript and svelte knowledge is very limited and I am not really satisfied with how I had to pass down the entire event attributes to the `EventDetailsRowExpanded` component to be able to get both the workflow and run IDs. I am not sure there is a better way given the current implementation which is a simple for loop to "display that attributes list" without full context around the attributes.