### PR TITLE
Use a Vite plugin for starting up a Temporal Server

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,3 @@
-VITE_API="http://localhost:7000"
-VITE_TEMPORAL_PORT="6000"
-VITE_UI_SERVER_PORT="7000"
+VITE_TEMPORAL_PORT="7233"
+VITE_API="http://localhost:8233"
 VITE_MODE="development"

--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
-VITE_API="http://localhost:8233"
+VITE_API="http://localhost:7000"
+VITE_TEMPORAL_PORT="6000"
+VITE_UI_SERVER_PORT="7000"
 VITE_MODE="development"

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+VITE_API="http://localhost:8234"
+VITE_TEMPORAL_PORT="7234"
+VITE_MODE="test"

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,2 @@
-VITE_API="http://localhost:8234"
-VITE_TEMPORAL_PORT="7234"
+VITE_API="http://localhost:8233"
 VITE_MODE="test"

--- a/.env.test.integration
+++ b/.env.test.integration
@@ -1,0 +1,3 @@
+VITE_TEMPORAL_PORT="4444"
+VITE_API="http://localhost:5555"
+VITE_MODE="development"

--- a/.env.testing
+++ b/.env.testing
@@ -1,4 +1,0 @@
-VITE_API="http://localhost:7777"
-VITE_TEMPORAL_PORT="6666"
-VITE_UI_SERVER_PORT="7777"
-VITE_MODE="testing"

--- a/.env.testing
+++ b/.env.testing
@@ -1,0 +1,4 @@
+VITE_API="http://localhost:7777"
+VITE_TEMPORAL_PORT="6666"
+VITE_UI_SERVER_PORT="7777"
+VITE_MODE="testing"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "name": "Start UI Development Server",
       "skipFiles": ["<node_internals>/**"],
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["run", "start:server"],
+      "runtimeArgs": ["run", "start"],
       "serverReadyAction": {
         "action": "startDebugging",
         "name": "Launch Browser",

--- a/README.md
+++ b/README.md
@@ -33,15 +33,20 @@ After pulling down the lastest version of Temporal's [`docker-compose`](https://
 
 ## Trying it out: Bleeding edge
 
-Starting the UI API server will give you a somewhat recent version on `localhost:8080`. If you want to use the most recent commit to `main`, you can spin up a bleeding-edge build as described below.
+If you want to use the most recent commit to `main`, you can spin up a bleeding-edge build as described below.
 
 Once you have the prerequisites going, run the following:
 
 ```bash
 pnpm install
-pnpm run build:local
-pnpm run preview:local
+pnpm start
 ```
+
+Running `pnpm install` will attempt to download and install the most recent version of [Temporal CLI][] into `./bin/cli/temporal`. The development server will attempt to use use this version of this Temporal when starting up.
+
+- If that port is already in use, the UI will fallback to trying to talk to whatever process is running on that port.
+- If you do not have a version of Temporal CLI at `./bin/cli/temporal`, the development server will look for a version of Temporal CLI in your path.
+- For Windows users, you will need to start Temporal using one of the methods listed above until we have sufficiently tested this functionality on Windows. (We would absolutely welcome a pull request.)
 
 ### Using Docker
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/temporalio/ui/tree/main",
   "scripts": {
     "start": "pnpm run dev:local -- --open",
-    "prepare": "husky install && svelte-kit sync",
+    "prepare": "esno scripts/download-temporal.ts && husky install && svelte-kit sync",
     "dev:local": ". ./.env && VITE_TEMPORAL_UI_BUILD_TARGET=local vite dev --port 3000",
     "dev:docker": ". ./.env && VITE_API=http://localhost:8080 vite dev --port 3000",
     "dev:cloud": "VITE_TEMPORAL_UI_BUILD_TARGET=cloud vite dev --port 3000",
@@ -105,6 +105,7 @@
     "eslint-plugin-playwright": "^0.12.0",
     "eslint-plugin-svelte3": "^3.2.0",
     "eslint-plugin-vitest": "^0.0.8",
+    "esno": "^0.16.3",
     "google-protobuf": "^3.17.3",
     "histoire": "^0.12.4",
     "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "sanitize-html": "^2.7.1",
     "url-pattern": "^1.0.3",
     "uuid": "^9.0.0",
+    "wait-port": "^1.0.4",
     "websocket-as-promised": "^2.0.1"
   },
   "devDependencies": {
@@ -141,8 +142,10 @@
     "typescript": "^4.4.2",
     "vite": "^4.0.2",
     "vite-node": "^0.23.2",
+    "vite-plugin-child-process": "^1.0.5",
     "vitest": "^0.15.2",
-    "webpack": "^5.73.0"
+    "webpack": "^5.73.0",
+    "zx": "^7.1.1"
   },
   "peerDependencies": {
     "date-fns": "2.29.x",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
   "homepage": "https://github.com/temporalio/ui/tree/main",
   "scripts": {
     "start": "pnpm run dev:local -- --open",
-    "server": "./bin/cli/temporal server start-dev",
-    "start:server": "concurrently \"pnpm run server\" \"pnpm run dev:local\"",
-    "prepare": "node download-temporal-cli.js && husky install && svelte-kit sync",
+    "prepare": "husky install && svelte-kit sync",
     "dev:local": ". ./.env && VITE_TEMPORAL_UI_BUILD_TARGET=local vite dev --port 3000",
     "dev:docker": ". ./.env && VITE_API=http://localhost:8080 vite dev --port 3000",
     "dev:cloud": "VITE_TEMPORAL_UI_BUILD_TARGET=cloud vite dev --port 3000",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     "typescript": "^4.4.2",
     "vite": "^4.0.2",
     "vite-node": "^0.23.2",
-    "vite-plugin-child-process": "^1.0.5",
     "vitest": "^0.15.2",
     "webpack": "^5.73.0",
     "zx": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@sveltejs/kit": "1.0.1",
     "@sveltejs/vite-plugin-svelte": "^2.0.2",
     "@temporalio/proto": "^1.4.4",
+    "@temporalio/testing": "^1.6.0",
     "@types/base-64": "^1.0.0",
     "@types/json-bigint": "^1.0.1",
     "@types/mkdirp": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://github.com/temporalio/ui/tree/main",
   "scripts": {
     "start": "pnpm run dev:local -- --open",
-    "prepare": "esno scripts/download-temporal.ts && husky install && svelte-kit sync",
+    "prepare": "svelte-kit sync && esno scripts/download-temporal.ts && husky install",
     "dev:local": ". ./.env && VITE_TEMPORAL_UI_BUILD_TARGET=local vite dev --port 3000",
     "dev:docker": ". ./.env && VITE_API=http://localhost:8080 vite dev --port 3000",
     "dev:cloud": "VITE_TEMPORAL_UI_BUILD_TARGET=cloud vite dev --port 3000",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "husky": "^8.0.1",
     "jest-websocket-mock": "^2.2.1",
     "jsdom": "^20.0.0",
-    "kleur": "^4.1.5",
     "lint-staged": "^13.1.0",
     "mkdirp": "^2.1.3",
     "mock-socket": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "sanitize-html": "^2.7.1",
     "url-pattern": "^1.0.3",
     "uuid": "^9.0.0",
-    "wait-port": "^1.0.4",
     "websocket-as-promised": "^2.0.1"
   },
   "devDependencies": {
@@ -144,6 +143,7 @@
     "vite": "^4.0.2",
     "vite-node": "^0.23.2",
     "vitest": "^0.15.2",
+    "wait-port": "^1.0.4",
     "webpack": "^5.73.0",
     "zx": "^7.1.1"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: [
     ['html'],
-    ['json', { outputFile: 'test-results.json' }],
+    ['json', { outputFile: 'playwright-report/test-results.json' }],
     [process.env.CI ? 'list' : 'github'],
   ],
   use: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,14 +39,8 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'VITE_API=http://localhost:7777 pnpm run dev:local --port=3333',
+      command: 'pnpm run dev:local --port=3333 --mode testing',
       port: 3333,
-      reuseExistingServer: !process.env.CI,
-    },
-    {
-      command: 'pnpm run server --ui-port=7777 --port=6666',
-      port: 7777,
-      reuseExistingServer: !process.env.CI,
     },
   ],
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'pnpm run dev:local --port=3333 --mode testing',
+      command: 'pnpm run dev:local --port=3333 --mode=test',
       port: 3333,
     },
   ],

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -12,6 +12,8 @@ let temporal: TemporalServer;
 const shouldSkip = (): boolean => {
   if (process.env.VERCEL) return true;
   if (temporal) return true;
+  if (process.platform === 'win32') return true;
+
   return false;
 };
 

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -1,11 +1,11 @@
+import { chalk } from 'zx';
 import type { Plugin } from 'vite';
 import {
   type TemporalServer,
   createTemporalServer,
 } from '../scripts/start-temporal-server';
