### PR TITLE
Fix event history sort order stickiness

### DIFF
--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -6,9 +6,15 @@
   import PageTransition from '$lib/holocene/page-transition.svelte';
   import Header from '$lib/layouts/workflow-header.svelte';
   import Loading from '$holocene/loading.svelte';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import { eventFilterSort, EventSortOrder } from '$lib/stores/event-view';
 
   const { namespace } = $page.params;
+
+  onMount(() => {
+    const sort = $page.url.searchParams.get('sort');
+    if (sort) $eventFilterSort = sort as EventSortOrder;
+  });
 
   onDestroy(() => {
     $timelineEvents = null;

--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -48,13 +48,10 @@ export const supportsReverseOrder = derived(
 export const eventSortOrder: Readable<EventSortOrder> = derived(
   [eventFilterSort, supportsReverseOrder],
   ([$eventFilterSort, $supportsReverseOrder]) => {
-    let sortOrder: EventSortOrder;
+    let sortOrder: EventSortOrder = 'ascending';
     if ($supportsReverseOrder) {
       sortOrder = $eventFilterSort;
-    } else {
-      sortOrder = 'ascending';
     }
-
     return sortOrder;
   },
 );

--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -36,15 +36,6 @@ export const eventCategoryParam = derived([page], ([$page]) =>
   $page.url.searchParams.get('category'),
 );
 
-export const eventSortParam: Readable<EventSortOrder> = derived<
-  [PageStore],
-  EventSortOrder
->([page], ([$page]): EventSortOrder => {
-  const sortParameter = $page.url.searchParams.get('sort');
-  if (isSortOrder(sortParameter)) return sortParameter;
-  return 'descending';
-});
-
 export const supportsReverseOrder = derived(
   [temporalVersion, settings],
   ([$temporalVersion, $settings]) => {

--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -55,15 +55,15 @@ export const supportsReverseOrder = derived(
 );
 
 export const eventSortOrder: Readable<EventSortOrder> = derived(
-  [eventFilterSort, supportsReverseOrder, eventSortParam],
-  ([$eventFilterSort, $supportsReverseOrder, $eventSortParam]) => {
+  [eventFilterSort, supportsReverseOrder],
+  ([$eventFilterSort, $supportsReverseOrder]) => {
     let sortOrder: EventSortOrder;
     if ($supportsReverseOrder) {
-      if ($eventSortParam) return $eventSortParam;
       sortOrder = $eventFilterSort;
     } else {
       sortOrder = 'ascending';
     }
+
     return sortOrder;
   },
 );


### PR DESCRIPTION
## What was changed
When navigating away from the workflow details page, the $eventSortParam store was always being set to 'descending', thus always setting eventSortOrder to 'descending'. Removing that store dependencies fixes the issue and keeps the correct behavior.

