### PR TITLE
[DT-376] Remove active row on load in recent events 

### DIFF
--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -75,7 +75,7 @@
   $: updating = currentEvents.length && !fullHistory.length;
 </script>
 
-{#key [$eventFilterSort, category, $refresh]}
+{#key [$eventFilterSort, category]}
   <Pagination
     floatId="event-view-toggle"
     {items}

--- a/src/lib/stores/pagination.test.ts
+++ b/src/lib/stores/pagination.test.ts
@@ -273,15 +273,29 @@ describe('pagination', () => {
     expect(initialItem).toBe(0);
   });
 
-  it('should have default active row index', () => {
+  it('should not have default active row index', () => {
     const store = pagination(oneHundredResolutions, 5);
     const { activeRowIndex } = get(store);
 
-    expect(activeRowIndex).toBe(0);
+    expect(activeRowIndex).toBe(undefined);
+  });
+
+  it('should go to the first row', () => {
+    const store = pagination(oneHundredResolutions, 5);
+
+    expect(get(store).activeRowIndex).toBe(undefined);
+
+    store.nextRow();
+
+    expect(get(store).activeRowIndex).toBe(0);
   });
 
   it('should go to the next row', () => {
     const store = pagination(oneHundredResolutions, 5);
+
+    expect(get(store).activeRowIndex).toBe(undefined);
+
+    store.nextRow();
 
     expect(get(store).activeRowIndex).toBe(0);
 
@@ -299,7 +313,7 @@ describe('pagination', () => {
   it('should go to the previous row', () => {
     const store = pagination(oneHundredResolutions, 5);
 
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 4; i++) {
       store.nextRow();
     }
 
@@ -335,7 +349,7 @@ describe('pagination', () => {
   it('should set active row to current row item on next ', () => {
     const store = pagination(oneHundredResolutions, 5);
 
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 4; i++) {
       store.nextRow();
     }
 
@@ -349,7 +363,7 @@ describe('pagination', () => {
   it('should set active row to last row item on next if next page has less items', () => {
     const store = pagination([1, 2, 3, 4, 5, 6, 7, 8], 5);
 
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 5; i++) {
       store.nextRow();
     }
 
@@ -376,7 +390,7 @@ describe('pagination', () => {
   it('should set active row index', () => {
     const store = pagination(oneHundredResolutions, 5);
 
-    expect(get(store).activeRowIndex).toBe(0);
+    expect(get(store).activeRowIndex).toBe(undefined);
 
     store.setActiveRowIndex(4);
 
@@ -386,21 +400,21 @@ describe('pagination', () => {
   it('should not exceed pageSize on set active row index', () => {
     const store = pagination(oneHundredResolutions, 5);
 
-    expect(get(store).activeRowIndex).toBe(0);
+    expect(get(store).activeRowIndex).toBe(undefined);
 
     store.setActiveRowIndex(8);
 
-    expect(get(store).activeRowIndex).toBe(0);
+    expect(get(store).activeRowIndex).toBe(undefined);
   });
 
   it('should not exceed item size on set active row index', () => {
     const store = pagination([1, 2], 5);
 
-    expect(get(store).activeRowIndex).toBe(0);
+    expect(get(store).activeRowIndex).toBe(undefined);
 
     store.setActiveRowIndex(8);
 
-    expect(get(store).activeRowIndex).toBe(0);
+    expect(get(store).activeRowIndex).toBe(undefined);
   });
 });
 

--- a/src/lib/stores/pagination.ts
+++ b/src/lib/stores/pagination.ts
@@ -31,7 +31,7 @@ type PaginationStore<T> = PaginationMethods<T> &
     pageSize: number;
     currentPage: number;
     totalPages: number;
-    activeRowIndex: number;
+    activeRowIndex: number | undefined;
   }>;
 
 export const getPageForIndex = (i: number, pageSize: number): number => {
@@ -123,7 +123,7 @@ export const pagination = <T>(
 
   const pageSize = writable(perPage);
   const index = writable(start);
-  const activeRowIndex = writable(start);
+  const activeRowIndex = writable(undefined);
 
   const adjustPageSize = (n: number | string) => {
     pageSize.set(toNumber(n));
@@ -194,7 +194,9 @@ export const pagination = <T>(
       get(index) + get(pageSize),
     ).length;
     const maxRowIndex = getMaxRowIndex(pageItemSize, get(pageSize));
-    if (get(activeRowIndex) < maxRowIndex) {
+    if (get(activeRowIndex) === undefined) {
+      activeRowIndex.set(0);
+    } else if (get(activeRowIndex) < maxRowIndex) {
       activeRowIndex.set(get(activeRowIndex) + 1);
     }
   };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Removed default active row in `Pagination`
* Removed `$refresh` key from `event-summary` component 
## Why?
<!-- Tell your future self why have you made these changes -->
* First event row in `Recent events` is no longer open by default
* Auto refresh doesn't reload entire `Recent events` table (events are still added on refresh)
## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-376` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify there is no open row by default for `Recent events`
- [ ] Verify selecting an event row in `Recent events` works/looks as expected
- [ ] Verify `Recent events` are still updated on a `Running` workflow with `Auto-refresh` turned on
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
