### PR TITLE
fix position of floating output value

### DIFF
--- a/src/lib/holocene/input/input.story.svelte
+++ b/src/lib/holocene/input/input.story.svelte
@@ -59,10 +59,10 @@
     />
   </Hst.Variant>
 
-  <Hst.Variant title="A Slider Input">
+  <Hst.Variant title="A Range Input">
     <RangeInput
       label="day(s) retention"
-      id="number-input-3"
+      id="range-input-1"
       min={1}
       max={90}
       bind:value={numberValue}

--- a/src/lib/holocene/input/input.story.svelte
+++ b/src/lib/holocene/input/input.story.svelte
@@ -7,7 +7,7 @@
   export let Hst: HST;
 
   let value: string = '';
-  let numberValue: string = '20';
+  let numberValue: number;
   let hintText: string | undefined;
   let valid = true;
   let maxLength: number | undefined;

--- a/src/lib/holocene/input/input.story.svelte
+++ b/src/lib/holocene/input/input.story.svelte
@@ -14,6 +14,8 @@
   let dark = false;
   let disabled = false;
   let clearable = false;
+  let min = 0;
+  let max = 100;
 </script>
 
 <Hst.Story>
@@ -63,8 +65,8 @@
     <RangeInput
       label="day(s) retention"
       id="range-input-1"
-      min={1}
-      max={90}
+      {min}
+      {max}
       bind:value={numberValue}
     />
   </Hst.Variant>
@@ -76,5 +78,7 @@
     <Hst.Checkbox title="Dark: " bind:value={dark} />
     <Hst.Checkbox title="Disabled: " bind:value={disabled} />
     <Hst.Checkbox title="Clearable: " bind:value={clearable} />
+    <Hst.Number title="Min:" bind:value={min} />
+    <Hst.Number title="Max:" bind:value={max} />
   </svelte:fragment>
 </Hst.Story>

--- a/src/lib/holocene/input/range-input.svelte
+++ b/src/lib/holocene/input/range-input.svelte
@@ -18,13 +18,14 @@
   export let id: string = undefined;
 
   let valid: boolean = true;
+  let outputElement: HTMLOutputElement;
 
   $: outputXPos = getOutputXPos();
-  $: outputXPosPadding = getOutputXPosPadding();
+  $: outputXPosOffset = getOutputXPosOffset();
   $: {
     if (value) {
       outputXPos = getOutputXPos();
-      outputXPosPadding = getOutputXPosPadding();
+      outputXPosOffset = getOutputXPosOffset();
     }
   }
 
@@ -39,18 +40,19 @@
 
   const getOutputXPos = () => {
     // calculates the value as a percentage to position the output text
-    return Math.floor(((Number(value) - min) * 100) / (max - min));
+    return ((Number(value) - min) * 100) / (max - min);
   };
 
-  const getOutputXPosPadding = () => {
+  const getOutputXPosOffset = () => {
     // as the output text moves to the right with the slider thumb, it needs to shift left slightly
     // such that it doesn't overflow the width of the slider track.
-    return Math.floor(outputXPos * 0.15);
+    const offset = outputElement?.clientWidth ?? 15;
+    return Math.floor((outputXPos * offset) / 100);
   };
 
   const handleWindowResize = () => {
     outputXPos = getOutputXPos();
-    outputXPosPadding = getOutputXPosPadding();
+    outputXPosOffset = getOutputXPosOffset();
   };
 </script>
 
@@ -63,10 +65,11 @@
       </span>
       <div class="relative flex items-center">
         <output
+          bind:this={outputElement}
           class:hidden={!valid}
           class="absolute -top-6 text-center text-xs font-normal"
-          style="left: calc({outputXPos}% - ({outputXPosPadding}px))"
-          for="range">{value}</output
+          style="left: calc({outputXPos}% - ({outputXPosOffset}px))"
+          for="range">{value ?? ''}</output
         >
         <input
           name="range"

--- a/src/lib/holocene/input/range-input.svelte
+++ b/src/lib/holocene/input/range-input.svelte
@@ -3,7 +3,7 @@
   import type { HTMLInputAttributes } from 'svelte/elements';
 
   interface $$Props extends HTMLInputAttributes {
-    value: string;
+    value: number;
     id: string;
     label?: string;
     min?: number;
@@ -12,11 +12,10 @@
   }
 
   export let label: string = undefined;
-  export let value: string;
   export let min: number = undefined;
   export let max: number = undefined;
   export let id: string = undefined;
-
+  export let value: number = Math.round((min + max) / 2);
   let valid: boolean = true;
   let outputElement: HTMLOutputElement;
 
@@ -26,13 +25,19 @@
     if (value) {
       outputXPos = getOutputXPos();
       outputXPosOffset = getOutputXPosOffset();
+    } else {
+      outputXPos = 0;
+      outputXPosOffset = 0;
     }
   }
 
   const handleInput = (
     event: Event & { currentTarget: EventTarget & HTMLInputElement },
   ) => {
-    if (Number.isNaN(event.currentTarget.valueAsNumber)) return;
+    if (Number.isNaN(event.currentTarget.valueAsNumber)) {
+      value = min;
+      return;
+    }
     valid =
       event.currentTarget.valueAsNumber >= min &&
       event.currentTarget.valueAsNumber <= max;
@@ -40,7 +45,7 @@
 
   const getOutputXPos = () => {
     // calculates the value as a percentage to position the output text
-    return ((Number(value) - min) * 100) / (max - min);
+    return ((value - min) * 100) / (max - min);
   };
 
   const getOutputXPosOffset = () => {

--- a/src/lib/holocene/input/range-input.svelte
+++ b/src/lib/holocene/input/range-input.svelte
@@ -60,7 +60,7 @@
   <div class="range-input-container">
     <span
       bind:this={floatingValueSpanElement}
-      class="absolute top-2 text-center text-xs font-normal"
+      class="absolute -top-1.5 text-center text-xs font-normal"
       class:hidden={!valid}
       style="transform: translateX({floatingValueXPos}px);"
     >
@@ -111,7 +111,7 @@
 
 <style lang="postcss">
   .range-input-container {
-    @apply inline-flex w-full flex-row items-center gap-4 whitespace-nowrap;
+    @apply relative inline-flex w-full flex-row items-center gap-4 whitespace-nowrap;
   }
 
   .numeric-input {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Add `position: relative` to the element containing the output value so that it isn't positioned absolutely to the whole window and instead positioned absolutely to its parent.
- calculate the position of the floating output as a percentage based on the value, min, and max so that it displays properly when created with an initial value.
## Why?
<!-- Tell your future self why have you made these changes -->
Fixes a visual bug with RangeInput
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- `pnpm package` and `pnpm link` in cloud-ui to visually verify changes
<img width="1008" alt="Screen Shot 2023-02-02 at 10 52 14 AM" src="https://user-images.githubusercontent.com/11775628/216403208-25bbb3cd-8a3f-4364-8b44-e16c553a6e64.png">

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
