### PR TITLE
Clear workflowQuery when no workflowSort and workflowFilters

### DIFF
--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -56,6 +56,12 @@
     }
   }
 
+  $: {
+    if (!$workflowFilters.length && !$workflowSorts.length) {
+      $workflowsQuery = '';
+    }
+  }
+
   onMount(() => {
     $lastUsedNamespace = $page.params.namespace;
     if (query) {


### PR DESCRIPTION
## What was changed
When a single filter was applied (i.e. WorkflowType), and then cleared from the filter input and not the advanced search input, the workflowQuery would not get cleared and so when a user clicked on a workflow and then Back to Workflows, it would apply the filter even after being cleared. This would happen only if a single filter was applied. 

This PR fixes that behavior and clears the workflowQuery in the case when no workflow filters or sorts are applied.
