### PR TITLE
Show parent link in child workflow event history, add Loading spinner to event history

### DIFF
--- a/src/lib/components/event/event-details-full.svelte
+++ b/src/lib/components/event/event-details-full.svelte
@@ -41,7 +41,7 @@
       />
       {#each Object.entries(attributes) as [key, value] (key)}
         {#if attributeGrouping[activePill]?.includes(key)}
-          <EventDetailsRowExpanded {key} {value} class="w-full" />
+          <EventDetailsRowExpanded {key} {value} {attributes} class="w-full" />
         {/if}
       {/each}
     </div>
@@ -55,7 +55,7 @@
     />
     {#each Object.entries(attributes) as [key, value] (key)}
       {#if attributeGrouping[activePill]?.includes(key)}
-        <EventDetailsRowExpanded {key} {value} class="w-full" />
+        <EventDetailsRowExpanded {key} {value} {attributes} class="w-full" />
       {/if}
     {/each}
   </div>

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -31,9 +31,9 @@
 <article class="row flex px-4 first:pt-0 {$$props.class}">
   {#if typeof value === 'object'}
     <div class="code-block-row">
-      <h2 class="text-sm">
+      <p class="text-sm">
         {format(key)}
-      </h2>
+      </p>
       <CodeBlock
         content={getCodeBlockValue(value)}
         class="w-full text-right lg:h-auto"
@@ -42,7 +42,7 @@
     </div>
   {:else if shouldDisplayAsExecutionLink(key)}
     <div class="detail-row">
-      <h2 class="text-sm">{format(key)}</h2>
+      <p class="text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable
           content={value}
@@ -56,7 +56,7 @@
     </div>
   {:else if shouldDisplayChildWorkflowLink(key, attributes)}
     <div class="detail-row">
-      <h2 class="text-sm">{format(key)}</h2>
+      <p class="text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link
@@ -73,7 +73,7 @@
     </div>
   {:else if shouldDisplayAsTaskQueueLink(key)}
     <div class="detail-row">
-      <h2 class="text-sm">{format(key)}</h2>
+      <p class="text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link href={routeForTaskQueue({ namespace, queue: value })}>
@@ -84,7 +84,7 @@
     </div>
   {:else}
     <div class="detail-row">
-      <h2 class="text-sm">{format(key)}</h2>
+      <p class="text-sm">{format(key)}</p>
       <p class="text-sm">
         <span
           class="select-all px-2"

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -12,18 +12,20 @@
     shouldDisplayAsExecutionLink,
     shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
+    shouldDisplayChildWorkflowLink,
   } from '$lib/utilities/get-single-attribute-for-event';
 
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Link from '$lib/holocene/link.svelte';
   import Copyable from '../copyable.svelte';
+  import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
 
   export let key: string;
   export let value: string | Record<string, unknown>;
-
+  export let attributes: CombinedAttributes;
   export let inline = false;
 
-  const { workflow, namespace, run } = $page.params;
+  const { workflow, namespace } = $page.params;
 </script>
 
 <article class="row flex px-4 first:pt-0 {$$props.class}">
@@ -47,6 +49,23 @@
           container-class="flex-row-reverse xl:flex-row"
         >
           <Link href={routeForWorkflow({ namespace, workflow, run: value })}>
+            {value}
+          </Link>
+        </Copyable>
+      </div>
+    </div>
+  {:else if shouldDisplayChildWorkflowLink(key, attributes)}
+    <div class="detail-row">
+      <h2 class="text-sm">{format(key)}</h2>
+      <div class="text-sm">
+        <Copyable content={value} container-class="xl:flex-row">
+          <Link
+            href={routeForWorkflow({
+              namespace,
+              workflow: attributes.workflowExecutionWorkflowId,
+              run: attributes.workflowExecutionRunId,
+            })}
+          >
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -48,7 +48,10 @@
           content={value}
           container-class="flex-row-reverse xl:flex-row"
         >
-          <Link href={routeForWorkflow({ namespace, workflow, run: value })}>
+          <Link
+            newTab
+            href={routeForWorkflow({ namespace, workflow, run: value })}
+          >
             {value}
           </Link>
         </Copyable>
@@ -60,6 +63,7 @@
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link
+            newTab
             href={routeForWorkflow({
               namespace,
               workflow: attributes.workflowExecutionWorkflowId,
@@ -76,7 +80,7 @@
       <p class="text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
-          <Link href={routeForTaskQueue({ namespace, queue: value })}>
+          <Link newTab href={routeForTaskQueue({ namespace, queue: value })}>
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -11,17 +11,20 @@
     shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
     getCodeBlockValue,
+    shouldDisplayChildWorkflowLink,
   } from '$lib/utilities/get-single-attribute-for-event';
 
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Link from '$lib/holocene/link.svelte';
   import Copyable from '../copyable.svelte';
+  import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
 
   export let key: string;
   export let value: string | Record<string, unknown>;
+  export let attributes: CombinedAttributes;
   export let inline = false;
 
-  const { workflow, namespace, run } = $page.params;
+  const { workflow, namespace } = $page.params;
 </script>
 
 <article
@@ -41,6 +44,23 @@
           container-class="flex-row-reverse xl:flex-row"
         >
           <Link href={routeForWorkflow({ namespace, workflow, run: value })}>
+            {value}
+          </Link>
+        </Copyable>
+      </div>
+    </div>
+  {:else if shouldDisplayChildWorkflowLink(key, attributes)}
+    <div class="detail-row">
+      <h2 class="text-sm">{format(key)}</h2>
+      <div class="text-sm">
+        <Copyable content={value} container-class="xl:flex-row">
+          <Link
+            href={routeForWorkflow({
+              namespace,
+              workflow: attributes.workflowExecutionWorkflowId,
+              run: attributes.workflowExecutionRunId,
+            })}
+          >
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -43,7 +43,10 @@
           content={value}
           container-class="flex-row-reverse xl:flex-row"
         >
-          <Link href={routeForWorkflow({ namespace, workflow, run: value })}>
+          <Link
+            newTab
+            href={routeForWorkflow({ namespace, workflow, run: value })}
+          >
             {value}
           </Link>
         </Copyable>
@@ -55,6 +58,7 @@
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link
+            newTab
             href={routeForWorkflow({
               namespace,
               workflow: attributes.workflowExecutionWorkflowId,
@@ -74,7 +78,7 @@
           content={value}
           container-class="flex-row-reverse xl:flex-row"
         >
-          <Link href={routeForTaskQueue({ namespace, queue: value })}>
+          <Link newTab href={routeForTaskQueue({ namespace, queue: value })}>
             {value}
           </Link>
         </Copyable>

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -31,13 +31,13 @@
   class="flex flex-row gap-2 border-b-2 border-gray-200 py-2 first:pt-0 last:border-b-0 xl:gap-4 {$$props.class}"
 >
   {#if typeof value === 'object'}
-    <h2 class="min-w-fit items-center text-sm xl:items-start">
+    <p class="min-w-fit items-center text-sm xl:items-start">
       {format(key)}
-    </h2>
+    </p>
     <CodeBlock content={getCodeBlockValue(value)} class="w-full" {inline} />
   {:else if shouldDisplayAsExecutionLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="mr-3 text-sm">{format(key)}</h2>
+      <p class="mr-3 text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable
           content={value}
@@ -51,7 +51,7 @@
     </div>
   {:else if shouldDisplayChildWorkflowLink(key, attributes)}
     <div class="detail-row">
-      <h2 class="text-sm">{format(key)}</h2>
+      <p class="text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable content={value} container-class="xl:flex-row">
           <Link
@@ -68,7 +68,7 @@
     </div>
   {:else if shouldDisplayAsTaskQueueLink(key)}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="mr-3 text-sm">{format(key)}</h2>
+      <p class="mr-3 text-sm">{format(key)}</p>
       <div class="text-sm">
         <Copyable
           content={value}
@@ -82,7 +82,7 @@
     </div>
   {:else}
     <div class="xl:3/4 flex w-full items-center xl:items-start">
-      <h2 class="mr-3 text-sm">{format(key)}</h2>
+      <p class="mr-3 text-sm">{format(key)}</p>
       <p class="text-right text-sm xl:text-left">
         <span
           class="select-all px-2 text-gray-700"

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -23,6 +23,7 @@
 
   import EventDetailsRow from './event-details-row.svelte';
   import EventDetailsFull from './event-details-full.svelte';
+  import { formatAttributes } from '$lib/utilities/format-event-attributes';
 
   export let event: IterableEvent;
   export let groups: EventGroups;
@@ -42,6 +43,7 @@
   $: currentEvent = compact ? eventGroup.events.get(selectedId) : event;
   $: descending = $eventSortOrder === 'descending';
   $: showElapsed = $eventShowElapsed === 'true';
+  $: attributes = formatAttributes(event, { compact });
 
   $: timeDiffChange = '';
   $: {
@@ -123,7 +125,11 @@
   </td>
   <td class="cell links">
     {#if !expanded}
-      <EventDetailsRow {...getSingleAttributeForEvent(currentEvent)} inline />
+      <EventDetailsRow
+        {...getSingleAttributeForEvent(currentEvent)}
+        {attributes}
+        inline
+      />
     {/if}
   </td>
   <td class="cell text-right">

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -5,9 +5,11 @@
   import EventSummaryTable from '$lib/components/event/event-summary-table.svelte';
   import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
   import EventEmptyRow from './event-empty-row.svelte';
+  import Loading from '$lib/holocene/loading.svelte';
 
   export let items: IterableEvents;
   export let groups: EventGroups;
+  export let loading = false;
   export let compact = false;
 
   function handleExpandChange(event: CustomEvent) {
@@ -15,24 +17,28 @@
   }
 </script>
 
-<Pagination
-  {items}
-  floatId="event-view-toggle"
-  let:visibleItems
-  let:initialItem
->
-  <EventSummaryTable {compact} on:expandAll={handleExpandChange}>
-    {#each visibleItems as event (`${event.id}-${event.timestamp}`)}
-      <EventSummaryRow
-        {event}
-        {groups}
-        {compact}
-        expandAll={$expandAllEvents === 'true'}
-        {initialItem}
-        {visibleItems}
-      />
-    {:else}
-      <EventEmptyRow />
-    {/each}
-  </EventSummaryTable>
-</Pagination>
+{#if loading}
+  <Loading />
+{:else}
+  <Pagination
+    {items}
+    floatId="event-view-toggle"
+    let:visibleItems
+    let:initialItem
+  >
+    <EventSummaryTable {compact} on:expandAll={handleExpandChange}>
+      {#each visibleItems as event (`${event.id}-${event.timestamp}`)}
+        <EventSummaryRow
+          {event}
+          {groups}
+          {compact}
+          expandAll={$expandAllEvents === 'true'}
+          {initialItem}
+          {visibleItems}
+        />
+      {:else}
+        <EventEmptyRow />
+      {/each}
+    </EventSummaryTable>
+  </Pagination>
+{/if}

--- a/src/lib/holocene/link.svelte
+++ b/src/lib/holocene/link.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   export let href: string;
   export let active = false;
+  export let newTab = false;
 </script>
 
 <a
   {href}
+  target={newTab ? '_blank' : '_self'}
   class:text-blue-900={active}
   {...$$props}
   class="{$$props.class} underline underline-offset-2 hover:text-blue-700"

--- a/src/lib/pages/workflow-history-compact.svelte
+++ b/src/lib/pages/workflow-history-compact.svelte
@@ -3,7 +3,7 @@
 
   import EventSummary from '$lib/components/event/event-summary.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
-  import { ascendingEventGroups } from '$lib/stores/events';
+  import { ascendingEventGroups, loading } from '$lib/stores/events';
 
   const workflow = $page.params?.workflow;
 </script>
@@ -13,4 +13,5 @@
   items={$ascendingEventGroups}
   groups={$ascendingEventGroups}
   compact={true}
+  loading={$loading}
 />

--- a/src/lib/pages/workflow-history-feed.svelte
+++ b/src/lib/pages/workflow-history-feed.svelte
@@ -4,7 +4,7 @@
   import { timelineEvents } from '$lib/stores/events';
   import EventSummary from '$lib/components/event/event-summary.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
-  import { events, eventGroups } from '$lib/stores/events';
+  import { events, eventGroups, loading } from '$lib/stores/events';
   import { onDestroy } from 'svelte';
 
   onDestroy(() => {
@@ -15,4 +15,4 @@
 </script>
 
 <PageTitle title={`Workflow History | ${workflow}`} url={$page.url.href} />
-<EventSummary items={$events} groups={$eventGroups} />
+<EventSummary items={$events} groups={$eventGroups} loading={$loading} />

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -7,6 +7,8 @@ import { capitalize } from '$lib/utilities/format-camel-case';
 
 export type CombinedAttributes = EventAttribute & {
   eventTime?: string;
+  workflowExecutionRunId?: string;
+  workflowExecutionWorkflowId?: string;
 };
 
 const keysToOmit: Readonly<Set<string>> = new Set(['header']);

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -1,5 +1,6 @@
 import { isEventGroup } from '$lib/models/event-groups';
 import { capitalize } from '$lib/utilities/format-camel-case';
+import type { CombinedAttributes } from './format-event-attributes';
 
 type SummaryAttribute = {
   key: string;
@@ -86,6 +87,27 @@ export const shouldDisplayAsTaskQueueLink = (
   return false;
 };
 
+const keysWithChildExecutionLinks = [
+  'workflowExecutionWorkflowId',
+  'workflowExecutionRunId',
+] as const;
+
+// For linking to a child workflow
+export const shouldDisplayChildWorkflowLink = (
+  key: string,
+  attributes: CombinedAttributes,
+): key is typeof keysWithChildExecutionLinks[number] => {
+  const workflowLinkAttributesExist = Boolean(
+    attributes?.workflowExecutionWorkflowId &&
+      attributes?.workflowExecutionRunId,
+  );
+  for (const workflowKey of keysWithChildExecutionLinks) {
+    if (key === workflowKey && workflowLinkAttributesExist) return true;
+  }
+
+  return false;
+};
+
 const formatSummaryValue = (key: string, value: unknown): SummaryAttribute => {
   if (typeof value === 'object') {
     const [firstKey] = Object.keys(value);
@@ -103,6 +125,7 @@ const preferredSummaryKeys = [
   'input',
   'activityType',
   'parentInitiatedEventId',
+  'workflowExecution',
   'workflowType',
   'taskQueue',
 ] as const;


### PR DESCRIPTION
## What was changed
For child workflows, add a link to the workflowId and workflowRunId of the parent workflow in the event history. This also adds the workflowId as the preferred key to show on the collapsed row with a link. The links will open in new tab. The labels for all events are changed to p tags so the font is consistent for all data.

Included in this is also adding the Loading component to the event history when the event history is being loaded into the table. 

<img width="1682" alt="BeforeLink1" src="https://user-images.githubusercontent.com/7967403/192315524-2fd6de03-5628-487c-909a-769489e0559f.png">
<img width="1601" alt="BeforeLink2" src="https://user-images.githubusercontent.com/7967403/192315533-f785adec-e738-4cf7-b6ad-e450a96dc4b8.png">
<img width="1686" alt="AfterLink1" src="https://user-images.githubusercontent.com/7967403/192315540-c0310fcd-2a11-49a5-b8c9-e255086629c1.png">
<img width="1567" alt="AfterLink2" src="https://user-images.githubusercontent.com/7967403/192315545-d0d984fe-0347-448e-bcee-74c94b131c0c.png">

## Why?
Easier to jump to parent workflow, better UX.


1. Closes #845 

2. How was this tested:
All tests are passing, manually tested feed/compact of multiple workflows

## Contributors
@lminaudier
