### PR TITLE
Add passing accessToken to queries/pending activities

### DIFF
--- a/e2e/data_converter.go
+++ b/e2e/data_converter.go
@@ -33,7 +33,7 @@ func (e *Codec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error
 		// Compress
 		b := snappy.Encode(nil, origBytes)
 		result[i] = &commonpb.Payload{
-			Metadata: map[string][]byte{converter.MetadataEncoding: []byte("json/snappy")},
+			Metadata: map[string][]byte{converter.MetadataEncoding: []byte("binary/snappy")},
 			Data:     b,
 		}
 	}
@@ -46,7 +46,7 @@ func (*Codec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) 
 	result := make([]*commonpb.Payload, len(payloads))
 	for i, p := range payloads {
 		// Only if it's our encoding
-		if string(p.Metadata[converter.MetadataEncoding]) != "json/snappy" {
+		if string(p.Metadata[converter.MetadataEncoding]) != "binary/snappy" {
 			result[i] = p
 			continue
 		}

--- a/e2e/data_converter.go
+++ b/e2e/data_converter.go
@@ -33,7 +33,7 @@ func (e *Codec) Encode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error
 		// Compress
 		b := snappy.Encode(nil, origBytes)
 		result[i] = &commonpb.Payload{
-			Metadata: map[string][]byte{converter.MetadataEncoding: []byte("binary/snappy")},
+			Metadata: map[string][]byte{converter.MetadataEncoding: []byte("json/snappy")},
 			Data:     b,
 		}
 	}
@@ -46,7 +46,7 @@ func (*Codec) Decode(payloads []*commonpb.Payload) ([]*commonpb.Payload, error) 
 	result := make([]*commonpb.Payload, len(payloads))
 	for i, p := range payloads {
 		// Only if it's our encoding
-		if string(p.Metadata[converter.MetadataEncoding]) != "binary/snappy" {
+		if string(p.Metadata[converter.MetadataEncoding]) != "json/snappy" {
 			result[i] = p
 			continue
 		}

--- a/src/lib/models/pending-activities/index.ts
+++ b/src/lib/models/pending-activities/index.ts
@@ -1,11 +1,17 @@
-import { codecEndpoint } from '$lib/stores/data-encoder-config';
+import {
+  codecEndpoint,
+  passAccessToken as codecPassAccessToken,
+} from '$lib/stores/data-encoder-config';
 import {
   convertPayloadToJsonWithCodec,
   convertPayloadToJsonWithWebsocket,
   decodePayloadAttributes,
   type DecodeFunctions,
 } from '$lib/utilities/decode-payload';
-import { getCodecEndpoint } from '$lib/utilities/get-codec';
+import {
+  getCodecEndpoint,
+  getCodecPassAccessToken,
+} from '$lib/utilities/get-codec';
 
 export async function getActivityAttributes(
   { activity, namespace, settings, accessToken }: PendingActivityWithMetadata,
@@ -18,7 +24,14 @@ export async function getActivityAttributes(
 ): Promise<PendingActivity> {
   // Use locally set endpoint over settings endpoint for testing purposes
   const endpoint = getCodecEndpoint(settings, encoderEndpoint);
-  const _settings = { ...settings, codec: { ...settings?.codec, endpoint } };
+  const passAccessToken = getCodecPassAccessToken(
+    settings,
+    codecPassAccessToken,
+  );
+  const _settings = {
+    ...settings,
+    codec: { ...settings?.codec, endpoint, passAccessToken },
+  };
 
   const convertedAttributes = endpoint
     ? await convertWithCodec({

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -11,7 +11,6 @@
   import { authUser } from '$lib/stores/auth-user';
 
   const { namespace, workflow: workflowId, run: runId } = $page.params;
-  const { settings } = $page.data?.settings;
 
   const params = {
     id: workflowId,
@@ -38,7 +37,7 @@
         workflow: params,
         queryType,
       },
-      settings,
+      $page.data?.settings,
       $authUser?.accessToken,
     );
   };

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -11,6 +11,8 @@
   import { authUser } from '$lib/stores/auth-user';
 
   const { namespace, workflow: workflowId, run: runId } = $page.params;
+  const { settings } = $page.data?.settings;
+
   const params = {
     id: workflowId,
     runId,
@@ -36,7 +38,7 @@
         workflow: params,
         queryType,
       },
-      $page.data?.settings,
+      settings,
       $authUser?.accessToken,
     );
   };

--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -31,7 +31,6 @@ export async function convertPayloadsWithCodec({
       headers['Authorization'] = `Bearer ${accessToken}`;
     } else {
       setLastDataEncoderFailure();
-
       return payloads;
     }
   }

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -124,7 +124,6 @@ export const fetchStartAndEndEvents = async (
     ...parameters,
     sort: 'descending',
   });
-
   const [start, end] = await Promise.all([
     toEventHistory({
       response: startEventsRaw,

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -3,9 +3,11 @@ import {
   requestFromAPI,
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
-
 import { getQueryTypesFromError } from '$lib/utilities/get-query-types-from-error';
-import { getCodecEndpoint } from '$lib/utilities/get-codec';
+import {
+  getCodecEndpoint,
+  getCodecPassAccessToken,
+} from '$lib/utilities/get-codec';
 import {
   convertPayloadToJsonWithCodec,
   convertPayloadToJsonWithWebsocket,
@@ -14,6 +16,7 @@ import {
   parseWithBigInt,
   stringifyWithBigInt,
 } from '$lib/utilities/parse-with-big-int';
+import { passAccessToken as codecPassAccessToken } from '$lib/stores/data-encoder-config';
 
 type QueryRequestParameters = {
   workflow: Eventual<{ id: string; runId: string }>;
@@ -120,9 +123,13 @@ export async function getQuery(
     try {
       if (data[0]) {
         const endpoint = getCodecEndpoint(settings);
+        const passAccessToken = getCodecPassAccessToken(
+          settings,
+          codecPassAccessToken,
+        );
         const _settings = {
           ...settings,
-          codec: { ...settings?.codec, endpoint },
+          codec: { ...settings?.codec, endpoint, passAccessToken },
         };
         const convertedAttributes = endpoint
           ? await convertPayloadToJsonWithCodec({

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -129,7 +129,7 @@ export async function getQuery(
         );
         const _settings = {
           ...settings,
-          codec: { ...settings?.codec, endpoint },
+          codec: { ...settings?.codec, endpoint, passAccessToken },
         };
         const convertedAttributes = endpoint
           ? await convertPayloadToJsonWithCodec({

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -129,7 +129,7 @@ export async function getQuery(
         );
         const _settings = {
           ...settings,
-          codec: { ...settings?.codec, endpoint, passAccessToken },
+          codec: { ...settings?.codec, endpoint },
         };
         const convertedAttributes = endpoint
           ? await convertPayloadToJsonWithCodec({


### PR DESCRIPTION
## What was changed
Add logic to read local 'Pass access token' from localStorage when fetching queries and pending activities. 

We need to refactor all of our codec logic to simplify passing options. But this fixes the issue.

## Why?
Allow passing access tokens for queries and pending activities to be decoded.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
