### PR TITLE
Don't try to decode a null payloads

### DIFF
--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -33,6 +33,10 @@ export function decodePayload(
   // This could decode to any object. So we either use the payload object passed in or decode it
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Payload | Record<any, any> | string {
+  if (payload == null) {
+    return payload;
+  }
+
   const encoding = atob(String(payload?.metadata?.encoding ?? ''));
 
   // Help users out with an english encoding


### PR DESCRIPTION
## What was changed

Due to a bug in the implementation of one of out context propagators, we ended up propagating `null` values which have been persisted in our workflow history.

To make it clear, our workflow history is looking like ⬇️. We have that `buggy-header` set to `null`.

```
    "header": {
        "fields": {
...
          "dd_trace_span": {
            "metadata": {
              "encoding": "..."
            },
            "data": "..."
          },
          "buggy-header": null,
```


When we tried to view workflows with such bad histories, the UI paniced and returned the following stack trace.

```
with-loading-f07bedaf.js:1 TypeError: Cannot read properties of null (reading 'metadata')
    at b (get-codec-b824633f.js:2:39627)
    at get-codec-b824633f.js:2:40250
    at Array.forEach (<anonymous>)
    at Kn (get-codec-b824633f.js:2:40227)
    at F (index-fb84e94f.js:1:995)
    at async I (index-fb84e94f.js:1:1172)
    at async Promise.all (index 2)
    at async K (index-fb84e94f.js:1:1409)
    at async events-284adb3f.js:1:1266
    at async r (with-loading-f07bedaf.js:1:44)
r @ with-loading-f07bedaf.js:1
```

Events were not displayed in the History or Compact views (but history can still be viewed as JSON).

Stack trace pointed at that code.

![image](https://user-images.githubusercontent.com/406923/210838067-07513330-32e8-400d-891d-52af9d61a6ba.png)

I tracked down the problem to the `decodePayload` function which assumes the provided `payload` is not `null` which in our case was.

I think it might be good to account for that case even if you probably shouldn't try to propagate `null` payloads in the first place just because histories are already persisted and corrupted and handling that case allow to render them in the UI no matter what.

<!-- Describe what has changed in this PR -->

## Why?

Just adds a simple `null`-check.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Pointing a local build of the UI to one of our temporal instance with and loaded the corrupted workflow events succesfully.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
