### PR TITLE
[DT-132] Include workflow event with error in strongly typed error message

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -220,17 +220,10 @@
     @apply border-b-0;
   }
 
-  .row {
-    &.typedError {
-      @apply rounded-lg;
-    }
-  }
-
-  .row {
-    &.typedError {
-      &.expanded {
-        @apply rounded-b-none;
-      }
+  .row.typedError {
+    @apply rounded-lg;
+    &.expanded {
+      @apply rounded-b-none;
     }
   }
 

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -29,6 +29,7 @@
   export let initialItem: IterableEvent;
   export let compact = false;
   export let expandAll = false;
+  export let typedError = false;
 
   let selectedId = event.id;
 
@@ -82,6 +83,7 @@
   class:failure
   class:canceled
   class:terminated
+  class:typedError
   data-cy="event-summary-row"
   on:click|stopPropagation={onLinkClick}
 >
@@ -135,7 +137,7 @@
   </td>
 </tr>
 {#if expanded}
-  <tr class="expanded-row">
+  <tr class="expanded-row" class:typedError>
     <td class="expanded-cell" colspan="5">
       <EventDetailsFull
         event={currentEvent}
@@ -212,5 +214,28 @@
 
   .expanded-cell {
     @apply flex w-full flex-wrap border-b-2 border-gray-700 text-sm no-underline xl:table-cell xl:text-base;
+  }
+
+  .typedError .expanded-cell {
+    @apply border-b-0;
+  }
+
+  .row {
+    &.typedError {
+      @apply rounded-lg;
+    }
+  }
+
+  .row {
+    &.typedError {
+      &.expanded {
+        @apply rounded-b-none;
+      }
+    }
+  }
+
+  .typedError .cell,
+  .typedError .id-cell {
+    @apply first-of-type:rounded-tl-lg  last-of-type:rounded-tr-lg;
   }
 </style>

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -27,15 +27,13 @@
 </script>
 
 <section
-  class="event-table {typedError
-    ? 'table border border-yellow-700'
-    : 'border-2 border-gray-900 xl:table'}"
+  class="event-table"
+  class:error-table={typedError}
   data-cy="event-summary-table"
 >
   <div
-    class="table-header-row xl:table-header-group {typedError
-      ? 'header-hidden'
-      : ''}"
+    class="table-header-row xl:table-header-group"
+    class:header-hidden={typedError}
     data-cy="event-summary-table-header-desktop"
   >
     <div class="hidden xl:table-row">
@@ -63,9 +61,8 @@
     </div>
   </div>
   <div
-    class="table-header-row-responsive rounded-t-md {typedError
-      ? 'header-hidden-responsive'
-      : ''}"
+    class="table-header-row-responsive rounded-t-md"
+    class:header-hidden-responsive={typedError}
   >
     <div class="table-header-responsive w-2/3">
       Date & Time
@@ -96,7 +93,7 @@
 
 <style lang="postcss">
   .event-table {
-    @apply w-full table-fixed rounded-lg;
+    @apply w-full table-fixed rounded-lg border-2 border-gray-900 xl:table;
   }
 
   .table-header-row {
@@ -113,6 +110,10 @@
 
   .table-header-responsive {
     @apply flex items-center p-2;
+  }
+
+  .error-table {
+    @apply table border border-yellow-700;
   }
 
   .header-hidden {

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -10,6 +10,7 @@
   import { expandAllEvents } from '$lib/stores/event-view';
 
   export let compact = false;
+  export let typedError = false;
 
   let title = compact ? 'Event Type' : 'Workflow Events';
   let expandAll = $expandAllEvents === 'true';
@@ -25,9 +26,16 @@
   }
 </script>
 
-<section class="event-table" data-cy="event-summary-table">
+<section
+  class="event-table {typedError
+    ? 'table border border-yellow-700'
+    : 'border-2 border-gray-900 xl:table'}"
+  data-cy="event-summary-table"
+>
   <div
-    class="table-header-row xl:table-header-group"
+    class="table-header-row xl:table-header-group {typedError
+      ? 'header-hidden'
+      : ''}"
     data-cy="event-summary-table-header-desktop"
   >
     <div class="hidden xl:table-row">
@@ -54,7 +62,11 @@
       </div>
     </div>
   </div>
