### PR TITLE
Fix gradient on hover in Safari

### DIFF
--- a/src/lib/components/event/event-group-details.svelte
+++ b/src/lib/components/event/event-group-details.svelte
@@ -18,6 +18,9 @@
       <tr
         class="row"
         class:active={id === selectedId}
+        class:failure={eventOrGroupIsFailureOrTimedOut(eventInGroup)}
+        class:canceled={eventOrGroupIsCanceled(eventInGroup)}
+        class:terminated={eventOrGroupIsTerminated(eventInGroup)}
         on:click|preventDefault|stopPropagation={() => onGroupClick(id)}
       >
         <td class="w-1/12" />
@@ -25,13 +28,7 @@
           <p class="truncate text-sm text-gray-500 md:text-base">{id}</p>
         </td>
         <td class="table-cell text-left">
-          <p
-            class="truncate text-sm md:text-base"
-            class:active={id === selectedId}
-            class:failure={eventOrGroupIsFailureOrTimedOut(eventInGroup)}
-            class:canceled={eventOrGroupIsCanceled(eventInGroup)}
-            class:terminated={eventOrGroupIsTerminated(eventInGroup)}
-          >
+          <p class="event-type truncate text-sm md:text-base">
             {isLocalActivityMarkerEvent(eventInGroup)
               ? 'LocalActivity'
               : eventInGroup.eventType}
@@ -52,19 +49,46 @@
     @apply cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
   }
 
-  .active.row {
+  .active {
     @apply bg-blue-50;
   }
 
   .failure {
+    @apply bg-red-50;
+  }
+
+  .failure .event-type {
     @apply text-red-700;
   }
 
   .canceled {
+    @apply bg-yellow-50;
+  }
+
+  .canceled .event-type {
     @apply text-yellow-700;
   }
 
   .terminated {
+    @apply bg-pink-50;
+  }
+
+  .terminated .event-type {
     @apply text-pink-700;
+  }
+
+  .failure:hover,
+  .active.canceled {
+    @apply bg-gradient-to-br from-red-100 to-red-200 bg-fixed;
+  }
+
+  .canceled:hover,
+  .active.canceled {
+    @apply bg-gradient-to-br from-yellow-100 to-yellow-200 bg-fixed;
+  }
+
+  .terminated:hover,
+  .active.terminated {
+    @apply bg-gradient-to-br from-pink-100 to-pink-200 bg-fixed;
   }
 </style>

--- a/src/lib/components/event/event-group-details.svelte
+++ b/src/lib/components/event/event-group-details.svelte
@@ -49,7 +49,7 @@
   }
 
   .row:hover {
-    @apply cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100;
+    @apply cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
   }
 
   .active.row {

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -150,7 +150,7 @@
   }
 
   .row:hover {
-    @apply z-50 cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100;
+    @apply z-50 cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
   }
 
   .expanded.row {
@@ -198,21 +198,21 @@
   }
 
   .active {
-    @apply z-50 cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100;
+    @apply z-50 cursor-pointer bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
   }
 
   .canceled:hover,
   .active.canceled {
-    @apply bg-gradient-to-br from-yellow-100 to-yellow-200;
+    @apply bg-gradient-to-br from-yellow-100 to-yellow-200 bg-fixed;
   }
 
   .failure:hover,
   .active.failure {
-    @apply bg-gradient-to-br from-red-100 to-red-200;
+    @apply bg-gradient-to-br from-red-100 to-red-200 bg-fixed;
   }
 
   .terminated:hover,
   .active.terminated {
-    @apply bg-gradient-to-br from-pink-100 to-pink-200;
+    @apply bg-gradient-to-br from-pink-100 to-pink-200 bg-fixed;
   }
 </style>

--- a/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
+++ b/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
@@ -148,7 +148,7 @@
 
 <style lang="postcss">
   :global(.workflow-summary-row:hover) {
-    @apply bg-gradient-to-br from-blue-100 to-purple-100;
+    @apply bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
 
     .table-link {
       @apply text-blue-700 underline decoration-blue-700;

--- a/src/lib/components/workflow/workflows-summary-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-row.svelte
@@ -105,7 +105,7 @@
 
 <style lang="postcss">
   :global(.workflow-summary-row:hover) {
-    @apply bg-gradient-to-br from-blue-100 to-purple-100;
+    @apply bg-gradient-to-br from-blue-100 to-purple-100 bg-fixed;
 
     .table-link {
       @apply text-blue-700 underline decoration-blue-700;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Added `bg-fixed` to gradients on table rows
* Added hover and background color to event group details row based on status
## Why?
<!-- Tell your future self why have you made these changes -->
Fix the looks of gradients in Safari.

|Before| After |
|-- |--|
|<img width="1571" alt="Screenshot 2023-01-31 at 6 26 53 PM" src="https://user-images.githubusercontent.com/15069288/215922392-2037529a-cc88-4153-8157-6753997c9491.png">|<img width="1578" alt="Screenshot 2023-01-31 at 6 25 46 PM" src="https://user-images.githubusercontent.com/15069288/215922251-cc69f0d3-032e-4754-913f-d9aea54b998d.png">|

## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: 
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify the following gradients on hover look as expected in Chrome and Safari
   - `Recent workflows`
   - Workflow > `Recent events`
      -  `History` view
      - `Compact` view
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
