### PR TITLE
Add try/catch around github service call to allow offline development

### DIFF
--- a/src/lib/services/github-service.ts
+++ b/src/lib/services/github-service.ts
@@ -1,20 +1,24 @@
 export const fetchLatestUiVersion = async (
   request = fetch,
 ): Promise<string> => {
-  const response = await request(
-    'https://api.github.com/repos/temporalio/ui-server/releases',
-  );
-  const body = await response.json();
+  try {
+    const response = await request(
+      'https://api.github.com/repos/temporalio/ui-server/releases',
+    );
+    const body = await response.json();
 
-  if (!response.ok) {
-    return;
+    if (!response.ok) {
+      return;
+    }
+
+    let version = undefined;
+    if (body.length > 0) {
+      const { tag_name } = body[0];
+      version = tag_name.replace('v', '');
+    }
+
+    return version;
+  } catch (e) {
+    return '';
   }
-
-  let version = undefined;
-  if (body.length > 0) {
-    const { tag_name } = body[0];
-    version = tag_name.replace('v', '');
-  }
-
-  return version;
 };


### PR DESCRIPTION
## What was changed
If offline, fail silently on github-service call to allow for development when offline.

Fixes  #868 

cc @flossypurse 