### PR TITLE
Fix lint issue in handleErrors; add type casting to `has`

### DIFF
--- a/src/lib/components/hamburger-header.svelte
+++ b/src/lib/components/hamburger-header.svelte
@@ -3,7 +3,7 @@
 
   import { fly } from 'svelte/transition';
 
-  import { hasKeys } from '$lib/utilities/has';
+  import { hasAnyKeys } from '$lib/utilities/has';
 
   import DataEncoderStatus from '$lib/holocene/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
@@ -30,7 +30,7 @@
     </a>
   </div>
   <div class="col-span-4 flex items-center justify-end gap-4">
-    {#if hasKeys(user)}
+    {#if hasAnyKeys(user)}
       <DataEncoderStatus />
     {/if}
   </div>

--- a/src/lib/components/navigation-header.svelte
+++ b/src/lib/components/navigation-header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { hasKeys } from '$lib/utilities/has';
+  import { hasAnyKeys } from '$lib/utilities/has';
   import DataEncoderStatus from '$lib/holocene/data-encoder-status.svelte';
   import FeedbackButton from '$lib/components/feedback-button.svelte';
   import Logo from '$lib/vendor/logo.svg';
@@ -19,7 +19,7 @@
     <slot name="links" />
   </div>
   <div class="col-span-5 col-end-13 flex items-center justify-end gap-4">
-    {#if hasKeys(user)}
+    {#if hasAnyKeys(user)}
       <DataEncoderStatus />
     {/if}
     <FeedbackButton />

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -70,11 +70,11 @@ const hasStatusCode = (
   statusCode: number | string,
 ): error is TemporalAPIError => {
   if (has(error, 'statusCode')) {
-    return error?.statusCode === statusCode;
+    return error.statusCode === statusCode;
   }
 
   if (has(error, 'status')) {
-    return error?.status === statusCode;
+    return error.status === statusCode;
   }
 
   return false;

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -13,7 +13,6 @@ export const handleError = (
   errors = networkError,
   isBrowser = browser,
 ): void => {
-  console.log({ error });
   if (typeof error === 'string') {
     return toasts.push({ variant: 'error', message: error });
   }

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -2,24 +2,32 @@ import { browser } from '$app/environment';
 import { networkError } from '$lib/stores/error';
 import { toaster } from '$lib/stores/toaster';
 import { isNetworkError } from './is-network-error';
-import type { APIErrorResponse } from './request-from-api';
 import { routeForLoginPage } from './route-for';
+import { has } from './has';
 
-// This will eventually be expanded on.
+import type { APIErrorResponse, TemporalAPIError } from './request-from-api';
+
 export const handleError = (
-  error: any,
+  error: unknown,
   toasts = toaster,
   errors = networkError,
   isBrowser = browser,
 ): void => {
+  console.log({ error });
+  if (typeof error === 'string') {
+    return toasts.push({ variant: 'error', message: error });
+  }
+
+  if (error instanceof Error) {
+    return toasts.push({ variant: 'error', message: error.message });
+  }
+
   if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage(error?.message));
-    return;
+    return window.location.assign(routeForLoginPage(error?.message));
   }
 
   if (isForbidden(error) && isBrowser) {
-    window.location.assign(routeForLoginPage(error?.message));
-    return;
+    return window.location.assign(routeForLoginPage(error?.message));
   }
 
   if (isNetworkError(error)) {
@@ -30,14 +38,6 @@ export const handleError = (
     // Re-throw error to prevent other code from attempting to render
     errors.set(error);
     throw error;
-  }
-
-  if (typeof error === 'string') {
-    toasts.push({ variant: 'error', message: error });
-  }
-
-  if (error instanceof Error) {
-    toasts.push({ variant: 'error', message: error.message });
   }
 };
 
@@ -58,10 +58,25 @@ export const handleUnauthorizedOrForbiddenError = (
   }
 };
 
-export const isUnauthorized = (error: any): boolean => {
-  return error?.statusCode === 401 || error?.status === 401;
+export const isUnauthorized = (error: unknown): error is TemporalAPIError => {
+  return hasStatusCode(error, 401);
 };
 
-export const isForbidden = (error: any): boolean => {
-  return error?.statusCode === 403 || error?.status === 403;
+export const isForbidden = (error: unknown): error is TemporalAPIError => {
+  return hasStatusCode(error, 403);
+};
+
+const hasStatusCode = (
+  error: unknown,
+  statusCode: number | string,
+): error is TemporalAPIError => {
+  if (has(error, 'statusCode')) {
+    return error?.statusCode === statusCode;
+  }
+
+  if (has(error, 'status')) {
+    return error?.status === statusCode;
+  }
+
+  return false;
 };

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { has, hasAnyKeys } from './has';
+import { has, hasAnyKeys, hasKeys } from './has';
 
 describe('has', () => {
   it('returns true if an object has a key', () => {
@@ -46,5 +46,27 @@ describe('hasAnyKeys', () => {
     expect(
       hasAnyKeys(true as unknown as Parameters<typeof hasAnyKeys>[0]),
     ).toBe(false);
+  });
+});
+
+describe('hasKeys', () => {
+  it('returns true if an object has a key', () => {
+    const source = { foo: 123 };
+    expect(hasKeys(source, 'foo')).toBe(true);
+  });
+
+  it('returns true if an object has a multiple keys', () => {
+    const source = { foo: 123, bar: 456 };
+    expect(hasKeys(source, 'foo', 'bar')).toBe(true);
+  });
+
+  it('returns false if an object has a no keys', () => {
+    const source = {};
+    expect(hasKeys(source, 'foo', 'bar')).toBe(false);
+  });
+
+  it('returns false if an object does not have the required keys', () => {
+    const source = { foo: 123 };
+    expect(hasKeys(source, 'foo', 'bar')).toBe(false);
   });
 });

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -40,26 +40,18 @@ describe('hasAnyKeys', () => {
   });
 
   it('should return false if given null', () => {
-    expect(
-      hasAnyKeys(null as unknown as Parameters<typeof hasAnyKeys>[0]),
-    ).toBe(false);
+    expect(hasAnyKeys(null)).toBe(false);
   });
 
   it('should return false if given undefined', () => {
-    expect(
-      hasAnyKeys(undefined as unknown as Parameters<typeof hasAnyKeys>[0]),
-    ).toBe(false);
+    expect(hasAnyKeys(undefined)).toBe(false);
   });
 
   it('should return false if given a number', () => {
-    expect(hasAnyKeys(3 as unknown as Parameters<typeof hasAnyKeys>[0])).toBe(
-      false,
-    );
+    expect(hasAnyKeys(3)).toBe(false);
   });
 
   it('should return false if given a boolean', () => {
-    expect(
-      hasAnyKeys(true as unknown as Parameters<typeof hasAnyKeys>[0]),
-    ).toBe(false);
+    expect(hasAnyKeys(true)).toBe(false);
   });
 });

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { has, hasKeys } from './has';
+import { has, hasAnyKeys } from './has';
 
 describe('has', () => {
   it('returns true if an object has a key', () => {
@@ -13,36 +13,38 @@ describe('has', () => {
   });
 });
 
-describe('hasKeys', () => {
+describe('hasAnyKeys', () => {
   it('returns true if an object has keys', () => {
     const source = { foo: 123 };
-    expect(hasKeys(source)).toBe(true);
+    expect(hasAnyKeys(source)).toBe(true);
   });
 
   it('returns false if an object has no keys', () => {
     const source = {};
-    expect(hasKeys(source)).toBe(false);
+    expect(hasAnyKeys(source)).toBe(false);
   });
 
   it('should return false if given null', () => {
-    expect(hasKeys(null as unknown as Parameters<typeof hasKeys>[0])).toBe(
-      false,
-    );
+    expect(
+      hasAnyKeys(null as unknown as Parameters<typeof hasAnyKeys>[0]),
+    ).toBe(false);
   });
 
   it('should return false if given undefined', () => {
-    expect(hasKeys(undefined as unknown as Parameters<typeof hasKeys>[0])).toBe(
-      false,
-    );
+    expect(
+      hasAnyKeys(undefined as unknown as Parameters<typeof hasAnyKeys>[0]),
+    ).toBe(false);
   });
 
   it('should return false if given a number', () => {
-    expect(hasKeys(3 as unknown as Parameters<typeof hasKeys>[0])).toBe(false);
+    expect(hasAnyKeys(3 as unknown as Parameters<typeof hasAnyKeys>[0])).toBe(
+      false,
+    );
   });
 
   it('should return false if given a boolean', () => {
-    expect(hasKeys(true as unknown as Parameters<typeof hasKeys>[0])).toBe(
-      false,
-    );
+    expect(
+      hasAnyKeys(true as unknown as Parameters<typeof hasAnyKeys>[0]),
+    ).toBe(false);
   });
 });

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -26,6 +26,27 @@ describe('has', () => {
     const source = { foo: 123 };
     expect(has(source, 'foo', 'bar')).toBe(false);
   });
+
+  it('returns false if an object has no keys', () => {
+    const source = {};
+    expect(has(source)).toBe(false);
+  });
+
+  it('should return false if given null', () => {
+    expect(has(null)).toBe(false);
+  });
+
+  it('should return false if given undefined', () => {
+    expect(has(undefined)).toBe(false);
+  });
+
+  it('should return false if given a number', () => {
+    expect(has(3)).toBe(false);
+  });
+
+  it('should return false if given a boolean', () => {
+    expect(has(true)).toBe(false);
+  });
 });
 
 describe('hasAnyKeys', () => {

--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { has, hasAnyKeys, hasKeys } from './has';
+import { has, hasAnyKeys } from './has';
 
 describe('has', () => {
   it('returns true if an object has a key', () => {
@@ -10,6 +10,21 @@ describe('has', () => {
   it('returns false if an object does not have key', () => {
     const source = { foo: 123 };
     expect(has(source, 'bar')).toBe(false);
+  });
+
+  it('returns true if an object has a multiple keys', () => {
+    const source = { foo: 123, bar: 456 };
+    expect(has(source, 'foo', 'bar')).toBe(true);
+  });
+
+  it('returns false if an object has a no keys', () => {
+    const source = {};
+    expect(has(source, 'foo', 'bar')).toBe(false);
+  });
+
+  it('returns false if an object does not have the required keys', () => {
+    const source = { foo: 123 };
+    expect(has(source, 'foo', 'bar')).toBe(false);
   });
 });
 
@@ -46,27 +61,5 @@ describe('hasAnyKeys', () => {
     expect(
       hasAnyKeys(true as unknown as Parameters<typeof hasAnyKeys>[0]),
     ).toBe(false);
-  });
-});
-
-describe('hasKeys', () => {
-  it('returns true if an object has a key', () => {
-    const source = { foo: 123 };
-    expect(hasKeys(source, 'foo')).toBe(true);
-  });
-
-  it('returns true if an object has a multiple keys', () => {
-    const source = { foo: 123, bar: 456 };
-    expect(hasKeys(source, 'foo', 'bar')).toBe(true);
-  });
-
-  it('returns false if an object has a no keys', () => {
-    const source = {};
-    expect(hasKeys(source, 'foo', 'bar')).toBe(false);
-  });
-
-  it('returns false if an object does not have the required keys', () => {
-    const source = { foo: 123 };
-    expect(hasKeys(source, 'foo', 'bar')).toBe(false);
   });
 });

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -1,19 +1,12 @@
 import { isObject } from './is';
 
-export const has = <K extends string, V = unknown>(
+export const has = <K extends Readonly<string[]>, V = unknown>(
   target: unknown,
-  property: K,
-): target is Record<K, V> => {
-  return Object.prototype.hasOwnProperty.call(target, property);
-};
-
-export const hasKeys = <K extends Readonly<string[]>>(
-  target: unknown,
-  ...keys: K
-): target is Record<K[number], unknown> => {
-  if (!hasAnyKeys) return false;
-  for (const key of keys) {
-    if (!has(target, key)) return false;
+  ...properties: K
+): target is Record<K[number], V> => {
+  if (!hasAnyKeys(target)) return false;
+  for (const property of properties) {
+    if (!Object.prototype.hasOwnProperty.call(target, property)) return false;
   }
   return true;
 };

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -18,9 +18,9 @@ export const hasKeys = <K extends Readonly<string[]>>(
   return true;
 };
 
-export const hasAnyKeys = (obj: {
-  [key: string | number | symbol]: unknown;
-}): boolean => {
+export const hasAnyKeys = (
+  obj: unknown,
+): obj is ReturnType<typeof isObject> => {
   if (!isObject(obj)) return false;
   return !!Object.keys(obj).length;
 };

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -7,7 +7,18 @@ export const has = <K extends string, V = unknown>(
   return Object.prototype.hasOwnProperty.call(target, property);
 };
 
-export const hasKeys = (obj: {
+export const hasKeys = <K extends Readonly<string[]>>(
+  target: unknown,
+  ...keys: K
+): target is Record<K[number], unknown> => {
+  if (!hasAnyKeys) return false;
+  for (const key of keys) {
+    if (!has(target, key)) return false;
+  }
+  return true;
+};
+
+export const hasAnyKeys = (obj: {
   [key: string | number | symbol]: unknown;
 }): boolean => {
   if (!isObject(obj)) return false;

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -1,6 +1,9 @@
 import { isObject } from './is';
 
-export const has = (target: unknown, property: string): boolean => {
+export const has = <K extends string, V = unknown>(
+  target: unknown,
+  property: K,
+): target is Record<K, V> => {
   return Object.prototype.hasOwnProperty.call(target, property);
 };
 

--- a/src/lib/utilities/is-network-error.test.ts
+++ b/src/lib/utilities/is-network-error.test.ts
@@ -1,20 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import { isNetworkError } from './is-network-error';
 
-const networkErr = {
+const networkError = {
   statusCode: 200,
-  statusText: "Error'd",
+  statusText: 'Error',
   response: {},
 };
 
 describe('isNetworkError', () => {
   it('Should infer a networkError error with the correct shape', () => {
     try {
-      throw networkErr;
+      throw networkError;
     } catch (err) {
       expect(isNetworkError(err)).toBeTruthy();
     }
   });
+
   it('Should not infer a networkError error with the incorrecrt shape', () => {
     try {
       throw { somethingElse: '' };
@@ -22,6 +23,7 @@ describe('isNetworkError', () => {
       expect(isNetworkError(err)).toBeFalsy();
     }
   });
+
   it("Should not infer a networkError when it's a js error", () => {
     try {
       throw new Error('error');
@@ -29,6 +31,7 @@ describe('isNetworkError', () => {
       expect(isNetworkError(err)).toBeFalsy();
     }
   });
+
   it("Should not infer a networkError when it's a promise", async () => {
     try {
       await Promise.reject();

--- a/src/lib/utilities/is-network-error.ts
+++ b/src/lib/utilities/is-network-error.ts
@@ -1,8 +1,8 @@
-import { hasKeys } from './has';
+import { has } from './has';
 
 export function isNetworkError(
   error: unknown | NetworkError,
 ): error is NetworkError {
   if (!error) return false;
-  return hasKeys(error, 'statusCode', 'statusText', 'response');
+  return has(error, 'statusCode', 'statusText', 'response');
 }

--- a/src/lib/utilities/is-network-error.ts
+++ b/src/lib/utilities/is-network-error.ts
@@ -1,10 +1,8 @@
+import { hasKeys } from './has';
+
 export function isNetworkError(
   error: unknown | NetworkError,
 ): error is NetworkError {
-  const networkErr = error as NetworkError;
-  return (
-    networkErr?.statusCode !== undefined &&
-    networkErr?.statusText !== undefined &&
-    networkErr?.response !== undefined
-  );
+  if (!error) return false;
+  return hasKeys(error, 'statusCode', 'statusText', 'response');
 }

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -16,6 +16,7 @@ export type RetryCallback = (retriesRemaining: number) => void;
 export type APIErrorResponse = {
   status: number;
   statusText: string;
+  statusCode?: number;
   body: TemporalAPIError;
 };
 


### PR DESCRIPTION
- Uses `unknown` instead of any in `handleErrors`.
- `has` now lets TypeScript know that an object has a property that it just confirmed existed.
