### PR TITLE
Remove key block for event-summary

### DIFF
--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -77,30 +77,28 @@
   $: updating = currentEvents.length && !fullHistory.length;
 </script>
 
-{#key [$eventFilterSort, category]}
-  <Pagination
-    floatId="event-view-toggle"
-    {items}
-    {updating}
-    let:visibleItems
-    let:activeRowIndex
-    let:setActiveRowIndex
-    aria-label="recent events"
-  >
-    <EventSummaryTable {updating} {compact} on:expandAll={handleExpandChange}>
-      {#each visibleItems as event, index (`${event.id}-${event.timestamp}`)}
-        <EventSummaryRow
-          {event}
-          {compact}
-          {visibleItems}
-          expandAll={$expandAllEvents === 'true'}
-          {initialItem}
-          active={activeRowIndex === index}
-          onRowClick={() => setActiveRowIndex(index)}
-        />
-      {:else}
-        <EventEmptyRow {loading} />
-      {/each}
-    </EventSummaryTable>
-  </Pagination>
-{/key}
+<Pagination
+  floatId="event-view-toggle"
+  {items}
+  {updating}
+  let:visibleItems
+  let:activeRowIndex
+  let:setActiveRowIndex
+  aria-label="recent events"
+>
+  <EventSummaryTable {updating} {compact} on:expandAll={handleExpandChange}>
+    {#each visibleItems as event, index (`${event.id}-${event.timestamp}`)}
+      <EventSummaryRow
+        {event}
+        {compact}
+        {visibleItems}
+        expandAll={$expandAllEvents === 'true'}
+        {initialItem}
+        active={activeRowIndex === index}
+        onRowClick={() => setActiveRowIndex(index)}
+      />
+    {:else}
+      <EventEmptyRow {loading} />
+    {/each}
+  </EventSummaryTable>
+</Pagination>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
With the SvelteKit upgrade, using the {#key [$eventFilterSort, category]} block on the event-summary caused rendering issues. This PR removes the key block, and the event history renders correctly on filter changes.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

**BEFORE**
<img width="1728" alt="Screen Shot 2023-03-27 at 11 25 32 AM" src="https://user-images.githubusercontent.com/7967403/228003762-025badd1-a6e4-4643-a2bd-5f3c9593d38d.png">

**AFTER**
<img width="1696" alt="Screen Shot 2023-03-27 at 11 26 15 AM" src="https://user-images.githubusercontent.com/7967403/228003873-c63d7f06-df61-47ae-8e9d-1109e064bfca.png">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
