### PR TITLE
Add max height to the CodeBlock on the expanded event details row

### DIFF
--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -40,7 +40,7 @@
         <p class="text-sm">{format(key)}</p>
         <CodeBlock
           content={codeBlockValue}
-          class="h-auto {stackTrace ? 'mb-2' : ''}"
+          class="h-auto {stackTrace ? 'mb-2' : ''} max-h-96 overflow-auto"
           {inline}
         />
       </div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Adds a `max-h` property to the `CodeBlock` on expanded event details rows so the user doesn't have to scroll though all of it to see the rest of the event detail info.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1371" alt="Screenshot 2023-04-04 at 5 30 05 PM" src="https://user-images.githubusercontent.com/15069288/229944746-456aa898-4542-41e3-a716-4c99cec331ce.png">

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists


### Issue(s) closed <!-- add issue number here -->
n/a
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
n/a