### PR TITLE
[DT-305] Use authUser instead of user prop to pass accessToken

### DIFF
--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -7,6 +7,7 @@
   } from '$lib/stores/event-view';
   import { refresh } from '$lib/stores/workflow-run';
   import { eventHistory } from '$lib/stores/events';
+  import { authUser } from '$lib/stores/auth-user';
 
   import EventSummaryTable from '$lib/components/event/event-summary-table.svelte';
   import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
@@ -33,14 +34,14 @@
     runId: string,
     sort: EventSortOrder,
   ) => {
-    const { settings, user } = $page.data;
+    const { settings } = $page.data;
     resetFullHistory();
     fullHistory = await fetchAllEvents({
       namespace,
       workflowId,
       runId,
       settings,
-      accessToken: user?.accessToken,
+      accessToken: $authUser?.accessToken,
       sort: compact ? 'ascending' : sort,
     });
     loading = false;

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -10,6 +10,7 @@
     eventHistory,
     initialEventHistory,
   } from '$lib/stores/events';
+  import { authUser } from '$lib/stores/auth-user';
 
   import Header from '$lib/layouts/workflow-header.svelte';
   import Loading from '$lib/holocene/loading.svelte';
@@ -32,7 +33,7 @@
     workflowId: string,
     runId: string,
   ) => {
-    const { settings, user } = $page.data;
+    const { settings } = $page.data;
 
     const workflow = await fetchWorkflow({
       namespace,
@@ -45,7 +46,7 @@
       workflow,
       namespace,
       settings,
-      user?.accessToken,
+      $authUser?.accessToken,
     );
     $workflowRun = { workflow, workers };
     const events = await fetchStartAndEndEvents({
@@ -53,7 +54,7 @@
       workflowId,
       runId,
       settings,
-      accessToken: user?.accessToken,
+      accessToken: $authUser?.accessToken,
     });
     $eventHistory = events;
   };


### PR DESCRIPTION
## What was changed
As part of the Sveltekit upgrade, the workflow events was switched to pass the user prop accessToken instead of the $authUser accessToken. This broke decoding payloads for cloud users wanting to pass the access token. Move back to using authUser.

## Why?
Fix DT-305

Verified it fixes passing Bearer token in cloud
