### PR TITLE
Fix branch names for e2e tests.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -2,10 +2,9 @@ name: End To End Integration Tests
 
 on:
   push:
-    # branches: [main]
-    branches: [rh-integration]
-  # pull_request:
-  #   branches: [rh-integration]
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   e2e-integration:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Fixed the branch names for which the e2e integration tests workflow should trigger.

## Why?
It was still set the branch name for the PR which added the test. It needs to run on main.
