### PR TITLE
Change Results to Continued as New with Input for Workflows with a Continued As New status

### DIFF
--- a/cypress/integration/workflow-input-and-results.spec.js
+++ b/cypress/integration/workflow-input-and-results.spec.js
@@ -161,7 +161,9 @@ describe('Workflow Input and Results', () => {
       'base64',
     ).toString();
     cy.get('[data-testid="workflow-input"]').contains(input);
-    cy.get('[data-testid="workflow-results"]').contains('In progress');
+    cy.get('[data-testid="workflow-results"]').contains(
+      'Results will appear upon completion',
+    );
   });
 
   it('should show the input and results for failed workflow', () => {

--- a/cypress/integration/workflow-input-and-results.spec.js
+++ b/cypress/integration/workflow-input-and-results.spec.js
@@ -283,7 +283,7 @@ describe('Workflow Input and Results', () => {
     cy.get('[data-testid="workflow-results"]').contains('Timeout');
   });
 
-  it('should show the input and results for continued as new workflow', () => {
+  it('should show the input and continued as new input for continued as new workflow', () => {
     cy.intercept(
       Cypress.env('VITE_API_HOST') +
         `/api/v1/namespaces/default/workflows/${workflowId}/runs/${runId}/events?maximumPageSize=20`,
@@ -312,11 +312,20 @@ describe('Workflow Input and Results', () => {
     cy.get('[data-testid="input-and-results"]').click();
 
     const firstEvent = eventsContinuedAsNewFixture.history.events[0];
+    const lastEvent =
+      eventsContinuedAsNewFixture.history.events[
+        eventsContinuedAsNewFixture.history.events.length - 1
+      ];
     const input = Buffer.from(
       firstEvent.workflowExecutionStartedEventAttributes.input.payloads[0].data,
       'base64',
     ).toString();
+    const result = Buffer.from(
+      lastEvent.workflowExecutionContinuedAsNewEventAttributes.input.payloads[0]
+        .data,
+      'base64',
+    ).toString();
     cy.get('[data-testid="workflow-input"]').contains(input);
-    cy.get('[data-testid="workflow-results"]').contains('ContinuedAsNew');
+    cy.get('[data-testid="workflow-results"]').contains(result);
   });
 });

--- a/src/lib/components/workflow/input-and-results.svelte
+++ b/src/lib/components/workflow/input-and-results.svelte
@@ -6,8 +6,9 @@
 
   export let type: 'input' | 'results';
   export let content: string;
+  export let title: string = null;
 
-  $: title = capitalize(type);
+  $: title = title ?? capitalize(type);
 </script>
 
 <article class="flex w-full flex-col lg:w-1/2" data-testid="workflow-{type}">

--- a/src/lib/components/workflow/input-and-results.svelte
+++ b/src/lib/components/workflow/input-and-results.svelte
@@ -1,17 +1,12 @@
 <script lang="ts">
-  import { capitalize } from '$lib/utilities/format-camel-case';
-
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Loading from '$lib/holocene/loading.svelte';
 
-  export let type: 'input' | 'results';
   export let content: string;
-  export let title: string = null;
-
-  $: title = title ?? capitalize(type);
+  export let title: string;
 </script>
 
-<article class="flex w-full flex-col lg:w-1/2" data-testid="workflow-{type}">
+<article class="flex w-full flex-col lg:w-1/2" {...$$restProps}>
   <h3 class="text-lg">{title}</h3>
   {#if content}
     <CodeBlock {content} class="mb-2 max-h-96" />

--- a/src/lib/components/workflow/input-and-results.svelte
+++ b/src/lib/components/workflow/input-and-results.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import CodeBlock from '$lib/holocene/code-block.svelte';
-  import Loading from '$lib/holocene/loading.svelte';
 
   export let content: string;
   export let title: string;
@@ -11,6 +10,11 @@
   {#if content}
     <CodeBlock {content} class="mb-2 max-h-96" />
   {:else}
-    <Loading title="In progress..." />
+    <CodeBlock
+      content="Results will appear upon completion."
+      language="text"
+      class="mb-2 max-h-96"
+      copyable={false}
+    />
   {/if}
 </article>

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -9,6 +9,7 @@
   export let content: Parameters<typeof JSON.stringify>[0];
   export let inline = false;
   export let language = 'json';
+  export let copyable = true;
 
   let root: HTMLElement;
   let isJSON = language === 'json';
@@ -64,15 +65,17 @@
           data-testid={$$props['data-testid']}
         /></pre>
 
-      <button
-        on:click={(e) => copy(e, parsedContent)}
-        class="absolute top-2.5 right-2.5 rounded-md bg-gray-900 opacity-90 hover:bg-white"
-      >
-        <Icon
-          name={$copied ? 'checkmark' : 'copy'}
-          class="text-white hover:text-gray-900"
-        />
-      </button>
+      {#if copyable}
+        <button
+          on:click={(e) => copy(e, parsedContent)}
+          class="absolute top-2.5 right-2.5 rounded-md bg-gray-900 opacity-90 hover:bg-white"
+        >
+          <Icon
+            name={$copied ? 'checkmark' : 'copy'}
+            class="text-white hover:text-gray-900"
+          />
+        </button>
+      {/if}
     </div>
   </div>
 {/if}

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -24,6 +24,7 @@
     getWorkflowStartedCompletedAndTaskFailedEvents($eventHistory);
   $: ({ workflow } = $workflowRun);
   $: workflowRelationships = getWorkflowRelationships(workflow, $eventHistory);
+  $: isContinuedAsNew = workflow?.status === 'ContinuedAsNew';
 
   const onViewClick = (view: EventView) => {
     if ($page.url.searchParams.get('page')) {
@@ -40,14 +41,20 @@
   <WorkflowRelationships {...workflowRelationships} />
   <PendingActivities />
   <Accordion
-    title="Input and Results"
+    title="Input and {isContinuedAsNew
+      ? 'Continued as New with Input'
+      : 'Results'}"
     icon="json"
     class="border-gray-900"
     data-testid="input-and-results"
   >
     <div class="flex w-full flex-col gap-2 lg:flex-row">
       <InputAndResults type="input" content={workflowEvents.input} />
-      <InputAndResults type="results" content={workflowEvents.results} />
+      <InputAndResults
+        type="results"
+        content={workflowEvents.results}
+        title={isContinuedAsNew ? 'Continued as New with Input' : null}
+      />
     </div>
   </Accordion>
   <slot name="timeline" />

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -24,7 +24,6 @@
     getWorkflowStartedCompletedAndTaskFailedEvents($eventHistory);
   $: ({ workflow } = $workflowRun);
   $: workflowRelationships = getWorkflowRelationships(workflow, $eventHistory);
-  $: isContinuedAsNew = workflow?.status === 'ContinuedAsNew';
 
   const onViewClick = (view: EventView) => {
     if ($page.url.searchParams.get('page')) {
@@ -42,19 +41,23 @@
   <PendingActivities />
   <section>
     <Accordion
-      title="Input and {isContinuedAsNew
-        ? 'Continued as New with Input'
-        : 'Results'}"
+      title={workflowEvents.contAsNew ? 'Input' : 'Input and Results'}
       icon="json"
       class="border-gray-900"
       data-testid="input-and-results"
     >
       <div class="flex w-full flex-col gap-2 lg:flex-row">
-        <InputAndResults type="input" content={workflowEvents.input} />
         <InputAndResults
-          type="results"
+          title="Input"
+          content={workflowEvents.input}
+          data-testid="workflow-input"
+        />
+        <InputAndResults
           content={workflowEvents.results}
-          title={isContinuedAsNew ? 'Continued as New with Input' : null}
+          title={workflowEvents.contAsNew
+            ? 'Continued as New with Input'
+            : 'Results'}
+          data-testid="workflow-results"
         />
       </div>
     </Accordion>

--- a/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
+++ b/src/lib/utilities/get-started-completed-and-task-failed-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { getWorkflowStartedCompletedAndTaskFailedEvents } from './get-started-completed-and-task-failed-events';
 
 import completedEventHistory from '$fixtures/events.completed.json';
+import continuedAsNewEventHistory from '$fixtures/events.continued-as-new.json';
 import canceledEventHistory from '$fixtures/events.canceled.json';
 import failedEventHistory from '$fixtures/events.failed.json';
 import runningEventHistory from '$fixtures/events.running.json';
@@ -224,6 +225,38 @@ describe('getWorkflowStartedCompletedAndTaskFailedEvents', () => {
     expect(results).toMatchInlineSnapshot(
       '"{\\"type\\":\\"workflowExecutionTimedOutEventAttributes\\",\\"retryState\\":\\"RetryPolicyNotSet\\",\\"newExecutionRunId\\":\\"\\"}"',
     );
+  });
+
+  it('should set contAsNew to false for a non continuedAsNew event history', () => {
+    const { contAsNew } = getWorkflowStartedCompletedAndTaskFailedEvents({
+      start: timedOutEventHistory,
+      end: timedOutEventHistory,
+    });
+    expect(contAsNew).toBe(false);
+  });
+
+  it('should get the correct input for a continuedAsNew event history', () => {
+    const { input } = getWorkflowStartedCompletedAndTaskFailedEvents({
+      start: continuedAsNewEventHistory,
+      end: continuedAsNewEventHistory,
+    });
+    expect(input).toMatchInlineSnapshot('"[3,2]"');
+  });
+
+  it('should get the correct result for a continuedAsNew event history', () => {
+    const { results } = getWorkflowStartedCompletedAndTaskFailedEvents({
+      start: continuedAsNewEventHistory,
+      end: continuedAsNewEventHistory,
+    });
+    expect(results).toMatchInlineSnapshot('"[4,1]"');
+  });
+
+  it('should set contAsNew to true for a continuedAsNew event history', () => {
+    const { contAsNew } = getWorkflowStartedCompletedAndTaskFailedEvents({
+      start: continuedAsNewEventHistory,
+      end: continuedAsNewEventHistory,
+    });
+    expect(contAsNew).toBe(true);
   });
 
   it('should work as expected with a WorkflowCompletedEvent with a null result', () => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
* Changed `Results` to `Continued as New Input` on the workflow detail page for workflows where the last event is `Continued As New` 
<img width="1623" alt="Screenshot 2023-02-24 at 3 08 11 PM" src="https://user-images.githubusercontent.com/15069288/221302676-8f59e9ed-5fa0-44c3-b382-bc5609aadfcc.png">

* Shows `Results will appear upon completion` in `Results` for `Running` workflows
<img width="1641" alt="Screenshot 2023-02-24 at 3 09 11 PM" src="https://user-images.githubusercontent.com/15069288/221302825-88165262-87b5-43c3-badb-4c659f9ba6f5.png">


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes: `DT-383` <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify the dropdown and code block on the workflow detail page have `Input` and `Continued as New with Input` for a workflow with a `Continued As New` event instead of `Input and Results` and `Results`
- [ ] Verify the dropdown and code block on the workflow detail page have `Results` for a workflow with any other status
- [ ] Verify `Results` show `Results will appear upon completion` for a `Running` workflow
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
