### PR TITLE
Use a promise for determining base url for api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.59",
+  "version": "2.1.60",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/services/cluster-service.ts
+++ b/src/lib/services/cluster-service.ts
@@ -9,7 +9,8 @@ export const fetchCluster = async (
 ): Promise<GetClusterInfoResponse> => {
   if (settings.runtimeEnvironment.isCloud) return;
 
-  return await requestFromAPI(routeForApi('cluster'), {
+  const route = await routeForApi('cluster');
+  return await requestFromAPI(route, {
     request,
   }).then((clusterInformation) => {
     cluster.set(clusterInformation);

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -38,11 +38,11 @@ export const fetchRawEvents = async ({
   onComplete,
 }: FetchEventsParameters): Promise<HistoryEvent[]> => {
   const endpoint = getEndpointForSortOrder(sort);
-
+  const route = await routeForApi(endpoint, { namespace, workflowId, runId });
   const response = await paginated(
     async (token: string) => {
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
-        routeForApi(endpoint, { namespace, workflowId, runId }),
+        route,
         {
           token,
           request: fetch,

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -41,13 +41,10 @@ export const fetchRawEvents = async ({
   const route = await routeForApi(endpoint, { namespace, workflowId, runId });
   const response = await paginated(
     async (token: string) => {
-      return requestFromAPI<GetWorkflowExecutionHistoryResponse>(
-        route,
-        {
-          token,
-          request: fetch,
-        },
-      );
+      return requestFromAPI<GetWorkflowExecutionHistoryResponse>(route, {
+        token,
+        request: fetch,
+      });
     },
     { onStart, onUpdate, onComplete },
   );

--- a/src/lib/services/namespaces-service.ts
+++ b/src/lib/services/namespaces-service.ts
@@ -17,8 +17,9 @@ export async function fetchNamespaces(
     return emptyNamespace;
   }
 
+  const route = await routeForApi('namespaces');
   const results = await paginated(async (token: string) =>
-    requestFromAPI<ListNamespacesResponse>(routeForApi('namespaces'), {
+    requestFromAPI<ListNamespacesResponse>(route, {
       request,
       token,
       onError: () => notifications.add('error', 'Unable to fetch namespaces'),

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -30,15 +30,15 @@ export async function getPollers(
   request = fetch,
 ): Promise<GetPollersResponse> {
   const route = await routeForApi('task-queue', parameters);
-  const workflowPollers = await requestFromAPI<GetPollersResponse>(
-    route,
-    { request, params: { taskQueueType: '1' } },
-  );
+  const workflowPollers = await requestFromAPI<GetPollersResponse>(route, {
+    request,
+    params: { taskQueueType: '1' },
+  });
 
-  const activityPollers = await requestFromAPI<GetPollersResponse>(
-    route,
-    { request, params: { taskQueueType: '2' } },
-  );
+  const activityPollers = await requestFromAPI<GetPollersResponse>(route, {
+    request,
+    params: { taskQueueType: '2' },
+  });
 
   activityPollers.pollers.forEach((poller: PollerWithTaskQueueTypes) => {
     poller.taskQueueTypes = ['ACTIVITY'];
@@ -58,7 +58,7 @@ export async function getPollers(
       pollers[poller.identity] = {
         lastAccessTime:
           !currentPoller.lastAccessTime ||
-            currentPoller.lastAccessTime < poller.lastAccessTime
+          currentPoller.lastAccessTime < poller.lastAccessTime
             ? poller.lastAccessTime
             : currentPoller.lastAccessTime,
         taskQueueTypes: currentPoller.taskQueueTypes.concat([type]),

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -29,13 +29,14 @@ export async function getPollers(
   options = { returnAllPollers: false },
   request = fetch,
 ): Promise<GetPollersResponse> {
+  const route = await routeForApi('task-queue', parameters);
   const workflowPollers = await requestFromAPI<GetPollersResponse>(
-    routeForApi('task-queue', parameters),
+    route,
     { request, params: { taskQueueType: '1' } },
   );
 
   const activityPollers = await requestFromAPI<GetPollersResponse>(
-    routeForApi('task-queue', parameters),
+    route,
     { request, params: { taskQueueType: '2' } },
   );
 
@@ -57,7 +58,7 @@ export async function getPollers(
       pollers[poller.identity] = {
         lastAccessTime:
           !currentPoller.lastAccessTime ||
-          currentPoller.lastAccessTime < poller.lastAccessTime
+            currentPoller.lastAccessTime < poller.lastAccessTime
             ? poller.lastAccessTime
             : currentPoller.lastAccessTime,
         taskQueueTypes: currentPoller.taskQueueTypes.concat([type]),

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -56,8 +56,9 @@ async function fetchQuery(
 ): Promise<QueryResponse> {
   workflow = await workflow;
   const parameters = await formatParameters(namespace, workflow);
+  const route = await routeForApi('query', parameters);
 
-  return await requestFromAPI<QueryResponse>(routeForApi('query', parameters), {
+  return await requestFromAPI<QueryResponse>(route, {
     options: {
       method: 'POST',
       body: JSON.stringify({

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -30,13 +30,14 @@ export const fetchAllSchedules = async (
 ): Promise<ScheduleResponse> => {
   let error = '';
   const onError: ErrorCallback = (err) =>
-    (error =
-      err?.body?.message ??
-      `Error fetching schedules: ${err.status}: ${err.statusText}`);
+  (error =
+    err?.body?.message ??
+    `Error fetching schedules: ${err.status}: ${err.statusText}`);
 
+  const route = await routeForApi('schedules', { namespace });
   const { schedules, nextPageToken } =
     (await requestFromAPI<ListScheduleResponse>(
-      routeForApi('schedules', { namespace }),
+      route,
       {
         params: {},
         onError,
@@ -55,14 +56,16 @@ export async function fetchSchedule(
   parameters: ScheduleParameters,
   request = fetch,
 ): Promise<DescribeScheduleResponse> {
-  return requestFromAPI(routeForApi('schedule', parameters), { request });
+  const route = await routeForApi('schedule', parameters);
+  return requestFromAPI(route, { request });
 }
 
 export async function deleteSchedule(
   parameters: ScheduleParameters,
   request = fetch,
 ): Promise<void> {
-  return requestFromAPI(routeForApi('schedule.delete', parameters), {
+  const route = await routeForApi('schedule.delete', parameters);
+  return requestFromAPI(route, {
     request,
     options: { method: 'DELETE' },
   });
@@ -79,14 +82,15 @@ export async function createSchedule({
 }: CreateScheduleOptions): Promise<{ error: string; conflictToken: string }> {
   let error = '';
   const onError: ErrorCallback = (err) =>
-    (error =
-      err?.body?.message ??
-      `Error creating schedule: ${err.status}: ${err.statusText}`);
+  (error =
+    err?.body?.message ??
+    `Error creating schedule: ${err.status}: ${err.statusText}`);
 
+  const route = await routeForApi('schedules', {
+    namespace,
+  });
   const { conflictToken } = await requestFromAPI<{ conflictToken: string }>(
-    routeForApi('schedules', {
-      namespace,
-    }),
+    route,
     {
       options: {
         method: 'POST',
@@ -115,11 +119,12 @@ export async function editSchedule({
   scheduleId,
   body,
 }: EditScheduleOptions): Promise<null> {
+  const route = await routeForApi('schedule', {
+    namespace,
+    scheduleId,
+  });
   return await requestFromAPI<null>(
-    routeForApi('schedule', {
-      namespace,
-      scheduleId,
-    }),
+    route,
     {
       options: {
         method: 'POST',
@@ -151,11 +156,12 @@ export async function pauseSchedule({
     },
   };
 
+  const route = await routeForApi('schedule', {
+    namespace,
+    scheduleId: scheduleId,
+  });
   return await requestFromAPI<null>(
-    routeForApi('schedule', {
-      namespace,
-      scheduleId: scheduleId,
-    }),
+    route,
     {
       options: {
         method: 'PATCH',
@@ -187,11 +193,12 @@ export async function unpauseSchedule({
     },
   };
 
+  const route = await routeForApi('schedule', {
+    namespace,
+    scheduleId: scheduleId,
+  });
   return await requestFromAPI<null>(
-    routeForApi('schedule', {
-      namespace,
-      scheduleId: scheduleId,
-    }),
+    route,
     {
       options: {
         method: 'PATCH',

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -30,20 +30,17 @@ export const fetchAllSchedules = async (
 ): Promise<ScheduleResponse> => {
   let error = '';
   const onError: ErrorCallback = (err) =>
-  (error =
-    err?.body?.message ??
-    `Error fetching schedules: ${err.status}: ${err.statusText}`);
+    (error =
+      err?.body?.message ??
+      `Error fetching schedules: ${err.status}: ${err.statusText}`);
 
   const route = await routeForApi('schedules', { namespace });
   const { schedules, nextPageToken } =
-    (await requestFromAPI<ListScheduleResponse>(
-      route,
-      {
-        params: {},
-        onError,
-        request,
-      },
-    )) ?? { schedules: [], nextPageToken: '' };
+    (await requestFromAPI<ListScheduleResponse>(route, {
+      params: {},
+      onError,
+      request,
+    })) ?? { schedules: [], nextPageToken: '' };
 
   return {
     schedules,
@@ -82,9 +79,9 @@ export async function createSchedule({
 }: CreateScheduleOptions): Promise<{ error: string; conflictToken: string }> {
   let error = '';
   const onError: ErrorCallback = (err) =>
-  (error =
-    err?.body?.message ??
-    `Error creating schedule: ${err.status}: ${err.statusText}`);
+    (error =
+      err?.body?.message ??
+      `Error creating schedule: ${err.status}: ${err.statusText}`);
 
   const route = await routeForApi('schedules', {
     namespace,
@@ -123,20 +120,17 @@ export async function editSchedule({
     namespace,
     scheduleId,
   });
-  return await requestFromAPI<null>(
-    route,
-    {
-      options: {
-        method: 'POST',
-        body: JSON.stringify({
-          request_id: uuidv4(),
-          ...body,
-        }),
-      },
-      shouldRetry: false,
-      onError: (error) => console.error(error),
+  return await requestFromAPI<null>(route, {
+    options: {
+      method: 'POST',
+      body: JSON.stringify({
+        request_id: uuidv4(),
+        ...body,
+      }),
     },
-  );
+    shouldRetry: false,
+    onError: (error) => console.error(error),
+  });
 }
 
 type PauseScheduleOptions = {
@@ -160,20 +154,17 @@ export async function pauseSchedule({
     namespace,
     scheduleId: scheduleId,
   });
-  return await requestFromAPI<null>(
-    route,
-    {
-      options: {
-        method: 'PATCH',
-        body: JSON.stringify({
-          ...options,
-          request_id: uuidv4(),
-        }),
-      },
-      shouldRetry: false,
-      onError: (error) => console.error(error),
+  return await requestFromAPI<null>(route, {
+    options: {
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...options,
+        request_id: uuidv4(),
+      }),
     },
-  );
+    shouldRetry: false,
+    onError: (error) => console.error(error),
+  });
 }
 
 type UnpauseScheduleOptions = {
@@ -197,17 +188,14 @@ export async function unpauseSchedule({
     namespace,
     scheduleId: scheduleId,
   });
-  return await requestFromAPI<null>(
-    route,
-    {
-      options: {
-        method: 'PATCH',
-        body: JSON.stringify({
-          ...options,
-          request_id: uuidv4(),
-        }),
-      },
-      shouldRetry: false,
+  return await requestFromAPI<null>(route, {
+    options: {
+      method: 'PATCH',
+      body: JSON.stringify({
+        ...options,
+        request_id: uuidv4(),
+      }),
     },
-  );
+    shouldRetry: false,
+  });
 }

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -9,12 +9,9 @@ export const fetchSearchAttributes = async (
   if (settings.runtimeEnvironment.isCloud) return;
 
   const route = await routeForApi('search-attributes');
-  return await requestFromAPI<SearchAttributesResponse>(
-    route,
-    {
-      request,
-    },
-  ).then((searchAttributesResponse) => {
+  return await requestFromAPI<SearchAttributesResponse>(route, {
+    request,
+  }).then((searchAttributesResponse) => {
     if (searchAttributesResponse?.keys) {
       searchAttributes.set(searchAttributesResponse.keys);
     }

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -8,8 +8,9 @@ export const fetchSearchAttributes = async (
 ): Promise<SearchAttributesResponse> => {
   if (settings.runtimeEnvironment.isCloud) return;
 
+  const route = await routeForApi('search-attributes');
   return await requestFromAPI<SearchAttributesResponse>(
-    routeForApi('search-attributes'),
+    route,
     {
       request,
     },

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -9,8 +9,9 @@ import type { SettingsResponse } from '$types';
 export const isCloudMatch = /(tmprl\.cloud|tmprl-test\.cloud)$/;
 
 export const fetchSettings = async (request = fetch): Promise<Settings> => {
+  const route = await routeForApi('settings');
   const settingsResponse: SettingsResponse = await requestFromAPI(
-    routeForApi('settings'),
+    route,
     { request },
   );
 

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -10,10 +10,9 @@ export const isCloudMatch = /(tmprl\.cloud|tmprl-test\.cloud)$/;
 
 export const fetchSettings = async (request = fetch): Promise<Settings> => {
   const route = await routeForApi('settings');
-  const settingsResponse: SettingsResponse = await requestFromAPI(
-    route,
-    { request },
-  );
+  const settingsResponse: SettingsResponse = await requestFromAPI(route, {
+    request,
+  });
 
   const EnvironmentOverride = getEnvironment();
 

--- a/src/lib/services/terminate-service.ts
+++ b/src/lib/services/terminate-service.ts
@@ -12,12 +12,13 @@ export async function terminateWorkflow({
   namespace,
   reason,
 }: TerminateWorkflowOptions): Promise<null> {
+  const route = await routeForApi('workflow.terminate', {
+    namespace,
+    workflowId: workflow.id,
+    runId: workflow.runId,
+  });
   return await requestFromAPI<null>(
-    routeForApi('workflow.terminate', {
-      namespace,
-      workflowId: workflow.id,
-      runId: workflow.runId,
-    }),
+    route,
     {
       options: { method: 'POST', body: JSON.stringify({ reason }) },
       shouldRetry: false,

--- a/src/lib/services/terminate-service.ts
+++ b/src/lib/services/terminate-service.ts
@@ -17,12 +17,9 @@ export async function terminateWorkflow({
     workflowId: workflow.id,
     runId: workflow.runId,
   });
-  return await requestFromAPI<null>(
-    route,
-    {
-      options: { method: 'POST', body: JSON.stringify({ reason }) },
-      shouldRetry: false,
-      notifyOnError: false,
-    },
-  );
+  return await requestFromAPI<null>(route, {
+    options: { method: 'POST', body: JSON.stringify({ reason }) },
+    shouldRetry: false,
+    notifyOnError: false,
+  });
 }

--- a/src/lib/services/user-service.ts
+++ b/src/lib/services/user-service.ts
@@ -2,8 +2,9 @@ import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
 export const fetchUser = async (request = fetch): Promise<User> => {
+  const route = await routeForApi('user');
   const user: { Name: string; Email: string; Picture: string } =
-    await requestFromAPI(routeForApi('user'), {
+    await requestFromAPI(route, {
       request,
     });
 

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -53,9 +53,10 @@ export const fetchAllWorkflows = async (
     error = 'Failed to fetch workflows';
   };
 
+  const route = await routeForApi(endpoint, { namespace })
   const { executions, nextPageToken } =
     (await requestFromAPI<ListWorkflowExecutionsResponse>(
-      routeForApi(endpoint, { namespace }),
+      route,
       {
         params: { query },
         onError,
@@ -83,7 +84,8 @@ export async function fetchWorkflow(
   parameters: GetWorkflowExecutionRequest,
   request = fetch,
 ): Promise<WorkflowExecution> {
-  return requestFromAPI(routeForApi('workflow', parameters), { request }).then(
+  const route = await routeForApi('workflow', parameters);
+  return requestFromAPI(route, { request }).then(
     toWorkflowExecution,
   );
 }

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -53,17 +53,14 @@ export const fetchAllWorkflows = async (
     error = 'Failed to fetch workflows';
   };
 
-  const route = await routeForApi(endpoint, { namespace })
+  const route = await routeForApi(endpoint, { namespace });
   const { executions, nextPageToken } =
-    (await requestFromAPI<ListWorkflowExecutionsResponse>(
-      route,
-      {
-        params: { query },
-        onError,
-        handleError,
-        request,
-      },
-    )) ?? { executions: [], nextPageToken: '' };
+    (await requestFromAPI<ListWorkflowExecutionsResponse>(route, {
+      params: { query },
+      onError,
+      handleError,
+      request,
+    })) ?? { executions: [], nextPageToken: '' };
 
   return {
     workflows: toWorkflowExecutions({ executions }),
@@ -85,7 +82,5 @@ export async function fetchWorkflow(
   request = fetch,
 ): Promise<WorkflowExecution> {
   const route = await routeForApi('workflow', parameters);
-  return requestFromAPI(route, { request }).then(
-    toWorkflowExecution,
-  );
+  return requestFromAPI(route, { request }).then(toWorkflowExecution);
 }

--- a/src/lib/utilities/route-for-api.test.ts
+++ b/src/lib/utilities/route-for-api.test.ts
@@ -44,9 +44,7 @@ describe('routeForApi', () => {
 
   it('should return a route for settings', async () => {
     const route = await routeForApi('settings');
-    expect(route).toBe(
-      'http://localhost:8080/api/v1/settings',
-    );
+    expect(route).toBe('http://localhost:8080/api/v1/settings');
   });
 
   it('should return a route for user', async () => {
@@ -68,9 +66,7 @@ describe('API Request Encoding', () => {
       ...parameters,
       workflowId: 'workflow#with#hashes',
     });
-    expect(
-      route,
-    ).toBe(
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow%2523with%2523hashes/runs/run',
     );
   });
@@ -83,9 +79,7 @@ describe('API Request Encoding', () => {
       workflowId:
         'temporal.canary.cron-workflow.sanity-2022-05-02T16:03:11-06:00/workflow.advanced-visibility.scan',
     });
-    expect(
-      route,
-    ).toBe(
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%253A03%253A11-06%253A00%252Fworkflow.advanced-visibility.scan/runs/47e33895-aff5-475a-9b53-73abdee8bebe',
     );
   });

--- a/src/lib/utilities/route-for-api.test.ts
+++ b/src/lib/utilities/route-for-api.test.ts
@@ -9,72 +9,82 @@ const parameters = {
 };
 
 describe('routeForApi', () => {
-  it('should return a route for workflow', () => {
-    expect(routeForApi('workflow', parameters)).toBe(
+  it('should return a route for workflow', async () => {
+    const route = await routeForApi('workflow', parameters);
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow/runs/run',
     );
   });
 
-  it('should return a route for events', () => {
-    expect(routeForApi('events.ascending', parameters)).toBe(
+  it('should return a route for events', async () => {
+    const route = await routeForApi('events.ascending', parameters);
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow/runs/run/events',
     );
   });
 
-  it('should return a route for events', () => {
-    expect(routeForApi('events.descending', parameters)).toBe(
+  it('should return a route for events', async () => {
+    const route = await routeForApi('events.descending', parameters);
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow/runs/run/events/reverse',
     );
   });
 
-  it('should return a route for task-queue', () => {
-    expect(routeForApi('task-queue', parameters)).toBe(
+  it('should return a route for task-queue', async () => {
+    const route = await routeForApi('task-queue', parameters);
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/task-queues/queue',
     );
   });
 
-  it('should return a route for cluster', () => {
-    expect(routeForApi('cluster')).toBe('http://localhost:8080/api/v1/cluster');
+  it('should return a route for cluster', async () => {
+    const route = await routeForApi('cluster');
+    expect(route).toBe('http://localhost:8080/api/v1/cluster');
   });
 
-  it('should return a route for settings', () => {
-    expect(routeForApi('settings')).toBe(
+  it('should return a route for settings', async () => {
+    const route = await routeForApi('settings');
+    expect(route).toBe(
       'http://localhost:8080/api/v1/settings',
     );
   });
 
-  it('should return a route for user', () => {
-    expect(routeForApi('user')).toBe('http://localhost:8080/api/v1/me');
+  it('should return a route for user', async () => {
+    const route = await routeForApi('user');
+    expect(route).toBe('http://localhost:8080/api/v1/me');
   });
 
-  it('should return a route for workflow.terminate', () => {
-    expect(routeForApi('workflow.terminate', parameters)).toBe(
+  it('should return a route for workflow.terminate', async () => {
+    const route = await routeForApi('workflow.terminate', parameters);
+    expect(route).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow/runs/run/terminate',
     );
   });
 });
 
 describe('API Request Encoding', () => {
-  it('should return a route for workflow', () => {
+  it('should return a route for workflow', async () => {
+    const route = await routeForApi('workflow', {
+      ...parameters,
+      workflowId: 'workflow#with#hashes',
+    });
     expect(
-      routeForApi('workflow', {
-        ...parameters,
-        workflowId: 'workflow#with#hashes',
-      }),
+      route,
     ).toBe(
       'http://localhost:8080/api/v1/namespaces/namespace/workflows/workflow%2523with%2523hashes/runs/run',
     );
   });
 
-  it('should handle slashes', () => {
+  it('should handle slashes', async () => {
+    const route = await routeForApi('workflow', {
+      ...parameters,
+      namespace: 'canary',
+      runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
+      workflowId:
+        'temporal.canary.cron-workflow.sanity-2022-05-02T16:03:11-06:00/workflow.advanced-visibility.scan',
+    });
     expect(
-      routeForApi('workflow', {
-        ...parameters,
-        namespace: 'canary',
-        runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
-        workflowId:
-          'temporal.canary.cron-workflow.sanity-2022-05-02T16:03:11-06:00/workflow.advanced-visibility.scan',
-      }),
+      route,
     ).toBe(
       'http://localhost:8080/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%253A03%253A11-06%253A00%252Fworkflow.advanced-visibility.scan/runs/47e33895-aff5-475a-9b53-73abdee8bebe',
     );

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -6,8 +6,8 @@ const base = async (namespace?: string): Promise<string> => {
 
   if (globalThis?.GetNamespaces) {
     const namespaces = await globalThis?.GetNamespaces();
-    const configNamespace = namespaces?.find(n => n.namespace === namespace)
-    baseUrl = configNamespace?.webUri;
+    const configNamespace = namespaces?.find((n) => n.namespace === namespace);
+    baseUrl = configNamespace?.webUri ?? getApiOrigin();
   } else {
     baseUrl = getApiOrigin();
   }
@@ -18,7 +18,10 @@ const base = async (namespace?: string): Promise<string> => {
   return baseUrl;
 };
 
-const withBase = async (endpoint: string, namespace?: string): Promise<string> => {
+const withBase = async (
+  endpoint: string,
+  namespace?: string,
+): Promise<string> => {
   if (endpoint.startsWith('/')) endpoint = endpoint.slice(1);
   const baseUrl = await base(namespace);
   return `${baseUrl}/api/v1/${endpoint}`;

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -4,7 +4,7 @@ import { publicPath } from './get-public-path';
 const base = async (namespace?: string): Promise<string> => {
   let baseUrl = '';
 
-  if (globalThis?.GetNamespaces) {
+  if (globalThis?.GetNamespaces && namespace) {
     const namespaces = await globalThis?.GetNamespaces();
     const configNamespace = namespaces?.find((n) => n.namespace === namespace);
     baseUrl = configNamespace?.webUri ?? getApiOrigin();

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,12 +1,13 @@
 import { getApiOrigin } from './get-api-origin';
 import { publicPath } from './get-public-path';
 
-const base = (namespace?: string): string => {
+const base = async (namespace?: string): Promise<string> => {
   let baseUrl = '';
 
-  const configNamespace = globalThis?.AppConfig?.namespaces?.find(n => n.namespace === namespace)
-  if (configNamespace) {
-    baseUrl = configNamespace.webUri;
+  if (globalThis?.GetNamespaces) {
+    const namespaces = await globalThis?.GetNamespaces();
+    const configNamespace = namespaces?.find(n => n.namespace === namespace)
+    baseUrl = configNamespace?.webUri;
   } else {
     baseUrl = getApiOrigin();
   }
@@ -17,9 +18,10 @@ const base = (namespace?: string): string => {
   return baseUrl;
 };
 
-const withBase = (endpoint: string, namespace?: string): string => {
+const withBase = async (endpoint: string, namespace?: string): Promise<string> => {
   if (endpoint.startsWith('/')) endpoint = endpoint.slice(1);
-  return `${base(namespace)}/api/v1/${endpoint}`;
+  const baseUrl = await base(namespace);
+  return `${baseUrl}/api/v1/${endpoint}`;
 };
 
 const encode = (parameters: APIRouteParameters): APIRouteParameters => {
@@ -42,34 +44,34 @@ export function routeForApi(
   route: WorkflowsAPIRoutePath,
   parameters: WorkflowListRouteParameters,
   shouldEncode?: boolean,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: SchedulesAPIRoutePath,
   parameters: ScheduleListRouteParameters,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: WorkflowAPIRoutePath,
   parameters: WorkflowRouteParameters,
   shouldEncode?: boolean,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: ScheduleAPIRoutePath,
   parameters: ScheduleRouteParameters,
   shouldEncode?: boolean,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: TaskQueueAPIRoutePath,
   parameters: TaskQueueRouteParameters,
   shouldEncode?: boolean,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: ParameterlessAPIRoutePath | SearchAttributesRoutePath,
-): string;
+): Promise<string>;
 export function routeForApi(
   route: APIRoutePath,
   parameters?: APIRouteParameters,
   shouldEncode = true,
-): string {
+): Promise<string> {
   if (shouldEncode) parameters = encode(parameters);
 
   const routes: { [K in APIRoutePath]: string } = {

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,18 +1,12 @@
 import { getApiOrigin } from './get-api-origin';
 import { publicPath } from './get-public-path';
 
-const replaceNamespaceInApiUrl = (
-  apiUrl: string,
-  namespace: string,
-): string => {
-  return apiUrl.replace('%namespace%', namespace);
-};
-
 const base = (namespace?: string): string => {
   let baseUrl = '';
 
-  if (globalThis?.AppConfig?.apiUrl && namespace) {
-    baseUrl = replaceNamespaceInApiUrl(globalThis.AppConfig.apiUrl, namespace);
+  const configNamespace = globalThis?.AppConfig?.namespaces?.find(n => n.namespace === namespace)
+  if (configNamespace) {
+    baseUrl = configNamespace.webUri;
   } else {
     baseUrl = getApiOrigin();
   }

--- a/src/lib/utilities/route-for-api.with-api-url.test.ts
+++ b/src/lib/utilities/route-for-api.with-api-url.test.ts
@@ -9,10 +9,12 @@ const parameters = {
 };
 
 vi.stubGlobal('GetNamespaces', async () => {
-  return [{
-    namespace: 'namespace',
-    webUri: 'https://api.url/',
-  }]
+  return [
+    {
+      namespace: 'namespace',
+      webUri: 'https://api.url/',
+    },
+  ];
 });
 
 describe('routeForApi with AppConfig.apiUrl', () => {

--- a/src/lib/utilities/route-for-api.with-api-url.test.ts
+++ b/src/lib/utilities/route-for-api.with-api-url.test.ts
@@ -8,16 +8,17 @@ const parameters = {
   queue: 'queue',
 };
 
-vi.stubGlobal('AppConfig', {
-  namespaces: [{
+vi.stubGlobal('GetNamespaces', async () => {
+  return [{
     namespace: 'namespace',
     webUri: 'https://api.url/',
   }]
 });
 
 describe('routeForApi with AppConfig.apiUrl', () => {
-  it('should return a route for workflow', () => {
-    expect(routeForApi('workflow', parameters)).toBe(
+  it('should return a route for workflow', async () => {
+    const route = await routeForApi('workflow', parameters);
+    expect(route).toBe(
       'https://api.url/api/v1/namespaces/namespace/workflows/workflow/runs/run',
     );
   });

--- a/src/lib/utilities/route-for-api.with-api-url.test.ts
+++ b/src/lib/utilities/route-for-api.with-api-url.test.ts
@@ -9,7 +9,10 @@ const parameters = {
 };
 
 vi.stubGlobal('AppConfig', {
-  apiUrl: 'https://api.url/',
+  namespaces: [{
+    namespace: 'namespace',
+    webUri: 'https://api.url/',
+  }]
 });
 
 describe('routeForApi with AppConfig.apiUrl', () => {


### PR DESCRIPTION
## What was changed
Remove string template for building the base url for the api url and instead check for GetNamespaces() promise. This requires all routeForApi()'s to be promises. In OSS, this will be resolved immediately since globalThis?.GetNamespaces() is not defined and will continue to use getApiOrigin().  

## Why?
Because the url isn't guaranteed to be well named/consistent, we want to return a promise that resolves the api url for a namespace. 

## Checklist

2. How was this tested:
Updated all unit tests for routeForApi to pass, all other tests pass. Manually tested all parts of app.
