### PR TITLE
Add a toggle for CookieSecure.

### DIFF
--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -63,7 +63,8 @@ type (
 	}
 
 	CORS struct {
-		AllowOrigins []string `yaml:"allowOrigins"`
+		AllowOrigins   []string `yaml:"allowOrigins"`
+		CookieInsecure bool     `yaml:"cookieInsecure"`
 	}
 
 	TLS struct {

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -92,7 +92,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		CookiePath:     "/",
 		CookieHTTPOnly: false,
 		CookieSameSite: http.SameSiteStrictMode,
-		CookieSecure:   true,
+		CookieSecure:   !cfg.CORS.CookieInsecure,
 		Skipper:        csrf.SkipOnAuthorizationHeader,
 	}))
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add an option to turn off CookieSecure in CSRF middleware.
<!-- Describe what has changed in this PR -->

## Why?
This is useful for users who secure the UI server with systems other than HTTPS (like VPN for example). Fixes https://github.com/temporalio/ui-server/issues/281

<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
