### PR TITLE
Add try/catch around Broadcast channel for old Safari versions

### DIFF
--- a/src/lib/stores/persist-store.ts
+++ b/src/lib/stores/persist-store.ts
@@ -28,10 +28,14 @@ export function persistStore<T>(
   const { subscribe, set } = writable<T>(initialStoreValue);
 
   if (browser && broadcastToAll) {
-    broadcaster = new BroadcastChannel(`persist-store-${name}`);
-    broadcaster?.addEventListener('message', (event) => {
-      set(event.data);
-    });
+    try {
+      broadcaster = new BroadcastChannel(`persist-store-${name}`);
+      broadcaster?.addEventListener('message', (event) => {
+        set(event.data);
+      });
+    } catch (e) {
+      console.error('Browser does not support BroadcastChannel');
+    }
   }
 
   return {


### PR DESCRIPTION
## What was changed
For old Safari versions, BroadcastChannel is not supported. Add try/catch to prevent error from throwing

## Why?
Doesn't throw 500 page

