### PR TITLE
API Pagination fixes

### DIFF
--- a/e2e/tests/workflows.spec.ts
+++ b/e2e/tests/workflows.spec.ts
@@ -67,7 +67,9 @@ test.describe('Workflows list', () => {
     await page.getByText('Stack Trace').click();
 
     await expect(
-      page.getByRole('code').filter({ hasText: 'github.com/temporalio/ui/e2e.Workflow' }),
+      page
+        .getByRole('code')
+        .filter({ hasText: 'github.com/temporalio/ui/e2e.Workflow' }),
     ).toBeVisible();
   });
 
@@ -78,7 +80,9 @@ test.describe('Workflows list', () => {
     await page.getByLabel('Query Type').selectOption('current_result');
 
     await expect(
-      page.getByRole('code').filter({ hasText: '"Received Plain text input 2"' }),
+      page
+        .getByRole('code')
+        .filter({ hasText: '"Received Plain text input 2"' }),
     ).toBeVisible();
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0-beta.1",
   "type": "module",
   "description": "Temporal.io UI",
   "keywords": [

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from '$app/stores';
   import Alert from '$lib/holocene/alert.svelte';
   import FilterSelect from '$lib/holocene/select/filter-select.svelte';
   import SkeletonTable from '$lib/holocene/skeleton/table.svelte';
@@ -30,9 +31,20 @@
     if (error) error = undefined;
   }
 
+  $: isEmpty = $store.visibleItems.length === 0 && !$store.loading;
+  $: pageSizeChange =
+    !$store.loading && $store.pageSize !== $store.previousPageSize;
+
   onMount(() => {
     initalDataFetch();
   });
+
+  $: {
+    if (pageSizeChange) {
+      store.resetPageSize($store.pageSize);
+      initalDataFetch();
+    }
+  }
 
   async function initalDataFetch() {
     const fetchData: PaginatedRequest = await onFetch();
@@ -175,6 +187,8 @@
   </div>
   {#if $store.loading}
     <SkeletonTable rows={15} />
+  {:else if isEmpty}
+    <slot name="empty">No Items</slot>
   {:else}
     <slot
       updating={$store.updating}

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/stores';
   import Alert from '$lib/holocene/alert.svelte';
   import FilterSelect from '$lib/holocene/select/filter-select.svelte';
   import SkeletonTable from '$lib/holocene/skeleton/table.svelte';

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -20,10 +20,11 @@
     undefined;
   export let onSpace: (event: KeyboardEvent) => void | undefined = undefined;
 
-  export let pageSizeOptions: string[] = options;
+  export let pageSizeOptions: string[] | number[] = options;
+  export let defaultPageSize: string | number | undefined = undefined;
   export let total: string | number = '';
 
-  let store = createPaginationStore(pageSizeOptions);
+  let store = createPaginationStore(pageSizeOptions, defaultPageSize);
   let error: any;
 
   function clearError() {

--- a/src/lib/holocene/select/filter-select.svelte
+++ b/src/lib/holocene/select/filter-select.svelte
@@ -32,7 +32,7 @@
   class="border-[1px] border-gray-900 outline-none"
 >
   <slot>
-    {#each options as option}
+    {#each options.map((o) => o.toString()) as option}
       <Option value={option} />
     {/each}
   </slot>

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -4,7 +4,6 @@ import { routeForApi } from '$lib/utilities/route-for-api';
 import { toEventHistory } from '$lib/models/event-history';
 import { isSortOrder } from '$lib/utilities/is';
 
-import { supportsReverseOrder } from '$lib/stores/event-view';
 import type { EventSortOrder } from '$lib/stores/event-view';
 
 export type FetchEventsParameters = NamespaceScopedRequest &

--- a/src/lib/stores/api-pagination.test.ts
+++ b/src/lib/stores/api-pagination.test.ts
@@ -474,6 +474,27 @@ describe('createPaginationStore with custom pageSizeOptions', () => {
     expect(pageSize).toBe(100);
   });
 
+  it('should set correct getInitialPageSize with defaultPageSize', () => {
+    const options = [10, 25, 50];
+    const defaultPageSize = 25;
+    const pageSize = getInitialPageSize(options, defaultPageSize);
+    expect(pageSize).toBe(25);
+  });
+
+  it('should set correct getInitialPageSize with defaultPageSize that does not match options', () => {
+    const options = [10, 25, 50];
+    const defaultPageSize = 20;
+    const pageSize = getInitialPageSize(options, defaultPageSize);
+    expect(pageSize).toBe(20);
+  });
+
+  it('should set fallback getInitialPageSize with bad defaultPageSize', () => {
+    const options = [10, 25, 50];
+    const defaultPageSize = 'cats';
+    const pageSize = getInitialPageSize(options, defaultPageSize);
+    expect(pageSize).toBe(10);
+  });
+
   it('should set default values', () => {
     const store = createPaginationStore(['10', '20', '50']);
 

--- a/src/lib/stores/api-pagination.test.ts
+++ b/src/lib/stores/api-pagination.test.ts
@@ -26,6 +26,7 @@ describe('createPaginationStore with default pageSizeOptions', () => {
       activeIndex,
       indexData,
       pageSize,
+      previousPageSize,
       hasNext,
       hasPrevious,
     } = get(store);
@@ -39,6 +40,7 @@ describe('createPaginationStore with default pageSizeOptions', () => {
     expect(indexEnd).toBe(0);
     expect(indexData).toStrictEqual({});
     expect(pageSize).toBe(100);
+    expect(previousPageSize).toBe(100);
     expect(activeIndex).toBe(0);
     expect(hasPrevious).toBe(false);
     expect(hasNext).toBe(false);
@@ -432,6 +434,7 @@ describe('createPaginationStore with default pageSizeOptions', () => {
       activeIndex,
       indexData,
       pageSize,
+      previousPageSize,
       hasNext,
       hasPrevious,
     } = get(store);
@@ -445,23 +448,11 @@ describe('createPaginationStore with default pageSizeOptions', () => {
     expect(indexEnd).toBe(0);
     expect(indexData).toStrictEqual({});
     expect(pageSize).toBe(100);
+    expect(previousPageSize).toBe(100);
     expect(activeIndex).toBe(0);
     expect(hasPrevious).toBe(false);
     expect(hasNext).toBe(false);
   });
-
-  // it('should set hasNext to false and not update items if next page has no items', () => {
-  //   store.setNextPageToken('token1', items);
-
-  //   const { hasNext: initialHasNext } = get(store);
-  //   expect(initialHasNext).toBe(true);
-
-  //   store.setNextPageToken('', []);
-
-  //   const { hasNext, items: storeItems } = get(store);
-  //   expect(hasNext).toBe(false);
-  //   expect(storeItems).toEqual(items);
-  // });
 });
 
 describe('createPaginationStore with custom pageSizeOptions', () => {
@@ -496,6 +487,7 @@ describe('createPaginationStore with custom pageSizeOptions', () => {
       indexEnd,
       indexData,
       pageSize,
+      previousPageSize,
       activeIndex,
       hasNext,
       hasPrevious,
@@ -510,6 +502,42 @@ describe('createPaginationStore with custom pageSizeOptions', () => {
     expect(indexEnd).toBe(0);
     expect(indexData).toStrictEqual({});
     expect(pageSize).toBe(10);
+    expect(previousPageSize).toBe(10);
+    expect(activeIndex).toBe(0);
+    expect(hasPrevious).toBe(false);
+    expect(hasNext).toBe(false);
+  });
+
+  it('should resetPageSize', () => {
+    const store = createPaginationStore(['10', '20', '50']);
+    store.resetPageSize(50);
+
+    const {
+      key,
+      loading,
+      updating,
+      index,
+      hasNextIndexData,
+      indexStart,
+      indexEnd,
+      indexData,
+      pageSize,
+      previousPageSize,
+      activeIndex,
+      hasNext,
+      hasPrevious,
+    } = get(store);
+
+    expect(key).toBe('per-page');
+    expect(loading).toBe(true);
+    expect(updating).toBe(false);
+    expect(index).toBe(0);
+    expect(hasNextIndexData).toBe(false);
+    expect(indexStart).toBe(0);
+    expect(indexEnd).toBe(0);
+    expect(indexData).toStrictEqual({});
+    expect(pageSize).toBe(50);
+    expect(previousPageSize).toBe(50);
     expect(activeIndex).toBe(0);
     expect(hasPrevious).toBe(false);
     expect(hasNext).toBe(false);

--- a/src/lib/stores/api-pagination.ts
+++ b/src/lib/stores/api-pagination.ts
@@ -70,11 +70,11 @@ const setFirstOption = (options: string[] | number[]) => {
 
 export const getInitialPageSize = (
   options: string[] | number[],
-  defaultPageSize: string | number | undefined,
+  defaultPageSize: string | number | undefined = undefined,
 ) => {
   if (defaultPageSize) {
     const optionAsInt = parseInt(defaultPageSize.toString());
-    if (!isNaN(optionAsInt)) return setFirstOption(options);
+    if (isNaN(optionAsInt)) return setFirstOption(options);
     return optionAsInt;
   } else {
     return setFirstOption(options);
@@ -83,7 +83,7 @@ export const getInitialPageSize = (
 
 export function createPaginationStore(
   pageSizeOptions: string[] | number[] = options,
-  defaultPageSize: string | number | undefined,
+  defaultPageSize: string | number | undefined = undefined,
 ): PaginationStore {
   const initialPageSize = getInitialPageSize(pageSizeOptions, defaultPageSize);
   const paginationStore = writable({

--- a/src/lib/stores/api-pagination.ts
+++ b/src/lib/stores/api-pagination.ts
@@ -60,18 +60,32 @@ const defaultStore: PaginationItems = {
 
 export type PaginationStore = PaginationMethods & Readable<PaginationItems>;
 
-export const getInitialPageSize = (options: string[]) => {
+const setFirstOption = (options: string[] | number[]) => {
   const defaultOption = options[0];
   if (!defaultOption) return defaultItemsPerPage;
-  const optionAsInt = parseInt(defaultOption);
+  const optionAsInt = parseInt(defaultOption.toString());
   if (isNaN(optionAsInt)) return defaultItemsPerPage;
   return optionAsInt;
 };
 
+export const getInitialPageSize = (
+  options: string[] | number[],
+  defaultPageSize: string | number | undefined,
+) => {
+  if (defaultPageSize) {
+    const optionAsInt = parseInt(defaultPageSize.toString());
+    if (!isNaN(optionAsInt)) return setFirstOption(options);
+    return optionAsInt;
+  } else {
+    return setFirstOption(options);
+  }
+};
+
 export function createPaginationStore(
-  pageSizeOptions: string[] = options,
+  pageSizeOptions: string[] | number[] = options,
+  defaultPageSize: string | number | undefined,
 ): PaginationStore {
-  const initialPageSize = getInitialPageSize(pageSizeOptions);
+  const initialPageSize = getInitialPageSize(pageSizeOptions, defaultPageSize);
   const paginationStore = writable({
     ...defaultStore,
     previousPageSize: initialPageSize,

--- a/src/lib/stores/api-pagination.ts
+++ b/src/lib/stores/api-pagination.ts
@@ -15,7 +15,7 @@ type PaginationMethods = {
   previousPage: () => void;
   setUpdating: () => void;
   reset: () => void;
-  resetPageSize: () => void;
+  resetPageSize: (pageSize: number) => void;
   nextRow: () => void;
   previousRow: () => void;
   setActiveIndex: (activeIndex: number) => void;
@@ -28,6 +28,7 @@ type PaginationItems = {
   hasNext: boolean;
   hasPrevious: boolean;
   index: number;
+  previousPageSize: number;
   pageSize: number;
   indexData: Record<
     number,
@@ -47,6 +48,7 @@ const defaultStore: PaginationItems = {
   hasNext: false,
   hasPrevious: false,
   index: 0,
+  previousPageSize: defaultItemsPerPage,
   pageSize: defaultItemsPerPage,
   indexData: {},
   visibleItems: [],
@@ -72,6 +74,7 @@ export function createPaginationStore(
   const initialPageSize = getInitialPageSize(pageSizeOptions);
   const paginationStore = writable({
     ...defaultStore,
+    previousPageSize: initialPageSize,
     pageSize: initialPageSize,
   });
   const { set, update } = paginationStore;
@@ -197,12 +200,15 @@ export function createPaginationStore(
     return { ..._store, activeIndex };
   };
 
-  const resetPageSize = (_store: PaginationItems) => {
+  const resetPageSize = (_store: PaginationItems, pageSize) => {
     return {
       ..._store,
+      pageSize,
+      previousPageSize: pageSize,
       index: 0,
       indexData: {},
-      updating: true,
+      loading: true,
+      updating: false,
     };
   };
 
@@ -214,7 +220,8 @@ export function createPaginationStore(
     previousPage: () => update((store) => setPreviousPage(store)),
     setUpdating: () => update((store) => ({ ...store, updating: true })),
     reset: () => set(defaultStore),
-    resetPageSize: () => update((store) => resetPageSize(store)),
+    resetPageSize: (pageSize) =>
+      update((store) => resetPageSize(store, pageSize)),
     nextRow: () => update((store) => setNextRow(store)),
     previousRow: () => update((store) => setPreviousRow(store)),
     setActiveIndex: (activeIndex: number) =>


### PR DESCRIPTION
## What was changed
1. Add back `empty` slot to support custom no results pages and default 'No items' text if no visibleItems
2. Trigger resetPageSize and initialPageFetch when the page size changes.

## Why?
Support custom no items UI and fix bug when picking a new page size in the dropdown doesn't trigger a refetch with the page size.