### PR TITLE
[DT-340] Add stack trace on expanded event details

### DIFF
--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -36,14 +36,22 @@
       class="content code-block-row"
       class:code-with-stack-trace={stackTrace}
     >
-      <div>
+      <div class="flex flex-col {stackTrace ? 'lg:w-1/2' : ''}">
         <p class="text-sm">{format(key)}</p>
-        <CodeBlock content={codeBlockValue} class="h-auto" {inline} />
+        <CodeBlock
+          content={codeBlockValue}
+          class="h-auto {stackTrace ? 'mb-2' : ''}"
+          {inline}
+        />
       </div>
       {#if stackTrace && !inline}
-        <div>
+        <div class="flex flex-col lg:w-1/2">
           <p class="text-sm">Stack trace</p>
-          <CodeBlock content={stackTrace} class="h-auto" language="text" />
+          <CodeBlock
+            content={stackTrace}
+            class="mb-2 h-full lg:pr-2"
+            language="text"
+          />
         </div>
       {/if}
     </div>
@@ -124,7 +132,7 @@
   }
 
   .code-with-stack-trace {
-    @apply grid grid-cols-1 gap-2 lg:grid-cols-2;
+    @apply flex flex-col gap-2 lg:flex-row;
   }
 
   .detail-row {

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -25,15 +25,27 @@
   export let inline = false;
 
   const { workflow, namespace } = $page.params;
+  $: codeBlockValue = getCodeBlockValue(value);
+  $: stackTrace =
+    codeBlockValue?.stackTrace || codeBlockValue?.cause?.stackTrace;
 </script>
 
 <div class="row {$$props.class}">
   {#if typeof value === 'object'}
-    <div class="content code-block-row">
-      <p class="text-sm">
-        {format(key)}
-      </p>
-      <CodeBlock content={getCodeBlockValue(value)} class="h-auto" {inline} />
+    <div
+      class="content code-block-row"
+      class:code-with-stack-trace={stackTrace}
+    >
+      <div>
+        <p class="text-sm">{format(key)}</p>
+        <CodeBlock content={codeBlockValue} class="h-auto" {inline} />
+      </div>
+      {#if stackTrace && !inline}
+        <div>
+          <p class="text-sm">Stack trace</p>
+          <CodeBlock content={stackTrace} class="h-auto" language="text" />
+        </div>
+      {/if}
     </div>
   {:else if shouldDisplayAsExecutionLink(key)}
     <div class="content detail-row">
@@ -109,6 +121,10 @@
 
   .code-block-row {
     @apply block w-full py-2 text-left;
+  }
+
+  .code-with-stack-trace {
+    @apply grid grid-cols-1 gap-2 lg:grid-cols-2;
   }
 
   .detail-row {

--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -8,6 +8,7 @@
   } from '$lib/utilities/route-for';
   import {
     getCodeBlockValue,
+    getStackTrace,
     shouldDisplayAsExecutionLink,
     shouldDisplayAsTaskQueueLink,
     shouldDisplayAsPlainText,
@@ -26,8 +27,7 @@
 
   const { workflow, namespace } = $page.params;
   $: codeBlockValue = getCodeBlockValue(value);
-  $: stackTrace =
-    codeBlockValue?.stackTrace || codeBlockValue?.cause?.stackTrace;
+  $: stackTrace = getStackTrace(codeBlockValue);
 </script>
 
 <div class="row {$$props.class}">

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -2,6 +2,7 @@ import { isEventGroup } from '$lib/models/event-groups';
 import { capitalize } from '$lib/utilities/format-camel-case';
 import { has } from './has';
 import { isLocalActivityMarkerEvent } from './is-event-type';
+import { isObject } from './is';
 
 import type { Payload } from '$types';
 import type { CombinedAttributes } from './format-event-attributes';
@@ -57,6 +58,17 @@ export const getCodeBlockValue: Parameters<typeof JSON.stringify>[0] = (
 ) => {
   if (typeof value === 'string') return value;
   return value?.payloads ?? value?.indexedFields ?? value?.points ?? value;
+};
+
+export const getStackTrace = (value: unknown) => {
+  if (!isObject(value)) return undefined;
+  if (has(value, 'stackTrace') && value.stackTrace) return value.stackTrace;
+
+  for (const key in value) {
+    if (isObject(value[key])) {
+      return getStackTrace(value[key]);
+    }
+  }
 };
 
 const keysWithExecutionLinks = [


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Conditionally renders a `Stack trace` code block next to the `Failure` block on expanded event details if there is a `stackTrace` property.

|Example 1 | Example 2|
|--|--|
|<img width="1377" alt="Screenshot 2023-02-09 at 11 48 23 AM" src="https://user-images.githubusercontent.com/15069288/217908868-c2d68686-99c3-44e4-8560-cc48eacabcf9.png">|<img width="1373" alt="Screenshot 2023-02-09 at 11 48 53 AM" src="https://user-images.githubusercontent.com/15069288/217908880-98ad5116-3f39-4aa1-b5e1-240127ba9fe7.png">|

## Why?
<!-- Tell your future self why have you made these changes -->
Easier to view the stack trace for debugging.

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-340` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify there is a `Stack trace` block if there is a `Failure` on an event with a `stackTrace` property
- [ ] Verify the event row with a `Stack trace` block is responsive
- [ ] Verify there is **not** a `Stack trace` block if there is a `Failure` on an event **without** a `stackTrace` property
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
