### PR TITLE
Add Pagination to Namespaces

### DIFF
--- a/src/routes/namespaces/index@root.svelte
+++ b/src/routes/namespaces/index@root.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
-  import type { DescribeNamespaceResponse as Namespace } from '$types';
   import { routeForNamespace } from '$lib/utilities/route-for';
   import { page } from '$app/stores';
+  import EmptyState from '$lib/holocene/empty-state.svelte';
   import PageTitle from '$lib/holocene/page-title.svelte';
+  import Pagination from '$lib/holocene/pagination.svelte';
   import Table from '$holocene/table/table.svelte';
   import TableHeaderRow from '$holocene/table/table-header-row.svelte';
   import TableRow from '$holocene/table/table-row.svelte';
+  import type { DescribeNamespaceResponse as Namespace } from '$types';
 
   const { showTemporalSystemNamespace } = $page.stuff.settings;
-  const namespaces = ($page.stuff.namespaces || []).filter(
+  const namespaces: Namespace[] = ($page.stuff.namespaces || []).filter(
     (namespace: Namespace) =>
       showTemporalSystemNamespace ||
       namespace.namespaceInfo.name !== 'temporal-system',
@@ -18,31 +20,29 @@
 <PageTitle title="Namespaces" url={$page.url.href} />
 <h1 data-cy="namespace-selector-title" class="mb-8 text-2xl">Namespaces</h1>
 {#if namespaces?.length > 0}
-  <Table variant="fancy" class="w-full">
-    <TableHeaderRow slot="headers">
-      <th>Name</th>
-    </TableHeaderRow>
-    {#each namespaces as namespace}
-      <TableRow>
-        <td>
-          <a
-            href={routeForNamespace({
-              namespace: namespace.namespaceInfo.name,
-            })}
-            class="hover:text-blue-700 hover:underline hover:decoration-blue-700"
-            >{namespace.namespaceInfo.name}</a
-          >
-        </td>
-      </TableRow>
-    {/each}
-  </Table>
+  <Pagination items={namespaces} let:visibleItems>
+    <Table variant="fancy" class="w-full">
+      <TableHeaderRow slot="headers">
+        <th>Name</th>
+      </TableHeaderRow>
+      {#each visibleItems as namespace}
+        <TableRow>
+          <td>
+            <a
+              href={routeForNamespace({
+                namespace: namespace.namespaceInfo.name,
+              })}
+              class="hover:text-blue-700 hover:underline hover:decoration-blue-700"
+              >{namespace.namespaceInfo.name}</a
+            >
+          </td>
+        </TableRow>
+      {/each}
+    </Table>
+  </Pagination>
 {:else}
-  <div class="prose mt-[15vh] max-w-none text-center">
-    <h3>No Namespaces Found</h3>
-    <p>
-      You do not have access to a Namespace.
-      <br />
-      Contact your Administrator for assistance.
-    </p>
-  </div>
+  <EmptyState
+    title={'No Namespaces Found'}
+    content={'You do not have access to a Namespace. Contact your Administrator for assistance.'}
+  />
 {/if}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Adds the holocene `Pagination` component to the `Namespaces` page
* Updates the empty state to use the holocene `EmptyState` component

| Before | After |
| -- | -- |
|![Screen Shot 2022-10-13 at 4 09 11 PM](https://user-images.githubusercontent.com/15069288/195720085-78e6cf7a-cc94-4af7-889f-915e8fae9289.png)|![Screen Shot 2022-10-13 at 4 09 21 PM](https://user-images.githubusercontent.com/15069288/195720092-aa814749-6a31-4ba5-8859-1b9c8304114f.png)|
|![Screen Shot 2022-10-13 at 3 22 43 PM](https://user-images.githubusercontent.com/15069288/195718776-b0e4e679-e829-4ff4-8142-4347248dc537.png)|![Screen Shot 2022-10-13 at 3 22 02 PM](https://user-images.githubusercontent.com/15069288/195718756-5741b904-a043-47a2-99ba-c58d276ccae8.png)|

## Why?
<!-- Tell your future self why have you made these changes -->
To allow for pagination of namespaces.

## Checklist
<!--- add/delete as needed --->

1. Closes: DT-36 <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify namespaces load and display as expected
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
