### PR TITLE
Remove isWorkflowsPage check

### DIFF
--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -8,21 +8,18 @@ import {
 import { withLoading } from '$lib/utilities/stores/with-loading';
 
 import type { StartStopNotifier } from 'svelte/store';
-import { publicPath } from '$lib/utilities/get-public-path';
 import { supportsAdvancedVisibility } from './bulk-actions';
 
 export const refresh = writable(0);
+
 const namespace = derived([page], ([$page]) => $page.params.namespace);
 const query = derived([page], ([$page]) => $page.url.searchParams.get('query'));
-const path = derived([page], ([$page]) => $page.url.pathname);
-
 const parameters = derived(
-  [namespace, query, path, refresh, supportsAdvancedVisibility],
-  ([$namespace, $query, $path, $refresh, $supportsAdvancedVisibility]) => {
+  [namespace, query, refresh, supportsAdvancedVisibility],
+  ([$namespace, $query, $refresh, $supportsAdvancedVisibility]) => {
     return {
       namespace: $namespace,
       query: $query,
-      path: $path,
       refresh: $refresh,
       supportsAdvancedVisibility: $supportsAdvancedVisibility,
     };
@@ -35,29 +32,24 @@ const setCounts = (_workflowCount: { totalCount: number; count: number }) => {
 
 const updateWorkflows: StartStopNotifier<WorkflowExecution[]> = (set) => {
   return parameters.subscribe(
-    ({ namespace, query, path, supportsAdvancedVisibility }) => {
-      const isWorkflowsPage =
-        path == `${publicPath}/namespaces/${namespace}/workflows`;
-
-      if (isWorkflowsPage) {
-        withLoading(loading, updating, async () => {
-          const { workflows, error } = await fetchAllWorkflows(namespace, {
-            query,
-          });
-          set(workflows);
-
-          if (supportsAdvancedVisibility) {
-            const workflowCount = await fetchWorkflowCount(namespace, query);
-            setCounts(workflowCount);
-          }
-
-          if (error) {
-            workflowError.set(error);
-          } else {
-            workflowError.set('');
-          }
+    ({ namespace, query, supportsAdvancedVisibility }) => {
+      withLoading(loading, updating, async () => {
+        const { workflows, error } = await fetchAllWorkflows(namespace, {
+          query,
         });
-      }
+        set(workflows);
+
+        if (supportsAdvancedVisibility) {
+          const workflowCount = await fetchWorkflowCount(namespace, query);
+          setCounts(workflowCount);
+        }
+
+        if (error) {
+          workflowError.set(error);
+        } else {
+          workflowError.set('');
+        }
+      });
     },
   );
 };


### PR DESCRIPTION
## What was changed
Before the SvelteKit upgrade, we needed the isWorkflowsPage check on the workflows store to prevent over-fetching workflows. However, that check would return false if a namespace included `|` due to the encoding of that character with svelte.

With the upgrade, we no longer need this check. 

## Why?
Fix issue with switching to namespaces with `|` in them. It would never load the workflows.

## Checklist
2. How was this tested:
Tested locally in both ui and cloud-ui with namespaces with `|` in them. Also checked other namespace characters.
