### PR TITLE
Add TEMPORAL_CODEC_INCLUDE_CREDENTIALS env var to pass credentials header

### DIFF
--- a/cypress/fixtures/settings.json
+++ b/cypress/fixtures/settings.json
@@ -1,10 +1,17 @@
 {
   "Version": "2.0.0",
-  "Auth": { "Enabled": false, "Options": null },
+  "Auth": {
+    "Enabled": false,
+    "Options": null
+  },
   "DefaultNamespace": "default",
   "DisableWriteActions": false,
   "ShowTemporalSystemNamespace": false,
   "FeedbackURL": "",
   "NotifyOnNewVersion": true,
-  "Codec": { "Endpoint": "", "PassAccessToken": false }
+  "Codec": {
+    "Endpoint": "",
+    "PassAccessToken": false,
+    "IncludeCredentials": false
+  }
 }

--- a/cypress/fixtures/settings.write-actions-disabled.json
+++ b/cypress/fixtures/settings.write-actions-disabled.json
@@ -1,10 +1,17 @@
 {
   "Version": "2.0.0",
-  "Auth": { "Enabled": false, "Options": null },
+  "Auth": {
+    "Enabled": false,
+    "Options": null
+  },
   "DefaultNamespace": "default",
   "DisableWriteActions": true,
   "ShowTemporalSystemNamespace": false,
   "FeedbackURL": "",
   "NotifyOnNewVersion": true,
-  "Codec": { "Endpoint": "", "PassAccessToken": false }
+  "Codec": {
+    "Endpoint": "",
+    "PassAccessToken": false,
+    "IncludeCredentials": false
+  }
 }

--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -8,7 +8,11 @@ describe('Login page', () => {
       ShowTemporalSystemNamespace: false,
       FeedbackURL: '',
       NotifyOnNewVersion: true,
-      Codec: { Endpoint: '', PassAccessToken: false },
+      Codec: {
+        Endpoint: '',
+        PassAccessToken: false,
+        IncludeCredentials: false,
+      },
     }).as('settings-api');
   });
 

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -47,5 +47,6 @@ tls:
 codec:
   endpoint:
   passAccessToken: false
+  includeCredentials: false
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For

--- a/server/docker/config_template.yaml
+++ b/server/docker/config_template.yaml
@@ -45,5 +45,6 @@ auth:
 codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
