### PR TITLE
Move clearPreviousEventParameters to layout of workflow/run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.70",
+  "version": "2.1.71",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -10,9 +10,6 @@
   import { formatDate } from '$lib/utilities/format-date';
   import { eventViewType } from '$lib/stores/event-view';
 
-  import { onDestroy } from 'svelte';
-  import { clearPreviousEventParameters } from '$lib/stores/events';
-
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
   import PendingActivities from '$lib/components/workflow/pending-activities.svelte';
@@ -39,10 +36,6 @@
     workflow: workflow.id,
     run: workflow.runId,
   };
-
-  onDestroy(() => {
-    clearPreviousEventParameters();
-  });
 </script>
 
 <section class="flex flex-col gap-4">

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import WorkflowRunLayout from '$lib/layouts/workflow-run-layout.svelte';
+  import { onDestroy } from 'svelte';
+  import { clearPreviousEventParameters } from '$lib/stores/events';
+
+  onDestroy(() => {
+    clearPreviousEventParameters();
+  });
 </script>
 
 <WorkflowRunLayout>

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { workflowRun } from '$lib/stores/workflow-run';
 
   import WorkflowHistoryLayout from '$lib/layouts/workflow-history-layout.svelte';
   import PageTitle from '$lib/components/page-title.svelte';


### PR DESCRIPTION
## What was changed
Our clearPreviousEventParameters() was not running since onDestroy of the imported layout never ran. Moved clearPreviousEventParameters() to the page layout of [workflow]/[run] to successfully clear params and refetch the event history when the same workflow is view again.

## Why?
Prevent stale event history when navigating to the same workflow run repeatedly
