### PR TITLE
Add back No Events Match for empty slot for Event History

### DIFF
--- a/cypress/integration/events-in-ascending-order-in-json-view.spec.js
+++ b/cypress/integration/events-in-ascending-order-in-json-view.spec.js
@@ -50,7 +50,6 @@ describe('Fallback to Ascending Ordering of Event History on Older Versions of T
     cy.wait('@workflow-api');
     cy.wait('@event-history-start');
     cy.wait('@event-history-end');
-    cy.wait('@event-history-descending');
 
     cy.get('[data-cy="json"]').click();
 

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -10,6 +10,7 @@
   import ApiPagination from '$lib/holocene/api-pagination.svelte';
   import { groupEvents } from '$lib/models/event-groups';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
+  import EmptyState from '$lib/holocene/empty-state.svelte';
 
   export let compact = false;
 
@@ -77,5 +78,17 @@
         <EventEmptyRow />
       {/each}
     </EventSummaryTable>
+    <div slot="empty">
+      <EventSummaryTable {updating} {compact} on:expandAll={handleExpandChange}>
+        <tr>
+          <td colspan="6">
+            <EmptyState
+              title="No Events Match"
+              content="There are no events that match your filters or selected view. Adjust your filters or view to see your events."
+            />
+          </td>
+        </tr>
+      </EventSummaryTable>
+    </div>
   </ApiPagination>
 {/key}


### PR DESCRIPTION
## What was changed
Add No Events Match EmptyState component
Remove unused api mock in test for ascending json view

## Why?
Fix Cypress tests

