### PR TITLE
Fix workflow worker only bug and update Cypress workers/task-queues tests

### DIFF
--- a/cypress/fixtures/activity-task-queues.json
+++ b/cypress/fixtures/activity-task-queues.json
@@ -1,0 +1,10 @@
+{
+  "pollers": [
+    {
+      "lastAccessTime": "2022-05-05T21:42:46.576609378Z",
+      "identity": "@poller",
+      "ratePerSecond": 100000
+    }
+  ],
+  "taskQueueStatus": null
+}

--- a/cypress/fixtures/empty-task-queues.json
+++ b/cypress/fixtures/empty-task-queues.json
@@ -1,0 +1,4 @@
+{
+  "pollers": [],
+  "taskQueueStatus": null
+}

--- a/cypress/fixtures/worker-task-queues.json
+++ b/cypress/fixtures/worker-task-queues.json
@@ -2,7 +2,7 @@
   "pollers": [
     {
       "lastAccessTime": "2022-05-04T21:42:46.576609378Z",
-      "identity": "60411@user0@",
+      "identity": "@poller",
       "ratePerSecond": 100000
     }
   ],

--- a/cypress/integration/task-queues.spec.js
+++ b/cypress/integration/task-queues.spec.js
@@ -30,7 +30,7 @@ describe('Task Queues Page', () => {
     ).as('activity-task-queues-api');
   });
 
