### PR TITLE
Break out previousEvents to its own store so it can be imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.71",
+  "version": "2.1.72",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -21,6 +21,7 @@ import { withLoading, delay } from '$lib/utilities/stores/with-loading';
 import { groupEvents } from '$lib/models/event-groups';
 import { refresh } from '$lib/stores/workflow-run';
 import { authUser } from '$lib/stores/auth-user';
+import { previous } from '$lib/stores/previous-events';
 
 const emptyEvents: FetchEventsResponse = {
   events: [],
@@ -54,20 +55,6 @@ const accessToken = derived(
   [authUser],
   ([$authUser]) => $authUser?.accessToken,
 );
-
-const emptyPrevious: FetchEventsParameters = {
-  namespace: null,
-  workflowId: null,
-  runId: null,
-  rawPayloads: null,
-  sort: null,
-};
-
-const previous: Writable<FetchEventsParameters> = writable(emptyPrevious);
-
-export const clearPreviousEventParameters = (): void => {
-  previous.set(emptyPrevious);
-};
 
 const isNewRequest = (
   params: FetchEventsParameters,

--- a/src/lib/stores/previous-events.ts
+++ b/src/lib/stores/previous-events.ts
@@ -1,0 +1,18 @@
+import { writable, Writable } from 'svelte/store';
+
+import type { FetchEventsParameters } from '$lib/services/events-service';
+
+const emptyPrevious: FetchEventsParameters = {
+  namespace: null,
+  workflowId: null,
+  runId: null,
+  rawPayloads: null,
+  sort: null,
+};
+
+export const previous: Writable<FetchEventsParameters> =
+  writable(emptyPrevious);
+
+export const clearPreviousEventParameters = (): void => {
+  previous.set(emptyPrevious);
+};

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import WorkflowRunLayout from '$lib/layouts/workflow-run-layout.svelte';
   import { onDestroy } from 'svelte';
-  import { clearPreviousEventParameters } from '$lib/stores/events';
+  import { clearPreviousEventParameters } from '$lib/stores/previous-events';
 
   onDestroy(() => {
     clearPreviousEventParameters();


### PR DESCRIPTION
## What was changed
Same logic, just moving store to its own file so it can be imported without needing the $app/stores

## Why?
Allow clearEventParamaters to be imported through package
