### PR TITLE
Make batch action checkboxes less error prone

### DIFF
--- a/cypress/integration/workflow-executions-with-new-search.spec.js
+++ b/cypress/integration/workflow-executions-with-new-search.spec.js
@@ -194,13 +194,14 @@ describe('Workflow Executions List With Search', () => {
       it('should keep single workflow filter after navigating away and back to workflow list', () => {
         cy.get('[data-testid="execution-status-filter-button"]').click();
         cy.get('[data-testid="Running"]').click();
+        cy.get('body').click(0, 0); // close the filter dropdown
 
         cy.url().should(
           'contain',
           encodeURIComponent(`ExecutionStatus="Running"`),
         );
 
-        cy.get('.workflow-summary-row').first().click();
+        cy.get('.workflow-summary-row:first-child a').click();
 
         cy.wait('@workflow-api');
         cy.wait('@event-history-api');
@@ -410,13 +411,14 @@ describe('Workflow Executions List With Search using only MySql on 1.20', () => 
       it('should keep single workflow filter after navigating away and back to workflow list', () => {
         cy.get('[data-testid="execution-status-filter-button"]').click();
         cy.get('[data-testid="Running"]').click();
+        cy.get('body').click(0, 0); // close the filter dropdown
 
         cy.url().should(
           'contain',
           encodeURIComponent(`ExecutionStatus="Running"`),
         );
 
-        cy.get('.workflow-summary-row').first().click();
+        cy.get('.workflow-summary-row:first-child a').click();
 
         cy.wait('@workflow-api');
         cy.wait('@event-history-api');

--- a/cypress/integration/workflow-executions-with-new-search.spec.js
+++ b/cypress/integration/workflow-executions-with-new-search.spec.js
@@ -194,14 +194,13 @@ describe('Workflow Executions List With Search', () => {
       it('should keep single workflow filter after navigating away and back to workflow list', () => {
         cy.get('[data-testid="execution-status-filter-button"]').click();
         cy.get('[data-testid="Running"]').click();
-        cy.get('body').click(0, 0); // close the filter dropdown
 
         cy.url().should(
           'contain',
           encodeURIComponent(`ExecutionStatus="Running"`),
         );
 
-        cy.get('.workflow-summary-row:first-child a').click();
+        cy.get('.workflow-summary-row').first().click();
 
         cy.wait('@workflow-api');
         cy.wait('@event-history-api');
@@ -411,14 +410,13 @@ describe('Workflow Executions List With Search using only MySql on 1.20', () => 
       it('should keep single workflow filter after navigating away and back to workflow list', () => {
         cy.get('[data-testid="execution-status-filter-button"]').click();
         cy.get('[data-testid="Running"]').click();
-        cy.get('body').click(0, 0); // close the filter dropdown
 
         cy.url().should(
           'contain',
           encodeURIComponent(`ExecutionStatus="Running"`),
         );
 
-        cy.get('.workflow-summary-row:first-child a').click();
+        cy.get('.workflow-summary-row').first().click();
 
         cy.wait('@workflow-api');
         cy.wait('@event-history-api');

--- a/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
+++ b/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
@@ -64,16 +64,15 @@
   };
 </script>
 
-<TableRow href={bulkActionsEnabled ? null : href} class="workflow-summary-row">
+<TableRow {href} class="workflow-summary-row">
   {#if bulkActionsEnabled}
-    <td on:keypress|stopPropagation on:click|stopPropagation>
-      <div class="absolute">
-        <Checkbox
-          disabled={checkboxDisabled}
-          bind:checked={selected}
-          on:change={handleCheckboxChange}
-        />
-      </div>
+    <td style="padding: 0;">
+      <Checkbox
+        hoverable
+        disabled={checkboxDisabled}
+        bind:checked={selected}
+        on:change={handleCheckboxChange}
+      />
     </td>
   {/if}
   <td>
@@ -90,11 +89,7 @@
     on:blur={() => (showFilterCopy = false)}
   >
     <span class="table-link">
-      {#if bulkActionsEnabled}
-        <a {href}>{workflow.id}</a>
-      {:else}
-        {workflow.id}
-      {/if}
+      {workflow.id}
     </span>
     <FilterOrCopyButtons
       show={showFilterCopy}

--- a/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
+++ b/src/lib/components/workflow/workflows-summary-row-with-filters.svelte
@@ -64,7 +64,7 @@
   };
 </script>
 
-<TableRow {href} class="workflow-summary-row">
+<TableRow href={bulkActionsEnabled ? null : href} class="workflow-summary-row">
   {#if bulkActionsEnabled}
     <td on:keypress|stopPropagation on:click|stopPropagation>
       <div class="absolute">
@@ -89,7 +89,13 @@
     on:mouseleave={() => (showFilterCopy = false)}
     on:blur={() => (showFilterCopy = false)}
   >
-    <span class="table-link">{workflow.id}</span>
+    <span class="table-link">
+      {#if bulkActionsEnabled}
+        <a {href}>{workflow.id}</a>
+      {:else}
+        {workflow.id}
+      {/if}
+    </span>
     <FilterOrCopyButtons
       show={showFilterCopy}
       content={workflow.id}

--- a/src/lib/components/workflow/workflows-summary-table-with-filters.svelte
+++ b/src/lib/components/workflow/workflows-summary-table-with-filters.svelte
@@ -92,18 +92,17 @@
     {updating}
   >
     <TableHeaderRow slot="headers">
-      <th class="table-cell h-10 w-12">
-        <div class="w-12">
-          {#if !updating}
-            <Checkbox
-              id="select-visible-workflows"
-              onDark
-              {checked}
-              {indeterminate}
-              on:change={handleCheckboxChange}
-            />
-          {/if}
-        </div>
+      <th style="padding: 0;" class="table-cell w-12">
+        {#if !updating}
+          <Checkbox
+            id="select-visible-workflows"
+            onDark
+            hoverable
+            {checked}
+            {indeterminate}
+            on:change={handleCheckboxChange}
+          />
+        {/if}
       </th>
       {#if showBulkActions}
         <th class="w-32 overflow-visible whitespace-nowrap">

--- a/src/lib/holocene/checkbox.story.svelte
+++ b/src/lib/holocene/checkbox.story.svelte
@@ -1,18 +1,28 @@
 <script lang="ts">
   import Checkbox from '$lib/holocene/checkbox.svelte';
   import type { Hst as HST } from '@histoire/plugin-svelte';
+  import { logEvent } from 'histoire/client';
 
   export let Hst: HST;
   let checked = true;
   let onDark = false;
   let indeterminate = false;
   let disabled = false;
-  let label = '';
+  let label = 'The Label';
+  let hoverable = false;
+  let group = ['A'];
+
+  const handleChange = (e: CustomEvent) => {
+    logEvent('change', e.detail);
+  };
 </script>
 
 <Hst.Story>
   <Hst.Variant title="A Checkbox">
-    <div class="h-20 w-20 py-5 px-4" class:bg-primary={onDark}>
+    <div
+      class="h-20 w-full flex items-center justify-center"
+      class:bg-primary={onDark}
+    >
       <Checkbox
         id="checkbox-input"
         bind:label
@@ -20,14 +30,45 @@
         bind:onDark
         bind:indeterminate
         bind:disabled
+        bind:hoverable
+        on:change={handleChange}
       />
     </div>
+    <p>Checked: {checked}</p>
+  </Hst.Variant>
+
+  <Hst.Variant title="A group of Checkboxes">
+    <div class="flex flex-col gap-2">
+      <Checkbox
+        id="checkbox-group-1"
+        label="Option A"
+        value="A"
+        on:change={handleChange}
+        bind:group
+      />
+      <Checkbox
+        id="checkbox-group-1"
+        label="Option B"
+        value="B"
+        on:change={handleChange}
+        bind:group
+      />
+      <Checkbox
+        id="checkbox-group-1"
+        label="Option C"
+        value="C"
+        on:change={handleChange}
+        bind:group
+      />
+    </div>
+    <pre class="mt-4">The Group: {JSON.stringify(group, undefined, 2)}</pre>
   </Hst.Variant>
 
   <svelte:fragment slot="controls">
     <Hst.Checkbox bind:value={onDark} title="On Dark:" />
     <Hst.Checkbox bind:value={indeterminate} title="Indeterminate:" />
     <Hst.Checkbox bind:value={disabled} title="Disabled:" />
+    <Hst.Checkbox bind:value={hoverable} title="Hoverable:" />
     <Hst.Text bind:value={label} title="Label:" />
   </svelte:fragment>
 </Hst.Story>

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -98,7 +98,7 @@
   }
 
   .checkbox.hoverable {
-    @apply h-[36px] w-[36px] rounded-full hover:outline hover:outline-purple-300 hover:bg-purple-200;
+    @apply h-[36px] w-[36px] rounded-full hover:border hover:border-purple-300 hover:bg-purple-200;
   }
 
   .checkbox.on-dark {
@@ -106,11 +106,11 @@
   }
 
   .label {
-    @apply ml-6 flex h-full items-center whitespace-nowrap;
+    @apply absolute top-0 left-6 flex h-full items-center whitespace-nowrap;
   }
 
   .label.hoverable {
-    @apply ml-10;
+    @apply left-10;
   }
 
   input {

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -94,11 +94,11 @@
 
 <style lang="postcss">
   .checkbox {
-    @apply block cursor-pointer select-none w-[18px] h-[18px] leading-[18px] text-sm text-primary;
+    @apply block cursor-pointer select-none w-[18px] leading-[18px] text-sm text-primary;
   }
 
   .checkbox.hoverable {
-    @apply h-[36px] w-[36px] rounded-full hover:border hover:border-purple-300 hover:bg-purple-200;
+    @apply h-9 w-9 rounded-full hover:bg-purple-200;
   }
 
   .checkbox.on-dark {

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -1,60 +1,104 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
+  import type { HTMLInputAttributes } from 'svelte/elements';
+
+  type T = $$Generic;
+
+  interface $$Props extends HTMLInputAttributes {
+    checked?: boolean;
+    label?: string;
+    onDark?: boolean;
+    indeterminate?: boolean;
+    hoverable?: boolean;
+    value?: T;
+    group?: T[];
+  }
+
   export let id: string = '';
   export let checked = false;
-  export let label: string = null;
+  export let label: string = '';
   export let onDark = false;
   export let indeterminate = false;
   export let disabled = false;
+  export let hoverable: boolean = false;
+  export let value: T = undefined;
+  export let group: T[] = undefined;
 
-  const dispatch = createEventDispatcher<{ change: { checked: boolean } }>();
+  const dispatch = createEventDispatcher<{
+    change: { checked: boolean; value?: T };
+  }>();
 
-  const handleChange = (event) => {
-    dispatch('change', { checked: event.target.checked });
+  const handleChange = (
+    event: Event & {
+      currentTarget: EventTarget & HTMLInputElement;
+    },
+  ) => {
+    const { checked: isChecked } = event.currentTarget;
+    if (group !== undefined) {
+      if (isChecked) {
+        group = [...group, value];
+      } else {
+        group = group.filter((v) => v !== value);
+      }
+    }
+
+    checked = isChecked;
+
+    dispatch('change', { checked: event.currentTarget.checked, value });
   };
+
+  checked = group !== undefined ? group.includes(value) : checked;
 </script>
 
-<label
-  on:click
-  on:keypress
-  class="checkbox {$$props.class}"
-  class:disabled
-  class:on-dark={onDark}
+<div
+  on:click|stopPropagation
+  on:keypress|stopPropagation
+  class="relative {$$props.class}"
 >
-  <span class="label">
-    {#if label}
-      {@html label}
-    {:else}
-      &nbsp;
-    {/if}
-  </span>
-  <input
-    on:click|stopPropagation
-    on:change={handleChange}
-    {id}
-    type="checkbox"
-    bind:checked
-    {indeterminate}
-    {disabled}
-    class:indeterminate
-  />
-  <span class="checkmark" class:on-dark={onDark}>
-    {#if indeterminate}
-      <Icon class="absolute top-0 left-0 h-4 w-4" name="hyphen" />
-    {:else if checked}
-      <Icon
-        class="absolute top-0 left-0 h-4 w-4"
-        name="checkmark"
-        strokeWidth={3}
-      />
-    {/if}
-  </span>
-</label>
+  <label
+    on:click
+    on:keypress
+    class="checkbox"
+    class:hoverable
+    class:disabled
+    class:on-dark={onDark}
+  >
+    <span class="label" class:hoverable>
+      {label}
+    </span>
+    <input
+      on:click|stopPropagation
+      on:change={handleChange}
+      {id}
+      {value}
+      type="checkbox"
+      bind:checked
+      {indeterminate}
+      {disabled}
+      class:indeterminate
+    />
+    <span class="checkmark" class:hoverable class:on-dark={onDark}>
+      {#if indeterminate}
+        <Icon class="absolute top-0 left-0 h-4 w-4" name="hyphen" />
+      {:else if checked}
+        <Icon
+          class="absolute top-0 left-0 h-4 w-4"
+          name="checkmark"
+          strokeWidth={3}
+        />
+      {/if}
+    </span>
+  </label>
+</div>
 
 <style lang="postcss">
   .checkbox {
-    @apply flex w-fit cursor-pointer select-none items-center text-sm leading-6 text-primary;
+    @apply block cursor-pointer select-none w-[18px] h-[18px] leading-[18px] text-sm text-primary;
+  }
+
+  .checkbox.hoverable {
+    @apply h-[36px] w-[36px] rounded-full hover:outline hover:outline-purple-300 hover:bg-purple-200;
   }
 
   .checkbox.on-dark {
@@ -62,7 +106,11 @@
   }
 
   .label {
-    @apply absolute ml-6 flex items-center whitespace-nowrap;
+    @apply ml-6 flex h-full items-center whitespace-nowrap;
+  }
+
+  .label.hoverable {
+    @apply ml-10;
   }
 
   input {
@@ -70,7 +118,11 @@
   }
 
   .checkmark {
-    @apply absolute box-content h-4 w-4 cursor-pointer rounded-sm border border-gray-500 bg-white;
+    @apply absolute box-content top-0 left-0 h-4 w-4 cursor-pointer rounded-sm border border-gray-500 bg-white;
+  }
+
+  .checkmark.hoverable {
+    @apply translate-x-1/2 translate-y-1/2;
   }
 
   .checkmark.on-dark {

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -181,10 +181,6 @@
       selectedWorkflows[workflow.runId] && workflow.status === 'Running',
   );
 
-  $: {
-    console.log($workflowCount);
-  }
-
   $: totalWorkflowCount = new Intl.NumberFormat('en-US').format(
     $workflowCount?.totalCount ?? 0,
   );

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -30,10 +30,8 @@
     batchTerminateByQuery,
     bulkCancelByIDs,
     bulkTerminateByIDs,
-    pollBatchOperation,
   } from '$lib/services/batch-service';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
-  import { toaster } from '$lib/stores/toaster';
   import BatchOperationConfirmationModal from '$lib/components/workflow/batch-operation-confirmation-modal.svelte';
   import { bulkActionsEnabled as workflowBulkActionsEnabled } from '$lib/utilities/bulk-actions-enabled';
   import { supportsAdvancedVisibility } from '$lib/stores/bulk-actions';
@@ -182,6 +180,10 @@
     (workflow) =>
       selectedWorkflows[workflow.runId] && workflow.status === 'Running',
   );
+
+  $: {
+    console.log($workflowCount);
+  }
 
   $: totalWorkflowCount = new Intl.NumberFormat('en-US').format(
     $workflowCount?.totalCount ?? 0,


### PR DESCRIPTION
<!-- Add a brief description of your change here. -->
Use new checkbox hover state to make the checkboxes in the Recent Workflows table rows easier to click. Also fix checkboxes to support `bind:group`

- [x] Does this change require a design review?
- Yes, worked with Candace on the checkbox hover state
- [x] Does this change require manual testing?
- Yes, I test locally but wouldn't mind another pair of eyes testing the UX of the checkboxes