### PR TITLE
Fix inconsistent time locale for Event Time

### DIFF
--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -1,9 +1,12 @@
-import { formatDate } from '$lib/utilities/format-date';
+import { get } from 'svelte/store';
+import { timeFormat } from '$lib/stores/time-format';
+
 import {
   shouldDisplayAttribute,
   shouldDisplayNestedAttribute,
 } from '$lib/utilities/get-single-attribute-for-event';
 import { capitalize } from '$lib/utilities/format-camel-case';
+import { formatDate } from '$lib/utilities/format-date';
 
 export type CombinedAttributes = EventAttribute & {
   eventTime?: string;
@@ -92,7 +95,8 @@ export const formatAttributes = (
 ): CombinedAttributes => {
   const attributes: CombinedAttributes = {};
 
-  if (compact) attributes.eventTime = formatDate(event.eventTime);
+  if (compact)
+    attributes.eventTime = formatDate(event.eventTime, get(timeFormat));
 
   for (const [key, value] of Object.entries(event.attributes)) {
     const shouldDisplay = shouldDisplayAttribute(key, value);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Format `Event Time` in the `Compact` expanded row view based on time format.

## Why?
<!-- Tell your future self why have you made these changes -->
Fix inconsistent time locale for `Event Time` in `Date & Time` column vs. `Compact` expanded row view.

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-386` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify the `Event Time` is the same format in the `Date & Time` column and in the `Compact` expanded row view
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
