### PR TITLE
Round first and last menu item in menu, keep table border radius at 3px

### DIFF
--- a/src/lib/holocene/primitives/menu/menu.svelte
+++ b/src/lib/holocene/primitives/menu/menu.svelte
@@ -20,6 +20,16 @@
 </ul>
 
 <style lang="postcss">
+  :global(.menu-item) {
+    &:first-child {
+      @apply rounded-t;
+    }
+
+    &:last-child {
+      @apply rounded-b;
+    }
+  }
+
   .left {
     @apply left-0 origin-top-left;
   }

--- a/src/lib/holocene/table/table.svelte
+++ b/src/lib/holocene/table/table.svelte
@@ -32,7 +32,7 @@
   }
 
   table.fancy {
-    @apply border-separate border-spacing-0 rounded-xl border-2 border-gray-900 bg-white;
+    @apply border-separate border-spacing-0 rounded-xl border-[3px] border-gray-900 bg-white;
 
     thead {
       @apply bg-gray-900 text-gray-100;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
With changing border-3 to border-2, it exposed a couple of very small issues with our border radiuses. This PR adds rounding to the first and last menu item in a menu and keeps border radius at 3px for the fancy table. I am open to a better fix for the table, I think the border thickness masked small border radius issues but we can go with this for now.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="649" alt="Screen Shot 2023-03-23 at 8 25 32 AM" src="https://user-images.githubusercontent.com/7967403/227222227-a9529e0a-3f26-418a-9f4c-4d61eef7abad.png">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
