### PR TITLE
persist pinned columns width in local storage

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
@@ -14,6 +14,7 @@
     removeColumn,
     moveColumn,
     pinColumn,
+    pinnedColumnsWidth,
     MAX_PINNED_COLUMNS,
   } from '$lib/stores/workflow-table-columns';
   import Drawer from '$lib/holocene/drawer.svelte';
@@ -114,7 +115,7 @@
   };
 
   let resizableContainer: HTMLDivElement;
-  let resizableContainerWidth: number;
+  let resizableContainerWidth: number = $pinnedColumnsWidth;
   let resizing: boolean = false;
 
   const handleMouseDown = () => {
@@ -124,6 +125,7 @@
 
   const handleMouseUp = () => {
     resizing = false;
+    $pinnedColumnsWidth = resizableContainerWidth;
   };
 
   const handleMouseMove = (event: MouseEvent) => {

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -135,6 +135,10 @@ const workflowTableColumns = persistStore(
   DEFAULT_COLUMNS,
 );
 
+const pinnedColumnsWidth = persistStore<number>(
+  'workflow-table-pinned-columns-width',
+);
+
 const availableWorkflowColumns: Readable<WorkflowHeader[]> = derived(
   [workflowTableColumns],
   ([$workflowTableColumns]) =>
@@ -253,6 +257,7 @@ export {
   workflowTableColumns,
   availableSearchAttributes,
   availableWorkflowColumns,
+  pinnedColumnsWidth,
   addColumn,
   removeColumn,
   moveColumn,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Persist the width of the workflows summary table pinned columns in local storage
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
N/A
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
N/A
## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- open the workflows list page, resize the pinned column section, refresh the page and ensure the column(s) are still the same width.
## Checklists
N/A
### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs
N/A
### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
