### PR TITLE
Stop propagation on keydown of inputs

### DIFF
--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -71,6 +71,7 @@
       autocomplete={autocomplete ? 'on' : 'off'}
       bind:value
       on:input
+      on:keydown|stopPropagation
       on:change
       on:focus
       on:blur


### PR DESCRIPTION
## What was changed
Stop propagation of keydown on inputs. This prevents keyboard navigation from occurring on input typing.

## Why?
Small UX fix, don't navigation if a navigation key is active on page on input typing.

