### PR TITLE
Remove check for failed to show heartbeat details

### DIFF
--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -94,32 +94,28 @@
                   </div>
                 </div>
               </a>
-              {#if failed}
-                <div class="pending-activity-failure-details">
-                  {#if pendingActivity.heartbeatDetails}
-                    <div class="w-full">
-                      <h4 class="pending-activity-detail-header">
-                        Heartbeat Details
-                      </h4>
-                      <CodeBlock
-                        class="max-h-32"
-                        content={pendingActivity.heartbeatDetails}
-                      />
-                    </div>
-                  {/if}
-                  {#if pendingActivity.lastFailure}
-                    <div class="w-full">
-                      <h4 class="pending-activity-detail-header">
-                        Last Failure
-                      </h4>
-                      <CodeBlock
-                        class="max-h-32"
-                        content={pendingActivity.lastFailure}
-                      />
-                    </div>
-                  {/if}
-                </div>
-              {/if}
+              <div class="pending-activity-failure-details">
+                {#if pendingActivity?.heartbeatDetails}
+                  <div class="w-1/2 grow">
+                    <h4 class="pending-activity-detail-header">
+                      Heartbeat Details
+                    </h4>
+                    <CodeBlock
+                      class="max-h-32"
+                      content={pendingActivity.heartbeatDetails}
+                    />
+                  </div>
+                {/if}
+                {#if pendingActivity?.lastFailure}
+                  <div class="w-1/2 grow">
+                    <h4 class="pending-activity-detail-header">Last Failure</h4>
+                    <CodeBlock
+                      class="max-h-32"
+                      content={pendingActivity.lastFailure}
+                    />
+                  </div>
+                {/if}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What was changed
There was a check to show heartbeat details and last failure information for only failed activities. Heartbeat details are still valuable information without an activity having failed.

This PR removes the failed check to always show heartbeat details if they exist.

## Why?
Show heartbeat details on non-failed activities.


Closes #962 
