### PR TITLE
Add invalidate to workflow pathname for workflows to update $page.url changes

### DIFF
--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -39,7 +39,9 @@ export const updateQueryParameters = async ({
   if (browser && url.href !== window.location.href) {
     const namespace = get(page)?.params?.namespace;
     if (url.pathname === `/namespaces/${namespace}/workflows`) {
-      await invalidate(() => true);
+      await invalidate(
+        (url) => url.pathname === `/namespaces/${namespace}/workflows`,
+      );
     }
     goto(url, gotoOptions);
   }


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
With Sveltekit 1.0.12 upgrade, we need to use invalidate the workflows page url to update the derived query store for workflows.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Apply multiple filters in a row and url and workflow list updates correctly

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
