### PR TITLE
Decode pending activities

### DIFF
--- a/src/events.d.ts
+++ b/src/events.d.ts
@@ -47,6 +47,10 @@ interface PendingActivity extends PendingActivityInfo {
   activityType: { name: string };
 }
 
+type PendingActivityWithMetadata = {
+  activity: PendingActivity;
+} & EventRequestMetadata;
+
 type CommonEventKey =
   | 'id'
   | 'eventType'

--- a/src/fixtures/workflow.pending-activities.json
+++ b/src/fixtures/workflow.pending-activities.json
@@ -1,0 +1,151 @@
+{
+  "executionConfig": {
+    "taskQueue": {
+      "name": "rainbow-statuses",
+      "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "0s",
+    "defaultWorkflowTaskTimeout": "10s"
+  },
+  "workflowExecutionInfo": {
+    "execution": {
+      "workflowId": "09db15_Running",
+      "runId": "4284ef9a-947f-4db2-bf15-dbc377e71fa6"
+    },
+    "type": {
+      "name": "RainbowStatusesWorkflow"
+    },
+    "startTime": "2022-04-28T05:50:48.264756929Z",
+    "closeTime": null,
+    "status": "Running",
+    "historyLength": "6",
+    "parentNamespaceId": "",
+    "parentExecution": null,
+    "executionTime": "2022-04-28T05:50:48.264756929Z",
+    "memo": {
+      "fields": {}
+    },
+    "searchAttributes": {
+      "indexedFields": {
+        "BinaryChecksums": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "S2V5d29yZA=="
+          },
+          "data": "WyIzN2VhNzVjMzc4MDFjMTY2N2IyOThlNGYxZjk1NWE3MCJd"
+        },
+        "CustomBoolField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "Qm9vbA=="
+          },
+          "data": "dHJ1ZQ=="
+        },
+        "CustomDatetimeField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "RGF0ZXRpbWU="
+          },
+          "data": "IjIwMjItMDQtMjhUMDU6NTA6NDguMjYzNTE2MDVaIg=="
+        },
+        "CustomDoubleField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "RG91Ymxl"
+          },
+          "data": "MA=="
+        },
+        "CustomIntField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "SW50"
+          },
+          "data": "MA=="
+        },
+        "CustomKeywordField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "S2V5d29yZA=="
+          },
+          "data": "InJhaW5ib3ctc3RhdHVzZXMtMDlkYjE1Ig=="
+        },
+        "CustomStringField": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "VGV4dA=="
+          },
+          "data": "InJhaW5ib3cgc3RhdHVzZXMgMDlkYjE1IFJ1bm5pbmci"
+        }
+      }
+    },
+    "autoResetPoints": {
+      "points": [
+        {
+          "binaryChecksum": "37ea75c37801c1667b298e4f1f955a70",
+          "runId": "4284ef9a-947f-4db2-bf15-dbc377e71fa6",
+          "firstWorkflowTaskCompletedId": "5",
+          "createTime": "2022-04-28T05:50:48.291718480Z",
+          "expireTime": null,
+          "resettable": true
+        }
+      ]
+    },
+    "taskQueue": "rainbow-statuses",
+    "stateTransitionCount": "5"
+  },
+  "pendingActivities": [
+    {
+      "activityId": "1",
+      "activityType": {
+        "name": "LongActivity1"
+      },
+      "state": "Started",
+      "heartbeatDetails": {
+        "payloads": [
+          {
+            "metadata": {
+              "encoding": "anNvbi9wbGFpbg=="
+            },
+            "data": "Mg=="
+          }
+        ]
+      },
+      "lastHeartbeatTime": "2022-04-28T05:50:48.306477858Z",
+      "lastStartedTime": "2022-04-28T05:50:48.306477858Z",
+      "attempt": 1,
+      "maximumAttempts": 1,
+      "scheduledTime": null,
+      "expirationTime": "0001-01-01T00:00:00Z",
+      "lastFailure": null,
+      "lastWorkerIdentity": "173471@user0@"
+    },
+    {
+      "activityId": "2",
+      "activityType": {
+        "name": "LongActivity2"
+      },
+      "state": "Started",
+      "heartbeatDetails": {
+        "payloads": [
+          {
+            "metadata": {
+              "encoding": "anNvbi9wbGFpbg=="
+            },
+            "data": "OA=="
+          }
+        ]
+      },
+      "lastHeartbeatTime": "2022-04-28T05:50:48.306477858Z",
+      "lastStartedTime": "2022-04-28T05:50:48.306477858Z",
+      "attempt": 1,
+      "maximumAttempts": 1,
+      "scheduledTime": null,
+      "expirationTime": "0001-01-01T00:00:00Z",
+      "lastFailure": null,
+      "lastWorkerIdentity": "173471@user0@"
+    }
+  ],
+  "pendingChildren": [],
+  "pendingWorkflowTask": null
+}

