### PR TITLE
Preserve 'constructor' keyword in json-bigint and add console.warn on decode error

### DIFF
--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -83,7 +83,17 @@ const JsonObjectEncoded = {
   data: 'eyAiVHJhbnNmb3JtZXIiOiAiT3B0aW11c1ByaW1lIiB9',
 };
 
+const JsonObjectEncodedWithConstructor = {
+  metadata: {
+    encoding: 'anNvbi9wbGFpbg==',
+    type: 'S2V5d29yZA==',
+  },
+  data: 'eyBDb25zdHJ1Y3RvcjogJ09wdGltdXNQcmltZScgfQ==',
+};
+
+
 const JsonObjectDecoded = { Transformer: 'OptimusPrime' };
+const JsonObjectDecodedWithConstructor = { Constructor: 'OptimusPrime' };
 
 describe('decodePayload', () => {
   it('Should not decode a payload with encoding binary/encrypted', () => {
@@ -105,6 +115,9 @@ describe('decodePayload', () => {
   });
   it('Should decode a json payload with encoding json/plain', () => {
     expect(decodePayload(JsonObjectEncoded)).toEqual(JsonObjectDecoded);
+  });
+  it('Should decode a json payload with constructor keyworkd with encoding json/plain', () => {
+    expect(decodePayload(JsonObjectEncodedWithConstructor)).toEqual(JsonObjectDecodedWithConstructor);
   });
 });
 

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -88,12 +88,11 @@ const JsonObjectEncodedWithConstructor = {
     encoding: 'anNvbi9wbGFpbg==',
     type: 'S2V5d29yZA==',
   },
-  data: 'eyBDb25zdHJ1Y3RvcjogJ09wdGltdXNQcmltZScgfQ==',
+  data: 'eyAiQ29uc3RydWN0b3JPdXRwdXQiOiAiT3B0aW11c1ByaW1lIiB9',
 };
 
-
 const JsonObjectDecoded = { Transformer: 'OptimusPrime' };
-const JsonObjectDecodedWithConstructor = { Constructor: 'OptimusPrime' };
+const JsonObjectDecodedWithConstructor = { ConstructorOutput: 'OptimusPrime' };
 
 describe('decodePayload', () => {
   it('Should not decode a payload with encoding binary/encrypted', () => {
@@ -116,8 +115,10 @@ describe('decodePayload', () => {
   it('Should decode a json payload with encoding json/plain', () => {
     expect(decodePayload(JsonObjectEncoded)).toEqual(JsonObjectDecoded);
   });
-  it('Should decode a json payload with constructor keyworkd with encoding json/plain', () => {
-    expect(decodePayload(JsonObjectEncodedWithConstructor)).toEqual(JsonObjectDecodedWithConstructor);
+  it('Should decode a json payload with constructor keyword with encoding json/plain', () => {
+    expect(decodePayload(JsonObjectEncodedWithConstructor)).toEqual(
+      JsonObjectDecodedWithConstructor,
+    );
   });
 });
 

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -44,8 +44,10 @@ export function decodePayload(
 
   if (encoding?.startsWith('json/')) {
     try {
+      // return JSON.parse(atob(String(payload?.data ?? '')))
       return parseWithBigInt(atob(String(payload?.data ?? '')));
     } catch (_e) {
+      console.warn('Could not parse payload: ', _e)
       // Couldn't correctly decode this just let the user deal with the data as is
     }
   }

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -46,7 +46,7 @@ export function decodePayload(
     try {
       return parseWithBigInt(atob(String(payload?.data ?? '')));
     } catch (_e) {
-      console.warn('Could not parse payload: ', _e)
+      console.warn('Could not parse payload: ', _e);
       // Couldn't correctly decode this just let the user deal with the data as is
     }
   }

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -44,7 +44,6 @@ export function decodePayload(
 
   if (encoding?.startsWith('json/')) {
     try {
-      // return JSON.parse(atob(String(payload?.data ?? '')))
       return parseWithBigInt(atob(String(payload?.data ?? '')));
     } catch (_e) {
       console.warn('Could not parse payload: ', _e)

--- a/src/lib/utilities/parse-with-big-int.ts
+++ b/src/lib/utilities/parse-with-big-int.ts
@@ -2,10 +2,11 @@ import JSONbig from 'json-bigint';
 
 const JSONBigNative = JSONbig({
   useNativeBigInt: true,
-  constructorAction: 'preserve'
+  constructorAction: 'preserve',
 });
 
-export const parseWithBigInt = (content: string) => JSONBigNative.parse(content);
+export const parseWithBigInt = (content: string) =>
+  JSONBigNative.parse(content);
 
 export const stringifyWithBigInt = <T = unknown>(
   value: T,

--- a/src/lib/utilities/parse-with-big-int.ts
+++ b/src/lib/utilities/parse-with-big-int.ts
@@ -1,15 +1,14 @@
 import JSONbig from 'json-bigint';
 
-JSONbig({
+const JSONBigNative = JSONbig({
   useNativeBigInt: true,
-  // This should work but doesn't
   constructorAction: 'preserve'
 });
 
-export const parseWithBigInt = (content: string) => JSONbig.parse(content);
+export const parseWithBigInt = (content: string) => JSONBigNative.parse(content);
 
 export const stringifyWithBigInt = <T = unknown>(
   value: T,
   replacer?: (key: string, value: T) => T,
   space?: string | number,
-) => JSONbig.stringify(value, replacer, space);
+) => JSONBigNative.stringify(value, replacer, space);

--- a/src/lib/utilities/parse-with-big-int.ts
+++ b/src/lib/utilities/parse-with-big-int.ts
@@ -2,6 +2,8 @@ import JSONbig from 'json-bigint';
 
 JSONbig({
   useNativeBigInt: true,
+  // This should work but doesn't
+  constructorAction: 'preserve'
 });
 
 export const parseWithBigInt = (content: string) => JSONbig.parse(content);


### PR DESCRIPTION
## What was changed
If payload objects included the key `constructor`, parsing would fail. Preserve that keyword and include unit test. Add console.warn on failed parsing.

Tested with supplied payloads, successfully parsed.
