### PR TITLE
reinstate rsync script for correct package types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format": "prettier --write --plugin-search-dir=. . && stylelint \"src/**/*.{css,postcss,svelte}\" --fix",
     "cypress": "concurrently \"pnpm run dev:test\" \"cypress open\"",
     "cypress:run": "cypress run",
-    "package": "svelte-package",
+    "package": "svelte-package && rsync -r ./package/lib/ ./package/ && rm -rf ./package/lib",
     "package:patch": "pnpm version patch && svelte-package",
     "package:minor": "pnpm version minor && svelte-package",
     "package:major": "pnpm version major && svelte-package",


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add back our `rsync` script when we build the svelte package cause there's still wonkiness with how svelte-package generates types.
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
