### PR TITLE
Add back support for globalThis.AccessToken

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.61",
+  "version": "2.1.62",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [


### PR DESCRIPTION
## What was changed
Add back previous support for awaiting the access token from globalThis.AccessToken. Need when authUser.accessToken is not yet set from auth provider.

