### PR TITLE
Add run-name to actions; ignore CODEOWNERS

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,5 @@
 name: End To End Integration Tests
+run-name: Merge ${{ github.ref_name }} into main by @${{ github.triggering_actor }} (Attempt \#${{ github.run_attempt }})
 
 on:
   push:
@@ -8,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
+      - 'CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,15 @@
 name: Cypress Tests
+run-name: Merge ${{ github.ref_name }} into main by @${{ github.triggering_actor }} (Attempt \#${{ github.run_attempt }})
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
 
 jobs:
   cypress-run:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,4 +1,5 @@
 name: Run Tests, Lint, and Check Types
+run-name: Merge ${{ github.ref_name }} into main by @${{ github.triggering_actor }} (Attempt \#${{ github.run_attempt }})
 
 on:
   push:
@@ -8,6 +9,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
+      - 'CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: Publish NPM Package
+name: Publish npm Package
 
 on:
   pull_request:


### PR DESCRIPTION
- Adds a `run-name` to actions.
- Don't run the tests if we're just updating `CODEOWNERS`.