### PR TITLE
Fix "cancel in progress" alert on event history page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.1.93",
+  "version": "2.1.94",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -6,7 +6,7 @@
   import { autoRefreshWorkflow } from '$lib/stores/event-view';
   import { workflowsQuery, workflowsSearch } from '$lib/stores/workflows';
   import { workflowRun, refresh } from '$lib/stores/workflow-run';
-  import { eventHistory } from '$lib/stores/events';
+  import { eventHistory, updating } from '$lib/stores/events';
 
   import {
     routeForEventHistory,
@@ -80,6 +80,7 @@
 
   $: cancelInProgress =
     $workflowRun?.workflow?.status === 'Running' &&
+    !$updating &&
     $eventHistory.events.some(
       (event) => event?.eventType === 'WorkflowExecutionCancelRequested',
     );
@@ -129,7 +130,7 @@
       {/if}
     </div>
     {#if cancelInProgress}
-      <div class="-mt-4 mb-4" transition:fly={{ duration: 200, delay: 100 }}>
+      <div class="-mt-4 mb-4" in:fly={{ duration: 200, delay: 100 }}>
         <Alert icon="info" intent="info" title="Cancel Request Sent">
           The request to cancel this Workflow Execution has been sent. If the
           Workflow uses the cancellation API, it'll cancel at the next available


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
The transition on this alert was causing a strange display bug when navigating back. I replaced the transition with just an `in` animation.
Also fix the logic on `$cancelInProgress` property to be false if the event history store is updating. This prevents the case where a stale event history store would cause the alert to flash on and off screen as a new even history was loaded into the store.
Bump version to 2.1.94 for use in cloud-ui

## Why?
<!-- Tell your future self why have you made these changes -->
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
