### PR TITLE
Fix Holocene component props type

### DIFF
--- a/src/lib/holocene/accordion.svelte
+++ b/src/lib/holocene/accordion.svelte
@@ -2,10 +2,10 @@
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import type { IconName } from './icon/paths';
-  import type { HoloceneComponentProps } from 'src/types/holocene';
+  import type { HTMLAttributes } from 'svelte/elements';
   import { v4 } from 'uuid';
 
-  interface $$Props extends HoloceneComponentProps<'div'> {
+  interface $$Props extends HTMLAttributes<HTMLDivElement> {
     title: string;
     id?: string;
     subtitle?: string;

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -7,9 +7,9 @@
   import { options } from '$lib/stores/pagination';
   import { onMount } from 'svelte';
 
-  import type { HoloceneComponentProps } from 'src/types/holocene';
+  import type { HTMLAttributes } from 'svelte/elements';
 
-  interface $$Props extends HoloceneComponentProps<'div'> {
+  interface $$Props extends HTMLAttributes<HTMLDivElement> {
     onError?: (error: any) => void | undefined;
     onFetch: () => Promise<PaginatedRequest>;
     onShiftUp?: (event: KeyboardEvent) => void | undefined;

--- a/src/lib/holocene/json-editor.svelte
+++ b/src/lib/holocene/json-editor.svelte
@@ -16,9 +16,9 @@
     TEMPORAL_SYNTAX,
     TEMPORAL_THEME,
   } from '$lib/vendor/codemirror/theme';
-  import type { HoloceneComponentProps } from 'src/types/holocene';
+  import type { HTMLAttributes } from 'svelte/elements';
 
-  interface $$Props extends HoloceneComponentProps<'div'> {
+  interface $$Props extends HTMLAttributes<HTMLDivElement> {
     value: string;
     class?: string;
   }

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -14,10 +14,10 @@
   import { getFloatStyle } from '$lib/utilities/get-float-style';
   import Skeleton from '$lib/holocene/skeleton/index.svelte';
 
-  import type { HoloceneComponentProps } from 'src/types/holocene';
+  import type { HTMLAttributes } from 'svelte/elements';
 
   type T = $$Generic;
-  interface $$Props extends HoloceneComponentProps<'div'> {
+  interface $$Props extends HTMLAttributes<HTMLDivElement> {
     items: T[];
     floatId?: string | undefined;
     startingIndex?: string | number;

--- a/src/types/holocene.ts
+++ b/src/types/holocene.ts
@@ -1,6 +1,3 @@
-export type HoloceneComponentProps<T extends keyof HTMLElementTagNameMap> =
-  svelte.JSX.HTMLProps<HTMLElementTagNameMap[T]> & DataAttributes;
-
 export type DataAttributes = {
   // [index: `data-${string}`]: any;
   'data-cy'?: string;


### PR DESCRIPTION
Co-authored-by: Ross Edfort <ross.edfort@temporal.io>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removes `HoloceneComponentProps` and uses `HTMLAttributes[...]` from `svelte/elements` instead.

## Why?
<!-- Tell your future self why have you made these changes -->
Props were being typed to `any`.
## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: n/a
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
