### PR TITLE
Clean auth user cookie immediately as it is read

### DIFF
--- a/src/lib/stores/auth-user.ts
+++ b/src/lib/stores/auth-user.ts
@@ -8,7 +8,7 @@ export const getAuthUser = (): User => get(authUser);
 export const setAuthUser = (user: User) => {
   const { accessToken, idToken, name, email, picture } = user;
 
-  if (!accessToken || accessToken == '{{.AccessToken}}') {
+  if (!accessToken) {
     throw new Error('No access token');
   }
 

--- a/src/lib/utilities/auth-user-cookie.ts
+++ b/src/lib/utilities/auth-user-cookie.ts
@@ -46,3 +46,18 @@ export const getAuthUserCookie = (isBrowser = browser): User => {
 
   return {};
 };
+
+export const cleanAuthUserCookie = (isBrowser = browser) => {
+  if (!isBrowser) return;
+
+  const cookies = document.cookie.split(';');
+  let i = 0;
+  let next = cookies.find((c) => c.includes(cookieName + i));
+
+  while (next) {
+    const [name] = next.split('=');
+    document.cookie = `${name}=; max-age=-1; path=/`;
+    i++;
+    next = cookies.find((c) => c.includes(cookieName + i));
+  }
+};

--- a/src/routes/__layout-root.svelte
+++ b/src/routes/__layout-root.svelte
@@ -13,7 +13,10 @@
   import { getDefaultNamespace } from '$lib/utilities/get-namespace';
   import { isAuthorized } from '$lib/utilities/is-authorized';
   import { routeForLoginPage } from '$lib/utilities/route-for';
-  import { getAuthUserCookie } from '$lib/utilities/get-auth-user-cookie';
+  import {
+    getAuthUserCookie,
+    cleanAuthUserCookie,
+  } from '$lib/utilities/auth-user-cookie';
 
   export const load: Load = async function ({ fetch }) {
     const settings: Settings = await fetchSettings(fetch);
@@ -21,6 +24,7 @@
     const authUser = getAuthUserCookie();
     if (authUser?.accessToken) {
       setAuthUser(authUser);
+      cleanAuthUserCookie();
     }
 
     const user = getAuthUser();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Cleans auth user cookie immediately as it is read

## Why?
<!-- Tell your future self why have you made these changes -->

Security + no need to store them as they are already read. Prior to the PR the cookie would stay for a minute until expired.
Cookie staying for a minute could also result in populating the AuthUser local storage entry after it is removed (during the first minute after logging in)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

verified the cookie is removed immediately after logging in

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