-  <div class="table-header-row-responsive rounded-t-md">
+  <div
+    class="table-header-row-responsive rounded-t-md {typedError
+      ? 'header-hidden-responsive'
+      : ''}"
+  >
     <div class="table-header-responsive w-2/3">
       Date & Time
       {#if !compact}<EventDateFilter />{/if}
@@ -84,7 +96,7 @@
 
 <style lang="postcss">
   .event-table {
-    @apply w-full table-fixed rounded-lg border-2 border-gray-900 xl:table;
+    @apply w-full table-fixed rounded-lg;
   }
 
   .table-header-row {
@@ -101,5 +113,13 @@
 
   .table-header-responsive {
     @apply flex items-center p-2;
+  }
+
+  .header-hidden {
+    visibility: collapse;
+  }
+
+  .header-hidden-responsive {
+    @apply hidden;
   }
 </style>

--- a/src/lib/components/workflow/workflow-typed-error.svelte
+++ b/src/lib/components/workflow/workflow-typed-error.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-  import { updating } from '$lib/stores/events';
+  import { events, eventGroups, updating } from '$lib/stores/events';
 
   import Alert from '$lib/holocene/alert.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import EventSummaryTable from '$lib/components/event/event-summary-table.svelte';
+  import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
 
   const WORKFLOW_TASK_FAILED_ERROR_COPY = {
     UnhandledCommand: {
@@ -107,5 +109,16 @@
         Learn more about <Link newTab href={link}>{actionCopy}</Link>.
       </p>
     {/if}
+    <div class="mt-2 bg-white">
+      <EventSummaryTable typedError>
+        <EventSummaryRow
+          event={error}
+          groups={$eventGroups}
+          initialItem={error}
+          visibleItems={$events}
+          typedError
+        />
+      </EventSummaryTable>
+    </div>
   </Alert>
 {/if}

--- a/src/lib/components/workflow/workflow-typed-error.svelte
+++ b/src/lib/components/workflow/workflow-typed-error.svelte
@@ -90,9 +90,12 @@
     },
   };
 
-  export let error: WorkflowTaskFailedCause;
+  export let error: WorkflowTaskFailedEvent;
 
-  $: errorCopy = WORKFLOW_TASK_FAILED_ERROR_COPY[error] ?? {};
+  $: errorCopy =
+    WORKFLOW_TASK_FAILED_ERROR_COPY[
+      error?.workflowTaskFailedEventAttributes?.cause
+    ] ?? {};
   $: ({ title = '', copy = '', actionCopy = '', link = '' } = errorCopy);
 </script>
 

--- a/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
+++ b/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
@@ -262,43 +262,41 @@ describe('getWorkflowStartedCompletedAndTaskFailedEvents', () => {
   });
 
   it('should get the correct error for a WorkflowTaskFailed event', () => {
-    const cause = 'NonDeterministicError';
-    const history = [
-      {
-        eventId: '11',
-        eventTime: '2022-10-31T22:41:28.917920758Z',
-        eventType: 'WorkflowTaskFailed',
-        version: '0',
-        taskId: '56713476',
-        workflowTaskFailedEventAttributes: {
-          cause,
-          failure: {
-            cause: null,
-          },
+    const failedEvent = {
+      eventId: '15',
+      eventTime: '2022-10-31T22:41:28.917920758Z',
+      eventType: 'WorkflowTaskFailed',
+      version: '0',
+      taskId: '56713476',
+      workflowTaskFailedEventAttributes: {
+        cause: 'NonDeterministicError',
+        failure: {
+          cause: null,
         },
-        attributes: {
-          type: 'workflowTaskFailedEventAttributes',
-          cause,
-          failure: {
-            cause: null,
-          },
-        },
-        classification: 'Failed',
-        category: 'workflow',
-        id: '11',
-        name: 'WorkflowTaskFailed',
-        timestamp: '2022-10-31 UTC 22:41:28.91',
       },
-    ];
+      attributes: {
+        type: 'workflowTaskFailedEventAttributes',
+        cause: 'NonDeterministicError',
+        failure: {
+          cause: null,
+        },
+      },
+      classification: 'Failed',
+      category: 'workflow',
+      id: '11',
+      name: 'WorkflowTaskFailed',
+      timestamp: '2022-10-31 UTC 22:41:28.91',
+    };
+    const history = [failedEvent, ...runningEventHistory];
 
     const { error } = getWorkflowStartedCompletedAndTaskFailedEvents(history);
-    expect(error).toBe(cause);
+    expect(error).toBe(failedEvent);
   });
 
   it('should get the correct error for a workflow that has a completed task after a failed task', () => {
     const history = [
       {
-        eventId: '17',
+        eventId: '12',
         eventTime: '2022-07-01T20:28:52.916365546Z',
         eventType: 'WorkflowTaskCompleted',
         version: '0',
@@ -318,7 +316,7 @@ describe('getWorkflowStartedCompletedAndTaskFailedEvents', () => {
         },
         classification: 'Completed',
         category: 'workflow',
-        id: '17',
+        id: '12',
         name: 'WorkflowTaskCompleted',
         timestamp: '2022-07-01 UTC 20:28:52.91',
       },

--- a/src/lib/utilities/get-started-completed-and-task-failed-events.ts
+++ b/src/lib/utilities/get-started-completed-and-task-failed-events.ts
@@ -4,7 +4,7 @@ import { stringifyWithBigInt } from './parse-with-big-int';
 type WorkflowInputAndResults = {
   input: string;
   results: string;
-  error: WorkflowTaskFailedCause;
+  error: WorkflowTaskFailedEvent;
 };
 
 type CompletionEvent =
@@ -63,7 +63,7 @@ export const getWorkflowStartedCompletedAndTaskFailedEvents = (
 ): WorkflowInputAndResults => {
   let input: string;
   let results: string;
-  let error: WorkflowTaskFailedCause;
+  let error: WorkflowTaskFailedEvent;
 
   let workflowStartedEvent: WorkflowExecutionStartedEvent;
   let workflowCompletedEvent: CompletionEvent;
@@ -100,7 +100,7 @@ export const getWorkflowStartedCompletedAndTaskFailedEvents = (
   }
 
   if (workflowTaskFailedEvent) {
-    error = workflowTaskFailedEvent.workflowTaskFailedEventAttributes.cause;
+    error = workflowTaskFailedEvent;
   }
 
   return {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
When a strongly-typed error occurs with an event in the workflow history the expandable event is included in the `Alert` along with the error message.

## Why?
<!-- Tell your future self why have you made these changes -->
Users can see event details immediately.

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-132` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] `getStartedCompletedAndTaskFailedEvents.test.ts`
- [ ]  Run `main.go` code attached to task for a `NonDeterministicError`
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
