### PR TITLE
Include credentials with the data codec decode request

### DIFF
--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -39,6 +39,7 @@ export async function convertPayloadsWithCodec({
   const encoderResponse: Promise<Payloads> = fetch(endpoint + '/decode', {
     headers,
     method: 'POST',
+    credentials: 'include',
     body: stringifyWithBigInt(payloads),
   })
     .then((r) => r.json())

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -276,6 +276,28 @@ describe('convertPayloadToJsonWithCodec', () => {
     const dataConverterStatus = get(lastDataEncoderStatus);
     expect(dataConverterStatus).toEqual('notRequested');
   });
+  it('Should include credentials with the request for cookie based authentication of data converters', async () => {
+    const mockFetch = vi.fn(async () => {
+      return {
+        json: () => Promise.resolve({ payloads: [JsonPlainEncoded] }),
+      };
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const endpoint = 'http://localhost:1337';
+    await convertPayloadToJsonWithCodec({
+      attributes: parseWithBigInt(stringifyWithBigInt(workflowStartedEvent)),
+      namespace: 'default',
+      settings: {
+        codec: {
+          endpoint,
+        },
+      },
+    });
+
+    expect(mockFetch).toBeCalledWith(expect.any(String), expect.objectContaining({credentials: 'include'}))
+  })
 });
 
 // Integration test

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -296,8 +296,11 @@ describe('convertPayloadToJsonWithCodec', () => {
       },
     });
 
-    expect(mockFetch).toBeCalledWith(expect.any(String), expect.objectContaining({credentials: 'include'}))
-  })
+    expect(mockFetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
 });
 
 // Integration test


### PR DESCRIPTION
## What was changed

The [`{credentials: 'include'}`](https://developer.mozilla.org/en-US/docs/Web/API/fetch#credentials) is added to the `fetch` request which performs the data conversions.

## Why?

Slack message: https://temporalio.slack.com/archives/C011AAP3GFP/p1671643822741769

We don't use the authorization header to authenticate users internally but instead use a browser cookie. Without this option the `POST` request doesn't contain this cookie (as the request is cross-origin) and so is rejected before it can reach the data converter.

## Checklist

_How was this tested?_

I've added a unit test for this but admittedly was not able to test this end-to-end due to limitations that mean that it's difficult for us to deploy a Docker image that isn't from one of your releases.

_Any docs updates needed?_

I don't believe so.