### PR TITLE
Namespace web uri fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.62",
+  "version": "2.1.63",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -1,13 +1,25 @@
 import { getApiOrigin } from './get-api-origin';
 import { publicPath } from './get-public-path';
 
+const replaceNamespaceInApiUrl = (
+  apiUrl: string,
+  namespace: string,
+): string => {
+  if (apiUrl) {
+    return apiUrl.replace('%namespace%', namespace);
+  }
+  return '';
+};
+
 const base = async (namespace?: string): Promise<string> => {
   let baseUrl = '';
 
   if (globalThis?.GetNamespaces && namespace) {
     const namespaces = await globalThis.GetNamespaces();
     const configNamespace = namespaces?.find((n) => n.namespace === namespace);
-    baseUrl = configNamespace?.webUri ?? getApiOrigin();
+    baseUrl =
+      configNamespace?.webUri ??
+      replaceNamespaceInApiUrl(globalThis?.AppConfig?.apiUrl, namespace);
   } else {
     baseUrl = getApiOrigin();
   }


### PR DESCRIPTION

## What was changed
In the case where a user is accessing a namespace that is not in the root account but they have access to, fallback to string template with env var to get the namespace API.

## Why?
In some cases, our users will need to view a namespace that is not in their root account, thus we need a fallback to get the namespace api url since GetNamespaces will not return the webUri (the namespace being fetched will not be in the response of GetNamespaces).
