### PR TITLE
[DT-325] Move errors above summary

### DIFF
--- a/src/lib/holocene/accordion.svelte
+++ b/src/lib/holocene/accordion.svelte
@@ -15,6 +15,7 @@
     readOnly?: boolean;
     error?: string;
     onToggle?: () => void;
+    'data-cy'?: String;
   }
 
   export let title: string;

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -41,19 +41,17 @@
   <WorkflowRelationships {...workflowRelationships} />
   <WorkflowStackTraceError />
   <PendingActivities />
-  <section class="flex w-full" data-cy="inputs-results">
-    <Accordion
-      title="Input and Results"
-      icon="json"
-      class="border-gray-900"
-      data-cy="input-and-results"
-    >
-      <div class="flex gap-2">
-        <InputAndResults type="input" content={workflowEvents.input} />
-        <InputAndResults type="results" content={workflowEvents.results} />
-      </div>
-    </Accordion>
-  </section>
+  <Accordion
+    title="Input and Results"
+    icon="json"
+    class="border-gray-900"
+    data-cy="input-and-results"
+  >
+    <div class="flex w-full flex-col gap-2 lg:flex-row">
+      <InputAndResults type="input" content={workflowEvents.input} />
+      <InputAndResults type="results" content={workflowEvents.results} />
+    </div>
+  </Accordion>
   <slot name="timeline" />
   <section id="event-history">
     <nav

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -36,10 +36,10 @@
 </script>
 
 <section class="flex flex-col gap-4">
+  <WorkflowStackTraceError />
   <WorkflowTypedError error={workflowEvents.error} />
   <WorkflowSummary />
   <WorkflowRelationships {...workflowRelationships} />
-  <WorkflowStackTraceError />
   <PendingActivities />
   <Accordion
     title="Input and Results"

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -36,10 +36,10 @@
 </script>
 
 <section class="flex flex-col gap-4">
+  <WorkflowTypedError error={workflowEvents.error} />
   <WorkflowSummary />
   <WorkflowRelationships {...workflowRelationships} />
   <WorkflowStackTraceError />
-  <WorkflowTypedError error={workflowEvents.error} />
   <PendingActivities />
   <section class="flex w-full" data-cy="inputs-results">
     <Accordion


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Moved strongly typed and stack track errors above the workflow `Summary`
* Made `Input and Results` section responsive 
* Added `data-cy` prop to the `Accordion` component

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-325` <!-- add issue number here -->

2. How was this tested: n/a
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