-  it('default to last viewed event view when visiting a workflow', () => {
+  it('View a task queue page with a worker', () => {
     cy.wait('@worker-task-queues-api');
     cy.wait('@activity-task-queues-api');
 

--- a/cypress/integration/task-queues.spec.js
+++ b/cypress/integration/task-queues.spec.js
@@ -2,7 +2,8 @@
 
 import * as dateTz from 'date-fns-tz';
 
-import tq from '../fixtures/task-queues.json';
+import wtq from '../fixtures/worker-task-queues.json';
+import atq from '../fixtures/activity-task-queues.json';
 
 describe('Task Queues Page', () => {
   beforeEach(() => {
@@ -11,21 +12,41 @@ describe('Task Queues Page', () => {
     cy.visit(`/namespaces/default/task-queues/a-task-queue`);
 
     cy.wait('@namespaces-api');
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
+        `/api/v1/namespaces/default/task-queues/a-task-queue?taskQueueType=1`,
+      {
+        fixture: 'worker-task-queues.json',
+      },
+    ).as('worker-task-queues-api');
+
+    cy.intercept(
+      Cypress.env('VITE_API_HOST') +
+        `/api/v1/namespaces/default/task-queues/a-task-queue?taskQueueType=2`,
+      {
+        fixture: 'activity-task-queues.json',
+      },
+    ).as('activity-task-queues-api');
   });
 
   it('default to last viewed event view when visiting a workflow', () => {
-    cy.wait('@task-queues-api');
+    cy.wait('@worker-task-queues-api');
+    cy.wait('@activity-task-queues-api');
 
     cy.get('[data-cy="pollers-title"]').contains('Pollers');
     cy.get('.text-lg').contains('Task Queue: a-task-queue');
     cy.get('[data-cy=worker-row]').should('have.length', 1);
-    cy.get('[data-cy=worker-identity]').contains(tq.pollers[0].identity);
+    cy.get('[data-cy=worker-identity]').contains(wtq.pollers[0].identity);
     cy.get('[data-cy=worker-last-access-time]').contains(
       dateTz.formatInTimeZone(
-        new Date(tq.pollers[0].lastAccessTime),
+        new Date(atq.pollers[0].lastAccessTime),
         'UTC',
         'yyyy-MM-dd z HH:mm:ss.SS',
       ),
     );
+
+    cy.get('[data-cy="workflow-poller"] > .text-blue-700').should('exist');
+    cy.get('[data-cy="activity-poller"] > .text-blue-700').should('exist');
   });
 });

--- a/cypress/integration/workers.spec.js
+++ b/cypress/integration/workers.spec.js
@@ -42,7 +42,7 @@ describe('Workflow Workers', () => {
     cy.wait('@workflow-api');
   });
 
-  it('default to last viewed event view when visiting a workflow', () => {
+  it('View both worker and activity poller', () => {
     cy.get('[data-cy=workers-tab]').click();
 
     cy.wait('@worker-task-queues-api');
@@ -95,7 +95,7 @@ describe('Workflow Workers - Workflow Worker Only', () => {
     cy.wait('@workflow-api');
   });
 
-  it('view workflow worker only poller', () => {
+  it('View workflow worker only poller', () => {
     cy.get('[data-cy=workers-tab]').click();
 
     cy.wait('@worker-task-queues-api');
@@ -148,7 +148,7 @@ describe('Workflow Workers - Activity Worker Only', () => {
     cy.wait('@workflow-api');
   });
 
-  it('view workflow worker only poller', () => {
+  it('View activity worker only poller', () => {
     cy.get('[data-cy=workers-tab]').click();
 
     cy.wait('@worker-task-queues-api');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -55,7 +55,7 @@ Cypress.Commands.add('interceptWorkflowsApi', () => {
 Cypress.Commands.add('interceptWorkflowsCountApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-    `/api/v1/namespaces/*/workflows/count?query=*`,
+      `/api/v1/namespaces/*/workflows/count?query=*`,
     { fixture: 'count.json' },
   ).as('workflows-count-api');
 });
@@ -83,7 +83,7 @@ Cypress.Commands.add('interceptClusterApi', (fixture = 'cluster.json') => {
 Cypress.Commands.add('interceptArchivedWorkflowsApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-    `/api/v1/namespaces/*/workflows/archived?query=*`,
+      `/api/v1/namespaces/*/workflows/archived?query=*`,
     { fixture: 'workflows.json' },
   ).as('workflows-archived-api');
 });
@@ -104,7 +104,7 @@ Cypress.Commands.add('interceptGithubReleasesApi', () => {
 Cypress.Commands.add('interceptQueryApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-    `/api/v1/namespaces/*/workflows/*/runs/*/query*`,
+      `/api/v1/namespaces/*/workflows/*/runs/*/query*`,
     { fixture: 'query-stack-trace.json' },
   ).as('query-api');
 });
@@ -112,7 +112,7 @@ Cypress.Commands.add('interceptQueryApi', () => {
 Cypress.Commands.add('interceptTaskQueuesApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-    `/api/v1/namespaces/*/task-queues/*?taskQueueType=*`,
+      `/api/v1/namespaces/*/task-queues/*?taskQueueType=*`,
     {
       fixture: 'worker-task-queues.json',
     },

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -109,16 +109,6 @@ Cypress.Commands.add('interceptQueryApi', () => {
   ).as('query-api');
 });
 
-Cypress.Commands.add('interceptTaskQueuesApi', () => {
-  cy.intercept(
-    Cypress.env('VITE_API_HOST') +
-      `/api/v1/namespaces/*/task-queues/*?taskQueueType=*`,
-    {
-      fixture: 'task-queues.json',
-    },
-  ).as('task-queues-api');
-});
-
 Cypress.Commands.add('interceptSchedulesApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') + `/api/v1/namespaces/*/schedules*`,
@@ -144,7 +134,6 @@ Cypress.Commands.add(
     cy.interceptArchivedWorkflowsApi();
     cy.interceptGithubReleasesApi();
     cy.interceptQueryApi();
-    cy.interceptTaskQueuesApi();
     cy.interceptSettingsApi();
     cy.interceptSearchAttributesApi();
     cy.interceptSchedulesApi();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -55,7 +55,7 @@ Cypress.Commands.add('interceptWorkflowsApi', () => {
 Cypress.Commands.add('interceptWorkflowsCountApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-      `/api/v1/namespaces/*/workflows/count?query=*`,
+    `/api/v1/namespaces/*/workflows/count?query=*`,
     { fixture: 'count.json' },
   ).as('workflows-count-api');
 });
@@ -83,7 +83,7 @@ Cypress.Commands.add('interceptClusterApi', (fixture = 'cluster.json') => {
 Cypress.Commands.add('interceptArchivedWorkflowsApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-      `/api/v1/namespaces/*/workflows/archived?query=*`,
+    `/api/v1/namespaces/*/workflows/archived?query=*`,
     { fixture: 'workflows.json' },
   ).as('workflows-archived-api');
 });
@@ -104,9 +104,19 @@ Cypress.Commands.add('interceptGithubReleasesApi', () => {
 Cypress.Commands.add('interceptQueryApi', () => {
   cy.intercept(
     Cypress.env('VITE_API_HOST') +
-      `/api/v1/namespaces/*/workflows/*/runs/*/query*`,
+    `/api/v1/namespaces/*/workflows/*/runs/*/query*`,
     { fixture: 'query-stack-trace.json' },
   ).as('query-api');
+});
+
+Cypress.Commands.add('interceptTaskQueuesApi', () => {
+  cy.intercept(
+    Cypress.env('VITE_API_HOST') +
+    `/api/v1/namespaces/*/task-queues/*?taskQueueType=*`,
+    {
+      fixture: 'worker-task-queues.json',
+    },
+  ).as('task-queues-api');
 });
 
 Cypress.Commands.add('interceptSchedulesApi', () => {
@@ -134,6 +144,7 @@ Cypress.Commands.add(
     cy.interceptArchivedWorkflowsApi();
     cy.interceptGithubReleasesApi();
     cy.interceptQueryApi();
+    cy.interceptTaskQueuesApi();
     cy.interceptSettingsApi();
     cy.interceptSearchAttributesApi();
     cy.interceptSchedulesApi();

--- a/src/lib/components/workers-list.svelte
+++ b/src/lib/components/workers-list.svelte
@@ -39,16 +39,16 @@
         </div>
         <div class="flex w-2/12 justify-center" data-cy="workflow-poller">
           {#if poller.taskQueueTypes.includes('WORKFLOW')}
-            <Icon name="checkmark" class="check text-blue-700" />
+            <Icon name="checkmark" class="text-blue-700" />
           {:else}
-            <Icon name="close" class="close text-primary" />
+            <Icon name="close" class="text-primary" />
           {/if}
         </div>
         <div class="flex w-2/12 justify-center" data-cy="activity-poller">
           {#if poller.taskQueueTypes.includes('ACTIVITY')}
-            <Icon name="checkmark" class="check text-blue-700" />
+            <Icon name="checkmark" class="text-blue-700" />
           {:else}
-            <Icon name="close" class="close text-primary" />
+            <Icon name="close" class="text-primary" />
           {/if}
         </div>
       </article>

--- a/src/lib/components/workers-list.svelte
+++ b/src/lib/components/workers-list.svelte
@@ -37,18 +37,18 @@
             </p>
           </h3>
         </div>
-        <div class="flex w-2/12 justify-center">
+        <div class="flex w-2/12 justify-center" data-cy="workflow-poller">
           {#if poller.taskQueueTypes.includes('WORKFLOW')}
-            <Icon name="checkmark" class="text-blue-700" />
+            <Icon name="checkmark" class="check text-blue-700" />
           {:else}
-            <Icon name="close" class="text-primary" />
+            <Icon name="close" class="close text-primary" />
           {/if}
         </div>
-        <div class="flex w-2/12 justify-center">
+        <div class="flex w-2/12 justify-center" data-cy="activity-poller">
           {#if poller.taskQueueTypes.includes('ACTIVITY')}
-            <Icon name="checkmark" class="text-blue-700" />
+            <Icon name="checkmark" class="check text-blue-700" />
           {:else}
-            <Icon name="close" class="text-primary" />
+            <Icon name="close" class="close text-primary" />
           {/if}
         </div>
       </article>

--- a/src/lib/pages/task-queue-workers.svelte
+++ b/src/lib/pages/task-queue-workers.svelte
@@ -6,7 +6,7 @@
 
   let { queue, namespace } = $page.params;
 
-  let workers = getPollers({ queue, namespace }, { returnAllPollers: true });
+  let workers = getPollers({ queue, namespace });
 </script>
 
 {#await workers then workers}

--- a/src/lib/services/pollers-service.ts
+++ b/src/lib/services/pollers-service.ts
@@ -26,7 +26,6 @@ export type PollerWithTaskQueueTypes = PollerInfo & {
 
 export async function getPollers(
   parameters: GetAllPollersRequest,
-  options = { returnAllPollers: false },
   request = fetch,
 ): Promise<GetPollersResponse> {
   const route = await routeForApi('task-queue', parameters);
@@ -84,14 +83,12 @@ export async function getPollers(
     workflowPollers.pollers.reduce(r('WORKFLOW'), {}),
   );
 
-  const pollers =
-    options?.returnAllPollers && !activityPollers.pollers.length
-      ? workflowPollers.pollers
-      : activityPollers.pollers;
-  const taskQueueStatus =
-    options?.returnAllPollers && !activityPollers.pollers.length
-      ? workflowPollers.taskQueueStatus
-      : activityPollers.taskQueueStatus;
+  const pollers = !activityPollers.pollers.length
+    ? workflowPollers.pollers
+    : activityPollers.pollers;
+  const taskQueueStatus = !activityPollers.pollers.length
+    ? workflowPollers.taskQueueStatus
+    : activityPollers.taskQueueStatus;
   return {
     pollers,
     taskQueueStatus,


### PR DESCRIPTION
## What was changed
We were only showing activity pollers in the Worker page of a workflow. This removes the check and shows workflow workers in the Worker page as well.

Before
<img width="1712" alt="Screen Shot 2022-11-03 at 3 07 21 PM" src="https://user-images.githubusercontent.com/7967403/199823548-c2bb8af6-f785-4ee0-a000-bc3d2c6ed714.png">

After
<img width="1712" alt="Screen Shot 2022-11-03 at 3 07 45 PM" src="https://user-images.githubusercontent.com/7967403/199823624-733fc848-8857-48a1-8d47-a30052e41cf5.png">

## Why?
Show all workers

Closes #762 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
