### PR TITLE
Check sort order when looking at completed task events

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -10,6 +10,7 @@
   import { formatDate } from '$lib/utilities/format-date';
   import { eventViewType } from '$lib/stores/event-view';
   import { eventHistory } from '$lib/stores/events';
+  import { eventSortOrder } from '$lib/stores/event-view';
 
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
@@ -42,6 +43,7 @@
 
   $: workflowEvents = getWorkflowStartedCompletedAndTaskFailedEvents(
     $eventHistory?.events ?? [],
+    $eventSortOrder,
   );
 </script>
 

--- a/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
+++ b/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
@@ -293,7 +293,7 @@ describe('getWorkflowStartedCompletedAndTaskFailedEvents', () => {
     expect(error).toBe(failedEvent);
   });
 
-  it('should get the correct error for a workflow that has a completed task after a failed task', () => {
+  it('should get the correct error for a workflow that has a completed task after a failed task in descending order', () => {
     const history = [
       {
         eventId: '12',
@@ -347,7 +347,71 @@ describe('getWorkflowStartedCompletedAndTaskFailedEvents', () => {
       },
     ];
 
-    const { error } = getWorkflowStartedCompletedAndTaskFailedEvents(history);
+    const { error } = getWorkflowStartedCompletedAndTaskFailedEvents(
+      history,
+      'descending',
+    );
+    expect(error).toMatchInlineSnapshot('undefined');
+  });
+
+  it('should get the correct error for a workflow that has a completed task after a failed task is ascending order', () => {
+    const history = [
+      {
+        eventId: '11',
+        eventTime: '2022-10-31T22:41:28.917920758Z',
+        eventType: 'WorkflowTaskFailed',
+        version: '0',
+        taskId: '56713476',
+        workflowTaskFailedEventAttributes: {
+          cause: 'NonDeterministicError',
+          failure: {
+            cause: null,
+          },
+        },
+        attributes: {
+          type: 'workflowTaskFailedEventAttributes',
+          cause: 'NonDeterministicError',
+          failure: {
+            cause: null,
+          },
+        },
+        classification: 'Failed',
+        category: 'workflow',
+        id: '11',
+        name: 'WorkflowTaskFailed',
+        timestamp: '2022-10-31 UTC 22:41:28.91',
+      },
+      {
+        eventId: '12',
+        eventTime: '2022-07-01T20:28:52.916365546Z',
+        eventType: 'WorkflowTaskCompleted',
+        version: '0',
+        taskId: '29887669',
+        workflowTaskCompletedEventAttributes: {
+          scheduledEventId: '15',
+          startedEventId: '16',
+          identity: '83579@MacBook-Pro-2.local@',
+          binaryChecksum: 'e56c0141e58df0bd405138565d0526f9',
+        },
+        attributes: {
+          type: 'workflowTaskCompletedEventAttributes',
+          scheduledEventId: '15',
+          startedEventId: '16',
+          identity: '83579@MacBook-Pro-2.local@',
+          binaryChecksum: 'e56c0141e58df0bd405138565d0526f9',
+        },
+        classification: 'Completed',
+        category: 'workflow',
+        id: '12',
+        name: 'WorkflowTaskCompleted',
+        timestamp: '2022-07-01 UTC 20:28:52.91',
+      },
+    ];
+
+    const { error } = getWorkflowStartedCompletedAndTaskFailedEvents(
+      history,
+      'ascending',
+    );
     expect(error).toMatchInlineSnapshot('undefined');
   });
 });

--- a/src/lib/utilities/get-started-completed-and-task-failed-events.ts
+++ b/src/lib/utilities/get-started-completed-and-task-failed-events.ts
@@ -1,5 +1,6 @@
 import { isWorkflowExecutionCompletedEvent } from './is-event-type';
 import { stringifyWithBigInt } from './parse-with-big-int';
+import type { EventSortOrder } from '$lib/stores/event-view';
 
 type WorkflowInputAndResults = {
   input: string;
@@ -60,6 +61,7 @@ const getEventResult = (event: CompletionEvent) => {
 
 export const getWorkflowStartedCompletedAndTaskFailedEvents = (
   events: WorkflowEvents,
+  eventSortOrder: EventSortOrder = 'descending',
 ): WorkflowInputAndResults => {
   let input: string;
   let results: string;
@@ -78,10 +80,15 @@ export const getWorkflowStartedCompletedAndTaskFailedEvents = (
       workflowCompletedEvent = event;
       continue;
     } else if (isCompletedTaskEvent(event)) {
-      // If there is a completed workflow task
-      hasCompletedTaskEvent = true;
+      // If there is a completed workflow task after a failed task
+      if (eventSortOrder === 'descending') {
+        // then we don't need to look for a failed task
+        hasCompletedTaskEvent = true;
+      } else if (eventSortOrder === 'ascending' && workflowTaskFailedEvent) {
+        // or we need to reset the failed event
+        workflowTaskFailedEvent = undefined;
+      }
       continue;
-      // then we don't need to look for a failed task
     } else if (!hasCompletedTaskEvent && isFailedTaskEvent(event)) {
       workflowTaskFailedEvent = event;
       continue;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Checks sort order for event history when determining if there is a completed workflow task after a failed task.

## Why?
<!-- Tell your future self why have you made these changes -->
Event history with an `ascending` sort order was not getting the workflow task failed event and relevant error.

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] `getStartedCompletedAndTaskFailedEvents.test.ts`
- [ ]  Run `main.go` code attached to task for a `NonDeterministicError`
   - Verify error shows up with `descending` sort order set under `Date & Time`
   - Verify error shows up with `ascending` sort order set under `Date & Time`
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
