### PR TITLE
Decode payloads if encoding starts with json/

### DIFF
--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -47,6 +47,14 @@ const JsonPlainEncoded = {
   data: 'InRlc3RAdGVzdC5jb20i',
 };
 
+const JsonFooEncoded = {
+  metadata: {
+    encoding: 'anNvbi9mb28=',
+    type: 'S2V5d29yZA==',
+  },
+  data: 'InRlc3RAdGVzdC5jb20i',
+};
+
 const ProtobufEncoded = {
   metadata: {
     encoding: 'anNvbi9wcm90b2J1Zg==',
@@ -85,6 +93,10 @@ describe('decodePayload', () => {
 
   it('Should decode a payload with encoding json/plain', () => {
     expect(decodePayload(JsonPlainEncoded)).toEqual(Base64Decoded);
+  });
+
+  it('Should decode a payload with encoding json/foo', () => {
+    expect(decodePayload(JsonFooEncoded)).toEqual(Base64Decoded);
   });
 
   it('Should decode a payload with encoding json/protobuf', () => {

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -33,14 +33,12 @@ export function decodePayload(
   // Help users out with an english encoding
   (payload.metadata.encodingDecoded as unknown as string) = encoding;
 
-  switch (encoding) {
-    case 'json/plain':
-    case 'json/protobuf':
-      try {
-        return parseWithBigInt(atob(String(payload.data)));
-      } catch (_e) {
-        // Couldn't correctly decode this just let the user deal with the data as is
-      }
+  if (encoding.startsWith('json/')) {
+    try {
+      return parseWithBigInt(atob(String(payload.data)));
+    } catch (_e) {
+      // Couldn't correctly decode this just let the user deal with the data as is
+    }
   }
 
   return payload;


### PR DESCRIPTION
## What was changed
To support custom user json encoding names, allow parsing of json with any encoding that starts with json/ instead of exclusively just json/plan and json/protobuf

## Why?
Prevent users from needing to build custom converters

