### PR TITLE
Use routeForEventHistory instead of routeForWorkflow to fix navigation

### DIFF
--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -3,8 +3,7 @@
 
   import { format } from '$lib/utilities/format-camel-case';
   import {
-    routeForWorkflow,
-    routeForWorkers,
+    routeForEventHistory,
     routeForTaskQueue,
   } from '$lib/utilities/route-for';
   import {
@@ -19,6 +18,7 @@
   import Link from '$lib/holocene/link.svelte';
   import Copyable from '../copyable.svelte';
   import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
+  import { eventViewType } from '$lib/stores/event-view';
 
   export let key: string;
   export let value: string | Record<string, unknown>;
@@ -50,7 +50,12 @@
         >
           <Link
             newTab
-            href={routeForWorkflow({ namespace, workflow, run: value })}
+            href={routeForEventHistory({
+              view: $eventViewType,
+              namespace,
+              workflow,
+              run: value,
+            })}
           >
             {value}
           </Link>
@@ -64,7 +69,8 @@
         <Copyable content={value} container-class="xl:flex-row">
           <Link
             newTab
-            href={routeForWorkflow({
+            href={routeForEventHistory({
+              view: $eventViewType,
               namespace,
               workflow: attributes.workflowExecutionWorkflowId,
               run: attributes.workflowExecutionRunId,

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -3,7 +3,7 @@
 
   import { format } from '$lib/utilities/format-camel-case';
   import {
-    routeForWorkflow,
+    routeForEventHistory,
     routeForTaskQueue,
   } from '$lib/utilities/route-for';
   import {
@@ -18,6 +18,7 @@
   import Link from '$lib/holocene/link.svelte';
   import Copyable from '../copyable.svelte';
   import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
+  import { eventViewType } from '$lib/stores/event-view';
 
   export let key: string;
   export let value: string | Record<string, unknown>;
@@ -45,7 +46,12 @@
         >
           <Link
             newTab
-            href={routeForWorkflow({ namespace, workflow, run: value })}
+            href={routeForEventHistory({
+              view: $eventViewType,
+              namespace,
+              workflow,
+              run: value,
+            })}
           >
             {value}
           </Link>
@@ -59,7 +65,8 @@
         <Copyable content={value} container-class="xl:flex-row">
           <Link
             newTab
-            href={routeForWorkflow({
+            href={routeForEventHistory({
+              view: $eventViewType,
               namespace,
               workflow: attributes.workflowExecutionWorkflowId,
               run: attributes.workflowExecutionRunId,

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -3,7 +3,7 @@
 
   import { formatDate } from '$lib/utilities/format-date';
   import { getMilliseconds } from '$lib/utilities/format-time';
-  import { routeForWorkflow } from '$lib/utilities/route-for';
+  import { routeForEventHistory } from '$lib/utilities/route-for';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
   import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
   import { toListWorkflowParameters } from '$lib/utilities/query/to-list-workflow-parameters';
@@ -12,6 +12,7 @@
   import FilterOrCopyButtons from '$holocene/filter-or-copy-buttons.svelte';
   import SelectableTableRow from '$holocene/table/selectable-table-row.svelte';
   import TableRow from '$lib/holocene/table/table-row.svelte';
+  import { eventViewType } from '$lib/stores/event-view';
 
   export let bulkActionsEnabled: boolean = false;
   export let selected: boolean = false;
@@ -19,7 +20,8 @@
   export let workflow: WorkflowExecution;
   export let timeFormat: TimeFormat | string;
 
-  $: href = routeForWorkflow({
+  $: href = routeForEventHistory({
+    view: $eventViewType,
     namespace,
     workflow: workflow.id,
     run: workflow.runId,

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { workflowRun } from '$lib/stores/workflow-run';
-
   import {
-    routeForWorkflow,
-    routeForWorkers,
     routeForEventHistory,
+    routeForWorkers,
   } from '$lib/utilities/route-for';
   import { formatDate } from '$lib/utilities/format-date';
   import { eventViewType } from '$lib/stores/event-view';
@@ -71,7 +69,8 @@
         <WorkflowDetail
           title="Parent"
           content={workflow.parent?.workflowId}
-          href={routeForWorkflow({
+          href={routeForEventHistory({
+            view: $eventViewType,
             namespace,
             workflow: workflow.parent?.workflowId,
             run: workflow.parent?.runId,
@@ -80,7 +79,8 @@
         <WorkflowDetail
           title="Parent ID"
           content={workflow.parent?.runId}
-          href={routeForWorkflow({
+          href={routeForEventHistory({
+            view: $eventViewType,
             namespace,
             workflow: workflow.parent?.workflowId,
             run: workflow.parent?.runId,
@@ -93,7 +93,8 @@
         <WorkflowDetail
           title="Child"
           content={child.workflowId}
-          href={routeForWorkflow({
+          href={routeForEventHistory({
+            view: $eventViewType,
             namespace,
             workflow: child.workflowId,
             run: child.runId,
@@ -102,7 +103,8 @@
         <WorkflowDetail
           title="Child ID"
           content={child.runId}
-          href={routeForWorkflow({
+          href={routeForEventHistory({
+            view: $eventViewType,
             namespace,
             workflow: child.workflowId,
             run: child.runId,


### PR DESCRIPTION
## What was changed
When href's are using routeForWorkflow, the back/forward buttons don't work for browser history since routeForWorkflow immediately redirects. By using routeForEventHistory, an href will go to the full, final url which allows back/forward to work.

We should not directly use routeForWorkflow for any hrefs.


Fixes #821 #822 