### PR TITLE
Expose CSRF cookie insecure setting as Docker env

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -3,6 +3,7 @@ port: 8081
 enableUi: true
 enableOpenApi: true
 cors:
+  cookieInsecure: false
   allowOrigins:
     - http://localhost:3000 # used at development by https://github.com/temporalio/ui
 refreshInterval: 1m

--- a/server/docker/config_template.yaml
+++ b/server/docker/config_template.yaml
@@ -16,7 +16,7 @@ workflowSignalDisabled: {{ default .Env.TEMPORAL_WORKFLOW_SIGNAL_DISABLED "false
 workflowResetDisabled: {{ default .Env.TEMPORAL_WORKFLOW_RESET_DISABLED "false" }}
 batchActionsDisabled: {{ default .Env.TEMPORAL_BATCH_ACTIONS_DISABLED "false" }}
 cors:
-  cookieInsecure: {{ default .Env.TEMPORAL_COOKIE_INSECURE "false" }}
+  cookieInsecure: {{ default .Env.TEMPORAL_CSRF_COOKIE_INSECURE "false" }}
   allowOrigins:
     # override framework's default that allows all origins "*"
     - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}

--- a/server/docker/config_template.yaml
+++ b/server/docker/config_template.yaml
@@ -16,6 +16,7 @@ workflowSignalDisabled: {{ default .Env.TEMPORAL_WORKFLOW_SIGNAL_DISABLED "false
 workflowResetDisabled: {{ default .Env.TEMPORAL_WORKFLOW_RESET_DISABLED "false" }}
 batchActionsDisabled: {{ default .Env.TEMPORAL_BATCH_ACTIONS_DISABLED "false" }}
 cors:
+  cookieInsecure: {{ default .Env.TEMPORAL_COOKIE_INSECURE "false" }}
   allowOrigins:
     # override framework's default that allows all origins "*"
     - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -63,8 +63,11 @@ type (
 	}
 
 	CORS struct {
-		AllowOrigins   []string `yaml:"allowOrigins"`
-		CookieInsecure bool     `yaml:"cookieInsecure"`
+		AllowOrigins []string `yaml:"allowOrigins"`
+		// CookieInsecure allows CSRF cookie to be sent to servers that the browser considers
+		// unsecured. Useful for cases where the connection is secured via VPN rather than
+		// HTTPS directly.
+		CookieInsecure bool `yaml:"cookieInsecure"`
 	}
 
 	TLS struct {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Exposed `cookieInsecure` as Docker env variable

## Why?
<!-- Tell your future self why have you made these changes -->

Users who secure their UI deployments in non-HTTPS manner may want to disable secure cookie so CSRF cookie is sent over HTTP 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

Changed the value in development.yaml and verified it is being set

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
