### PR TITLE
View latest Workflow Execution without needing to provide Run ID in the url

### DIFF
--- a/src/lib/services/workflow-service.test.ts
+++ b/src/lib/services/workflow-service.test.ts
@@ -1,6 +1,6 @@
 import { vi, afterEach, describe, test, expect } from 'vitest';
 import { requestFromAPI } from '../utilities/request-from-api';
-import { fetchAllWorkflows } from './workflow-service';
+import { fetchAllWorkflows, fetchWorkflowForRunId } from './workflow-service';
 
 vi.mock('../utilities/request-from-api', () => ({
   requestFromAPI: vi.fn().mockImplementation(
@@ -33,6 +33,25 @@ describe('workflow service', () => {
           onError: expect.any(Function),
           params: {
             query: 'WorkflowType LIKE "cron%"',
+          },
+          request: expect.any(Function),
+        },
+      );
+    });
+  });
+
+  describe('fetchWorkflowForRunId', () => {
+    test('is called with the correct params', async () => {
+      const workflowId = 'temporal.test%';
+      await fetchWorkflowForRunId({ namespace: 'test', workflowId });
+
+      expect(requestFromAPI).toHaveBeenCalledOnce();
+      expect(requestFromAPI).toHaveBeenCalledWith(
+        'http://localhost:8233/api/v1/namespaces/test/workflows',
+        {
+          params: {
+            query: `WorkflowId="${workflowId}"`,
+            pageSize: '1',
           },
           request: expect.any(Function),
         },

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -156,6 +156,31 @@ export const fetchAllWorkflows = async (
   };
 };
 
+export const fetchWorkflowForRunId = async (
+  parameters: { namespace: string; workflowId: string },
+  request = fetch,
+): Promise<{ runId: string }> => {
+  const { namespace, workflowId } = parameters;
+  const endpoint: ValidWorkflowEndpoints = 'workflows';
+
+  const route = routeForApi(endpoint, { namespace });
+  const { executions } = (await requestFromAPI<ListWorkflowExecutionsResponse>(
+    route,
+    {
+      params: {
+        query: `WorkflowId="${workflowId}"`,
+        pageSize: '1',
+      },
+      request,
+    },
+  )) ?? { executions: [] };
+  const latestExecution = toWorkflowExecutions({ executions })?.[0];
+
+  return {
+    runId: latestExecution?.runId,
+  };
+};
+
 export const fetchWorkflowForAuthorization = async (
   namespace: string,
   request = fetch,

--- a/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/+page.ts
+++ b/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/+page.ts
@@ -1,0 +1,14 @@
+import { redirect, error } from '@sveltejs/kit';
+import { fetchWorkflowForRunId } from '$lib/services/workflow-service';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async function ({ url, params }) {
+  const { namespace, workflow: workflowId } = params;
+  const { runId } = await fetchWorkflowForRunId({ namespace, workflowId });
+
+  if (runId) {
+    throw redirect(302, `${url.pathname}/${runId}`);
+  } else {
+    throw error(404);
+  }
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Allows a user to enter a url with a Workflow ID but without a Run ID and view the the latest Workflow Execution page for that Workflow ID.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
n/a
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
n/a
## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Go to a url with the Workflow ID (e.g. `/workflows/[Workflow ID]') 
   - [ ] Verify you are redirected to the latest Workflow Execution page
   - If there are no executions for the workflow ID or the workflow ID does not exists
      - [ ] Verify there is a 404
- Go to a url with the Workflow ID and Run ID (e.g. `/workflows/[Workflow ID]/[Run Id]` 
   - [ ] Verify it works as expected

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
- [x] ~Add this and test in cloud as well~ https://github.com/temporalio/cloud-ui/pull/416
### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
https://github.com/temporalio/ui/issues/1220
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
n/a