### PR TITLE
Fix First on Relationships

### DIFF
--- a/src/events.d.ts
+++ b/src/events.d.ts
@@ -90,6 +90,7 @@ type CommonEventKey =
   | 'timestamp'
   | 'classification'
   | 'category'
+  | 'workerMayIgnore'
   | 'name';
 
 type CommonHistoryEvent = Pick<WorkflowEvent, CommonEventKey>;

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -2,38 +2,27 @@
   import { page } from '$app/stores';
   import { routeForEventHistory } from '$lib/utilities/route-for';
   import { workflowRun } from '$lib/stores/workflow-run';
-  import { eventHistory } from '$lib/stores/events';
 
   import Accordion from '$lib/holocene/accordion.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
   import WorkflowDetail from '$lib/components/workflow/workflow-detail.svelte';
-  import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
 
-  type WorkflowEventWithAttributes = WorkflowEvent & {
-    attributes: CombinedAttributes;
-  };
+  export let hasChildren: boolean;
+  export let hasRelationships: boolean;
+  export let first: string;
+  export let parent: WorkflowIdentifier;
+  export let next: string;
+  export let previous: string;
 
-  $: children = $workflowRun.workflow?.pendingChildren.length;
-  $: parent = $workflowRun.workflow?.parent;
-  $: lastEvent = $eventHistory.end[0] as WorkflowEventWithAttributes;
-  $: firstEvent = $eventHistory.start[0] as WorkflowEventWithAttributes;
-  $: firstExecutionRunId = firstEvent?.attributes?.firstExecutionRunId;
-  $: first =
-    firstExecutionRunId === $workflowRun.workflow?.runId
-      ? undefined // don't show first if it is the same as the current workflow run ID
-      : firstExecutionRunId;
-  $: previous = firstEvent?.attributes?.continuedExecutionRunId;
-  $: next = lastEvent?.attributes?.newExecutionRunId;
-  $: hasRelationships = parent || children || first || previous || next;
   $: ({ workflow, namespace } = $page.params);
 </script>
 
 <Accordion title="Relationships" icon="relationship">
   <div slot="summary" class="hidden flex-row gap-2 lg:flex">
     <Badge type={parent ? 'purple' : 'gray'}>{parent ? 1 : 0} Parent</Badge>
-    <Badge type={children ? 'purple' : 'gray'}
-      >{children} Pending Children</Badge
+    <Badge type={hasChildren ? 'purple' : 'gray'}
+      >{$workflowRun.workflow.pendingChildren.length} Pending Children</Badge
     >
     <Badge type={first ? 'purple' : 'gray'}>{first ? 1 : 0} First</Badge>
     <Badge type={previous ? 'purple' : 'gray'}>
@@ -118,7 +107,7 @@
         </div>
       {/if}
     </div>
