### PR TITLE
Encode task queue URLs in routes

### DIFF
--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -141,6 +141,14 @@ describe('routeFor', () => {
     });
     expect(path).toBe('/namespaces/default/task-queues/some-task-queue');
   });
+
+  it('should route to a task queue containing slashes', () => {
+    const path = routeForTaskQueue({
+      namespace: 'default',
+      queue: 'some/task-queue',
+    });
+    expect(path).toBe('/namespaces/default/task-queues/some%2Ftask-queue');
+  });
 });
 
 describe('routeFor import ', () => {

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -110,9 +110,11 @@ export const routeForWorkers = (parameters: WorkflowParameters): string => {
 };
 
 export const routeForTaskQueue = (parameters: TaskQueueParameters): string => {
+  const queue = encodeURIForSvelte(parameters.queue);
+
   return `${routeForNamespace({
     namespace: parameters.namespace,
-  })}/task-queues/${parameters.queue}`;
+  })}/task-queues/${queue}`;
 };
 
 export const routeForStackTrace = (parameters: WorkflowParameters): string => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

This change ensures task queue names are URL-encoded.

## Why?

If a task queue name contains special characters (especially `/`), clicking a link to said task queue will result in a 404 as the route doesn't match.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:

- Tested with a local `temporalite` instance with a task queue containing slashes. Verified clicking the link works as expected.
- Added unit test coverage for this edge case.

3. Any docs updates needed?

N/A
