### PR TITLE
Automatically strip leading/trailing whitespace on ChipInput

### DIFF
--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -42,9 +42,10 @@
   });
 
   const handleKeydown = (e: KeyboardEvent) => {
-    if ((e.key === ',' || e.key === 'Enter') && displayValue !== '') {
+    const value = displayValue.trim();
+    if ((e.key === ',' || e.key === 'Enter') && value !== '') {
       e.preventDefault();
-      values.update((previous) => [...previous, displayValue]);
+      values.update((previous) => [...previous, value]);
       displayValue = '';
     }
 
@@ -62,12 +63,16 @@
   const handlePaste = (e: ClipboardEvent) => {
     e.preventDefault();
     const clipboardContents = e.clipboardData.getData('text/plain');
-    values.update((previous) => [...previous, ...clipboardContents.split(',')]);
+    values.update((previous) => [
+      ...previous,
+      ...clipboardContents.split(',').map((content) => content.trim()),
+    ]);
   };
 
   const handleBlur = () => {
-    if (displayValue !== '') {
-      values.update((previous) => [...previous, displayValue]);
+    const value = displayValue.trim();
+    if (value !== '') {
+      values.update((previous) => [...previous, value]);
       displayValue = '';
     }
   };

--- a/src/lib/holocene/input/input.story.svelte
+++ b/src/lib/holocene/input/input.story.svelte
@@ -3,6 +3,8 @@
   import Input from './input.svelte';
   import NumberInput from './number-input.svelte';
   import RangeInput from './range-input.svelte';
+  import ChipInput from './chip-input.svelte';
+  import { isEmail } from '../../utilities/is-email';
 
   export let Hst: HST;
 
@@ -16,6 +18,7 @@
   let clearable = false;
   let min = 0;
   let max = 100;
+  let emails = [];
 </script>
 
 <Hst.Story>
@@ -74,6 +77,17 @@
       {min}
       {max}
       bind:value={numberValue}
+    />
+  </Hst.Variant>
+
+  <Hst.Variant title="A Chip Input with validation">
+    <ChipInput
+      id="email-input"
+      bind:chips={emails}
+      label="Email Address(es)"
+      placeholder="Type or paste in email addresses"
+      hintText="Please enter a properly formatted email address."
+      validator={isEmail}
     />
   </Hst.Variant>
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When entering chips with validation (e.g. email addresses when inviting a user) any extra space at the beginning or end is causing a validation error. 

This PR adds `trim()` to remove the whitespace from both ends for entered and pasted values.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
n/a
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
n/a
## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [ ] Verify entering an email with a space in front and/or on the end is valid
- [ ] Verify pasting a list of emails with a `, ` between is valid and works as expected

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
n/a
### Merge Checklist <!-- Add todos if not ready to merge -->
n/a
### Issue(s) closed <!-- add issue number here -->
* `DT-564`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
n/a