### PR TITLE
Use reactive routeParameters for tabs

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -23,7 +23,7 @@
   import { getWorkflowStartedCompletedAndTaskFailedEvents } from '$lib/utilities/get-started-completed-and-task-failed-events';
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
 
-  const routeParameters = (view: EventView, eventId?: string) => ({
+  $: routeParameters = (view: EventView, eventId?: string) => ({
     namespace: $page.params.namespace,
     workflow: $workflowRun.workflow.id,
     run: $workflowRun.workflow.runId,


### PR DESCRIPTION
## What was changed
If you navigated from the workflow to its parent or child via the Child/Parent table links, and then clicked a different view (Feed/Compact/JSON), you would be taking to the original workflow. This fixes the issue by making the tab route parameters reactive.

