### PR TITLE
Fix pagination controls UI on window resize

### DIFF
--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -54,9 +54,8 @@
   let height: number | undefined;
 
   onMount(() => {
-    if (floatId) {
-      width = document.getElementById(floatId)?.clientWidth;
-    }
+    updateWidth();
+
     if (startingIndex > 0) {
       handlePageChange();
     }
@@ -70,10 +69,16 @@
     });
   };
 
+  const updateWidth = () => {
+    if (floatId) {
+      width = document.getElementById(floatId)?.clientWidth;
+    }
+  };
+
   $: floatStyle = getFloatStyle({ width, height, screenWidth });
 </script>
 
-<svelte:window bind:innerWidth={screenWidth} />
+<svelte:window bind:innerWidth={screenWidth} on:resize={updateWidth} />
 
 <div class="pagination relative mb-8 flex flex-col gap-4">
   <div


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Updates the `width` being passed to `getFloatStyle` in the Holocene `Pagination` component.

## Why?
<!-- Tell your future self why have you made these changes -->
Fixes wonkiness of pagination controls on window resize. 

![Screenshot 2022-12-09 at 12 25 23 PM](https://user-images.githubusercontent.com/15069288/206789529-67742640-2ab6-4019-8c1c-7428f45cf90b.png)

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- On a smaller breakpoint (e.g. `md` or smaller), change the history view (e.g. `Compact` --> `JSON`) and then increase the screen size to `lg` or larger
   - [ ] Verify the pagination control are in the correct position 
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
