### PR TITLE
Move workflow run loading store to it's own file so it can be imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.92",
+  "version": "2.1.93",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { workflowRun, loading } from '$lib/stores/workflow-run';
+  import { workflowRun } from '$lib/stores/workflow-run';
+  import { loading } from '$lib/stores/workflow-run-loading';
   import { timelineEvents } from '$lib/stores/events';
 
   import Header from '$lib/layouts/workflow-header.svelte';

--- a/src/lib/stores/workflow-run-loading.ts
+++ b/src/lib/stores/workflow-run-loading.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const loading = writable(true);

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -9,6 +9,7 @@ import type { GetPollersResponse } from '$lib/services/pollers-service';
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { toDecodedPendingActivities } from '$lib/models/pending-activities';
 import { authUser } from '$lib/stores/auth-user';
+import { loading } from '$lib/stores/workflow-run-loading';
 
 export const refresh = writable(0);
 const namespace = derived([page], ([$page]) => $page.params.namespace);
@@ -73,7 +74,6 @@ const updateWorkflowRun: StartStopNotifier<{
 };
 
 export const updating = writable(true);
-export const loading = writable(true);
 export const workflowRun = readable<WorkflowRunStore>(
   initialWorkflowRun,
   updateWorkflowRun,

--- a/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
+++ b/src/routes/namespaces/[namespace]/workflows/[workflow]/[run]/__layout@root.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
-  import { loading } from '$lib/stores/workflow-run';
+  import { loading } from '$lib/stores/workflow-run-loading';
   import { clearPreviousEventParameters } from '$lib/stores/previous-events';
 
   onDestroy(() => {


### PR DESCRIPTION
## What was changed
 Move loading store to it's own file so it can be imported in npm without gets errors due to $app/store bug from svelte;

