### PR TITLE
Fix modal event propagation

### DIFF
--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -32,7 +32,7 @@
 
 {#if as === 'button'}
   <button
-    on:click
+    on:click|stopPropagation
     class="button {variant} {classes}"
     class:selected={active}
     class:large
@@ -61,7 +61,7 @@
 {:else}
   <a
     {href}
-    on:click
+    on:click|stopPropagation
     class="button {variant} {classes}"
     class:selected={active}
     class:large

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -62,7 +62,7 @@
   <div class="modal">
     <div
       on:keyup|stopPropagation={noop}
-      on:click={cancelModal}
+      on:click|stopPropagation={cancelModal}
       class="overlay"
     />
     <div
@@ -78,7 +78,7 @@
         <button
           aria-label={cancelText}
           class="float-right m-4"
-          on:click={cancelModal}
+          on:click|stopPropagation={cancelModal}
         >
           <Icon
             name="close"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds `stopPropagation` to `on:click` for the `Modal` and `Button` components.

## Why?
<!-- Tell your future self why have you made these changes -->
When clicking on a button to open a `Modal` the `on:click` event for closing or clicking a button on the `Modal` would propagate to the button that opens the modal, therefore the `Modal` immediately opens again and appears not to be able to be closed.

## Checklist
<!--- add/delete as needed --->

1. Closes: Part of `DT-233` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify `Modal`s (e.g. `Data Encoder`) work as expected
- [ ] Verify `Button`s work as expected
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
