### PR TITLE
Fix Child Workflow Link, update Column Labels, fix Link href

### DIFF
--- a/src/lib/components/workflow/child-workflows-table.svelte
+++ b/src/lib/components/workflow/child-workflows-table.svelte
@@ -14,8 +14,8 @@
 <Pagination items={pendingChildren} itemsPerPage={10} let:visibleItems>
   <Table class="w-full">
     <TableHeaderRow slot="headers">
-      <th class="md:table-cell">Child Workflow</th>
-      <th class="md:table-cell">Child ID</th>
+      <th class="md:table-cell">Child Workflow ID</th>
+      <th class="md:table-cell">Child Run ID</th>
     </TableHeaderRow>
     {#each visibleItems as child (child.runId)}
       <TableRow

--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -15,10 +15,13 @@
   } from '$lib/utilities/format-event-attributes';
   import { toTimeDifference } from '$lib/utilities/to-time-difference';
 
-  const { namespace, workflow, run } = $page.params;
   $: pendingActivities = $workflowRun.workflow.pendingActivities;
 
-  const href = routeForPendingActivities({ namespace, workflow, run });
+  $: href = routeForPendingActivities({
+    namespace: $page.params.namespace,
+    workflow: $page.params.workflow,
+    run: $page.params.run,
+  });
 </script>
 
 {#if pendingActivities.length}

--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -15,11 +15,10 @@
   } from '$lib/utilities/format-event-attributes';
   import { toTimeDifference } from '$lib/utilities/to-time-difference';
 
-  const { namespace, run } = $page.params;
-  const { workflow } = $workflowRun;
-  const { pendingActivities, defaultWorkflowTaskTimeout, id } = workflow;
+  const { namespace, workflow, run } = $page.params;
+  $: pendingActivities = $workflowRun.workflow.pendingActivities;
 
-  const href = routeForPendingActivities({ namespace, workflow: id, run });
+  const href = routeForPendingActivities({ namespace, workflow, run });
 </script>
 
 {#if pendingActivities.length}

--- a/src/lib/holocene/link.svelte
+++ b/src/lib/holocene/link.svelte
@@ -4,13 +4,26 @@
   export let newTab = false;
 </script>
 
-<a
-  {href}
-  target={newTab ? '_blank' : '_self'}
-  class:text-blue-900={active}
-  {...$$props}
-  class="{$$props.class} underline underline-offset-2 hover:text-blue-700"
-  on:click|stopPropagation
->
-  <slot />
-</a>
+{#if newTab}
+  <a
+    {href}
+    target="_blank"
+    rel="noreferrer"
+    class:text-blue-900={active}
+    {...$$props}
+    class="{$$props.class} underline underline-offset-2 hover:text-blue-700"
+    on:click|stopPropagation
+  >
+    <slot />
+  </a>
+{:else}
+  <a
+    {href}
+    class:text-blue-900={active}
+    {...$$props}
+    class="{$$props.class} underline underline-offset-2 hover:text-blue-700"
+    on:click
+  >
+    <slot />
+  </a>
+{/if}

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -35,12 +35,6 @@
   let refreshInterval;
   const refreshRate = 15000;
 
-  const routeParameters = {
-    namespace,
-    workflow: workflow.id,
-    run: workflow.runId,
-  };
-
   const { parameters, searchType } = $workflowsSearch;
   const query = toListWorkflowQuery(parameters);
 
@@ -130,7 +124,9 @@
         label="History"
         href={routeForEventHistory({
           view: $eventViewType,
-          ...routeParameters,
+          namespace,
+          workflow: workflow.id,
+          run: workflow.runId,
         })}
         amount={workflow?.historyEvents}
         dataCy="history-tab"
@@ -138,46 +134,80 @@
           $page.url.pathname,
           routeForEventHistory({
             view: $eventViewType,
-            ...routeParameters,
+            namespace,
+            workflow: workflow.id,
+            run: workflow.runId,
           }),
         )}
       />
       <Tab
         label="Workers"
-        href={routeForWorkers(routeParameters)}
+        href={routeForWorkers({
+          namespace,
+          workflow: workflow.id,
+          run: workflow.runId,
+        })}
         amount={workers?.pollers?.length}
         dataCy="workers-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForWorkers(routeParameters),
+          routeForWorkers({
+            namespace,
+            workflow: workflow.id,
+            run: workflow.runId,
+          }),
         )}
       />
       <Tab
         label="Pending Activities"
-        href={routeForPendingActivities(routeParameters)}
+        href={routeForPendingActivities({
+          namespace,
+          workflow: workflow.id,
+          run: workflow.runId,
+        })}
         amount={workflow.pendingActivities?.length}
         dataCy="pending-activities-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForPendingActivities(routeParameters),
