### PR TITLE
[DT-375] Add reverse sort to Compact view for Recent Events

### DIFF
--- a/src/lib/components/event/event-date-filter.svelte
+++ b/src/lib/components/event/event-date-filter.svelte
@@ -66,25 +66,23 @@
     <span class="block md:hidden"><Icon name="clock" /></span>
   </svelte:fragment>
   <div class="w-56">
-    {#if !compact}
-      {#each sortOptions as { option, label } (option)}
-        <div class="option" class:active={$eventFilterSort === option}>
-          <div class="check active">
-            {#if $eventFilterSort === option}
-              <Icon name="checkmark" />
-            {/if}
-          </div>
-          <button on:click={() => onSortOptionClick(option)}>
-            {label}
-          </button>
+    {#each sortOptions as { option, label } (option)}
+      <div class="option" class:active={$eventFilterSort === option}>
+        <div class="check active">
+          {#if $eventFilterSort === option}
+            <Icon name="checkmark" />
+          {/if}
         </div>
-      {/each}
-
-      <div class="option pr-4">
-        <div class="check" />
-        <div class="my-2 w-full border-b-2 border-gray-300 pr-2" />
+        <button on:click={() => onSortOptionClick(option)}>
+          {label}
+        </button>
       </div>
-    {/if}
+    {/each}
+
+    <div class="option pr-4">
+      <div class="check" />
+      <div class="my-2 w-full border-b-2 border-gray-300 pr-2" />
+    </div>
     {#each dateOptions as { label, option } (option)}
       <div class="option" class:active={$timeFormat === option}>
         <div class="check active">

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -59,9 +59,11 @@
   ): IterableEvent[] => {
     if (category) {
       const filteredItems = items.filter((i) => i.category === category);
-      return compact ? groupEvents(filteredItems) : filteredItems;
+      return compact
+        ? groupEvents(filteredItems, $eventFilterSort)
+        : filteredItems;
     }
-    return compact ? groupEvents(items) : items;
+    return compact ? groupEvents(items, $eventFilterSort) : items;
   };
 
   $: category = $page.url.searchParams.get('category');

--- a/src/lib/models/event-groups/group-events.test.ts
+++ b/src/lib/models/event-groups/group-events.test.ts
@@ -99,11 +99,41 @@ describe('groupEvents', () => {
     expect(Object.keys(groups).length).toBe(2);
   });
 
+  it('should be able to get event groups in ascending order by default', () => {
+    const groups = groupEvents([
+      scheduledEvent,
+      anotherScheduledEvent,
+    ] as unknown as WorkflowEvents);
+
+    expect(groups[0].id).toBe(scheduledEvent.id);
+  });
+
+  it('should be able to get event groups in descending order', () => {
+    const groups = groupEvents(
+      [scheduledEvent, anotherScheduledEvent] as unknown as WorkflowEvents,
+      'descending',
+    );
+
+    expect(groups[0].id).toBe(anotherScheduledEvent.id);
+  });
+
   it('should add a completed event to the correct group', () => {
     const groups = groupEvents([
       scheduledEvent,
       completedEvent,
     ] as unknown as WorkflowEvents);
+
+    const group = groups.find(({ id }) => id === scheduledEvent.id);
+
+    expect(group.events.size).toBe(2);
+    expect(group.events.get(completedEvent.id)).toBe(completedEvent);
+  });
+
+  it('should add a completed event to the correct group in descending order', () => {
+    const groups = groupEvents(
+      [scheduledEvent, completedEvent] as unknown as WorkflowEvents,
+      'descending',
+    );
 
     const group = groups.find(({ id }) => id === scheduledEvent.id);
 

--- a/src/lib/models/event-groups/index.ts
+++ b/src/lib/models/event-groups/index.ts
@@ -2,6 +2,8 @@ import { has } from '$lib/utilities/has';
 import { createEventGroup } from './create-event-group';
 import { getGroupId } from './get-group-id';
 
+import type { EventSortOrder } from '$lib/stores/event-view';
+
 export { getGroupForEvent } from './get-group-for-event';
 
 const addToExistingGroup = (group: EventGroup, event: WorkflowEvent): void => {
@@ -13,7 +15,10 @@ const addToExistingGroup = (group: EventGroup, event: WorkflowEvent): void => {
   group.timestamp = event.timestamp;
 };
 
-export const groupEvents = (events: CommonHistoryEvent[]): EventGroups => {
+export const groupEvents = (
+  events: CommonHistoryEvent[],
+  sort: EventSortOrder = 'ascending',
+): EventGroups => {
   const groups: Record<string, EventGroup> = {};
 
   for (const event of events) {
@@ -27,7 +32,9 @@ export const groupEvents = (events: CommonHistoryEvent[]): EventGroups => {
     }
   }
 
-  return Object.values(groups);
+  return sort === 'descending'
+    ? Object.values(groups).reverse()
+    : Object.values(groups);
 };
 
 export const isEventGroup = (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Workflow details > `Recent Events` > `Compact` view now has an option to sort events from `descending` or `ascending`.
## Why?
<!-- Tell your future self why have you made these changes -->
Users can now see the last event group first.

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-375` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify selecting `Sort 1-9` shows events in `ascending` order for `History` and `Compact` views
- [ ] Verify selecting `Sort 9-1` shows events in `descending` order for `History` and `Compact` views
- [ ] Verify events are grouped correctly in the `Compact` view for both `ascending` and `descending` sort orders
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
