### PR TITLE
Add JSON Formatting toggle to queries view

### DIFF
--- a/src/lib/components/auto-refresh-workflow.svelte
+++ b/src/lib/components/auto-refresh-workflow.svelte
@@ -9,7 +9,9 @@
   $: checked = $autoRefreshWorkflow === 'on';
 </script>
 
-<label for="autorefresh" class="flex items-center gap-4 font-secondary text-sm"
+<label
+  for="autorefresh"
+  class="mt-2 flex items-center gap-4 font-secondary text-sm"
   >Auto refresh
   <Tooltip bottomLeft text="15 second page refresh">
     <ToggleSwitch id="autorefresh" {checked} on:change={onChange} />

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -11,7 +11,7 @@
   export let language = 'json';
 
   let root: HTMLElement;
-  let isJSON = language === 'json';
+  $: isJSON = language === 'json';
 
   const formatJSON = (jsonData: string): string => {
     if (!jsonData) return;

--- a/src/lib/holocene/toggle-switch.svelte
+++ b/src/lib/holocene/toggle-switch.svelte
@@ -10,7 +10,7 @@
 
 <style lang="postcss">
   .switch {
-    @apply relative mt-2 inline-block h-8 w-[52px] rounded-[8rem];
+    @apply relative inline-block h-8 w-[52px] rounded-[8rem];
   }
 
   .slider {

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -9,6 +9,7 @@
   import Button from '$lib/holocene/button.svelte';
   import Loading from '$lib/holocene/loading.svelte';
   import { authUser } from '$lib/stores/auth-user';
+  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
 
   const { namespace, workflow: workflowId, run: runId } = $page.params;
 
@@ -45,6 +46,8 @@
   $: {
     queryType && query(queryType);
   }
+
+  let jsonFormatting = true;
 </script>
 
 <section>
@@ -54,28 +57,45 @@
       <p>(This will fail if you have no workers running.)</p>
     </div>
   {:then types}
-    <div class="flex items-center gap-4">
-      <Select
-        id="query-select"
-        label="Query Type"
-        bind:value={queryType}
-        testId="query-select"
-      >
-        {#each types as value}
-          <Option {value}>{value}</Option>
-        {/each}
-      </Select>
-      <Button
-        on:click={() => query(queryType)}
-        icon="retry"
-        loading={isLoading}
-      >
-        Refresh
-      </Button>
+    <div class="flex justify-between">
+      <div class="flex items-center gap-4">
+        <Select
+          id="query-select"
+          label="Query Type"
+          bind:value={queryType}
+          testId="query-select"
+        >
+          {#each types as value}
+            <Option {value}>{value}</Option>
+          {/each}
+        </Select>
+        <Button
+          on:click={() => query(queryType)}
+          icon="retry"
+          loading={isLoading}
+        >
+          Refresh
+        </Button>
+      </div>
+      <div class="flex justify-end">
+        <label
+          for="json-formatting"
+          class="flex items-center gap-4 font-secondary text-sm"
+          >JSON Formatting
+          <ToggleSwitch
+            id="json-formatting"
+            checked={jsonFormatting}
+            on:change={() => (jsonFormatting = !jsonFormatting)}
+          />
+        </label>
+      </div>
     </div>
     <div class="flex items-start h-full">
       {#await queryResult then result}
-        <CodeBlock content={result} language="text" />
+        <CodeBlock
+          content={result}
+          language={jsonFormatting ? 'json' : 'text'}
+        />
       {/await}
     </div>
   {:catch _error}


### PR DESCRIPTION
## What was changed
Add a toggle to view queries as JSON formatted or as text formatted. Default to JSON.

<img width="1721" alt="Screen Shot 2023-02-17 at 9 48 41 AM" src="https://user-images.githubusercontent.com/7967403/219704479-a7371c8d-26ec-4b68-8815-254a786c48d2.png">

<img width="1728" alt="Screen Shot 2023-02-17 at 10 05 46 AM" src="https://user-images.githubusercontent.com/7967403/219704703-15cc932c-d00e-4dbd-8897-f5e4f19c69e4.png">

## Why?
Users want to view queries as either JSON or as text depending on the query. Some queries are json, while others can be text with newline breaks. Giving them the option for either will allow them to view either way.

