### PR TITLE
Fix Back to Workflows link on Workflow details page w Public Path

### DIFF
--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -12,7 +12,7 @@
     routeForStackTrace,
     routeForWorkers,
     routeForWorkflowQuery,
-    routeForWorkflows,
+    routeForWorkflowsWithQuery,
   } from '$lib/utilities/route-for';
   import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
 
@@ -79,7 +79,7 @@
   <main class="relative flex flex-col gap-1">
     <div class="-mt-3 -ml-2 mb-4 block">
       <a
-        href={routeForWorkflows({
+        href={routeForWorkflowsWithQuery({
           namespace,
           query,
           search: searchType,

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -12,6 +12,7 @@
     routeForStackTrace,
     routeForWorkers,
     routeForWorkflowQuery,
+    routeForWorkflows,
   } from '$lib/utilities/route-for';
   import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
 
@@ -20,7 +21,6 @@
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import TerminateWorkflow from '$lib/components/terminate-workflow.svelte';
   import Tab from '$lib/holocene/tab.svelte';
-  import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { page } from '$app/stores';
   import { pathMatches } from '$lib/utilities/path-matches';
   import AutoRefreshWorkflow from '$lib/components/auto-refresh-workflow.svelte';
@@ -79,9 +79,11 @@
   <main class="relative flex flex-col gap-1">
     <div class="-mt-3 -ml-2 mb-4 block">
       <a
-        href={`/namespaces/${namespace}/workflows?query=${encodeURIForSvelte(
+        href={routeForWorkflows({
+          namespace,
           query,
-        )}&search=${searchType}`}
+          search: searchType,
+        })}
         data-cy="back-to-workflows"
         class="back-to-workflows"
       >

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -23,6 +23,7 @@ import {
   routeForSchedule,
   routeForTaskQueue,
   isNamespaceParameter,
+  routeForWorkflowsWithQuery,
 } from './route-for';
 
 describe('routeFor', () => {
@@ -36,6 +37,17 @@ describe('routeFor', () => {
       namespace: 'default',
     });
     expect(path).toBe('/namespaces/default');
+  });
+
+  it('should route to "workflows with query"', () => {
+    const path = routeForWorkflowsWithQuery({
+      namespace: 'default',
+      query: 'ExecutionStatus="Running"',
+      search: 'basic',
+    });
+    expect(path).toBe(
+      '/namespaces/default/workflows?query=ExecutionStatus%3D%22Running%22&search=basic',
+    );
   });
 
   it('should route to "workflows"', () => {

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -13,6 +13,8 @@ type RouteParameters = {
   scheduleId: string;
   queue: string;
   schedule: string;
+  query?: string;
+  search?: string;
 };
 
 export const isEventView = (view: string): view is EventView => {
@@ -23,6 +25,10 @@ export const isEventView = (view: string): view is EventView => {
 };
 
 export type NamespaceParameter = Pick<RouteParameters, 'namespace'>;
+export type WorkflowsParameter = Pick<
+  RouteParameters,
+  'namespace' | 'query' | 'search'
+>;
 export type TaskQueueParameters = Pick<RouteParameters, 'namespace' | 'queue'>;
 export type WorkflowParameters = Pick<
   RouteParameters,
@@ -56,8 +62,29 @@ export const routeForNamespace = ({
   return `${publicPath}/namespaces/${namespace}`;
 };
 
-export const routeForWorkflows = (parameters: NamespaceParameter): string => {
-  return `${routeForNamespace(parameters)}/workflows`;
+export const routeForWorkflows = ({
+  namespace,
+  query,
+  search,
+}: WorkflowsParameter): string => {
+  if (!browser) {
+    return undefined;
+  }
+
+  const url = new URL(
+    `${routeForNamespace({ namespace })}/workflows`,
+    window.location.origin,
+  );
+
+  if (query) {
+    url.searchParams.set('query', encodeURIForSvelte(query));
+  }
+
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+
+  return url.toString();
 };
 
 export const routeForArchivalWorkfows = (

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -62,7 +62,11 @@ export const routeForNamespace = ({
   return `${publicPath}/namespaces/${namespace}`;
 };
 
-export const routeForWorkflows = ({
+export const routeForWorkflows = (parameters: NamespaceParameter): string => {
+  return `${routeForNamespace(parameters)}/workflows`;
+};
+
+export const routeForWorkflowsWithQuery = ({
   namespace,
   query,
   search,
@@ -71,20 +75,7 @@ export const routeForWorkflows = ({
     return undefined;
   }
 
-  const url = new URL(
-    `${routeForNamespace({ namespace })}/workflows`,
-    window.location.origin,
-  );
-
-  if (query) {
-    url.searchParams.set('query', encodeURIForSvelte(query));
-  }
-
-  if (search) {
-    url.searchParams.set('search', search);
-  }
-
-  return url.toString();
+  return toURL(routeForWorkflows({ namespace }), { query, search });
 };
 
 export const routeForArchivalWorkfows = (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Fixes `Back to Workflows` link when Public Path is enabled

## Why?
<!-- Tell your future self why have you made these changes -->

The link was static and broken if Public Path is enabled, replaced with routeForWorkflows

https://github.com/temporalio/ui/issues/576

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

verified it routes to Workflows page

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
