### PR TITLE
Add TEMPORAL_CODEC_INCLUDE_CREDENTIALS env var to set includeCredentials

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -47,5 +47,6 @@ tls:
 codec:
   endpoint:
   passAccessToken: false
+  includeCredentials: false
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For

--- a/server/docker/config_template.yaml
+++ b/server/docker/config_template.yaml
@@ -45,5 +45,6 @@ auth:
 codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
+  includeCredentials: {{ default .Env.TEMPORAL_CODEC_INCLUDE_CREDENTIALS "false" }}
 forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }} {{ end }} {{ end }}

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -45,8 +45,9 @@ type Auth struct {
 }
 
 type CodecResponse struct {
-	Endpoint        string
-	PassAccessToken bool
+	Endpoint           string
+	PassAccessToken    bool
+	IncludeCredentials bool
 }
 
 type SettingsResponse struct {
@@ -119,8 +120,9 @@ func GetSettings(cfgProvier *config.ConfigProviderWithRefresh) func(echo.Context
 			FeedbackURL:                 cfg.FeedbackURL,
 			NotifyOnNewVersion:          cfg.NotifyOnNewVersion,
 			Codec: &CodecResponse{
-				Endpoint:        cfg.Codec.Endpoint,
-				PassAccessToken: cfg.Codec.PassAccessToken,
+				Endpoint:           cfg.Codec.Endpoint,
+				PassAccessToken:    cfg.Codec.PassAccessToken,
+				IncludeCredentials: cfg.Codec.IncludeCredentials,
 			},
 			Version:                   version.UIVersion,
 			DisableWriteActions:       cfg.DisableWriteActions,

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -109,8 +109,9 @@ type (
 	}
 
 	Codec struct {
-		Endpoint        string `yaml:"endpoint"`
-		PassAccessToken bool   `yaml:"passAccessToken"`
+		Endpoint           string `yaml:"endpoint"`
+		PassAccessToken    bool   `yaml:"passAccessToken"`
+		IncludeCredentials bool   `yaml:"includeCredentials"`
 	}
 
 	Filesystem struct {


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Allow self-hosted folks to set TEMPORAL_CODEC_INCLUDE_CREDENTIALS env var to include credentials in all codec server api requests without needing to check the UI toggle.

@feedmeapples @robholland Open to different name for this env var

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
