### PR TITLE
Fix formatting and lint issue before commit

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.{ts,js,svelte}": "eslint --fix --ignore-path .gitignore",
+  "*.{ts,js,svelte}": ["eslint --fix", "prettier --write"],
   "*.{css,postcss,svelte}": "stylelint --fix",
   "*.{json,md}": "prettier --write"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,5 @@
+{
+  "*.{ts,js,svelte}": "eslint --fix --ignore-path .gitignore",
+  "*.{css,postcss,svelte}": "stylelint --fix",
+  "*.{json,md}": "prettier --write"
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "story:preview": "histoire preview",
     "coverage": "TZ=UTC vitest run --coverage",
     "test-ui": "TZ=UTC vitest --ui",
-    "postinstall": "node download-temporal-cli.js"
+    "prepare": "node download-temporal-cli.js && husky install"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.3.4",
@@ -147,8 +147,5 @@
     "date-fns": "2.29.x",
     "date-fns-tz": "1.3.x",
     "websocket-as-promised": "2.0.x"
-  },
-  "lint-staged": {
-    "*.{js,ts,json,css,svelte}": "pnpm format"
   }
 }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "jest-websocket-mock": "^2.2.1",
     "jsdom": "^20.0.0",
     "kleur": "^4.1.5",
-    "lint-staged": "^13.0.3",
+    "lint-staged": "^13.1.0",
     "mkdirp": "^2.1.3",
     "mock-socket": "^9.1.0",
     "node-fetch": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ specifiers:
   json-bigint: ^1.0.0
   just-debounce: ^1.1.0
   kleur: ^4.1.5
-  lint-staged: ^13.0.3
+  lint-staged: ^13.1.0
   mkdirp: ^2.1.3
   mock-socket: ^9.1.0
   node-fetch: ^3.3.0


### PR DESCRIPTION
Adds [Husky](https://typicode.github.io/husky/#/) and [`lint-staged`](https://github.com/okonet/lint-staged) to fix minor formatting issues when committing.