--- a/src/lib/models/event-history/index.ts
+++ b/src/lib/models/event-history/index.ts
@@ -1,10 +1,10 @@
 import { get } from 'svelte/store';
 import { dataEncoderEndpoint } from '$lib/stores/data-encoder-config';
 import {
-  Decode,
   convertPayloadToJsonWithCodec,
   convertPayloadToJsonWithWebsocket,
   decodePayloadAttributes,
+  type DecodeFunctions,
 } from '$lib/utilities/decode-payload';
 import { formatDate } from '$lib/utilities/format-date';
 import { has } from '$lib/utilities/has';
@@ -14,13 +14,6 @@ import { groupEvents } from '../event-groups';
 import { getEventCategory } from './get-event-categorization';
 import { getEventClassification } from './get-event-classification';
 import { simplifyAttributes } from './simplify-attributes';
-
-type DecodeFunctions = {
-  convertWithCodec?: Decode['convertPayloadToJsonWithCodec'];
-  convertWithWebsocket?: Decode['convertPayloadToJsonWithWebsocket'];
-  decodeAttributes?: Decode['decodePayloadAttributes'];
-  encoderEndpoint?: typeof dataEncoderEndpoint;
-};
 
 const getEndpoint = (
   settings: Settings,

--- a/src/lib/models/pending-activities/index.ts
+++ b/src/lib/models/pending-activities/index.ts
@@ -1,0 +1,55 @@
+import { get } from 'svelte/store';
+import { dataEncoderEndpoint } from '$lib/stores/data-encoder-config';
+import {
+  convertPayloadToJsonWithCodec,
+  convertPayloadToJsonWithWebsocket,
+  decodePayloadAttributes,
+  type DecodeFunctions,
+} from '$lib/utilities/decode-payload';
+
+const getEndpoint = (
+  settings: Settings,
+  encoderEndpoint = dataEncoderEndpoint,
+): string => {
+  return get(encoderEndpoint) || settings?.codec?.endpoint || '';
+};
+
+export async function getActivityAttributes(
+  { activity, namespace, settings }: PendingActivityWithMetadata,
+  {
+    convertWithCodec = convertPayloadToJsonWithCodec,
+    convertWithWebsocket = convertPayloadToJsonWithWebsocket,
+    decodeAttributes = decodePayloadAttributes,
+    encoderEndpoint = dataEncoderEndpoint,
+  }: DecodeFunctions = {},
+): Promise<PendingActivity> {
+  // Use locally set endpoint over settings endpoint for testing purposes
+  const endpoint = getEndpoint(settings, encoderEndpoint);
+  const _settings = { ...settings, codec: { ...settings?.codec, endpoint } };
+
+  const convertedAttributes = endpoint
+    ? await convertWithCodec({
+        attributes: activity,
+        namespace,
+        settings: _settings,
+      })
+    : await convertWithWebsocket(activity);
+
+  const decodedAttributes = decodeAttributes(
+    convertedAttributes,
+  ) as PendingActivity;
+  return decodedAttributes;
+}
+
+export const decodePendingActivity = async ({
+  activity,
+  namespace,
+  settings,
+}: PendingActivityWithMetadata): Promise<PendingActivity> => {
+  const decodedActivity = await getActivityAttributes({
+    activity,
+    namespace,
+    settings,
+  });
+  return decodedActivity;
+};

--- a/src/lib/models/pending-activities/index.ts
+++ b/src/lib/models/pending-activities/index.ts
@@ -41,7 +41,7 @@ export async function getActivityAttributes(
   return decodedAttributes;
 }
 
-export const decodePendingActivity = async ({
+const decodePendingActivity = async ({
   activity,
   namespace,
   settings,
@@ -52,4 +52,23 @@ export const decodePendingActivity = async ({
     settings,
   });
   return decodedActivity;
+};
+
+export const toDecodedPendingActivities = async (
+  workflow: WorkflowExecution,
+  namespace: string,
+  settings: Settings,
+) => {
+  const pendingActivities = workflow?.pendingActivities ?? [];
+  const decodedActivities: PendingActivity[] = [];
+  for (const activity of pendingActivities) {
+    const decodedActivity = await decodePendingActivity({
+      activity,
+      namespace,
+      settings,
+    });
+    decodedActivities.push(decodedActivity);
+  }
+
+  return decodedActivities;
 };

--- a/src/lib/models/pending-activities/to-decoded-pending-activities.test.ts
+++ b/src/lib/models/pending-activities/to-decoded-pending-activities.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import settingsFixture from '$fixtures/settings.json';
+import pendingActivityWorkflow from '$fixtures/workflow.pending-activities.json';
+import { toDecodedPendingActivities } from './index';
+
+const namespace = 'unit-tests';
+const settings = settingsFixture as unknown as Settings;
+
+describe('toDecodedPendingActivities', () => {
+  it(`should decode heartbeatDetails`, async () => {
+    const workflow = pendingActivityWorkflow as unknown as WorkflowExecution;
+    const decodedHeartbeatDetails = await toDecodedPendingActivities(
+      workflow,
+      namespace,
+      settings,
+    );
+
+    expect(decodedHeartbeatDetails[0].heartbeatDetails.payloads[0]).toBe(2);
+    expect(decodedHeartbeatDetails[1].heartbeatDetails.payloads[0]).toBe(8);
+  });
+});

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -7,19 +7,22 @@ import { fetchWorkflow } from '$lib/services/workflow-service';
 import { getPollers } from '$lib/services/pollers-service';
 import type { GetPollersResponse } from '$lib/services/pollers-service';
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
+import { decodePendingActivity } from '$lib/models/pending-activities';
 
 export const refresh = writable(0);
 const namespace = derived([page], ([$page]) => $page.params.namespace);
 const workflowId = derived([page], ([$page]) => $page.params.workflow);
 const runId = derived([page], ([$page]) => $page.params.run);
+const settings = derived([page], ([$page]) => $page.stuff.settings);
 
 const parameters = derived(
-  [namespace, workflowId, runId, refresh],
-  ([$namespace, $workflowId, $runId, $refresh]) => {
+  [namespace, workflowId, runId, settings, refresh],
+  ([$namespace, $workflowId, $runId, $settings, $refresh]) => {
     return {
       namespace: $namespace,
       workflowId: decodeURIForSvelte($workflowId ?? ''),
       runId: $runId,
+      settings: $settings,
       refresh: $refresh,
     };
   },
@@ -35,12 +38,26 @@ const updateWorkflowRun: StartStopNotifier<{
   workflow: WorkflowExecution;
   workers: GetPollersResponse;
 }> = (set) => {
-  return parameters.subscribe(({ namespace, workflowId, runId }) => {
+  return parameters.subscribe(({ namespace, workflowId, runId, settings }) => {
     if (namespace && workflowId && runId) {
       withLoading(loading, updating, async () => {
         const workflow = await fetchWorkflow({ namespace, workflowId, runId });
         const { taskQueue } = workflow;
         const workers = await getPollers({ queue: taskQueue, namespace });
+
+        // Decode pending activities
+        const pendingActivities = workflow?.pendingActivities ?? [];
+        const decodedActivities = [];
+        for (const activity of pendingActivities) {
+          const decodedActivity = await decodePendingActivity({
+            activity,
+            namespace,
+            settings,
+          });
+          decodedActivities.push(decodedActivity);
+        }
+        workflow.pendingActivities = decodedActivities;
+
         set({ workflow, workers });
       });
     } else {

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -7,10 +7,7 @@ import { fetchWorkflow } from '$lib/services/workflow-service';
 import { getPollers } from '$lib/services/pollers-service';
 import type { GetPollersResponse } from '$lib/services/pollers-service';
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
-import {
-  decodePendingActivity,
-  toDecodedPendingActivities,
-} from '$lib/models/pending-activities';
+import { toDecodedPendingActivities } from '$lib/models/pending-activities';
 
 export const refresh = writable(0);
 const namespace = derived([page], ([$page]) => $page.params.namespace);

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -6,12 +6,21 @@ import type { DataConverterWebsocketInterface } from '$lib/utilities/data-conver
 import { convertPayloadWithWebsocket } from '$lib/services/data-converter';
 import { convertPayloadsWithCodec } from '$lib/services/data-encoder';
 
+import type { dataEncoderEndpoint } from '$lib/stores/data-encoder-config';
+
 import { atob } from './atob';
 
 export type Decode = {
   convertPayloadToJsonWithCodec: typeof convertPayloadToJsonWithCodec;
   convertPayloadToJsonWithWebsocket: typeof convertPayloadToJsonWithWebsocket;
   decodePayloadAttributes: typeof decodePayloadAttributes;
+};
+
+export type DecodeFunctions = {
+  convertWithCodec?: Decode['convertPayloadToJsonWithCodec'];
+  convertWithWebsocket?: Decode['convertPayloadToJsonWithWebsocket'];
+  decodeAttributes?: Decode['decodePayloadAttributes'];
+  encoderEndpoint?: typeof dataEncoderEndpoint;
 };
 
 export function decodePayload(


### PR DESCRIPTION
## What was changed
In the event history store, loop through pending activities and decode any payloads. Reuses all of the current decode logic.

<img width="1686" alt="Screen Shot 2022-09-26 at 12 17 23 PM" src="https://user-images.githubusercontent.com/7967403/192341954-fc2eb5ec-6635-43a5-8b66-ab7294a03e0a.png">
<img width="1685" alt="Screen Shot 2022-09-26 at 12 17 31 PM" src="https://user-images.githubusercontent.com/7967403/192341956-54748f35-8803-4c6d-a251-57cbc818a946.png">


## Why?
Show heartbeatDetails payloads plus any other future payload fields on Pending Activities.