-    {#if children}
+    {#if hasChildren}
       <ChildWorkflowsTable
         pendingChildren={$workflowRun.workflow.pendingChildren}
         namespace={$page.params.namespace}

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -8,11 +8,16 @@
   import Badge from '$lib/holocene/badge.svelte';
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
   import WorkflowDetail from '$lib/components/workflow/workflow-detail.svelte';
+  import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
+
+  type WorkflowEventWithAttributes = WorkflowEvent & {
+    attributes: CombinedAttributes;
+  };
 
   $: children = $workflowRun.workflow?.pendingChildren.length;
   $: parent = $workflowRun.workflow?.parent;
-  $: lastEvent = $eventHistory.end[0];
-  $: firstEvent = $eventHistory.start[0];
+  $: lastEvent = $eventHistory.end[0] as WorkflowEventWithAttributes;
+  $: firstEvent = $eventHistory.start[0] as WorkflowEventWithAttributes;
   $: firstExecutionRunId = firstEvent?.attributes?.firstExecutionRunId;
   $: first =
     firstExecutionRunId === $workflowRun.workflow?.runId

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -13,18 +13,13 @@
   $: parent = $workflowRun.workflow?.parent;
   $: lastEvent = $eventHistory.end[0];
   $: firstEvent = $eventHistory.start[0];
-  $: firstExecutionRunId =
-    firstEvent?.workflowExecutionStartedEventAttributes?.firstExecutionRunId;
+  $: firstExecutionRunId = firstEvent?.attributes?.firstExecutionRunId;
   $: first =
     firstExecutionRunId === $workflowRun.workflow?.runId
       ? undefined // don't show first if it is the same as the current workflow run ID
       : firstExecutionRunId;
-  $: previous =
-    firstEvent?.workflowExecutionStartedEventAttributes
-      ?.continuedExecutionRunId;
-  $: next =
-    lastEvent?.workflowExecutionContinuedAsNewEventAttributes
-      ?.newExecutionRunId;
+  $: previous = firstEvent?.attributes?.continuedExecutionRunId;
+  $: next = lastEvent?.attributes?.newExecutionRunId;
   $: hasRelationships = parent || children || first || previous || next;
   $: ({ workflow, namespace } = $page.params);
 </script>

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
   import { eventViewType } from '$lib/stores/event-view';
   import { getWorkflowStartedCompletedAndTaskFailedEvents } from '$lib/utilities/get-started-completed-and-task-failed-events';
+  import { getWorkflowRelationships } from '$lib/utilities/get-workflow-relationships';
   import { exportHistory } from '$lib/utilities/export-history';
   import { workflowRun } from '$lib/stores/workflow-run';
   import { eventHistory } from '$lib/stores/events';
@@ -21,6 +22,10 @@
 
   $: workflowEvents =
     getWorkflowStartedCompletedAndTaskFailedEvents($eventHistory);
+  $: workflowRelationships = getWorkflowRelationships(
+    $workflowRun,
+    $eventHistory,
+  );
 
   const onViewClick = (view: EventView) => {
     if ($page.url.searchParams.get('page')) {
@@ -32,7 +37,7 @@
 
 <section class="flex flex-col gap-4">
   <WorkflowSummary />
-  <WorkflowRelationships />
+  <WorkflowRelationships {...workflowRelationships} />
   <WorkflowStackTraceError />
   <WorkflowTypedError error={workflowEvents.error} />
   <PendingActivities />

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -9,6 +9,9 @@ export type CombinedAttributes = EventAttribute & {
   eventTime?: string;
   workflowExecutionRunId?: string;
   workflowExecutionWorkflowId?: string;
+  firstExecutionRunId?: string;
+  continuedExecutionRunId?: string;
+  newExecutionRunId?: string;
 };
 
 const keysToOmit: Readonly<Set<string>> = new Set(['header']);

--- a/src/lib/utilities/get-workflow-relationships.ts
+++ b/src/lib/utilities/get-workflow-relationships.ts
@@ -1,0 +1,59 @@
+import { isWorkflowExecutionStartedEvent } from './is-event-type';
+import { has } from './has';
+import { isString } from './is';
+
+import type { WorkflowRunWithWorkers } from '../stores/workflow-run';
+import type { StartAndEndEventHistory } from '../stores/events';
+
+const getNewExecutionId = (events: WorkflowEvents): string | undefined => {
+  for (const event of events) {
+    if (
+      has(event.attributes, 'newExecutionRunId') &&
+      isString(event.attributes.newExecutionRunId)
+    ) {
+      return event.attributes.newExecutionRunId;
+    }
+  }
+};
+
+export const getWorkflowRelationships = (
+  workflowRun: WorkflowRunWithWorkers,
+  eventHistory: StartAndEndEventHistory,
+) => {
+  const hasChildren = !!workflowRun.workflow?.pendingChildren.length;
+  const parent = workflowRun.workflow?.parent;
+
+  const workflowExecutionStartedEvent = eventHistory.start.find(
+    isWorkflowExecutionStartedEvent,
+  );
+
+  const newExecutionRunId = getNewExecutionId(eventHistory.end);
+
+  const firstExecutionRunId =
+    workflowExecutionStartedEvent?.attributes?.firstExecutionRunId;
+
+  const first =
+    firstExecutionRunId === workflowRun.workflow?.runId
+      ? undefined
+      : firstExecutionRunId;
+
+  const previous =
+    workflowExecutionStartedEvent?.attributes?.continuedExecutionRunId;
+
+  const hasRelationships = !!(
+    parent ||
+    hasChildren ||
+    first ||
+    previous ||
+    newExecutionRunId
+  );
+
+  return {
+    hasRelationships,
+    hasChildren,
+    first,
+    previous,
+    parent,
+    next: newExecutionRunId,
+  };
+};

--- a/src/workflow.d.ts
+++ b/src/workflow.d.ts
@@ -2,8 +2,6 @@ type WorkflowExecutionStatus = import('$types').WorkflowExecutionStatus;
 type WorkflowTaskFailedCause = import('$types').WorkflowTaskFailedCause;
 type ListWorkflowExecutionsResponse =
   import('$types').ListWorkflowExecutionsResponse;
-type DescribeWorkflowExecutionResponse =
-  import('$types').DescribeWorkflowExecutionResponse;
 
 type WorkflowExecutionAPIResponse = Optional<
   DescribeWorkflowExecutionResponse,
@@ -40,6 +38,8 @@ type ArchiveFilterParameters = Omit<FilterParameters, 'timeRange'> & {
   closeTime?: Duration | string;
 };
 
+type WorkflowIdentifier = IWorkflowExecution;
+
 type WorkflowExecution = {
   name: string;
   id: string;
@@ -53,7 +53,7 @@ type WorkflowExecution = {
   pendingActivities: PendingActivity[];
   stateTransitionCount: string;
   parentNamespaceId?: string;
-  parent?: IWorkflowExecution;
+  parent?: WorkflowIdentifier;
   url: string;
   isRunning: boolean;
   defaultWorkflowTaskTimeout: Duration;

--- a/src/workflow.d.ts
+++ b/src/workflow.d.ts
@@ -2,6 +2,8 @@ type WorkflowExecutionStatus = import('$types').WorkflowExecutionStatus;
 type WorkflowTaskFailedCause = import('$types').WorkflowTaskFailedCause;
 type ListWorkflowExecutionsResponse =
   import('$types').ListWorkflowExecutionsResponse;
+type DescribeWorkflowExecutionResponse =
+  import('$types').DescribeWorkflowExecutionResponse;
 
 type WorkflowExecutionAPIResponse = Optional<
   DescribeWorkflowExecutionResponse,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Account for various event types and use the combined attributes to get the `first`, `previous`, and `next` run IDs.

## Why?
<!-- Tell your future self why have you made these changes -->
E.g. the `previous` event might not be `WorkflowExecutionStarted` and therefore `workflowExecutionStartedEventAttributes` won't work.

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify `first`, `previous`, and `next` show up as expected under `Workflow details`  > `Relationships`
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