-import kleur from 'kleur';
 
-const { cyan, magenta } = kleur;
+const { cyan, magenta } = chalk;
 
 let temporal: TemporalServer;
 

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -9,7 +9,7 @@ const { cyan, magenta } = kleur;
 
 let temporal: TemporalServer;
 
-const isVercel = !!process.env.VERCEL;
+const shouldStartUpServer = !!process.env.VERCEL;
 
 const getPortFromApiEndpoint = (endpoint: string, fallback = 8233): number => {
   return validatePort(
@@ -42,7 +42,7 @@ export function temporalServer(): Plugin {
     enforce: 'post',
     apply: 'serve',
     async configureServer(server) {
-      if (isVercel) return;
+      if (shouldStartUpServer) return;
       if (temporal) return;
 
       const port = validatePort(server.config.env.VITE_TEMPORAL_PORT, 7233);
@@ -62,6 +62,7 @@ export function temporalServer(): Plugin {
       console.log(cyan(`Temporal UI Server is running on Port ${uiPort}.`));
     },
     async closeBundle() {
+      if (shouldStartUpServer) return;
       await temporal?.shutdown();
     },
   };

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -3,8 +3,36 @@ import {
   type TemporalServer,
   createTemporalServer,
 } from '../scripts/start-temporal-server';
+import kleur from 'kleur';
+
+const { cyan, magenta } = kleur;
 
 let temporal: TemporalServer;
+
+const getPortFromApiEndpoint = (endpoint: string, fallback = 8233): number => {
+  return validatePort(
+    endpoint.slice(endpoint.lastIndexOf(':') + 1, endpoint.length),
+    fallback,
+  );
+};
+
+const isValidPort = (port: number): boolean => {
+  if (typeof port !== 'number') return false;
+  if (isNaN(port)) return false;
+  if (port <= 1024) return false;
+  if (port > 65536) return false;
+  return true;
+};
+
+const validatePort = (port: number | string, fallback: number): number => {
+  if (typeof port !== 'number') port = Number(port);
+  if (isValidPort(port)) return port;
+  console.error(`${port} is not a valid port. Falling back to ${fallback}`);
+  if (isValidPort(fallback)) return fallback;
+  throw new Error(
+    `Both the provided port, ${port}, and its fallback, ${fallback}, are invalid ports.`,
+  );
+};
 
 export function temporalServer(): Plugin {
   return {
@@ -14,11 +42,21 @@ export function temporalServer(): Plugin {
     async configureServer(server) {
       if (temporal) return;
 
-      const port = +server.config.env.VITE_TEMPORAL_PORT;
+      const port = validatePort(server.config.env.VITE_TEMPORAL_PORT, 7233);
+      const uiPort = getPortFromApiEndpoint(server.config.env.VITE_API);
 
-      temporal = createTemporalServer({ port });
+      console.log(magenta(`Starting Temporal Server on Port ${port}…`));
+      console.log(cyan(`Starting Temporal UI Server on Port ${uiPort}…`));
+
+      temporal = createTemporalServer({
+        port,
+        uiPort,
+      });
 
       await temporal.ready();
+
+      console.log(magenta(`Temporal Server is running on Port ${port}.`));
+      console.log(cyan(`Temporal UI Server is running on Port ${uiPort}.`));
     },
     async closeBundle() {
       await temporal.shutdown();

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -9,7 +9,7 @@ const { cyan, magenta } = kleur;
 
 let temporal: TemporalServer;
 
-const shouldStartUpServer = !!process.env.VERCEL;
+const shouldSkip = !!process.env.VERCEL;
 
 const getPortFromApiEndpoint = (endpoint: string, fallback = 8233): number => {
   return validatePort(
@@ -42,7 +42,7 @@ export function temporalServer(): Plugin {
     enforce: 'post',
     apply: 'serve',
     async configureServer(server) {
-      if (shouldStartUpServer) return;
+      if (shouldSkip) return;
       if (temporal) return;
 
       const port = validatePort(server.config.env.VITE_TEMPORAL_PORT, 7233);
@@ -62,7 +62,9 @@ export function temporalServer(): Plugin {
       console.log(cyan(`Temporal UI Server is running on Port ${uiPort}.`));
     },
     async closeBundle() {
-      if (shouldStartUpServer) return;
+      if (!shouldSkip) return;
+      if (!temporal) return;
+
       await temporal?.shutdown();
     },
   };

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -1,0 +1,26 @@
+import { TestWorkflowEnvironment } from '@temporalio/testing';
+import type { Plugin } from 'vite';
+
+export function temporalServer(): Plugin {
+  return {
+    name: 'vite-plugin-temporal-server',
+    configureServer(server) {
+      let temporalServer: TestWorkflowEnvironment;
+      const port = +server.config.env.VITE_TEMPORAL_PORT;
+      const api = server.config.env.VITE_UI_SERVER_PORT;
+      const extraArgs = [`--ui-port=${api}`];
+
+      console.log({ port, api, extraArgs });
+
+      server.httpServer?.on('listening', async () => {
+        temporalServer = await TestWorkflowEnvironment.createLocal({
+          server: { port, ui: true, extraArgs },
+        });
+      });
+
+      server.httpServer?.on('close', () => {
+        temporalServer.teardown();
+      });
+    },
+  };
+}

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -62,7 +62,7 @@ export function temporalServer(): Plugin {
       console.log(cyan(`Temporal UI Server is running on Port ${uiPort}.`));
     },
     async closeBundle() {
-      await temporal.shutdown();
+      await temporal?.shutdown();
     },
   };
 }

--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -9,6 +9,8 @@ const { cyan, magenta } = kleur;
 
 let temporal: TemporalServer;
 
+const isVercel = !!process.env.VERCEL;
+
 const getPortFromApiEndpoint = (endpoint: string, fallback = 8233): number => {
   return validatePort(
     endpoint.slice(endpoint.lastIndexOf(':') + 1, endpoint.length),
@@ -40,6 +42,7 @@ export function temporalServer(): Plugin {
     enforce: 'post',
     apply: 'serve',
     async configureServer(server) {
+      if (isVercel) return;
       if (temporal) return;
 
       const port = validatePort(server.config.env.VITE_TEMPORAL_PORT, 7233);
@@ -48,7 +51,7 @@ export function temporalServer(): Plugin {
       console.log(magenta(`Starting Temporal Server on Port ${port}…`));
       console.log(cyan(`Starting Temporal UI Server on Port ${uiPort}…`));
 
-      temporal = createTemporalServer({
+      temporal = await createTemporalServer({
         port,
         uiPort,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,7 +121,6 @@ dependencies:
   sanitize-html: 2.8.1
   url-pattern: 1.0.3
   uuid: 9.0.0
-  wait-port: 1.0.4
   websocket-as-promised: 2.0.1
 
 devDependencies:
@@ -205,6 +204,7 @@ devDependencies:
   vite: 4.0.4_@types+node@16.18.11
   vite-node: 0.23.4_@types+node@16.18.11
   vitest: 0.15.2_qiappldhh65w4ksb3oc7agamvi
+  wait-port: 1.0.4
   webpack: 5.75.0_esbuild@0.13.15
   zx: 7.1.1
 
@@ -2379,6 +2379,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+    dev: true
 
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -2780,6 +2781,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
 
   /chalk/5.2.0:
     resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
@@ -2914,6 +2916,7 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
+    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -2921,6 +2924,7 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+    dev: true
 
   /color-support/1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -2959,6 +2963,7 @@ packages:
   /commander/9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    dev: true
 
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -3321,6 +3326,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /debug/4.3.4_supports-color@8.1.1:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -5106,6 +5112,7 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -6240,6 +6247,7 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8020,6 +8028,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-color/8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -8964,7 +8973,7 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
-    dev: false
+    dev: true
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,12 @@ specifiers:
   uuid: ^9.0.0
   vite: ^4.0.2
   vite-node: ^0.23.2
+  vite-plugin-child-process: ^1.0.5
   vitest: ^0.15.2
+  wait-port: ^1.0.4
   webpack: ^5.73.0
   websocket-as-promised: ^2.0.1
+  zx: ^7.1.1
 
 dependencies:
   '@codemirror/autocomplete': 6.4.0_czcfkg2f66rxeiodoti7r2gulu
@@ -118,6 +121,7 @@ dependencies:
   sanitize-html: 2.8.1
   url-pattern: 1.0.3
   uuid: 9.0.0
+  wait-port: 1.0.4
   websocket-as-promised: 2.0.1
 
 devDependencies:
@@ -199,8 +203,10 @@ devDependencies:
   typescript: 4.9.4
   vite: 4.0.4_@types+node@16.18.11
   vite-node: 0.23.4_@types+node@16.18.11
+  vite-plugin-child-process: 1.0.5
   vitest: 0.15.2_qiappldhh65w4ksb3oc7agamvi
   webpack: 5.75.0_esbuild@0.13.15
+  zx: 7.1.1
 
 packages:
 
@@ -1655,6 +1661,10 @@ packages:
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
     dev: true
 
+  /@types/node/18.13.0:
+    resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+    dev: true
+
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
@@ -1665,6 +1675,10 @@ packages:
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
+    dev: true
+
+  /@types/ps-tree/1.1.2:
+    resolution: {integrity: sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==}
     dev: true
 
   /@types/pug/2.0.6:
@@ -1717,6 +1731,10 @@ packages:
 
   /@types/uuid/9.0.0:
     resolution: {integrity: sha512-kr90f+ERiQtKWMz5rP32ltJ/BtULDI5RVO0uavn1HQUOwjx0R1h0rnDYNL0CepF1zL5bSY6FISAfd9tOdDhU5Q==}
+    dev: true
+
+  /@types/which/2.0.1:
+    resolution: {integrity: sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==}
     dev: true
 
   /@types/yauzl/2.10.0:
@@ -2142,7 +2160,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles/5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -2544,6 +2561,10 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  /chalk/5.2.0:
+    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
   /change-case/4.1.2:
@@ -2674,7 +2695,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name/1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -2682,7 +2702,6 @@ packages:
 
   /color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /color-support/1.1.3:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
@@ -2721,7 +2740,6 @@ packages:
   /commander/9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
-    dev: true
 
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -3084,7 +3102,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug/4.3.4_supports-color@8.1.1:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -3293,6 +3310,10 @@ packages:
     resolution: {integrity: sha512-NTZOW9A7ipb0n7z7nC3wftvsbceircwVHSgzobJsEQa+7RnOMbhrfX5IflA6CtC4GA63DSAiHYXa4JKEy9F7cA==}
     dependencies:
       detect-libc: 1.0.3
+    dev: true
+
+  /duplexer/0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
     dev: true
 
   /eastasianwidth/0.2.0:
@@ -4263,6 +4284,18 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /event-stream/3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
+    dev: true
+
   /event-target-shim/5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -4516,6 +4549,10 @@ packages:
 
   /fraction.js/4.2.0:
     resolution: {integrity: sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==}
+    dev: true
+
+  /from/0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
     dev: true
 
   /fs-constants/1.0.0:
@@ -4809,7 +4846,6 @@ packages:
   /has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-property-descriptors/1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -5712,6 +5748,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /map-stream/0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
+    dev: true
+
   /markdown-it-anchor/8.6.6_2zb4u3vubltivolgu556vv4aom:
     resolution: {integrity: sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==}
     peerDependencies:
@@ -5940,7 +5980,6 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5988,6 +6027,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+    dev: true
+
+  /node-fetch/3.2.10:
+    resolution: {integrity: sha512-MhuzNwdURnZ1Cp4XTazr69K0BTizsBroX7Zx3UgDSVcZYKF/6p0CBe4EUb/hLqmzVhl0UpYfgRljQ4yxE+iCxA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
     dev: true
 
   /node-fetch/3.3.0:
@@ -6335,6 +6383,12 @@ packages:
 
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
+  /pause-stream/0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+    dependencies:
+      through: 2.3.8
     dev: true
 
   /pend/1.2.0:
@@ -6923,6 +6977,14 @@ packages:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
     dev: true
 
+  /ps-tree/1.2.0:
+    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+    dependencies:
+      event-stream: 3.3.4
+    dev: true
+
   /psl/1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: true
@@ -7441,6 +7503,12 @@ packages:
     resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
     dev: true
 
+  /split/0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+    dependencies:
+      through: 2.3.8
+    dev: true
+
   /sprintf-js/1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
     dev: true
@@ -7469,6 +7537,12 @@ packages:
   /statuses/1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /stream-combiner/0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+    dependencies:
+      duplexer: 0.1.2
     dev: true
 
   /streamsearch/1.1.0:
@@ -7686,7 +7760,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color/8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -8459,6 +8532,16 @@ packages:
       - terser
     dev: true
 
+  /vite-plugin-child-process/1.0.5:
+    resolution: {integrity: sha512-hBM4Xp4lkwPWygMKtQpaz8eI58Z8rdBovteBQn5ACQ0Mle/tHSQq2aqEaLRZAYshjeuu2Iw779/6ocw9UTPheg==}
+    dependencies:
+      debug: 4.3.4
+      rxjs: 7.8.0
+      zx: 7.1.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite/2.9.15:
     resolution: {integrity: sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==}
     engines: {node: '>=12.2.0'}
@@ -8609,6 +8692,18 @@ packages:
     dependencies:
       xml-name-validator: 4.0.0
     dev: true
+
+  /wait-port/1.0.4:
+    resolution: {integrity: sha512-w8Ftna3h6XSFWWc2JC5gZEgp64nz8bnaTp5cvzbJSZ53j+omktWTDdwXxEF0jM8YveviLgFWvNGrSvRHnkyHyw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      commander: 9.5.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
@@ -8931,4 +9026,24 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /zx/7.1.1:
+    resolution: {integrity: sha512-5YlTO2AJ+Ku2YuZKSSSqnUKuagcM/f/j4LmHs15O84Ch80Z9gzR09ZK3gR7GV+rc8IFpz2H/XNFtFVmj31yrZA==}
+    engines: {node: '>= 16.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      '@types/minimist': 1.2.2
+      '@types/node': 18.13.0
+      '@types/ps-tree': 1.1.2
+      '@types/which': 2.0.1
+      chalk: 5.2.0
+      fs-extra: 10.1.0
+      globby: 13.1.3
+      minimist: 1.2.7
+      node-fetch: 3.2.10
+      ps-tree: 1.2.0
+      which: 2.0.2
+      yaml: 2.2.1
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,7 @@ specifiers:
   eslint-plugin-playwright: ^0.12.0
   eslint-plugin-svelte3: ^3.2.0
   eslint-plugin-vitest: ^0.0.8
+  esno: ^0.16.3
   google-protobuf: ^3.17.3
   histoire: ^0.12.4
   husky: ^8.0.1
@@ -166,6 +167,7 @@ devDependencies:
   eslint-plugin-playwright: 0.12.0_eslint@8.31.0
   eslint-plugin-svelte3: 3.4.1_btuntbn75dxkba3nofpps2nvzm
   eslint-plugin-vitest: 0.0.8_iukboom6ndih5an6iafl45j2fe
+  esno: 0.16.3
   google-protobuf: 3.21.2
   histoire: 0.12.4_5uw3d2dd4sqml7zu2gkztj47im
   husky: 8.0.3
@@ -653,6 +655,27 @@ packages:
       - supports-color
     dev: true
 
+  /@esbuild-kit/cjs-loader/2.4.2:
+    resolution: {integrity: sha512-BDXFbYOJzT/NBEtp71cvsrGPwGAMGRB/349rwKuoxNSiKjPraNNnlK6MIIabViCjqZugu6j+xeMDlEkWdHHJSg==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
+    dev: true
+
+  /@esbuild-kit/core-utils/3.1.0:
+    resolution: {integrity: sha512-Uuk8RpCg/7fdHSceR1M6XbSZFSuMrxcePFuGgyvsBn+u339dk5OeL4jv2EojwTN2st/unJGsVm4qHWjWNmJ/tw==}
+    dependencies:
+      esbuild: 0.17.7
+      source-map-support: 0.5.21
+    dev: true
+
+  /@esbuild-kit/esm-loader/2.5.5:
+    resolution: {integrity: sha512-Qwfvj/qoPbClxCRNuac1Du01r9gvNOT+pMYtJDapfB1eoGN1YlJ1BixLyL9WVENRx5RXgNLdfYdx/CuswlGhMw==}
+    dependencies:
+      '@esbuild-kit/core-utils': 3.1.0
+      get-tsconfig: 4.4.0
+    dev: true
+
   /@esbuild/android-arm/0.15.18:
     resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
     engines: {node: '>=12'}
@@ -671,8 +694,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.17.7:
+    resolution: {integrity: sha512-Np6Lg8VUiuzHP5XvHU7zfSVPN4ILdiOhxA1GQ1uvCK2T2l3nI8igQV0c9FJx4hTkq8WGqhGEvn5UuRH8jMkExg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/android-arm64/0.16.16:
     resolution: {integrity: sha512-hFHVAzUKp9Tf8psGq+bDVv+6hTy1bAOoV/jJMUWwhUnIHsh6WbFMhw0ZTkqDuh7TdpffFoHOiIOIxmHc7oYRBQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.17.7:
+    resolution: {integrity: sha512-fOUBZvcbtbQJIj2K/LMKcjULGfXLV9R4qjXFsi3UuqFhIRJHz0Fp6kFjsMFI6vLuPrfC5G9Dmh+3RZOrSKY2Lg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -689,8 +730,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-x64/0.17.7:
+    resolution: {integrity: sha512-6YILpPvop1rPAvaO/n2iWQL45RyTVTR/1SK7P6Xi2fyu+hpEeX22fE2U2oJd1sfpovUJOWTRdugjddX6QCup3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/darwin-arm64/0.16.16:
     resolution: {integrity: sha512-8Z+wld+vr/prHPi2O0X7o1zQOfMbXWGAw9hT0jEyU/l/Yrg+0Z3FO9pjPho72dVkZs4ewZk0bDOFLdZHm8jEfw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.17.7:
+    resolution: {integrity: sha512-7i0gfFsDt1BBiurZz5oZIpzfxqy5QkJmhXdtrf2Hma/gI9vL2AqxHhRBoI1NeWc9IhN1qOzWZrslhiXZweMSFg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -707,8 +766,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/darwin-x64/0.17.7:
+    resolution: {integrity: sha512-hRvIu3vuVIcv4SJXEKOHVsNssM5tLE2xWdb9ZyJqsgYp+onRa5El3VJ4+WjTbkf/A2FD5wuMIbO2FCTV39LE0w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/freebsd-arm64/0.16.16:
     resolution: {integrity: sha512-fxrw4BYqQ39z/3Ja9xj/a1gMsVq0xEjhSyI4a9MjfvDDD8fUV8IYliac96i7tzZc3+VytyXX+XNsnpEk5sw5Wg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.17.7:
+    resolution: {integrity: sha512-2NJjeQ9kiabJkVXLM3sHkySqkL1KY8BeyLams3ITyiLW10IwDL0msU5Lq1cULCn9zNxt1Seh1I6QrqyHUvOtQw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -725,8 +802,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/freebsd-x64/0.17.7:
+    resolution: {integrity: sha512-8kSxlbjuLYMoIgvRxPybirHJeW45dflyIgHVs+jzMYJf87QOay1ZUTzKjNL3vqHQjmkSn8p6KDfHVrztn7Rprw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-arm/0.16.16:
     resolution: {integrity: sha512-bYaocE1/PTMRmkgSckZ0D0Xn2nox8v2qlk+MVVqm+VECNKDdZvghVZtH41dNtBbwADSvA6qkCHGYeWm9LrNCBw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.17.7:
+    resolution: {integrity: sha512-07RsAAzznWqdfJC+h3L2UVWwnUHepsFw5GmzySnUspHHb7glJ1+47rvlcH0SeUtoVOs8hF4/THgZbtJRyALaJA==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -743,8 +838,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-arm64/0.17.7:
+    resolution: {integrity: sha512-43Bbhq3Ia/mGFTCRA4NlY8VRH3dLQltJ4cqzhSfq+cdvdm9nKJXVh4NUkJvdZgEZIkf/ufeMmJ0/22v9btXTcw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-ia32/0.16.16:
     resolution: {integrity: sha512-dxjqLKUW8GqGemoRT9v8IgHk+T4tRm1rn1gUcArsp26W9EkK/27VSjBVUXhEG5NInHZ92JaQ3SSMdTwv/r9a2A==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.17.7:
+    resolution: {integrity: sha512-ViYkfcfnbwOoTS7xE4DvYFv7QOlW8kPBuccc4erJ0jx2mXDPR7e0lYOH9JelotS9qe8uJ0s2i3UjUvjunEp53A==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -779,8 +892,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-loong64/0.17.7:
+    resolution: {integrity: sha512-H1g+AwwcqYQ/Hl/sMcopRcNLY/fysIb/ksDfCa3/kOaHQNhBrLeDYw+88VAFV5U6oJL9GqnmUj72m9Nv3th3hA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-mips64el/0.16.16:
     resolution: {integrity: sha512-CO3YmO7jYMlGqGoeFeKzdwx/bx8Vtq/SZaMAi+ZLDUnDUdfC7GmGwXzIwDJ70Sg+P9pAemjJyJ1icKJ9R3q/Fg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.17.7:
+    resolution: {integrity: sha512-MDLGrVbTGYtmldlbcxfeDPdhxttUmWoX3ovk9u6jc8iM+ueBAFlaXKuUMCoyP/zfOJb+KElB61eSdBPSvNcCEg==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -797,8 +928,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-ppc64/0.17.7:
+    resolution: {integrity: sha512-UWtLhRPKzI+v2bKk4j9rBpGyXbLAXLCOeqt1tLVAt1mfagHpFjUzzIHCpPiUfY3x1xY5e45/+BWzGpqqvSglNw==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-riscv64/0.16.16:
     resolution: {integrity: sha512-sSVVMEXsqf1fQu0j7kkhXMViroixU5XoaJXl1u/u+jbXvvhhCt9YvA/B6VM3aM/77HuRQ94neS5bcisijGnKFQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.17.7:
+    resolution: {integrity: sha512-3C/RTKqZauUwBYtIQAv7ELTJd+H2dNKPyzwE2ZTbz2RNrNhNHRoeKnG5C++eM6nSZWUCLyyaWfq1v1YRwBS/+A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -815,8 +964,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/linux-s390x/0.17.7:
+    resolution: {integrity: sha512-x7cuRSCm998KFZqGEtSo8rI5hXLxWji4znZkBhg2FPF8A8lxLLCsSXe2P5utf0RBQflb3K97dkEH/BJwTqrbDw==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/linux-x64/0.16.16:
     resolution: {integrity: sha512-G1+09TopOzo59/55lk5Q0UokghYLyHTKKzD5lXsAOOlGDbieGEFJpJBr3BLDbf7cz89KX04sBeExAR/pL/26sA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.17.7:
+    resolution: {integrity: sha512-1Z2BtWgM0Wc92WWiZR5kZ5eC+IetI++X+nf9NMbUvVymt74fnQqwgM5btlTW7P5uCHfq03u5MWHjIZa4o+TnXQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -833,8 +1000,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/netbsd-x64/0.17.7:
+    resolution: {integrity: sha512-//VShPN4hgbmkDjYNCZermIhj8ORqoPNmAnwSPqPtBB0xOpHrXMlJhsqLNsgoBm0zi/5tmy//WyL6g81Uq2c6Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/openbsd-x64/0.16.16:
     resolution: {integrity: sha512-yeERkoxG2nR2oxO5n+Ms7MsCeNk23zrby2GXCqnfCpPp7KNc0vxaaacIxb21wPMfXXRhGBrNP4YLIupUBrWdlg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.17.7:
+    resolution: {integrity: sha512-IQ8BliXHiOsbQEOHzc7mVLIw2UYPpbOXJQ9cK1nClNYQjZthvfiA6rWZMz4BZpVzHZJ+/H2H23cZwRJ1NPYOGg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -851,8 +1036,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/sunos-x64/0.17.7:
+    resolution: {integrity: sha512-phO5HvU3SyURmcW6dfQXX4UEkFREUwaoiTgi1xH+CAFKPGsrcG6oDp1U70yQf5lxRKujoSCEIoBr0uFykJzN2g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-arm64/0.16.16:
     resolution: {integrity: sha512-pdD+M1ZOFy4hE15ZyPX09fd5g4DqbbL1wXGY90YmleVS6Y5YlraW4BvHjim/X/4yuCpTsAFvsT4Nca2lbyDH/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.17.7:
+    resolution: {integrity: sha512-G/cRKlYrwp1B0uvzEdnFPJ3A6zSWjnsRrWivsEW0IEHZk+czv0Bmiwa51RncruHLjQ4fGsvlYPmCmwzmutPzHA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -869,8 +1072,26 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/win32-ia32/0.17.7:
+    resolution: {integrity: sha512-/yMNVlMew07NrOflJdRAZcMdUoYTOCPbCHx0eHtg55l87wXeuhvYOPBQy5HLX31Ku+W2XsBD5HnjUjEUsTXJug==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/win32-x64/0.16.16:
     resolution: {integrity: sha512-1YYpoJ39WV/2bnShPwgdzJklc+XS0bysN6Tpnt1cWPdeoKOG4RMEY1g7i534QxXX/rPvNx/NLJQTTCeORYzipg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.17.7:
+    resolution: {integrity: sha512-K9/YybM6WZO71x73Iyab6mwieHtHjm9hrPR/a9FBPZmFO3w+fJaM2uu2rt3JYf/rZR24MFwTliI8VSoKKOtYtg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -4063,6 +4284,36 @@ packages:
       '@esbuild/win32-x64': 0.16.16
     dev: true
 
+  /esbuild/0.17.7:
+    resolution: {integrity: sha512-+5hHlrK108fT6C6/40juy0w4DYKtyZ5NjfBlTccBdsFutR7WBxpIY633JzZJewdsCy8xWA/u2z0MSniIJwufYg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.7
+      '@esbuild/android-arm64': 0.17.7
+      '@esbuild/android-x64': 0.17.7
+      '@esbuild/darwin-arm64': 0.17.7
+      '@esbuild/darwin-x64': 0.17.7
+      '@esbuild/freebsd-arm64': 0.17.7
+      '@esbuild/freebsd-x64': 0.17.7
+      '@esbuild/linux-arm': 0.17.7
+      '@esbuild/linux-arm64': 0.17.7
+      '@esbuild/linux-ia32': 0.17.7
+      '@esbuild/linux-loong64': 0.17.7
+      '@esbuild/linux-mips64el': 0.17.7
+      '@esbuild/linux-ppc64': 0.17.7
+      '@esbuild/linux-riscv64': 0.17.7
+      '@esbuild/linux-s390x': 0.17.7
+      '@esbuild/linux-x64': 0.17.7
+      '@esbuild/netbsd-x64': 0.17.7
+      '@esbuild/openbsd-x64': 0.17.7
+      '@esbuild/sunos-x64': 0.17.7
+      '@esbuild/win32-arm64': 0.17.7
+      '@esbuild/win32-ia32': 0.17.7
+      '@esbuild/win32-x64': 0.17.7
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -4234,6 +4485,13 @@ packages:
 
   /esm-env/1.0.0:
     resolution: {integrity: sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==}
+    dev: true
+
+  /esno/0.16.3:
+    resolution: {integrity: sha512-6slSBEV1lMKcX13DBifvnDFpNno5WXhw4j/ff7RI0y51BZiDqEe5dNhhjhIQ3iCOQuzsm2MbVzmwqbN78BBhPg==}
+    hasBin: true
+    dependencies:
+      tsx: 3.12.3
     dev: true
 
   /espree/9.4.1:
@@ -4674,6 +4932,10 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
+
+  /get-tsconfig/4.4.0:
+    resolution: {integrity: sha512-0Gdjo/9+FzsYhXCEFueo2aY1z1tpXrxWZzP7k8ul9qt1U5o8rYJwTJYmaeHdrVosYIVYkOy2iwCJ9FdpocJhPQ==}
+    dev: true
 
   /getos/3.2.1:
     resolution: {integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==}
@@ -8282,6 +8544,17 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.9.4
+    dev: true
+
+  /tsx/3.12.3:
+    resolution: {integrity: sha512-Wc5BFH1xccYTXaQob+lEcimkcb/Pq+0en2s+ruiX0VEIC80nV7/0s7XRahx8NnsoCnpCVUPz8wrqVSPi760LkA==}
+    hasBin: true
+    dependencies:
+      '@esbuild-kit/cjs-loader': 2.4.2
+      '@esbuild-kit/core-utils': 3.1.0
+      '@esbuild-kit/esm-loader': 2.5.5
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /tunnel-agent/0.6.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,6 @@ specifiers:
   json-beautify: ^1.1.1
   json-bigint: ^1.0.0
   just-debounce: ^1.1.0
-  kleur: ^4.1.5
   lint-staged: ^13.1.0
   mkdirp: ^2.1.3
   mock-socket: ^9.1.0
@@ -171,7 +170,6 @@ devDependencies:
   husky: 8.0.3
   jest-websocket-mock: 2.4.0
   jsdom: 20.0.3
-  kleur: 4.1.5
   lint-staged: 13.1.0
   mkdirp: 2.1.3
   mock-socket: 9.1.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,6 @@ specifiers:
   uuid: ^9.0.0
   vite: ^4.0.2
   vite-node: ^0.23.2
-  vite-plugin-child-process: ^1.0.5
   vitest: ^0.15.2
   wait-port: ^1.0.4
   webpack: ^5.73.0
@@ -205,7 +204,6 @@ devDependencies:
   typescript: 4.9.4
   vite: 4.0.4_@types+node@16.18.11
   vite-node: 0.23.4_@types+node@16.18.11
-  vite-plugin-child-process: 1.0.5
   vitest: 0.15.2_qiappldhh65w4ksb3oc7agamvi
   webpack: 5.75.0_esbuild@0.13.15
   zx: 7.1.1
@@ -8803,16 +8801,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: true
-
-  /vite-plugin-child-process/1.0.5:
-    resolution: {integrity: sha512-hBM4Xp4lkwPWygMKtQpaz8eI58Z8rdBovteBQn5ACQ0Mle/tHSQq2aqEaLRZAYshjeuu2Iw779/6ocw9UTPheg==}
-    dependencies:
-      debug: 4.3.4
-      rxjs: 7.8.0
-      zx: 7.1.1
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /vite/2.9.15:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ specifiers:
   '@sveltejs/svelte-virtual-list': ^3.0.1
   '@sveltejs/vite-plugin-svelte': ^2.0.2
   '@temporalio/proto': ^1.4.4
+  '@temporalio/testing': ^1.6.0
   '@types/base-64': ^1.0.0
   '@types/json-bigint': ^1.0.1
   '@types/mkdirp': ^1.0.2
@@ -133,6 +134,7 @@ devDependencies:
   '@sveltejs/kit': 1.0.1_svelte@3.55.1+vite@4.0.4
   '@sveltejs/vite-plugin-svelte': 2.0.2_svelte@3.55.1+vite@4.0.4
   '@temporalio/proto': 1.5.2
+  '@temporalio/testing': 1.6.0_esbuild@0.13.15
   '@types/base-64': 1.0.0
   '@types/json-bigint': 1.0.1
   '@types/mkdirp': 1.0.2
@@ -887,6 +889,14 @@ packages:
       - supports-color
     dev: true
 
+  /@grpc/grpc-js/1.7.3:
+    resolution: {integrity: sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+    dependencies:
+      '@grpc/proto-loader': 0.7.4
+      '@types/node': 16.18.11
+    dev: true
+
   /@grpc/grpc-js/1.8.3:
     resolution: {integrity: sha512-1oO40SPA9nyBEsSMg0Mq7aMxQMVH009NJLG4HeMPQ7kdDGWuC5fI6dmEjaEJzUbtmC1S2leLaDRMB4ByZ1cFew==}
     engines: {node: ^8.13.0 || >=10.10.0}
@@ -1107,6 +1117,11 @@ packages:
       fastq: 1.15.0
     dev: true
 
+  /@opentelemetry/api/1.4.0:
+    resolution: {integrity: sha512-IgMK9i3sFGNUqPMbjABm0G26g0QCKCUBfglhQ7rQq6WcxbKfEHRcmwsoER4hZcuYqJgkYn2OeuoJIv7Jsftp7g==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
   /@playwright/test/1.30.0:
     resolution: {integrity: sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==}
     engines: {node: '>=14'}
@@ -1263,11 +1278,220 @@ packages:
       - supports-color
     dev: true
 
+  /@swc/core-darwin-arm64/1.3.35:
+    resolution: {integrity: sha512-zQUFkHx4gZpu0uo2IspvPnKsz8bsdXd5bC33xwjtoAI1cpLerDyqo4v2zIahEp+FdKZjyVsLHtfJiQiA1Qka3A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-darwin-x64/1.3.35:
+    resolution: {integrity: sha512-oOSkSGWtALovaw22lNevKD434OQTPf8X+dVPvPMrJXJpJ34dWDlFWpLntoc+arvKLNZ7LQmTuk8rR1hkrAY7cw==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm-gnueabihf/1.3.35:
+    resolution: {integrity: sha512-Yie8k00O6O8BCATS/xeKStquV4OYSskUGRDXBQVDw1FrE23PHaSeHCgg4q6iNZjJzXCOJbaTCKnYoIDn9DMf7A==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu/1.3.35:
+    resolution: {integrity: sha512-Zlv3WHa/4x2p51HSvjUWXHfSe1Gl2prqImUZJc8NZOlj75BFzVuR0auhQ+LbwvIQ3gaA1LODX9lyS9wXL3yjxA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-musl/1.3.35:
+    resolution: {integrity: sha512-u6tCYsrSyZ8U+4jLMA/O82veBfLy2aUpn51WxQaeH7wqZGy9TGSJXoO8vWxARQ6b72vjsnKDJHP4MD8hFwcctg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-gnu/1.3.35:
+    resolution: {integrity: sha512-Dtxf2IbeH7XlNhP1Qt2/MvUPkpEbn7hhGfpSRs4ot8D3Vf5QEX4S/QtC1OsFWuciiYgHAT1Ybjt4xZic9DSkmA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-x64-musl/1.3.35:
+    resolution: {integrity: sha512-4XavNJ60GprjpTiESCu5daJUnmErixPAqDitJSMu4TV32LNIE8G00S9pDLXinDTW1rgcGtQdq1NLkNRmwwovtg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-arm64-msvc/1.3.35:
+    resolution: {integrity: sha512-dNGfKCUSX2M4qVyaS80Lyos0FkXyHRCvrdQ2Y4Hrg3FVokiuw3yY6fLohpUfQ5ws3n2A39dh7jGDeh34+l0sGA==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-ia32-msvc/1.3.35:
+    resolution: {integrity: sha512-ChuPSrDR+JBf7S7dEKPicnG8A3bM0uWPsW2vG+V2wH4iNfNxKVemESHosmYVeEZXqMpomNMvLyeHep1rjRsc0Q==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-win32-x64-msvc/1.3.35:
+    resolution: {integrity: sha512-/RvphT4WfuGfIK84Ha0dovdPrKB1bW/mc+dtdmhv2E3EGkNc5FoueNwYmXWRimxnU7X0X7IkcRhyKB4G5DeAmg==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core/1.3.35:
+    resolution: {integrity: sha512-KmiBin0XSVzJhzX19zTiCqmLslZ40Cl7zqskJcTDeIrRhfgKdiAsxzYUanJgMJIRjYtl9Kcg1V/Ip2o2wL8v3w==}
+    engines: {node: '>=10'}
+    requiresBuild: true
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.3.35
+      '@swc/core-darwin-x64': 1.3.35
+      '@swc/core-linux-arm-gnueabihf': 1.3.35
+      '@swc/core-linux-arm64-gnu': 1.3.35
+      '@swc/core-linux-arm64-musl': 1.3.35
+      '@swc/core-linux-x64-gnu': 1.3.35
+      '@swc/core-linux-x64-musl': 1.3.35
+      '@swc/core-win32-arm64-msvc': 1.3.35
+      '@swc/core-win32-ia32-msvc': 1.3.35
+      '@swc/core-win32-x64-msvc': 1.3.35
+    dev: true
+
+  /@temporalio/activity/1.6.0:
+    resolution: {integrity: sha512-lrdysDmt2IpUSIc9XxpWi56mT03P4OPgLafxG7BvHGjFHJrQgL753QR/uVPQfoAxRloQsJe3IIZDaaxqAYwOtw==}
+    dependencies:
+      '@temporalio/common': 1.6.0
+      abort-controller: 3.0.0
+    dev: true
+
+  /@temporalio/client/1.6.0:
+    resolution: {integrity: sha512-zmNY/s076MaR3Dwqu33urG1wdZfgSLYp23DWw5wh+l9ZJ69COkFJ5g+wjKVLkDWRcP8GqzDXqcNxqidhRf+fjg==}
+    dependencies:
+      '@grpc/grpc-js': 1.7.3
+      '@temporalio/common': 1.6.0
+      '@temporalio/proto': 1.6.0
+      abort-controller: 3.0.0
+      long: 5.2.1
+      uuid: 8.3.2
+    dev: true
+
+  /@temporalio/common/1.6.0:
+    resolution: {integrity: sha512-vmFeG0Ek7rrIEBx6pQbZq54IfYIhvJMf3AJRa/wcM68TFjgEnDVvKiYJacaiOJiisKkugwIezia+K3S2p7Q00g==}
+    dependencies:
+      '@opentelemetry/api': 1.4.0
+      '@temporalio/proto': 1.6.0
+      long: 5.2.1
+      ms: 2.1.3
+      proto3-json-serializer: 1.1.0
+      protobufjs: 7.1.2
+    dev: true
+
+  /@temporalio/core-bridge/1.6.0:
+    resolution: {integrity: sha512-QhnoKZ/wLI9+s4QJn6BqCAOqLV9ayxJHiB5goWJv2gihQylb92gmL+ig4p06VRCih3OPXbid3qf/iGJgYE5a8g==}
+    requiresBuild: true
+    dependencies:
+      '@opentelemetry/api': 1.4.0
+      '@temporalio/common': 1.6.0
+      arg: 5.0.2
+      cargo-cp-artifact: 0.1.7
+      which: 2.0.2
+    dev: true
+
   /@temporalio/proto/1.5.2:
     resolution: {integrity: sha512-yi9sktBF7EVM1wfh8IZe0iaz54zXpnfUD7zGsdWc7MyXZfl0Ub9Qrx7CxPVJSk+qbvQAx/2OpRzaFgXnyIkhEA==}
     dependencies:
       long: 5.2.1
       protobufjs: 7.1.2
+    dev: true
+
+  /@temporalio/proto/1.6.0:
+    resolution: {integrity: sha512-qFTlZdtVX1e7Aoq0MCySCnfyZpZC/VAxm19XNMKrx4veJTEdbXV69RXDthyUSJhdztgtN3GQ5jRldhrVDME+vg==}
+    dependencies:
+      long: 5.2.1
+      protobufjs: 7.1.2
+    dev: true
+
+  /@temporalio/testing/1.6.0_esbuild@0.13.15:
+    resolution: {integrity: sha512-QrL9wUEs8JgxePeGf1ghaXadNt0/lNyF5hNh1i1r2PISaJdqwntEF399ruiobdE2k1XLIRgTA50nhQYJ+QQFmQ==}
+    dependencies:
+      '@grpc/grpc-js': 1.7.3
+      '@temporalio/activity': 1.6.0
+      '@temporalio/client': 1.6.0
+      '@temporalio/common': 1.6.0
+      '@temporalio/core-bridge': 1.6.0
+      '@temporalio/proto': 1.6.0
+      '@temporalio/worker': 1.6.0_esbuild@0.13.15
+      '@temporalio/workflow': 1.6.0
+      abort-controller: 3.0.0
+      ms: 2.1.3
+    transitivePeerDependencies:
+      - esbuild
+      - uglify-js
+      - webpack-cli
+    dev: true
+
+  /@temporalio/worker/1.6.0_esbuild@0.13.15:
+    resolution: {integrity: sha512-8Rqtza5YF0ljRBTs6eJHaZQSS+6t6X55KprCZLaBwmPwcbdbJPN32OyQfgSexQ5f9QRuB3E1AwN+rhcveZPs4g==}
+    dependencies:
+      '@opentelemetry/api': 1.4.0
+      '@swc/core': 1.3.35
+      '@temporalio/activity': 1.6.0
+      '@temporalio/client': 1.6.0
+      '@temporalio/common': 1.6.0
+      '@temporalio/core-bridge': 1.6.0
+      '@temporalio/proto': 1.6.0
+      '@temporalio/workflow': 1.6.0
+      abort-controller: 3.0.0
+      cargo-cp-artifact: 0.1.7
+      heap-js: 2.2.0
+      memfs: 3.4.13
+      ms: 2.1.3
+      rxjs: 7.8.0
+      semver: 7.3.8
+      source-map: 0.7.4
+      source-map-loader: 4.0.1_webpack@5.75.0
+      swc-loader: 0.2.3_gwpkmym7uf5m6snr3dgsgj5rrq
+      unionfs: 4.4.0
+      webpack: 5.75.0_3txikk4omhtlbidmldv3q6r7ji
+    transitivePeerDependencies:
+      - esbuild
+      - uglify-js
+      - webpack-cli
+    dev: true
+
+  /@temporalio/workflow/1.6.0:
+    resolution: {integrity: sha512-BAUZNE9W67jrMGJ6Wlld0D7Jg4GTD+zDMa6CG6jPLeFjloPmWYs/0uXr8DVJ/BetiCQWmsmSuQXBo9YLuv+7Mw==}
+    dependencies:
+      '@temporalio/common': 1.6.0
+      '@temporalio/proto': 1.6.0
     dev: true
 
   /@tootallnate/once/2.0.0:
@@ -1781,6 +2005,13 @@ packages:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
     dev: true
 
+  /abort-controller/3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: true
+
   /acorn-globals/7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
     dependencies:
@@ -2269,6 +2500,11 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
       upper-case-first: 2.0.2
+    dev: true
+
+  /cargo-cp-artifact/0.1.7:
+    resolution: {integrity: sha512-pxEV9p1on8vu3BOKstVisF9TwMyGKCBRvzaVpQHuU2sLULCKrn3MJWx/4XlNzmG6xNCTPf78DJ7WCGgr2mOzjg==}
+    hasBin: true
     dev: true
 
   /case-anything/2.1.10:
@@ -4027,6 +4263,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /event-target-shim/5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: true
+
   /eventemitter2/6.4.9:
     resolution: {integrity: sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==}
     dev: true
@@ -4305,6 +4546,10 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       minipass: 3.3.6
+    dev: true
+
+  /fs-monkey/1.0.3:
+    resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==}
     dev: true
 
   /fs.realpath/1.0.0:
@@ -4600,6 +4845,11 @@ packages:
     dependencies:
       capital-case: 1.0.4
       tslib: 2.4.1
+    dev: true
+
+  /heap-js/2.2.0:
+    resolution: {integrity: sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw==}
+    engines: {node: '>=10.0.0'}
     dev: true
 
   /highlight.js/11.2.0:
@@ -5506,6 +5756,13 @@ packages:
 
   /mdurl/1.0.1:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
+    dev: true
+
+  /memfs/3.4.13:
+    resolution: {integrity: sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==}
+    engines: {node: '>= 4.0.0'}
+    dependencies:
+      fs-monkey: 1.0.3
     dev: true
 
   /memorystream/0.3.1:
@@ -6616,6 +6873,13 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /proto3-json-serializer/1.1.0:
+    resolution: {integrity: sha512-SjXwUWe/vANGs/mJJTbw5++7U67nwsymg7qsoPtw6GiXqw3kUy8ByojrlEdVE2efxAdKreX8WkDafxvYW95ZQg==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      protobufjs: 7.1.2
+    dev: true
+
   /protobufjs/6.11.3:
     resolution: {integrity: sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==}
     hasBin: true
@@ -7117,6 +7381,18 @@ packages:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
 
+  /source-map-loader/4.0.1_webpack@5.75.0:
+    resolution: {integrity: sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      webpack: ^5.72.1
+    dependencies:
+      abab: 2.0.6
+      iconv-lite: 0.6.3
+      source-map-js: 1.0.2
+      webpack: 5.75.0_3txikk4omhtlbidmldv3q6r7ji
+    dev: true
+
   /source-map-support/0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
     dependencies:
@@ -7127,6 +7403,11 @@ packages:
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map/0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /sourcemap-codec/1.4.8:
@@ -7594,6 +7875,16 @@ packages:
       stable: 0.1.8
     dev: true
 
+  /swc-loader/0.2.3_gwpkmym7uf5m6snr3dgsgj5rrq:
+    resolution: {integrity: sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==}
+    peerDependencies:
+      '@swc/core': ^1.2.147
+      webpack: '>=2'
+    dependencies:
+      '@swc/core': 1.3.35
+      webpack: 5.75.0_3txikk4omhtlbidmldv3q6r7ji
+    dev: true
+
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: true
@@ -7703,6 +7994,32 @@ packages:
       serialize-javascript: 6.0.0
       terser: 5.16.1
       webpack: 5.75.0_esbuild@0.13.15
+    dev: true
+
+  /terser-webpack-plugin/5.3.6_k4lsl5w7bntvncqjn5e76lltwm:
+    resolution: {integrity: sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      '@swc/core': 1.3.35
+      esbuild: 0.13.15
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      terser: 5.16.1
+      webpack: 5.75.0_3txikk4omhtlbidmldv3q6r7ji
     dev: true
 
   /terser/5.16.1:
@@ -7981,6 +8298,12 @@ packages:
     engines: {node: '>=12.18'}
     dependencies:
       busboy: 1.6.0
+    dev: true
+
+  /unionfs/4.4.0:
+    resolution: {integrity: sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==}
+    dependencies:
+      fs-monkey: 1.0.3
     dev: true
 
   /universalify/0.2.0:
@@ -8312,6 +8635,46 @@ packages:
   /webpack-sources/3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
+
+  /webpack/5.75.0_3txikk4omhtlbidmldv3q6r7ji:
+    resolution: {integrity: sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 0.0.51
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.8.1
+      acorn-import-assertions: 1.8.0_acorn@8.8.1
+      browserslist: 4.21.4
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.12.0
+      es-module-lexer: 0.9.3
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.6_k4lsl5w7bntvncqjn5e76lltwm
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
     dev: true
 
   /webpack/5.75.0_esbuild@0.13.15:

--- a/scripts/download-temporal.ts
+++ b/scripts/download-temporal.ts
@@ -4,22 +4,22 @@ import { finished } from 'stream/promises';
 import zlib from 'node:zlib';
 
 import fetch from 'node-fetch';
-import kleur from 'kleur';
+import { chalk } from 'zx';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
 import tar from 'tar-fs';
 
-console.log(kleur.cyan('Getting ready to download Temporal CLI…'));
+console.log(chalk.cyan('Getting ready to download Temporal CLI…'));
 
 if (process.env.VERCEL) {
   console.log(
-    kleur.blue('Running on Vercel; skipping downloading Temporal CLI.'),
+    chalk.blue('Running on Vercel; skipping downloading Temporal CLI.'),
   );
   process.exit(0);
 }
 
 const reportError = (error: string, exitCode = 1, callback?: () => void) => {
-  console.error(kleur.bgRed('Error:'), kleur.red(error));
+  console.error(chalk.bgRed('Error:'), chalk.red(error));
   if (callback && typeof callback === 'function') {
     callback();
   }
@@ -44,8 +44,8 @@ removeDirectory();
 await mkdirp(destinationDirectory);
 
 console.log(
-  kleur.bgYellow('Downloading:'),
-  kleur.yellow().underline(downloadUrl),
+  chalk.bgYellow('Downloading:'),
+  chalk.yellow.underline(downloadUrl),
 );
 
 try {
@@ -63,8 +63,8 @@ try {
   await chmod(destination, 0o755);
 
   console.log(
-    kleur.bgGreen('Download complete:'),
-    kleur.green().underline(join(destination, 'temporal')),
+    chalk.bgGreen('Download complete:'),
+    chalk.green.underline(join(destination, 'temporal')),
   );
 } catch (error) {
   reportError(error, 2, removeDirectory);

--- a/scripts/download-temporal.ts
+++ b/scripts/download-temporal.ts
@@ -51,6 +51,11 @@ console.log(
 try {
   const response = await fetch(downloadUrl);
 
+  if (!response.body)
+    throw new Error(
+      `Failed to find a "body" in the response form ${downloadUrl}.`,
+    );
+
   await finished(
     response.body.pipe(zlib.createGunzip()).pipe(tar.extract(destination)),
   );

--- a/scripts/download-temporal.ts
+++ b/scripts/download-temporal.ts
@@ -18,7 +18,7 @@ if (process.env.VERCEL) {
   process.exit(0);
 }
 
-const reportError = (error, exitCode = 1, callback) => {
+const reportError = (error: string, exitCode = 1, callback?: () => void) => {
   console.error(kleur.bgRed('Error:'), kleur.red(error));
   if (callback && typeof callback === 'function') {
     callback();

--- a/scripts/start-temporal-server.ts
+++ b/scripts/start-temporal-server.ts
@@ -20,15 +20,6 @@ export type TemporalServer = {
   ready: () => Promise<boolean>;
 };
 
-const findTemporalPath = async () => {
-  try {
-    const { stdout } = await $`which temporal`.quiet();
-    return stdout;
-  } catch {
-    return;
-  }
-};
-
 const getCLIPath = async (cliPath = localCLIPath): Promise<string | void> => {
   const stylizedPath = chalk.yellowBright(cliPath);
 

--- a/scripts/start-temporal-server.ts
+++ b/scripts/start-temporal-server.ts
@@ -10,6 +10,10 @@ type TemporalServerOptions = {
   logLevel?: string;
 };
 
+const warn = (message: string) => {
+  console.warn(`${chalk.bgYellow.black('WARN')}: ${message}`);
+};
+
 export type TemporalServer = {
   shutdown: () => Promise<number | null>;
   ready: () => Promise<boolean>;
@@ -31,10 +35,8 @@ export const createTemporalServer = async ({
   temporal.catch(async ({ stdout }) => {
     const { error }: { error: string } = JSON.parse(stdout);
     if (error.includes('address already in use')) {
-      return console.warn(
-        `${chalk.bgYellow.black(
-          'WARN',
-        )}: Port ${port} is already in use. Falling back to using whatever is running on that port.`,
+      return warn(
+        `Port ${port} is already in use. Falling back to whatever is running on that port.`,
       );
     }
 

--- a/scripts/start-temporal-server.ts
+++ b/scripts/start-temporal-server.ts
@@ -1,0 +1,42 @@
+import { join } from 'path';
+import waitForPort from 'wait-port';
+import { $ } from 'zx';
+
+const temporalCliPath = join(process.cwd(), 'bin', 'cli', 'temporal');
+
+type TemporalServerOptions = {
+  port?: number;
+  uiPort?: number;
+};
+
+export type TemporalServer = {
+  shutdown: () => Promise<number | null>;
+  ready: () => Promise<boolean>;
+};
+
+export const createTemporalServer = ({
+  port = 7233,
+  uiPort = port + 1000,
+}: TemporalServerOptions = {}) => {
+  const temporal = $`${temporalCliPath} server start-dev --port=${port} --ui-port=${uiPort} --log-level="fatal"`;
+
+  temporal.quiet();
+
+  const shutdown = async () => {
+    await temporal.kill();
+    return await temporal.exitCode;
+  };
+
+  const ready = async () => {
+    const ports = await Promise.all([
+      waitForPort({ port, output: 'silent' }),
+      waitForPort({ port: uiPort, output: 'silent' }),
+    ]);
+    return ports.every(({ open }) => open);
+  };
+
+  return {
+    shutdown,
+    ready,
+  };
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,12 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { HstSvelte } from '@histoire/plugin-svelte';
 import { defaultColors } from 'histoire';
+import { temporalServer } from './plugins/vite-plugin-temporal-server';
 import path from 'path';
 
 /** @type {import('vite').UserConfig} */
 export default {
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), temporalServer()],
   histoire: {
     plugins: [HstSvelte()],
     setupFile: './src/histoire.setup.ts',


### PR DESCRIPTION
- Uses the [TypeScript SDK's testing server](http://github.com/temporalio/sdk-typescript/tree/main/packages/testing) to spin up a server when the UI development server starts up.
- Switches the Vite configuration toy TypeScript.
- Removes the script that downloads Temporal CLI.
