### PR TITLE
Show Input and Results payloads individually in JSON

### DIFF
--- a/src/lib/components/workflow/input-and-results.svelte
+++ b/src/lib/components/workflow/input-and-results.svelte
@@ -1,19 +1,58 @@
 <script lang="ts">
   import CodeBlock from '$lib/holocene/code-block.svelte';
+  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
 
   export let content: string;
   export let title: string;
+
+  let parsedContent = [];
+  let showIndividually = false;
+
+  const parseContent = () => {
+    try {
+      const result = JSON.parse(content);
+      if (Array.isArray(result)) {
+        parsedContent = result;
+      }
+    } catch {
+      // do nothing
+    }
+  };
+
+  $: content && parseContent();
 </script>
 
 <article class="flex w-full flex-col lg:w-1/2" {...$$restProps}>
-  <h3 class="text-lg">{title}</h3>
+  <div class="flex flex-col sm:flex-row justify-between min-h-[32px] mb-2">
+    <h3 class="text-lg">{title}</h3>
+    {#if parsedContent.length > 0}
+      <label
+        for="{title}-show-individually"
+        class="flex items-center gap-4 font-secondary text-sm"
+        data-testid="{title}-show-individually"
+        >Show individually
+        <ToggleSwitch
+          id="{title}-show-individually"
+          bind:checked={showIndividually}
+        />
+      </label>
+    {/if}
+  </div>
   {#if content}
-    <CodeBlock {content} class="mb-2 lg:max-h-96" />
+    {#if showIndividually}
+      <div class="flex flex-col h-full lg:max-h-[24rem] overflow-scroll">
+        {#each parsedContent as content}
+          <CodeBlock content={JSON.stringify(content)} class="mb-2" />
+        {/each}
+      </div>
+    {:else}
+      <CodeBlock {content} class="mb-2 lg:max-h-[23.5rem]" />
+    {/if}
   {:else}
     <CodeBlock
       content="Results will appear upon completion."
       language="text"
-      class="mb-2 lg:max-h-96"
+      class="mb-2 lg:max-h-[24rem]"
       copyable={false}
     />
   {/if}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Allow users to individually copy JSON from `Input and Results` in the web UI and pass it directly as input to `totctl wf start / signal` commands (via the `--i `options).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

#### Show individually toggle
| Show Input individually  | Show Result individually |
|--|--|
| ![Screenshot 2023-03-21 at 3 23 00 PM](https://user-images.githubusercontent.com/15069288/226755913-8b55df87-2684-4c94-ae6c-427a5bf0abe0.png)|![Screenshot 2023-03-21 at 3 22 44 PM](https://user-images.githubusercontent.com/15069288/226755675-a079f98e-3ca7-40e8-9739-dc3ae852dba2.png)|

| Show none individually | Show both individually |
|--|--|
| ![Screenshot 2023-03-21 at 3 22 27 PM](https://user-images.githubusercontent.com/15069288/226755665-b541a2ab-8cca-4e3a-b2ae-33f432c3907e.png)|![Screenshot 2023-03-21 at 3 22 52 PM](https://user-images.githubusercontent.com/15069288/226755685-ecebee65-20f7-445b-bc6f-567e3195a05b.png)|

#### Don't show individually toggle
|Payload is an empty array or object | Running workflow |
|--|--|
|![Screenshot 2023-03-21 at 3 23 27 PM](https://user-images.githubusercontent.com/15069288/226756061-a096d04f-64e8-453e-bf2a-a7c94d2c6a32.png)|![Screenshot 2023-03-21 at 3 21 38 PM](https://user-images.githubusercontent.com/15069288/226756078-dcf47b95-b52c-48bd-8865-df3a1b796857.png)|

#### Large payload (scrollable) 
|Input | Results |
|--|--|
|![Screenshot 2023-03-21 at 4 30 07 PM](https://user-images.githubusercontent.com/15069288/226756608-c7941bf9-976c-4371-bc04-7ca8b82aebce.png)|![Screenshot 2023-03-21 at 4 30 34 PM](https://user-images.githubusercontent.com/15069288/226756618-429531a7-c3d0-4950-8a6e-ea6dd5d243d4.png)|

#### Responsiveness (smaller screens)
|Show individually | Don't show individually |
|--|--|
|![Screenshot 2023-03-21 at 4 33 05 PM](https://user-images.githubusercontent.com/15069288/226756873-88f626b4-4a23-4b51-869a-03ab20f6b00f.png)|![Screenshot 2023-03-21 at 4 33 13 PM](https://user-images.githubusercontent.com/15069288/226756895-c7a843c7-0cef-430e-8377-cfc2bf662dbd.png)|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
- Do we want a `Show individually` toggle or is there another potentially better design solution?
- If we do want a toggle, is the copy "Show individually" clear enough?

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
n/a
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
- [ ] Add tests (?)
### Merge Checklist <!-- Add todos if not ready to merge -->
n/a
### Issue(s) closed <!-- add issue number here -->
* `DT-596`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
n/a