+          routeForPendingActivities({
+            namespace,
+            workflow: workflow.id,
+            run: workflow.runId,
+          }),
         )}
       />
       <Tab
         label="Stack Trace"
-        href={routeForStackTrace(routeParameters)}
+        href={routeForStackTrace({
+          namespace,
+          workflow: workflow.id,
+          run: workflow.runId,
+        })}
         dataCy="stack-trace-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForStackTrace(routeParameters),
+          routeForStackTrace({
+            namespace,
+            workflow: workflow.id,
+            run: workflow.runId,
+          }),
         )}
       />
       <Tab
         label="Queries"
-        href={routeForWorkflowQuery(routeParameters)}
+        href={routeForWorkflowQuery({
+          namespace,
+          workflow: workflow.id,
+          run: workflow.runId,
+        })}
         dataCy="queries-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForWorkflowQuery(routeParameters),
+          routeForWorkflowQuery({
+            namespace,
+            workflow: workflow.id,
+            run: workflow.runId,
+          }),
         )}
       />
     </nav>

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -35,6 +35,12 @@
   let refreshInterval;
   const refreshRate = 15000;
 
+  $: routeParameters = {
+    namespace,
+    workflow: workflow.id,
+    run: workflow.runId,
+  };
+
   const { parameters, searchType } = $workflowsSearch;
   const query = toListWorkflowQuery(parameters);
 
@@ -124,9 +130,7 @@
         label="History"
         href={routeForEventHistory({
           view: $eventViewType,
-          namespace,
-          workflow: workflow.id,
-          run: workflow.runId,
+          ...routeParameters,
         })}
         amount={workflow?.historyEvents}
         dataCy="history-tab"
@@ -134,80 +138,46 @@
           $page.url.pathname,
           routeForEventHistory({
             view: $eventViewType,
-            namespace,
-            workflow: workflow.id,
-            run: workflow.runId,
+            ...routeParameters,
           }),
         )}
       />
       <Tab
         label="Workers"
-        href={routeForWorkers({
-          namespace,
-          workflow: workflow.id,
-          run: workflow.runId,
-        })}
+        href={routeForWorkers(routeParameters)}
         amount={workers?.pollers?.length}
         dataCy="workers-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForWorkers({
-            namespace,
-            workflow: workflow.id,
-            run: workflow.runId,
-          }),
+          routeForWorkers(routeParameters),
         )}
       />
       <Tab
         label="Pending Activities"
-        href={routeForPendingActivities({
-          namespace,
-          workflow: workflow.id,
-          run: workflow.runId,
-        })}
+        href={routeForPendingActivities(routeParameters)}
         amount={workflow.pendingActivities?.length}
         dataCy="pending-activities-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForPendingActivities({
-            namespace,
-            workflow: workflow.id,
-            run: workflow.runId,
-          }),
+          routeForPendingActivities(routeParameters),
         )}
       />
       <Tab
         label="Stack Trace"
-        href={routeForStackTrace({
-          namespace,
-          workflow: workflow.id,
-          run: workflow.runId,
-        })}
+        href={routeForStackTrace(routeParameters)}
         dataCy="stack-trace-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForStackTrace({
-            namespace,
-            workflow: workflow.id,
-            run: workflow.runId,
-          }),
+          routeForStackTrace(routeParameters),
         )}
       />
       <Tab
         label="Queries"
-        href={routeForWorkflowQuery({
-          namespace,
-          workflow: workflow.id,
-          run: workflow.runId,
-        })}
+        href={routeForWorkflowQuery(routeParameters)}
         dataCy="queries-tab"
         active={pathMatches(
           $page.url.pathname,
-          routeForWorkflowQuery({
-            namespace,
-            workflow: workflow.id,
-            run: workflow.runId,
-          }),
+          routeForWorkflowQuery(routeParameters),
         )}
       />
     </nav>

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -37,14 +37,14 @@
 
   $: routeParameters = {
     namespace,
-    workflow: workflow.id,
-    run: workflow.runId,
+    workflow: workflow?.id,
+    run: workflow?.runId,
   };
 
   const { parameters, searchType } = $workflowsSearch;
   const query = toListWorkflowQuery(parameters);
 
