### PR TITLE
Hide webkit search cancel button

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -31,3 +31,7 @@ labels {
   max-height: 25em;
   overflow-y: scroll;
 }
+
+input[type='search']::-webkit-search-cancel-button {
+  display: none;
+}

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -260,4 +260,8 @@
   .input-container.dark.disabled input {
     @apply border-gray-900 bg-gray-900;
   }
+
+  input[type='search']::-webkit-search-cancel-button {
+    @apply hidden;
+  }
 </style>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Hides [::-webkit-search-cancel-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button) for inputs with `type="search"`.

## Why?
<!-- Tell your future self why have you made these changes -->
Fix double `x` on clearable search inputs.

<img width="246" alt="Screenshot 2023-02-21 at 3 47 24 PM" src="https://user-images.githubusercontent.com/15069288/220476269-4277d873-ddd7-4545-b8cc-dea909e69494.png">
## Checklist
<!--- add/delete as needed --->

1. Closes: n/a <!-- add issue number here -->

2. How was this tested: 
<!--- Please describe how you tested your changes/how we can test them -->
- [ ] Verify webkit cancel button is **not** visible in search inputs for various browsers
3. Any docs updates needed? n/a
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
