### PR TITLE
Add bold class to Alert component

### DIFF
--- a/src/lib/components/workflow/workflow-typed-error.svelte
+++ b/src/lib/components/workflow/workflow-typed-error.svelte
@@ -170,12 +170,7 @@
 </script>
 
 {#if title || copy}
-  <Alert
-    class="rounded-xl border-[3px]"
-    icon="warning"
-    intent="warning"
-    {title}
-  >
+  <Alert bold icon="warning" intent="warning" {title}>
     <p>
       {copy}
       {#if contactSupport}

--- a/src/lib/holocene/alert.story.svelte
+++ b/src/lib/holocene/alert.story.svelte
@@ -16,9 +16,18 @@
       </p>
     </Alert>
   </Hst.Variant>
-
   <Hst.Variant title="An Error Alert">
     <Alert icon="error" intent="error" title="Alert Title">
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut cupiditate
+        exercitationem quia quibusdam excepturi rem saepe dolore quas, odit vero
+        sed rerum necessitatibus minima nobis, ullam minus inventore voluptates
+        itaque?
+      </p>
+    </Alert>
+  </Hst.Variant>
+  <Hst.Variant title="A Bold Error Alert">
+    <Alert icon="error" intent="error" title="Alert Title" bold>
       <p>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut cupiditate
         exercitationem quia quibusdam excepturi rem saepe dolore quas, odit vero

--- a/src/lib/holocene/alert.svelte
+++ b/src/lib/holocene/alert.svelte
@@ -6,9 +6,10 @@
 
   export let title: string;
   export let icon: IconName = null;
+  export let bold = false;
 </script>
 
-<div class="alert rounded-md border {intent} {$$props.class}">
+<div class="alert {intent} {$$props.class}" class:bold>
   {#if icon}
     <div>
       <Icon name={icon} />
@@ -26,7 +27,11 @@
 
 <style lang="postcss">
   .alert {
-    @apply flex p-5 font-secondary text-sm;
+    @apply flex rounded-md border p-5 font-secondary text-sm;
+  }
+
+  .alert.bold {
+    @apply rounded-xl border-[3px];
   }
 
   .alert.success {

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -140,8 +140,9 @@
   <slot name="error" />
 {:else if error}
   <Alert
+    bold
     intent="error"
-    class="mb-10 rounded-xl border-[3px]"
+    class="mb-10"
     title={error?.message ?? 'Error fetching data.'}
   />
 {/if}

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -136,12 +136,7 @@
   </div>
   {#if cancelInProgress}
     <div class="mb-4" in:fly={{ duration: 200, delay: 100 }}>
-      <Alert
-        class="rounded-xl border-[3px]"
-        icon="info"
-        intent="info"
-        title="Cancel Request Sent"
-      >
+      <Alert bold icon="info" intent="info" title="Cancel Request Sent">
         The request to cancel this Workflow Execution has been sent. If the
         Workflow uses the cancellation API, it'll cancel at the next available
         opportunity.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add an optional `bold` class to the Holocene `Alert` component with `rounded-xl` and `border-[3px]`.

## Why?
<!-- Tell your future self why have you made these changes -->
Order doesn't matter in the space-separated CSS class list in Tailwind, so `class="rounded-xl border-[3px]"` on the `Alert` component was being overridden with `rounded-md border`.
 
## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: n/a
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
