### PR TITLE
DT-131 - improve keyboard navigation for modals

### DIFF
--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -1,5 +1,3 @@
-<svelte:options accessors />
-
 <script lang="ts">
   import Icon from '$holocene/icon/icon.svelte';
   import type { IconName } from '$holocene/icon/paths';
@@ -30,15 +28,10 @@
   export let unroundRight: boolean = false;
   export let unroundLeft: boolean = false;
   export let id: string = null;
-
-  export let buttonElement: HTMLButtonElement | HTMLAnchorElement = null;
-
-  export const focus = () => buttonElement.focus();
 </script>
 
 {#if as === 'button'}
   <button
-    bind:this={buttonElement}
     on:click
     class="button {variant} {classes}"
     class:selected={active}
@@ -68,7 +61,6 @@
 {:else}
   <a
     {href}
-    bind:this={buttonElement}
     on:click
     class="button {variant} {classes}"
     class:selected={active}

--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -1,3 +1,5 @@
+<svelte:options accessors />
+
 <script lang="ts">
   import Icon from '$holocene/icon/icon.svelte';
   import type { IconName } from '$holocene/icon/paths';
@@ -28,10 +30,15 @@
   export let unroundRight: boolean = false;
   export let unroundLeft: boolean = false;
   export let id: string = null;
+
+  export let buttonElement: HTMLButtonElement | HTMLAnchorElement = null;
+
+  export const focus = () => buttonElement.focus();
 </script>
 
 {#if as === 'button'}
   <button
+    bind:this={buttonElement}
     on:click
     class="button {variant} {classes}"
     class:selected={active}
@@ -61,6 +68,7 @@
 {:else}
   <a
     {href}
+    bind:this={buttonElement}
     on:click
     class="button {variant} {classes}"
     class:selected={active}

--- a/src/lib/holocene/modal.story.svelte
+++ b/src/lib/holocene/modal.story.svelte
@@ -7,7 +7,7 @@
   import Modal from './modal.svelte';
 
   export let Hst: HST;
-  let open = true;
+  let open = false;
 
   const handleConfirm = () => {
     logEvent('Confirm', {});

--- a/src/lib/holocene/modal.story.svelte
+++ b/src/lib/holocene/modal.story.svelte
@@ -1,11 +1,23 @@
 <script lang="ts">
   import type { Hst as HST } from '@histoire/plugin-svelte';
+  import { logEvent } from 'histoire/client';
+
   import Button from './button.svelte';
 
   import Modal from './modal.svelte';
 
   export let Hst: HST;
   let open = true;
+
+  const handleConfirm = () => {
+    logEvent('Confirm', {});
+    open = false;
+  };
+
+  const handleCancel = () => {
+    logEvent('Cancel', {});
+    open = false;
+  };
 </script>
 
 <Hst.Story>
@@ -14,8 +26,8 @@
     bind:open
     confirmType="destructive"
     confirmText="Delete"
-    on:confirmModal={() => (open = false)}
-    on:cancelModal={() => (open = false)}
+    on:confirmModal={handleConfirm}
+    on:cancelModal={handleCancel}
   >
     <h3 slot="title">Delete User</h3>
     <p slot="content">

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -15,6 +15,7 @@
   let closeButton: HTMLButtonElement;
   let cancelButton: Button;
   let confirmButton: Button;
+  let modalElement: HTMLDivElement;
 
   const dispatch = createEventDispatcher<{
     cancelModal: undefined;
@@ -49,20 +50,20 @@
   };
 
   $: {
-    if (open && closeButton) {
-      closeButton.focus({ focusVisible: true } as any);
+    if (open && modalElement) {
+      modalElement.focus();
     }
   }
 </script>
 
 <svelte:window on:keydown={handleKeyboardNavigation} />
 {#if open}
-  <div class="modal">
+  <div bind:this={modalElement} class="modal">
     <div on:click={cancelModal} class="overlay" />
     <div
       class="body"
       class:large
-      aria-modal="true"
+      tabindex="-1"
       role="alertdialog"
       aria-labelledby="modal-title"
       aria-describedby="modal-description"

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -12,9 +12,6 @@
   export let large: boolean = false;
   export let loading: boolean = false;
 
-  let closeButton: HTMLButtonElement;
-  let cancelButton: Button;
-  let confirmButton: Button;
   let modalElement: HTMLDivElement;
 
   const dispatch = createEventDispatcher<{
@@ -36,14 +33,17 @@
       return;
     }
 
+    const focusable = modalElement.querySelectorAll('button');
+    const firstFocusable = focusable[0];
+    const lastFocusable = focusable[focusable.length - 1];
     if (event.key === 'Tab') {
       if (event.shiftKey) {
-        if (document.activeElement === closeButton) {
-          confirmButton.focus();
+        if (document.activeElement === firstFocusable) {
+          lastFocusable.focus();
           event.preventDefault();
         }
-      } else if (document.activeElement === confirmButton.buttonElement) {
-        closeButton.focus();
+      } else if (document.activeElement === lastFocusable) {
+        firstFocusable.focus();
         event.preventDefault();
       }
     }
@@ -58,9 +58,10 @@
 
 <svelte:window on:keydown={handleKeyboardNavigation} />
 {#if open}
-  <div bind:this={modalElement} class="modal">
+  <div class="modal">
     <div on:click={cancelModal} class="overlay" />
     <div
+      bind:this={modalElement}
       class="body"
       class:large
       tabindex="-1"
@@ -71,7 +72,6 @@
       {#if !loading}
         <button
           aria-label="Close Modal"
-          bind:this={closeButton}
           class="float-right m-4"
           on:click={cancelModal}
         >
@@ -93,7 +93,6 @@
       </div>
       <div class="flex items-center justify-end space-x-2 p-6">
         <Button
-          bind:this={cancelButton}
           thin
           variant="secondary"
           disabled={loading}
@@ -101,7 +100,6 @@
         >
         {#if !hideConfirm}
           <Button
-            bind:this={confirmButton}
             thin
             variant={confirmType}
             {loading}

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -47,15 +47,29 @@
       }
     }
   };
+
+  $: {
+    if (open && closeButton) {
+      closeButton.focus({ focusVisible: true } as any);
+    }
+  }
 </script>
 
 <svelte:window on:keydown={handleKeyboardNavigation} />
 {#if open}
   <div class="modal">
     <div on:click={cancelModal} class="overlay" />
-    <div class="body" class:large>
+    <div
+      class="body"
+      class:large
+      aria-modal="true"
+      role="alertdialog"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
       {#if !loading}
         <button
+          aria-label="Close Modal"
           bind:this={closeButton}
           class="float-right m-4"
           on:click={cancelModal}
@@ -66,12 +80,12 @@
           />
         </button>
       {/if}
-      <div class="title">
+      <div id="modal-title" class="title">
         <slot name="title">
           <h3>Title</h3>
         </slot>
       </div>
-      <div class="content">
+      <div id="modal-content" class="content">
         <slot name="content">
           <span>Content</span>
         </slot>

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -12,6 +12,10 @@
   export let large: boolean = false;
   export let loading: boolean = false;
 
+  let closeButton: HTMLButtonElement;
+  let cancelButton: Button;
+  let confirmButton: Button;
+
   const dispatch = createEventDispatcher<{
     cancelModal: undefined;
     confirmModal: undefined;
@@ -21,25 +25,46 @@
     dispatch('cancelModal');
   };
 
-  const handleKeyUp = (event: KeyboardEvent) => {
+  const handleKeyboardNavigation = (event: KeyboardEvent) => {
+    if (!open) {
+      return;
+    }
+
     if (event.key === 'Escape') {
       cancelModal();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      if (event.shiftKey) {
+        if (document.activeElement === closeButton) {
+          confirmButton.focus();
+          event.preventDefault();
+        }
+      } else if (document.activeElement === confirmButton.buttonElement) {
+        closeButton.focus();
+        event.preventDefault();
+      }
     }
   };
 </script>
 
-<svelte:window on:keyup={handleKeyUp} />
+<svelte:window on:keydown={handleKeyboardNavigation} />
 {#if open}
   <div class="modal">
     <div on:click={cancelModal} class="overlay" />
     <div class="body" class:large>
       {#if !loading}
-        <div class="float-right p-6" on:click={cancelModal}>
+        <button
+          bind:this={closeButton}
+          class="float-right m-4"
+          on:click={cancelModal}
+        >
           <Icon
             name="close"
             class="cursor-pointer rounded-full hover:bg-gray-900 hover:text-white"
           />
-        </div>
+        </button>
       {/if}
       <div class="title">
         <slot name="title">
@@ -53,6 +78,7 @@
       </div>
       <div class="flex items-center justify-end space-x-2 p-6">
         <Button
+          bind:this={cancelButton}
           thin
           variant="secondary"
           disabled={loading}
@@ -60,6 +86,7 @@
         >
         {#if !hideConfirm}
           <Button
+            bind:this={confirmButton}
             thin
             variant={confirmType}
             {loading}

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -71,7 +71,7 @@
     >
       {#if !loading}
         <button
-          aria-label="Close Modal"
+          aria-label={cancelText}
           class="float-right m-4"
           on:click={cancelModal}
         >


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- trap focus within modals by cycling to the previous element if the first/last focusable element is focused
- works for forward and backward navigation, i.e. `tab` and `shift+tab`


https://user-images.githubusercontent.com/11775628/204651804-9798489b-0eca-43cc-a733-42d0031fb246.mov



## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
