### PR TITLE
Reload page if new version of app is deployed

### DIFF
--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -59,6 +59,7 @@
 </script>
 
 <script lang="ts">
+  import { updated } from '$app/stores';
   import Header from './_header.svelte';
   import Notifications from '$lib/components/notifications.svelte';
   import Banners from '$lib/components/banner/banners.svelte';
@@ -68,6 +69,13 @@
 
   export let user: User;
   export let uiVersionInfo: UiVersionInfo;
+
+  updated.subscribe(async (value) => {
+    if (value) {
+      // Hard refresh when version does not match
+      window.location.reload();
+    }
+  });
 </script>
 
 <PageTitle />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -44,7 +44,7 @@ const config = {
         /^(?!.*\.(spec|test)\.ts$).*\.(svelte|ts)$/.test(filepath),
     },
     version: {
-      pollInterval: 5000
+      pollInterval: 10000
     }
   },
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -44,8 +44,8 @@ const config = {
         /^(?!.*\.(spec|test)\.ts$).*\.(svelte|ts)$/.test(filepath),
     },
     version: {
-      pollInterval: 10000
-    }
+      pollInterval: 10000,
+    },
   },
 };
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -43,6 +43,9 @@ const config = {
       files: (filepath) =>
         /^(?!.*\.(spec|test)\.ts$).*\.(svelte|ts)$/.test(filepath),
     },
+    version: {
+      pollInterval: 5000
+    }
   },
 };
 


### PR DESCRIPTION
To prevent stale files (i.e. new deploy and old js files are no longer available but user tries to fetch them), poll every 10 seconds for new application version and reload page if it detects new version.

> This PR will offer two options for navigation errors in the router. These errors occur for example if a new version of the site is deployed while being open in a browser. The JS files for pages might have changed and so has the filename. The previous page JS files, that the router still knows about, will give an import error 500 when trying to navigate to that page. For more detail on the problem, see https://github.com/sveltejs/kit/issues/87.


https://github.com/sveltejs/kit/pull/3412