### PR TITLE
Set language to text for query page code block to render with new lines

### DIFF
--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { getQuery, getQueryTypes } from '$lib/services/query-service';
-  import { workflowRun } from '$lib/stores/workflow-run';
 
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Select from '$lib/holocene/select/simple-select.svelte';

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -75,7 +75,7 @@
     </div>
     <div class="flex items-start h-full">
       {#await queryResult then result}
-        <CodeBlock content={result} />
+        <CodeBlock content={result} language="text" />
       {/await}
     </div>
   {:catch _error}


### PR DESCRIPTION
## What was changed
Don't parse content in workflow query result to show new lines with /n in them. We already do this for stack trace page.

