### PR TITLE
Add error message if response from temporal.download fails

### DIFF
--- a/scripts/download-temporal.ts
+++ b/scripts/download-temporal.ts
@@ -51,6 +51,15 @@ console.log(
 try {
   const response = await fetch(downloadUrl);
 
+  if (!response.ok) {
+    console.warn(
+      chalk.magenta.bold(`There was an error fetching Temporal CLI`),
+      chalk.bgRed.white.bold(` ${response.status} (${response.statusText}) `),
+      chalk.cyan('Skipping…'),
+    );
+    process.exit(0);
+  }
+
   if (!response.body)
     throw new Error(
       `Failed to find a "body" in the response form ${downloadUrl}.`,


### PR DESCRIPTION
Fails gracefully if we get back a 400- or 500-level error from https://temporal.download.

<img width="695" alt="image" src="https://user-images.githubusercontent.com/251000/218827697-6f21644f-633d-49a2-8048-791ff4b73483.png">
