### PR TITLE
Bump version of actions/checkout in end to end workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,14 +30,14 @@ jobs:
         run: |
           VITE_API="" pnpm build:local
       - name: Checkout CLI
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: temporalio/cli
           path: cli
       - name: Install CLI
         run: |
           cd cli && go install ./cmd/temporal
-      - name: Run Playwright Tests
+      - name: Run Playwright tests
         working-directory: e2e
         run: |
           pnpm install


### PR DESCRIPTION
This change seeks to suppress the following warning:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.