### PR TITLE
DT-551 - wrap decoding the workflow query in a try/catch

### DIFF
--- a/src/lib/services/workflow-service.test.ts
+++ b/src/lib/services/workflow-service.test.ts
@@ -1,0 +1,42 @@
+import { vi, afterEach, describe, test, expect } from 'vitest';
+import { requestFromAPI } from '../utilities/request-from-api';
+import { fetchAllWorkflows } from './workflow-service';
+
+vi.mock('../utilities/request-from-api', () => ({
+  requestFromAPI: vi.fn().mockImplementation(
+    () =>
+      new Promise((resolve) =>
+        resolve({
+          executions: [],
+          nextPageToken: '',
+        }),
+      ),
+  ),
+}));
+
+describe('workflow service', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchAllWorkflows', () => {
+    test('preserves queries with "%"', async () => {
+      const resp = await fetchAllWorkflows('test', {
+        query: 'WorkflowType LIKE "cron%"',
+      });
+
+      expect(requestFromAPI).toHaveBeenCalledOnce();
+      expect(requestFromAPI).toHaveBeenCalledWith(
+        'http://localhost:8233/api/v1/namespaces/test/workflows',
+        {
+          handleError: expect.any(Function),
+          onError: expect.any(Function),
+          params: {
+            query: 'WorkflowType LIKE "cron%"',
+          },
+          request: expect.any(Function),
+        },
+      );
+    });
+  });
+});

--- a/src/lib/services/workflow-service.test.ts
+++ b/src/lib/services/workflow-service.test.ts
@@ -21,7 +21,7 @@ describe('workflow service', () => {
 
   describe('fetchAllWorkflows', () => {
     test('preserves queries with "%"', async () => {
-      const resp = await fetchAllWorkflows('test', {
+      await fetchAllWorkflows('test', {
         query: 'WorkflowType LIKE "cron%"',
       });
 

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -114,9 +114,14 @@ export const fetchAllWorkflows = async (
   request = fetch,
   archived = false,
 ): Promise<CombinedWorkflowExecutionsResponse> => {
-  const query = decodeURIComponent(
-    parameters.query || toListWorkflowQuery(parameters, archived),
-  );
+  const rawQuery =
+    parameters.query || toListWorkflowQuery(parameters, archived);
+  let query: string;
+  try {
+    query = decodeURIComponent(rawQuery);
+  } catch {
+    query = rawQuery;
+  }
 
   const endpoint: ValidWorkflowEndpoints = archived
     ? 'workflows.archived'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
This PR wraps a `decodeURIComponent` call in a try/catch to solve a bug when a user enters a query with a "%" character. This should be a non-breaking change as all queries that do need to be decoded should still function properly.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
n/a
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
n/a
## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
This should be covered by existing advanced search e2e and unit tests, as well as my own manual testing.
### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
n/a
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
n/a
### Merge Checklist <!-- Add todos if not ready to merge -->
n/a
### Issue(s) closed <!-- add issue number here -->
closes #1030 
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
No