### PR TITLE
Add Local Activity support and show activity type for Local Activities in event history

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -22,6 +22,7 @@
   import EventDetailsRow from './event-details-row.svelte';
   import EventDetailsFull from './event-details-full.svelte';
   import { formatAttributes } from '$lib/utilities/format-event-attributes';
+  import { isLocalActivityMarkerEvent } from '$lib/utilities/is-event-type';
 
   export let event: IterableEvent;
   export let groups: EventGroups;
@@ -120,7 +121,10 @@
       {#if compact && terminated}
         <Icon class="inline text-pink-700" name="clock" />
       {/if}
-      {getTruncatedWord(event.name, truncateWidth - 30)}
+      {getTruncatedWord(
+        isLocalActivityMarkerEvent(event) ? 'LocalActivity' : event.name,
+        truncateWidth - 30,
+      )}
     </p>
   </td>
   <td class="cell links">

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -1,6 +1,7 @@
 import {
   isActivityTaskScheduledEvent,
   isMarkerRecordedEvent,
+  isLocalActivityMarkerEvent,
   isSignalExternalWorkflowExecutionInitiatedEvent,
   isStartChildWorkflowExecutionInitiatedEvent,
   isWorkflowExecutionSignaledEvent,
@@ -22,6 +23,7 @@ type StartingEvents = {
   Timer: TimerStartedEvent;
   Signal: SignalExternalWorkflowExecutionInitiatedEvent;
   SignalReceived: WorkflowExecutionSignaledEvent;
+  LocalActivity: MarkerRecordedEvent;
   Marker: MarkerRecordedEvent;
 };
 
@@ -88,5 +90,10 @@ export const createEventGroup = (event: CommonHistoryEvent): EventGroup => {
   if (isWorkflowExecutionSignaledEvent(event))
     return createGroupFor<'SignalReceived'>(event);
 
-  if (isMarkerRecordedEvent(event)) return createGroupFor<'Marker'>(event);
+  if (isMarkerRecordedEvent(event)) {
+    if (isLocalActivityMarkerEvent(event)) {
+      return createGroupFor<'LocalActivity'>(event);
+    }
+    return createGroupFor<'Marker'>(event);
+  }
 };

--- a/src/lib/models/event-groups/get-group-name.ts
+++ b/src/lib/models/event-groups/get-group-name.ts
@@ -5,6 +5,7 @@ import {
   isStartChildWorkflowExecutionInitiatedEvent,
   isWorkflowExecutionSignaledEvent,
   isTimerStartedEvent,
+  isLocalActivityMarkerEvent,
 } from '$lib/utilities/is-event-type';
 
 export const getEventGroupName = (event: CommonHistoryEvent): string => {
@@ -27,6 +28,9 @@ export const getEventGroupName = (event: CommonHistoryEvent): string => {
   }
 
   if (isMarkerRecordedEvent(event)) {
+    if (isLocalActivityMarkerEvent(event)) {
+      return 'Local Activity';
+    }
     return `Marker: ${event.markerRecordedEventAttributes?.markerName}`;
   }
 

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -155,7 +155,7 @@ const getSummaryAttribute = (event: WorkflowEvent): SummaryAttribute => {
   if (isLocalActivityMarkerEvent(event as MarkerRecordedEvent)) {
     const payload: any =
       event.markerRecordedEventAttributes?.details?.data?.payloads?.[0];
-    const activityType = payload?.ActivityType;
+    const activityType = payload?.ActivityType ?? payload?.activity_type;
     if (activityType) {
       return formatSummaryValue('ActivityType', activityType);
     }

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -1,6 +1,7 @@
 import { isEventGroup } from '$lib/models/event-groups';
 import { capitalize } from '$lib/utilities/format-camel-case';
 import type { CombinedAttributes } from './format-event-attributes';
+import { isLocalActivityMarkerEvent } from './is-event-type';
 
 type SummaryAttribute = {
   key: string;
@@ -150,6 +151,15 @@ const getFirstDisplayAttribute = ({
  */
 const getSummaryAttribute = (event: WorkflowEvent): SummaryAttribute => {
   const first = getFirstDisplayAttribute(event);
+
+  if (isLocalActivityMarkerEvent(event as MarkerRecordedEvent)) {
+    const activityType =
+      event.markerRecordedEventAttributes?.details?.data?.payloads?.[0]
+        ?.ActivityType;
+    if (activityType) {
+      return formatSummaryValue('ActivityType', activityType);
+    }
+  }
 
   for (const [key, value] of Object.entries(event.attributes)) {
     for (const preferredKey of preferredSummaryKeys) {

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -153,9 +153,9 @@ const getSummaryAttribute = (event: WorkflowEvent): SummaryAttribute => {
   const first = getFirstDisplayAttribute(event);
 
   if (isLocalActivityMarkerEvent(event as MarkerRecordedEvent)) {
-    const activityType =
-      event.markerRecordedEventAttributes?.details?.data?.payloads?.[0]
-        ?.ActivityType;
+    const payload: any =
+      event.markerRecordedEventAttributes?.details?.data?.payloads?.[0];
+    const activityType = payload?.ActivityType;
     if (activityType) {
       return formatSummaryValue('ActivityType', activityType);
     }

--- a/src/lib/utilities/is-event-type.ts
+++ b/src/lib/utilities/is-event-type.ts
@@ -331,6 +331,6 @@ export const isLocalActivityMarkerEvent = (event) => {
   return (
     isMarkerRecordedEvent(event) &&
     event?.markerRecordedEventAttributes?.markerName === 'LocalActivity' &&
-    Boolean(payload?.ActivityType)
+    Boolean(payload?.ActivityType ?? payload?.activity_type)
   );
 };

--- a/src/lib/utilities/is-event-type.ts
+++ b/src/lib/utilities/is-event-type.ts
@@ -326,12 +326,11 @@ export const isUpsertWorkflowSearchAttributesEvent =
   );
 
 export const isLocalActivityMarkerEvent = (event) => {
+  const payload: any =
+    event?.markerRecordedEventAttributes?.details?.data?.payloads?.[0];
   return (
     isMarkerRecordedEvent(event) &&
     event?.markerRecordedEventAttributes?.markerName === 'LocalActivity' &&
-    Boolean(
-      event.markerRecordedEventAttributes?.details?.data?.payloads?.[0]
-        ?.ActivityType,
-    )
+    Boolean(payload?.ActivityType)
   );
 };

--- a/src/lib/utilities/is-event-type.ts
+++ b/src/lib/utilities/is-event-type.ts
@@ -324,3 +324,14 @@ export const isUpsertWorkflowSearchAttributesEvent =
   hasAttributes<UpsertWorkflowSearchAttributesEvent>(
     'upsertWorkflowSearchAttributesEventAttributes',
   );
+
+export const isLocalActivityMarkerEvent = (event) => {
+  return (
+    isMarkerRecordedEvent(event) &&
+    event?.markerRecordedEventAttributes?.markerName === 'LocalActivity' &&
+    Boolean(
+      event.markerRecordedEventAttributes?.details?.data?.payloads?.[0]
+        ?.ActivityType,
+    )
+  );
+};


### PR DESCRIPTION
## What was changed
LocalActivity is a special marker and has an activity type associated with it. This change labels any localActivity markers as 'Local Activity' and finds the activity type from the details data payload.

**Before**
<img width="1626" alt="Screen Shot 2022-11-07 at 2 32 32 PM" src="https://user-images.githubusercontent.com/7967403/200411369-c53c3e44-ce59-4eee-abcb-475906739ac1.png">

**After**
<img width="1615" alt="Screen Shot 2022-11-07 at 2 32 48 PM" src="https://user-images.githubusercontent.com/7967403/200411356-682464c3-78fd-4daa-a471-839f8c620f0f.png">

<img width="1714" alt="Screen Shot 2022-11-07 at 2 42 25 PM" src="https://user-images.githubusercontent.com/7967403/200411293-f444d272-ddbf-46fa-a272-d88baed6ec25.png">

## Why?
Show specific information for a LocalActivity

## Checklist

- [x] Confirm with Dmitry