+  includeCredentials: {{ default .Env.TEMPORAL_CODEC_INCLUDE_CREDENTIALS "false" }}
 forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }} {{ end }} {{ end }}

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -45,8 +45,9 @@ type Auth struct {
 }
 
 type CodecResponse struct {
-	Endpoint        string
-	PassAccessToken bool
+	Endpoint           string
+	PassAccessToken    bool
+	IncludeCredentials bool
 }
 
 type SettingsResponse struct {
@@ -119,8 +120,9 @@ func GetSettings(cfgProvier *config.ConfigProviderWithRefresh) func(echo.Context
 			FeedbackURL:                 cfg.FeedbackURL,
 			NotifyOnNewVersion:          cfg.NotifyOnNewVersion,
 			Codec: &CodecResponse{
-				Endpoint:        cfg.Codec.Endpoint,
-				PassAccessToken: cfg.Codec.PassAccessToken,
+				Endpoint:           cfg.Codec.Endpoint,
+				PassAccessToken:    cfg.Codec.PassAccessToken,
+				IncludeCredentials: cfg.Codec.IncludeCredentials,
 			},
 			Version:                   version.UIVersion,
 			DisableWriteActions:       cfg.DisableWriteActions,

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -109,8 +109,9 @@ type (
 	}
 
 	Codec struct {
-		Endpoint        string `yaml:"endpoint"`
-		PassAccessToken bool   `yaml:"passAccessToken"`
+		Endpoint           string `yaml:"endpoint"`
+		PassAccessToken    bool   `yaml:"passAccessToken"`
+		IncludeCredentials bool   `yaml:"includeCredentials"`
 	}
 
 	Filesystem struct {

--- a/src/fixtures/settings.json
+++ b/src/fixtures/settings.json
@@ -1,9 +1,16 @@
 {
-  "Auth": { "Enabled": false, "Options": null },
+  "Auth": {
+    "Enabled": false,
+    "Options": null
+  },
   "DefaultNamespace": "default",
   "ShowTemporalSystemNamespace": false,
   "FeedbackURL": "",
   "NotifyOnNewVersion": true,
-  "Codec": { "Endpoint": "", "PassAccessToken": true },
+  "Codec": {
+    "Endpoint": "",
+    "PassAccessToken": true,
+    "IncludeCredentials": false
+  },
   "Version": "2.0.0"
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -59,6 +59,7 @@ type Settings = {
   codec: {
     endpoint?: string;
     passAccessToken?: boolean;
+    includeCredentials?: boolean;
   };
   defaultNamespace: string;
   disableWriteActions: boolean;

--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -20,11 +20,16 @@ export async function convertPayloadsWithCodec({
 }): Promise<Payloads> {
   const endpoint = settings?.codec?.endpoint;
   const passAccessToken = settings?.codec?.passAccessToken;
+  const includeCredentials = settings?.codec?.includeCredentials;
 
   const headers = {
     'Content-Type': 'application/json',
     'X-Namespace': namespace,
   };
+
+  if (includeCredentials) {
+    headers['credentials'] = 'include';
+  }
 
   if (passAccessToken) {
     if (validateHttps(endpoint)) {

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -25,6 +25,7 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     codec: {
       endpoint: settingsResponse?.Codec?.Endpoint,
       passAccessToken: settingsResponse?.Codec?.PassAccessToken,
+      includeCredentials: settingsResponse?.Codec?.IncludeCredentials,
     },
     defaultNamespace: settingsResponse?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
     disableWriteActions: !!settingsResponse?.DisableWriteActions || false,

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -9,6 +9,7 @@ export const settings = writable<Settings>({
   codec: {
     endpoint: '',
     passAccessToken: false,
+    includeCredentials: false,
   },
   defaultNamespace: null,
   disableWriteActions: false,

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -18,6 +18,7 @@ const settings: Settings = {
   codec: {
     endpoint: '',
     passAccessToken: false,
+    includeCredentials: false,
   },
   defaultNamespace: 'default',
   disableWriteActions: false,

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -290,6 +290,69 @@ describe('convertPayloadToJsonWithCodec', () => {
     const dataConverterStatus = get(lastDataEncoderStatus);
     expect(dataConverterStatus).toEqual('notRequested');
   });
+  it('Should include credentials with the request for cookie based authentication of data converters when includeCredentials is true', async () => {
+    const mockFetch = vi.fn(async () => {
+      return {
+        json: () => Promise.resolve({ payloads: [JsonPlainEncoded] }),
+      };
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const endpoint = 'http://localhost:1337';
+    await convertPayloadToJsonWithCodec({
+      attributes: parseWithBigInt(stringifyWithBigInt(workflowStartedEvent)),
+      namespace: 'default',
+      settings: {
+        codec: {
+          endpoint,
+          includeCredentials: true,
+        },
+      },
+    });
+
+    expect(mockFetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Namespace': 'default',
+          credentials: 'include',
+        },
+      }),
+    );
+  });
+  it('Should not include credentials with the request for cookie based authentication of data converters when includeCredentials is false', async () => {
+    const mockFetch = vi.fn(async () => {
+      return {
+        json: () => Promise.resolve({ payloads: [JsonPlainEncoded] }),
+      };
+    });
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const endpoint = 'http://localhost:1337';
+    await convertPayloadToJsonWithCodec({
+      attributes: parseWithBigInt(stringifyWithBigInt(workflowStartedEvent)),
+      namespace: 'default',
+      settings: {
+        codec: {
+          endpoint,
+          includeCredentials: false,
+        },
+      },
+    });
+
+    expect(mockFetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Namespace': 'default',
+        },
+      }),
+    );
+  });
 });
 
 // Integration test

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -162,7 +162,11 @@ export type Timestamp = google.protobuf.ITimestamp;
 // extra APIs
 export type SettingsResponse = {
   Auth: { Enabled: boolean; Options: string[] };
-  Codec: { Endpoint: string; PassAccessToken?: boolean };
+  Codec: {
+    Endpoint: string;
+    PassAccessToken?: boolean;
+    IncludeCredentials?: boolean;
+  };
   DefaultNamespace: string;
   DisableWriteActions: boolean;
   WorkflowTerminateDisabled: boolean;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add TEMPORAL_CODEC_INCLUDE_CREDENTIALS env var to allow passing credentials: 'include" header in codec server api requests.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
