### PR TITLE
Add toggle to decode JSON on JSON view

### DIFF
--- a/src/lib/components/auto-refresh-workflow.svelte
+++ b/src/lib/components/auto-refresh-workflow.svelte
@@ -9,7 +9,9 @@
   $: checked = $autoRefreshWorkflow === 'on';
 </script>
 
-<label for="autorefresh" class="flex items-center gap-4 font-secondary text-sm"
+<label
+  for="autorefresh"
+  class="mt-2 flex items-center gap-4 font-secondary text-sm"
   >Auto refresh
   <Tooltip bottomLeft text="15 second page refresh">
     <ToggleSwitch id="autorefresh" {checked} on:change={onChange} />

--- a/src/lib/holocene/toggle-switch.svelte
+++ b/src/lib/holocene/toggle-switch.svelte
@@ -10,7 +10,7 @@
 
 <style lang="postcss">
   .switch {
-    @apply relative mt-2 inline-block h-8 w-[52px] rounded-[8rem];
+    @apply relative inline-block h-8 w-[52px] rounded-[8rem];
   }
 
   .slider {

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -6,6 +6,7 @@
   import { exportHistory } from '$lib/utilities/export-history';
   import { workflowRun } from '$lib/stores/workflow-run';
   import { eventHistory } from '$lib/stores/events';
+  import { decodeJSON } from '$lib/stores/data-encoder-config';
 
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
@@ -17,6 +18,9 @@
   import InputAndResults from '$lib/components/workflow/input-and-results.svelte';
   import Accordion from '$lib/holocene/accordion.svelte';
   import EventShortcutKeys from '$lib/components/event/event-shortcut-keys.svelte';
+  import { authUser } from '$lib/stores/auth-user';
+
+  const { settings } = $page.data;
 
   let showShortcuts = false;
 
@@ -85,6 +89,9 @@
                 namespace: $page.params.namespace,
                 workflowId: $workflowRun.workflow?.id,
                 runId: $workflowRun.workflow?.runId,
+                decodeJSON: $decodeJSON,
+                settings,
+                accessToken: $authUser?.accessToken,
               })}>Download</ToggleButton
           >
         </ToggleButtons>

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -3,21 +3,44 @@
 
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Loading from '$lib/holocene/loading.svelte';
-  import { fetchRawEvents } from '$lib/services/events-service';
+  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
+  import { fetchAllEvents, fetchRawEvents } from '$lib/services/events-service';
+  import { authUser } from '$lib/stores/auth-user';
+  import { decodeJSON } from '$lib/stores/data-encoder-config';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 
   const { namespace, workflow: workflowId, run: runId } = $page.params;
+  const { settings } = $page.data;
 
-  const events = fetchRawEvents({
-    namespace: decodeURIForSvelte(namespace),
-    workflowId: decodeURIForSvelte(workflowId),
-    runId: decodeURIForSvelte(runId),
-    sort: 'ascending',
-  });
+  $: getEvents = $decodeJSON
+    ? fetchAllEvents({
+        namespace: decodeURIForSvelte(namespace),
+        workflowId: decodeURIForSvelte(workflowId),
+        runId: decodeURIForSvelte(runId),
+        settings,
+        accessToken: $authUser?.accessToken,
+        sort: 'ascending',
+      })
+    : fetchRawEvents({
+        namespace: decodeURIForSvelte(namespace),
+        workflowId: decodeURIForSvelte(workflowId),
+        runId: decodeURIForSvelte(runId),
+        sort: 'ascending',
+      });
+
+  const onChange = () => {
+    $decodeJSON = !$decodeJSON;
+  };
 </script>
 
-{#await events}
+{#await getEvents}
   <Loading />
 {:then events}
+  <div class="flex items-center justify-end mb-4">
+    <label for="decode" class="flex items-center gap-4 font-secondary text-sm"
+      >Decode JSON
+      <ToggleSwitch id="decode" checked={$decodeJSON} on:change={onChange} />
+    </label>
+  </div>
   <CodeBlock content={events} data-testid="event-history-json" />
 {/await}

--- a/src/lib/stores/data-encoder-config.ts
+++ b/src/lib/stores/data-encoder-config.ts
@@ -23,3 +23,5 @@ export function setLastDataEncoderSuccess(): void {
 export function resetLastDataEncoderSuccess(): void {
   lastDataEncoderStatus.set('notRequested');
 }
+
+export const decodeJSON = persistStore('decodeJSON', false, true);

--- a/src/lib/utilities/export-history.ts
+++ b/src/lib/utilities/export-history.ts
@@ -1,22 +1,38 @@
-import { fetchRawEvents } from '$lib/services/events-service';
+import { fetchAllEvents, fetchRawEvents } from '$lib/services/events-service';
+import { stringifyWithBigInt } from './parse-with-big-int';
 
 export const exportHistory = async ({
   namespace,
   workflowId,
   runId,
+  decodeJSON,
+  settings,
+  accessToken,
 }: {
   namespace: string;
   workflowId: string;
   runId: string;
+  decodeJSON: boolean;
+  settings?: Settings;
+  accessToken?: string;
 }) => {
-  const events = await fetchRawEvents({
-    namespace,
-    workflowId,
-    runId,
-    sort: 'ascending',
-  });
+  const events = decodeJSON
+    ? await fetchAllEvents({
+        namespace,
+        workflowId,
+        runId,
+        settings,
+        accessToken,
+        sort: 'ascending',
+      })
+    : await fetchRawEvents({
+        namespace,
+        workflowId,
+        runId,
+        sort: 'ascending',
+      });
 
-  const content = JSON.stringify({ events }, null, 2);
+  const content = stringifyWithBigInt({ events }, null, 2);
   download(content, `${runId}/events.json`, 'text/plain');
 
   function download(content: string, fileName: string, contentType: string) {


### PR DESCRIPTION
## What was changed
Add option to decode payloads on JSON view. If toggled on, the 'Download' event history button will also decode payloads.

## Why?
Users want to see and download decoded event histories.

<img width="1728" alt="Screen Shot 2023-02-13 at 2 17 37 PM" src="https://user-images.githubusercontent.com/7967403/218570049-dfaffe0d-0055-4049-bd30-504ee1a6d597.png">
<img width="1728" alt="Screen Shot 2023-02-13 at 2 17 46 PM" src="https://user-images.githubusercontent.com/7967403/218570108-3003b4ff-c722-48e3-a267-f47ca1de4cf1.png">


## Checklist


- [ ] @canvanooo review UI
