### PR TITLE
Make date/time filter sticky and reapply workflow list filters when switching namespaces

### DIFF
--- a/src/lib/components/namespace-list.svelte
+++ b/src/lib/components/namespace-list.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
   import { page } from '$app/stores';
 
+  import { workflowsQuery, workflowsSearch } from '$lib/stores/workflows';
+  import { routeForWorkflowsWithQuery } from '$lib/utilities/route-for';
+  import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
+
+  import EmptyState from '$lib/holocene/empty-state.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
 
-  import { onMount } from 'svelte';
-  import EmptyState from '$lib/holocene/empty-state.svelte';
-  import { createEventDispatcher } from 'svelte';
-
   export let getNamespaceList: () => Promise<NamespaceItem[]> = null;
-
+  const { parameters, searchType } = $workflowsSearch;
+  const query = toListWorkflowQuery(parameters);
   let namespaceList = null;
   let searchField: HTMLInputElement = null;
 
@@ -74,7 +77,11 @@
           class="first:rounded-t-xl first:border-t-3 last:rounded-b-xl last:border-b-3 border-b border-l-3 border-r-3 border-gray-900 flex border-collapse gap-2 hover:bg-gradient-to-br from-blue-100 to-purple-100 cursor-pointer"
         >
           <a
-            href={namespace.href(namespace.namespace)}
+            href={routeForWorkflowsWithQuery({
+              namespace: namespace.namespace,
+              query: $workflowsQuery || query,
+              search: searchType,
+            })}
             class="w-full flex p-3"
             class:active={namespace.namespace === $page.params?.namespace}
           >

--- a/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
+++ b/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
@@ -86,14 +86,18 @@
 
   const onChange = (_value: string) => {
     value = _value;
+
+    if (value === 'Custom') {
+      custom = true;
+      return;
+    }
+
     if (value === 'All Time') {
       $workflowFilters = [...getOtherFilters($workflowFilters)];
       $persistedWorkflowFilters = [
         ...getOtherFilters($persistedWorkflowFilters),
       ];
       custom = false;
-    } else if (value === 'Custom') {
-      custom = true;
     } else {
       const filter = {
         attribute: timeField,

--- a/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
+++ b/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { timeFormat } from '$lib/stores/time-format';
   import { capitalize } from '$lib/utilities/format-camel-case';
   import {
@@ -66,13 +65,6 @@
   };
 
   $: timeFilter, setTimeValues();
-
-  onMount(() => {
-    const persistedTimeFilter = getTimeFilter($persistedWorkflowFilters);
-    if (persistedTimeFilter) {
-      timeFilter = persistedTimeFilter;
-    }
-  });
 
   const getTimeFilter = (filters: WorkflowFilter[]) =>
     filters.find(

--- a/src/lib/components/workflow/workflow-advanced-search.svelte
+++ b/src/lib/components/workflow/workflow-advanced-search.svelte
@@ -7,7 +7,11 @@
 
   import Input from '$lib/holocene/input/input.svelte';
   import Button from '$lib/holocene/button.svelte';
-  import { workflowFilters, workflowSorts } from '$lib/stores/filters';
+  import {
+    persistedWorkflowFilters,
+    workflowFilters,
+    workflowSorts,
+  } from '$lib/stores/filters';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
   import { refresh, workflowsQuery } from '$lib/stores/workflows';
 
@@ -26,6 +30,7 @@
   const onSearch = () => {
     if (!manualSearchString) {
       $workflowFilters = [];
+      $persistedWorkflowFilters = [];
       $workflowSorts = [];
       $workflowsQuery = '';
     } else {

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -12,9 +12,14 @@
     workflowsQuery,
   } from '$lib/stores/workflows';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
-  import { workflowFilters, workflowSorts } from '$lib/stores/filters';
+  import {
+    persistedWorkflowFilters,
+    workflowFilters,
+    workflowSorts,
+  } from '$lib/stores/filters';
 
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
+  import { updateQueryParamsFromFilter } from '$lib/utilities/query/to-list-workflow-filters';
 
   import EmptyState from '$lib/holocene/empty-state.svelte';
   import Pagination from '$lib/holocene/pagination.svelte';
@@ -69,7 +74,11 @@
       // Set filters from inital page load query if it exists
       $workflowFilters = toListWorkflowFilters(query);
     } else {
-      $workflowFilters = [];
+      updateQueryParamsFromFilter(
+        $page.url,
+        $persistedWorkflowFilters,
+        $workflowSorts,
+      );
     }
   });
 

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -74,11 +74,8 @@
       // Set filters from inital page load query if it exists
       $workflowFilters = toListWorkflowFilters(query);
     } else {
-      updateQueryParamsFromFilter(
-        $page.url,
-        $persistedWorkflowFilters,
-        $workflowSorts,
-      );
+      $workflowFilters = $persistedWorkflowFilters;
+      updateQueryParamsFromFilter($page.url, $workflowFilters, $workflowSorts);
     }
   });
 

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, afterUpdate } from 'svelte';
   import { page } from '$app/stores';
   import { timeFormat } from '$lib/stores/time-format';
   import {
@@ -75,6 +75,12 @@
       $workflowFilters = toListWorkflowFilters(query);
     } else {
       $workflowFilters = $persistedWorkflowFilters;
+      updateQueryParamsFromFilter($page.url, $workflowFilters, $workflowSorts);
+    }
+  });
+
+  afterUpdate(() => {
+    if (!query && ($workflowFilters.length || $workflowSorts.length)) {
       updateQueryParamsFromFilter($page.url, $workflowFilters, $workflowSorts);
     }
   });

