### PR TITLE
Add registry url

### DIFF
--- a/.github/actions/checkout-and-setup/action.yml
+++ b/.github/actions/checkout-and-setup/action.yml
@@ -13,6 +13,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
+        registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
     - name: Get pnpm store directory
       id: pnpm-cache


### PR DESCRIPTION
## What was changed
Our publish-package action was broken since the registry-url was removed. Added it back.

**Question**: Is it okay for this to be added to the checkout-and-setup for all actions? Or just for the publish-package?

## Why?
Get package publishing working again.
