### PR TITLE
On network error, set report to false on error to prevent Sentry errors

### DIFF
--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -36,6 +36,7 @@ export const handleError = (
     });
     // Re-throw error to prevent other code from attempting to render
     errors.set(error);
+    (error as any).report = false;
     throw error;
   }
 };

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -7,6 +7,10 @@ import { has } from './has';
 
 import type { APIErrorResponse, TemporalAPIError } from './request-from-api';
 
+interface NetworkErrorWithReport extends NetworkError {
+  report?: boolean;
+}
+
 export const handleError = (
   error: unknown,
   toasts = toaster,
@@ -36,7 +40,7 @@ export const handleError = (
     });
     // Re-throw error to prevent other code from attempting to render
     errors.set(error);
-    (error as any).report = false;
+    (error as NetworkErrorWithReport).report = false;
     throw error;
   }
 };


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We purposefully throw in network errors in our code, but we don't want to report them when being used in Cloud with Sentry. This sets the error.report to false for Sentry to ignore.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