--- a/src/lib/stores/filters.ts
+++ b/src/lib/stores/filters.ts
@@ -3,6 +3,11 @@ import type {
   WorkflowSort,
 } from '$lib/models/workflow-filters';
 import { writable } from 'svelte/store';
+import { persistStore } from '$lib/stores/persist-store';
 
 export const workflowFilters = writable<WorkflowFilter[]>([]);
+export const persistedWorkflowFilters = persistStore<WorkflowFilter[]>(
+  'workflowFilters',
+  [],
+);
 export const workflowSorts = writable<WorkflowSort[]>([]);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Date/time filter (e.g. last `15 Minutes`, `All Time`, etc.) is persisted on the user's device so that when they access Temporal it applies the filter on the `Recent Workflows` page.

All filters on the `Recent Workflows` page. (e.g. `ExecutionStatus`, `WorkflowType`, `StartTime`, etc.) are persisted when switching namespaces.

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
- [ ] Do we actually want to reapply workflow list filters when switching namespaces? It's possible that those applied filters will not return any results.
- [ ] Should we alert the user that the date/time filter is persisted? Could be confusing since none of the other filters are. Maybe we make it an opt-in feature? 

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added 
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
On the `Recent Workflows` page with advanced visibility and the new search enabled
- Select a date/time from the dropdown
   - Navigate away and then navigate to back to `/workflows` 
      - [ ] Verify the date/time filter is still applied
   - Log out, log in again, and then navigate to `/workflows` 
      - [ ] Verify the date/time filter is still applied
   - Change namespaces
      - [ ] Verify the date/time filter is still applied

- Navigate to a link with a date/time `query` that does not match one of the available dropdown options (e.g. `20 minutes`)
   - [ ] Verify the date/time filter says `Custom`
   - Navigate to `/workflows` without a query
      - [ ]  Verify the date/time from the link is not automatically applied
   - Navigate back to the link
   - Click on `Custom`
      - [ ] Verify the `Custom` query is not immediately reapplied and the inputs are blank
   - Add new `Custom` start and end times and click `Apply`
      - [ ] Verify the query is updated

- Select various filters/sorts
   - Change namespaces
      - [ ] Verify the filters/sorts are applied
   - Change some filters/sorts
      - [ ] Verify the filters/sorts are updated for the current namespace 


- Navigate to the workflow details page
   - [ ] Verify the `Back to Workflows` works as expected

- Click on the workflow nav links while on the `Recent Workflows` page
   - [ ] Verify all filters/sorts are still applied
- Click away from `Recent Workflows` and then on the workflow nav links 
   - [ ] Verify only the persisted filters are applied
---
On the `Recent Workflows` page **without** advanced visibility (and without the new search)
- [ ] Verify changing filters/sorts works as expected 
- [ ] Verify changing namespaces works as expected 
   - No filters/sorts will be applied
- [ ] Add a date/time filter and navigate to `/workflows`
   - The date/time filter will not be persisted

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
- [ ] Review design considerations

### Issue(s) closed: 
* `DT-24` 
* `DT-40` <!-- add issue number here -->

