### PR TITLE
Prevent pending activity negative attempts / max attempts

### DIFF
--- a/src/lib/utilities/format-event-attributes.test.ts
+++ b/src/lib/utilities/format-event-attributes.test.ts
@@ -134,16 +134,24 @@ describe('formatAttributes', () => {
     expect(formatAttemptsLeft(10, 3)).toBe(7);
   });
 
-  it('should format attempts left with unlimited max attempts', () => {
+  it('should format attempts left with 0 max attempts to be unlimited', () => {
     expect(formatAttemptsLeft(0, 3)).toBe(UnlimitedAttempts);
+  });
+
+  it('should format attempts left with null max attempts to be unlimited', () => {
+    expect(formatAttemptsLeft(null, 18)).toBe(UnlimitedAttempts);
   });
 
   it('should format max attempts left with limited max attempts', () => {
     expect(formatMaximumAttempts(2393)).toBe(2393);
   });
 
-  it('should format max attempts left with unlimited max attempts', () => {
+  it('should format max attempts left with 0 max attempts', () => {
     expect(formatMaximumAttempts(0)).toBe(UnlimitedAttempts);
+  });
+
+  it('should format max attempts left with null max attempts', () => {
+    expect(formatMaximumAttempts(null)).toBe(UnlimitedAttempts);
   });
 
   it('should format expiration with unlimited max attempts', () => {

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -36,7 +36,7 @@ export const formatRetryExpiration = (
 };
 
 export const formatAttemptsLeft = (
-  maxAttempts: number,
+  maxAttempts: number | null,
   attempt: number,
 ): number | string => {
   if (!maxAttempts) {
@@ -45,7 +45,9 @@ export const formatAttemptsLeft = (
   return maxAttempts - attempt;
 };
 
-export const formatMaximumAttempts = (maxAttempts: number): number | string => {
+export const formatMaximumAttempts = (
+  maxAttempts: number | null,
+): number | string => {
   if (!maxAttempts) {
     return UnlimitedAttempts;
   }
@@ -53,7 +55,7 @@ export const formatMaximumAttempts = (maxAttempts: number): number | string => {
 };
 
 const formatValue = (key: string, value: unknown) => {
-  if (key === 'maximumAttempts' && value === 0) {
+  if (key === 'maximumAttempts' && !value) {
     return UnlimitedAttempts;
   }
   return value;

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -39,14 +39,14 @@ export const formatAttemptsLeft = (
   maxAttempts: number,
   attempt: number,
 ): number | string => {
-  if (maxAttempts === 0) {
+  if (!maxAttempts) {
     return UnlimitedAttempts;
   }
   return maxAttempts - attempt;
 };
 
 export const formatMaximumAttempts = (maxAttempts: number): number | string => {
-  if (maxAttempts === 0) {
+  if (!maxAttempts) {
     return UnlimitedAttempts;
   }
   return maxAttempts;


### PR DESCRIPTION
# What was changed
Check for null values instead of == 0 for max attempts. Since maximumAttempts can be a number or null, update the code for the maximum attempts and attempts left to prevent negative numbers (`i.e. null - 6 = -6 because Javascript`). If maximumAttempts is null or 0, show `Unlimited` label.

```
   /** PendingActivityInfo maximumAttempts */
   maximumAttempts?: (number|null);
```

## Why?
Prevent confusing negative attempts
