### PR TITLE
[DT-318] Fix Summary layout in Safari

### DIFF
--- a/src/lib/components/copyable.svelte
+++ b/src/lib/components/copyable.svelte
@@ -24,7 +24,7 @@
     <Icon
       name={$copied ? 'checkmark' : 'copy'}
       stroke={color}
-      class={`${visible ? 'visible' : 'invisible group-hover:visible'} h-fit`}
+      class={`${visible ? 'visible' : 'invisible group-hover:visible'}`}
     />
   </button>
 </div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Removed `h-fit` on icon in `copyable` component.

## Why?
<!-- Tell your future self why have you made these changes -->
It was causing copyable items in the `Summary` layout to have a bigger height than they should.

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-318` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify `Summary` on the workflow detail page is correct in Chrome and Safari
- [ ] Verify other copyable elements (e.g. on the event details or workflow rows) appear as expected in Chrome and Safari
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
