### PR TITLE
Fix all remaining lint issues

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,5 +43,13 @@ module.exports = {
         varsIgnorePattern: '^_',
       },
     ],
+    '@typescript-eslint/no-explicit-any': 'error',
+    '@typescript-eslint/array-type': 'error',
+    '@typescript-eslint/class-literal-property-style': 'error',
+    '@typescript-eslint/consistent-generic-constructors': 'error',
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      { assertionStyle: 'as' },
+    ],
   },
 };

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -38,7 +38,6 @@
     ],
     "function-linear-gradient-no-nonstandard-direction": null,
     "keyframes-name-pattern": null,
-    "max-line-length": null,
     "no-descending-specificity": null,
     "selector-class-pattern": null,
     "selector-pseudo-class-no-unknown": [

--- a/e2e/test-utilities/mock-apis.ts
+++ b/e2e/test-utilities/mock-apis.ts
@@ -3,7 +3,6 @@ import { Page } from '@playwright/test';
 export const apiUrl = 'http://localhost:8233/api/v1';
 export const namespacesApi = apiUrl + '/namespaces**';
 
-const clusterApi = apiUrl + '/cluster**';
 const namespacesInfo = {
   namespaces: [
     {

--- a/e2e/test-utilities/mock-local-storage.ts
+++ b/e2e/test-utilities/mock-local-storage.ts
@@ -1,6 +1,10 @@
 import { Page } from '@playwright/test';
 
-export const setLocalStorage = async (key: string, value: any, page: Page) => {
+export const setLocalStorage = async (
+  key: string,
+  value: string,
+  page: Page,
+) => {
   await page.addInitScript(
     (item) => {
       window.localStorage.setItem(item.key, item.value);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:ui": "TZ=UTC vitest --ui",
     "test:coverage": "TZ=UTC vitest run --coverage",
     "test:integration": "playwright test",
-    "lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore . && stylelint \"src/**/*.{css,postcss,svelte}\"",
+    "lint": "prettier --check --plugin-search-dir=. . && eslint --ignore-path .gitignore --max-warnings=0 . && stylelint \"src/**/*.{css,postcss,svelte}\"",
     "lint:fix": "eslint --ignore-path .gitignore --fix",
     "format": "prettier --write --plugin-search-dir=. . && stylelint \"src/**/*.{css,postcss,svelte}\" --fix",
     "check": "VITE_TEMPORAL_UI_BUILD_TARGET=local svelte-check --tsconfig ./tsconfig.json",

--- a/src/lib/models/workflow-execution.test.ts
+++ b/src/lib/models/workflow-execution.test.ts
@@ -19,12 +19,12 @@ const workflows = [
   runningWorkflow,
   terminatedWorkflow,
   timedOutWorkflow,
-];
+] as unknown as WorkflowExecutionAPIResponse[];
 
 describe('toWorkflowExecution', () => {
   for (const workflow of workflows) {
     it(`should match the snapshot for ${workflow.workflowExecutionInfo.status} workflows`, () => {
-      expect(toWorkflowExecution(workflow as any)).toMatchSnapshot();
+      expect(toWorkflowExecution(workflow)).toMatchSnapshot();
     });
   }
 });

--- a/src/lib/models/workflow-execution.write-disabled.test.ts
+++ b/src/lib/models/workflow-execution.write-disabled.test.ts
@@ -25,12 +25,12 @@ const workflows = [
   runningWorkflow,
   terminatedWorkflow,
   timedOutWorkflow,
-];
+] as unknown as WorkflowExecutionAPIResponse[];
 
 describe('toWorkflowExecution', () => {
   for (const workflow of workflows) {
     it(`should match the snapshot for ${workflow.workflowExecutionInfo.status} workflows`, () => {
-      expect(toWorkflowExecution(workflow as any)).toMatchSnapshot();
+      expect(toWorkflowExecution(workflow)).toMatchSnapshot();
     });
   }
 });

--- a/src/lib/stores/api-pagination.ts
+++ b/src/lib/stores/api-pagination.ts
@@ -9,8 +9,8 @@ import {
 
 import type { Readable } from 'svelte/store';
 
-type PaginationMethods = {
-  nextPageWithItems: (t: NextPageToken, items: any[]) => void;
+type PaginationMethods<T> = {
+  nextPageWithItems: (t: NextPageToken, items: T[]) => void;
   nextPage: () => void;
   previousPage: () => void;
   setUpdating: () => void;
@@ -21,7 +21,7 @@ type PaginationMethods = {
   setActiveIndex: (activeIndex: number) => void;
 };
 
-type PaginationItems = {
+type PaginationItems<T> = {
   key: string;
   loading: boolean;
   updating: boolean;
@@ -32,16 +32,16 @@ type PaginationItems = {
   pageSize: number;
   indexData: Record<
     number,
-    { nextToken: string; start: number; end: number; items: any[] }
+    { nextToken: string; start: number; end: number; items: T[] }
   >;
-  visibleItems: any[];
+  visibleItems: T[];
   hasNextIndexData: boolean;
   indexStart: number;
   indexEnd: number;
   activeIndex: number;
 };
 
-const defaultStore: PaginationItems = {
+const defaultStore = {
   key: perPageKey,
   loading: true,
   updating: false,
@@ -58,7 +58,8 @@ const defaultStore: PaginationItems = {
   activeIndex: 0,
 };
 
-export type PaginationStore = PaginationMethods & Readable<PaginationItems>;
+export type PaginationStore<T> = PaginationMethods<T> &
+  Readable<PaginationItems<T>>;
 
 const setFirstOption = (options: string[] | number[]) => {
   const defaultOption = options[0];
@@ -81,10 +82,10 @@ export const getInitialPageSize = (
   }
 };
 
-export function createPaginationStore(
+export function createPaginationStore<T>(
   pageSizeOptions: string[] | number[] = options,
   defaultPageSize: string | number | undefined = undefined,
-): PaginationStore {
+): PaginationStore<T> {
   const initialPageSize = getInitialPageSize(pageSizeOptions, defaultPageSize);
   const paginationStore = writable({
     ...defaultStore,
@@ -120,10 +121,10 @@ export function createPaginationStore(
     },
   );
 
-  const setNextPageWithItems = (
+  const setNextPageWithItems = <T>(
     nextToken: string,
-    items: any[],
-    _store: PaginationItems,
+    items: T[],
+    _store: PaginationItems<T>,
   ) => {
     const currentIndex = _store.index;
     const store = {
@@ -158,7 +159,7 @@ export function createPaginationStore(
     return store;
   };
 
-  const setNextPage = (_store: PaginationItems) => {
+  const setNextPage = <T>(_store: PaginationItems<T>) => {
     const store = {
       ..._store,
       index: _store.index + 1,
@@ -174,7 +175,7 @@ export function createPaginationStore(
     return store;
   };
 
-  const setPreviousPage = (_store: PaginationItems) => {
+  const setPreviousPage = <T>(_store: PaginationItems<T>) => {
     const store = {
       ..._store,
       hasNext: true,
@@ -190,7 +191,7 @@ export function createPaginationStore(
     return store;
   };
 
-  const setNextRow = (_store: PaginationItems) => {
+  const setNextRow = <T>(_store: PaginationItems<T>) => {
     const store = { ..._store };
     const indexLength = store.indexData[store.index]?.items?.length ?? 0;
 
@@ -201,7 +202,7 @@ export function createPaginationStore(
     return store;
   };
 
-  const setPreviousRow = (_store: PaginationItems) => {
+  const setPreviousRow = <T>(_store: PaginationItems<T>) => {
     const store = { ..._store };
     const activeIndex = store.activeIndex >= 1 ? store.activeIndex - 1 : 0;
 
@@ -210,11 +211,14 @@ export function createPaginationStore(
     return store;
   };
 
-  const setActiveIndex = (_store: PaginationItems, activeIndex: number) => {
+  const setActiveIndex = <T>(
+    _store: PaginationItems<T>,
+    activeIndex: number,
+  ) => {
     return { ..._store, activeIndex };
   };
 
-  const resetPageSize = (_store: PaginationItems, pageSize) => {
+  const resetPageSize = <T>(_store: PaginationItems<T>, pageSize) => {
     return {
       ..._store,
       pageSize,
@@ -228,7 +232,7 @@ export function createPaginationStore(
 
   return {
     subscribe,
-    nextPageWithItems: (token: string, items: any[]) =>
+    nextPageWithItems: (token: string, items: T[]) =>
       update((store) => setNextPageWithItems(token, items, store)),
     nextPage: () => update((store) => setNextPage(store)),
     previousPage: () => update((store) => setPreviousPage(store)),

--- a/src/workflow.d.ts
+++ b/src/workflow.d.ts
@@ -39,7 +39,10 @@ type Decodable = {
   queryResult: import('$types').QueryResult;
 };
 
-type DecodedPayload = import('$types').Payload | Record<any, any> | string;
+type DecodedPayload =
+  | import('$types').Payload
+  | Record<string, string>
+  | string;
 
 type Decoded = {
   searchAttributes: { indexedFields: Record<string, DecodedPayload> };
@@ -47,7 +50,7 @@ type Decoded = {
   header: { fields: Record<string, DecodedPayload> };
   queryResult: Replace<
     import('$types').QueryResult,
-    { answer: Array<DecodedPayload> }
+    { answer: DecodedPayload[] }
   >;
 };
 

--- a/tests/test-utilities/mock-local-storage.ts
+++ b/tests/test-utilities/mock-local-storage.ts
@@ -1,6 +1,10 @@
 import { Page } from '@playwright/test';
 
-export const setLocalStorage = async (key: string, value: any, page: Page) => {
+export const setLocalStorage = async (
+  key: string,
+  value: string,
+  page: Page,
+) => {
   await page.addInitScript(
     (item) => {
       window.localStorage.setItem(item.key, item.value);


### PR DESCRIPTION
Fixes *all* remaining lint issues, adds rules not enforced in `@typescript-eslint/recommended` that already pass to make sure that we don't regress.