-  $: isRunning = $workflowRun.workflow.isRunning;
+  $: isRunning = $workflowRun?.workflow?.isRunning;
 
   onMount(() => {
     if (isRunning && $autoRefreshWorkflow === 'on') {

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -23,22 +23,13 @@
   import { getWorkflowStartedCompletedAndTaskFailedEvents } from '$lib/utilities/get-started-completed-and-task-failed-events';
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
 
-  const { namespace } = $page.params;
-  const { workflow, workers } = $workflowRun;
-
   const routeParameters = (view: EventView, eventId?: string) => ({
-    namespace,
-    workflow: workflow.id,
-    run: workflow.runId,
+    namespace: $page.params.namespace,
+    workflow: $workflowRun.workflow.id,
+    run: $workflowRun.workflow.runId,
     view,
     eventId,
   });
-
-  const workflowRoute = {
-    namespace,
-    workflow: workflow.id,
-    run: workflow.runId,
-  };
 
   $: workflowEvents = getWorkflowStartedCompletedAndTaskFailedEvents(
     $eventHistory?.events ?? [],
@@ -48,59 +39,69 @@
 
 <section class="flex flex-col gap-4">
   <section class="flex flex-col gap-1">
-    <WorkflowDetail title="Workflow Type" content={workflow.name} />
-    <WorkflowDetail title="Run ID" content={workflow.runId} />
+    <WorkflowDetail
+      title="Workflow Type"
+      content={$workflowRun.workflow.name}
+    />
+    <WorkflowDetail title="Run ID" content={$workflowRun.workflow.runId} />
     <div class="flex flex-col gap-1 md:flex-row md:gap-6">
       <WorkflowDetail
         title="Start Time"
-        content={formatDate(workflow.startTime, $timeFormat)}
+        content={formatDate($workflowRun.workflow.startTime, $timeFormat)}
       />
       <WorkflowDetail
         title="Close Time"
-        content={formatDate(workflow.endTime, $timeFormat)}
+        content={formatDate($workflowRun.workflow.endTime, $timeFormat)}
       />
     </div>
     <WorkflowDetail
       title="Task Queue"
-      content={workflow.taskQueue}
-      href={routeForWorkers(workflowRoute)}
+      content={$workflowRun.workflow.taskQueue}
+      href={routeForWorkers({
+        namespace: $page.params.namespace,
+        workflow: $workflowRun.workflow.id,
+        run: $workflowRun.workflow.runId,
+      })}
     />
     <WorkflowDetail
       title="State Transitions"
-      content={workflow.stateTransitionCount}
+      content={$workflowRun.workflow.stateTransitionCount}
     />
-    {#if workflow?.parent}
+    {#if $workflowRun.workflow?.parent}
       <div class="gap-2 xl:flex">
         <WorkflowDetail
-          title="Parent"
-          content={workflow.parent?.workflowId}
+          title="Parent Workflow ID"
+          content={$workflowRun.workflow.parent?.workflowId}
           href={routeForEventHistory({
             view: $eventViewType,
-            namespace,
-            workflow: workflow.parent?.workflowId,
-            run: workflow.parent?.runId,
+            namespace: $page.params.namespace,
+            workflow: $workflowRun.workflow.parent?.workflowId,
+            run: $workflowRun.workflow.parent?.runId,
           })}
         />
         <WorkflowDetail
-          title="Parent ID"
-          content={workflow.parent?.runId}
+          title="Parent Run ID"
+          content={$workflowRun.workflow.parent?.runId}
           href={routeForEventHistory({
             view: $eventViewType,
-            namespace,
-            workflow: workflow.parent?.workflowId,
-            run: workflow.parent?.runId,
+            namespace: $page.params.namespace,
+            workflow: $workflowRun.workflow.parent?.workflowId,
+            run: $workflowRun.workflow.parent?.runId,
           })}
         />
       </div>
     {/if}
-    {#if workflow?.pendingChildren.length}
+    {#if $workflowRun.workflow?.pendingChildren.length}
       <ChildWorkflowsTable
-        pendingChildren={workflow?.pendingChildren}
-        {namespace}
+        pendingChildren={$workflowRun.workflow?.pendingChildren}
+        namespace={$page.params.namespace}
       />
     {/if}
   </section>
-  <WorkflowStackTraceError {workflow} {workers} />
+  <WorkflowStackTraceError
+    workflow={$workflowRun.workflow}
+    workers={$workflowRun.workers}
+  />
   <WorkflowTypedError error={workflowEvents.error} />
   <PendingActivities />
   <section class="flex w-full">
@@ -144,9 +145,9 @@
             data-cy="download"
             on:click={() =>
               exportHistory({
-                namespace,
-                workflowId: workflow.id,
-                runId: workflow.runId,
+                namespace: $page.params.namespace,
+                workflowId: $workflowRun.workflow.id,
+                runId: $workflowRun.workflow.runId,
               })}>Download</ToggleButton
           >
         </ToggleButtons>

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -9,8 +9,6 @@
   import { onDestroy, onMount } from 'svelte';
   import { eventFilterSort, EventSortOrder } from '$lib/stores/event-view';
 
-  const { namespace } = $page.params;
-
   onMount(() => {
     const sort = $page.url.searchParams.get('sort');
     if (sort) $eventFilterSort = sort as EventSortOrder;
@@ -27,7 +25,7 @@
   {:else}
     <PageTransition>
       <Header
-        {namespace}
+        namespace={$page.params.namespace}
         workflow={$workflowRun.workflow}
         workers={$workflowRun.workers}
       />

--- a/src/lib/utilities/encode-uri.ts
+++ b/src/lib/utilities/encode-uri.ts
@@ -1,36 +1,42 @@
 // Encode reserved URI characters, \ and %
 // TODO: related issue https://github.com/sveltejs/kit/issues/3069
 export function encodeURIForSvelte(uri: string): string {
-  return uri
-    .replace(/%/g, '%25')
-    .replace(/,/g, '%2C')
-    .replace(/\//g, '%2F')
-    .replace(/\\/g, '%5C')
-    .replace(/\?/g, '%3F')
-    .replace(/:/g, '%3A')
-    .replace(/@/g, '%40')
-    .replace(/&/g, '%26')
-    .replace(/=/g, '%3D')
-    .replace(/\+/g, '%2B')
-    .replace(/\$/g, '%24')
-    .replace(/#/g, '%23');
+  if (uri) {
+    return uri
+      .replace(/%/g, '%25')
+      .replace(/,/g, '%2C')
+      .replace(/\//g, '%2F')
+      .replace(/\\/g, '%5C')
+      .replace(/\?/g, '%3F')
+      .replace(/:/g, '%3A')
+      .replace(/@/g, '%40')
+      .replace(/&/g, '%26')
+      .replace(/=/g, '%3D')
+      .replace(/\+/g, '%2B')
+      .replace(/\$/g, '%24')
+      .replace(/#/g, '%23');
+  }
+  return uri;
 }
 
 // Decodes reserved URI characters, \ and % that are not automatically decoded by svelte kit/vite.
 // Note: Using decodeURIComponent is not going to work after vite's decodeURI as it errors on strings like %myworkflowid
 // TODO: related issue https://github.com/sveltejs/kit/issues/3069
 export function decodeURIForSvelte(uri: string): string {
-  return uri
-    .replace(/%2C/g, ',')
-    .replace(/%2F/g, '/')
-    .replace(/%5C/g, '\\')
-    .replace(/%3F/g, '?')
-    .replace(/%3A/g, ':')
-    .replace(/%40/g, '@')
-    .replace(/%26/g, '&')
-    .replace(/%3D/g, '=')
-    .replace(/%2B/g, '+')
-    .replace(/%24/g, '$')
-    .replace(/%23/g, '#')
-    .replace(/%25/g, '%');
+  if (uri) {
+    return uri
+      .replace(/%2C/g, ',')
+      .replace(/%2F/g, '/')
+      .replace(/%5C/g, '\\')
+      .replace(/%3F/g, '?')
+      .replace(/%3A/g, ':')
+      .replace(/%40/g, '@')
+      .replace(/%26/g, '&')
+      .replace(/%3D/g, '=')
+      .replace(/%2B/g, '+')
+      .replace(/%24/g, '$')
+      .replace(/%23/g, '#')
+      .replace(/%25/g, '%');
+  }
+  return uri;
 }

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -3,12 +3,11 @@
 
   import WorkflowHistoryLayout from '$lib/layouts/workflow-history-layout.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
+
+  const workflow = $page.params.workflow;
 </script>
 
-<PageTitle
-  title={`Workflow History | ${$page.params.workflow}`}
-  url={$page.url.href}
-/>
+<PageTitle title={`Workflow History | ${workflow}`} url={$page.url.href} />
 <WorkflowHistoryLayout>
   <!-- <svelte:fragment slot="timeline">
     <EventHistoryTimelineContainer />

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/history/__layout.svelte
@@ -3,11 +3,12 @@
 
   import WorkflowHistoryLayout from '$lib/layouts/workflow-history-layout.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
-
-  const workflow = $page.params.workflow;
 </script>
 
-<PageTitle title={`Workflow History | ${workflow}`} url={$page.url.href} />
+<PageTitle
+  title={`Workflow History | ${$page.params.workflow}`}
+  url={$page.url.href}
+/>
 <WorkflowHistoryLayout>
   <!-- <svelte:fragment slot="timeline">
     <EventHistoryTimelineContainer />

--- a/src/routes/namespaces/[namespace]/workflows/index@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/index@root.svelte
@@ -11,5 +11,4 @@
   title={`Workflows | ${$page.params.namespace}`}
   url={$page.url.href}
 />
-
 <Workflows bulkActionsEnabled={$supportsBulkActions} />


### PR DESCRIPTION
## What was changed
With moving to the Table for child workflows, the links are now client-side only (not a hard refresh link), which exposed issues in our references to data in the workflow run layouts. This updates the references to look at store values instead of top-level consts.

As a benefit, I've refactored the link to not use target="_self" for non-new tab links. This removes the hard refresh linking and provides faster navigation.

