### PR TITLE
Don't show full payload when the activity result is null

### DIFF
--- a/src/lib/utilities/decode-payload-test-fixtures.ts
+++ b/src/lib/utilities/decode-payload-test-fixtures.ts
@@ -50,12 +50,7 @@ export const workflowStartedEvent = {
   prevAutoResetPoints: null,
   header: {
     fields: {
-      encryption: {
-        metadata: {
-          encoding: 'YmluYXJ5L251bGw=',
-        },
-        data: null,
-      },
+      encryption: null,
     },
   },
 };
@@ -88,13 +83,7 @@ export const dataConvertedWorkflowStartedEvent = {
   prevAutoResetPoints: null,
   header: {
     fields: {
-      encryption: {
-        metadata: {
-          encoding: 'YmluYXJ5L251bGw=',
-          encodingDecoded: 'binary/null',
-        },
-        data: null,
-      },
+      encryption: null,
     },
   },
 };
@@ -136,13 +125,7 @@ export const dataConvertedFailureWorkflowStartedEvent = {
   prevAutoResetPoints: null,
   header: {
     fields: {
-      encryption: {
-        metadata: {
-          encoding: 'YmluYXJ5L251bGw=',
-          encodingDecoded: 'binary/null',
-        },
-        data: null,
-      },
+      encryption: null,
     },
   },
 };
@@ -175,13 +158,7 @@ export const noRemoteDataConverterWorkflowStartedEvent = {
   prevAutoResetPoints: null,
   header: {
     fields: {
-      encryption: {
-        metadata: {
-          encoding: 'YmluYXJ5L251bGw=',
-          encodingDecoded: 'binary/null',
-        },
-        data: null,
-      },
+      encryption: null,
     },
   },
 };
@@ -239,12 +216,7 @@ export const workflowStartedHistoryEvent = {
     prevAutoResetPoints: null,
     header: {
       fields: {
-        encryption: {
-          metadata: {
-            encoding: 'YmluYXJ5L251bGw=',
-          },
-          data: null,
-        },
+        encryption: null,
       },
     },
   },

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -99,10 +99,8 @@ describe('decodePayload', () => {
   it('Should not decode a payload with encoding binary/encrypted', () => {
     expect(decodePayload(WebDecodePayload)).toEqual(WebDecodePayload);
   });
-  it('Should not decode a payload with encoding binary/encrypted', () => {
-    expect(decodePayload(BinaryNullEncodedNoData)).toEqual(
-      BinaryNullEncodedNoData,
-    );
+  it('Should not decode a payload with encoding binary/null', () => {
+    expect(decodePayload(BinaryNullEncodedNoData)).toEqual(null);
   });
   it('Should decode a payload with encoding json/plain', () => {
     expect(decodePayload(JsonPlainEncoded)).toEqual(Base64Decoded);

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -66,6 +66,10 @@ export function decodePayload(
     }
   }
 
+  if (encoding === 'binary/null') {
+    return null;
+  }
+
   return payload;
 }
 

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -3,6 +3,7 @@ import {
   getSingleAttributeForEvent,
   shouldDisplayAsExecutionLink,
   shouldDisplayAttribute,
+  getCodeBlockValue,
 } from './get-single-attribute-for-event';
 
 describe('getSingleAttributeForEvent', () => {
@@ -187,5 +188,34 @@ describe('shouldDisplayAttribute', () => {
     expect(shouldDisplayAttribute('suggestContinueAsNew', false)).toBe(false);
     expect(shouldDisplayAttribute('historySizeBytes', '256')).toBe(true);
     expect(shouldDisplayAttribute('historySizeBytes', '0')).toBe(false);
+  });
+});
+
+describe('getCodeBlockValue', () => {
+  it('should return value if value is a string', () => {
+    expect(getCodeBlockValue('test')).toBe('test');
+  });
+
+  it('should return payloads if they exist', () => {
+    expect(getCodeBlockValue({ payloads: [1, 2, 3] })).toEqual([1, 2, 3]);
+    expect(getCodeBlockValue({ payloads: null })).toBe(null);
+  });
+
+  it('should return indexedFields if they exist', () => {
+    expect(getCodeBlockValue({ indexedFields: [1, 2, 3] })).toEqual([1, 2, 3]);
+    expect(getCodeBlockValue({ indexedFields: null })).toBe(null);
+  });
+
+  it('should return points if they exist', () => {
+    expect(getCodeBlockValue({ points: [1, 2, 3] })).toEqual([1, 2, 3]);
+    expect(getCodeBlockValue({ points: null })).toBe(null);
+  });
+
+  it("should return the value if it is not a string and payloads, indexedFields, or points don't exist", () => {
+    expect(getCodeBlockValue({ test: [1, 2, 3] })).toEqual({ test: [1, 2, 3] });
+    expect(getCodeBlockValue(0)).toBe(0);
+    expect(getCodeBlockValue(1)).toBe(1);
+    expect(getCodeBlockValue(null)).toBe(null);
+    expect(getCodeBlockValue([1, 2, 3])).toEqual([1, 2, 3]);
   });
 });

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -64,7 +64,10 @@ export const getCodeBlockValue: Parameters<typeof JSON.stringify>[0] = (
   value: string | Record<string, unknown>,
 ) => {
   if (typeof value === 'string') return value;
-  return value?.payloads ?? value?.indexedFields ?? value?.points ?? value;
+
+  return [value?.payloads, value?.indexedFields, value?.points, value].find(
+    (v) => v !== undefined,
+  );
 };
 
 export const getStackTrace = (value: unknown) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When a result is `null`, the UI shows the full payload. This does not happen when the returned value is empty or any other value. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
![Screenshot 2023-04-19 at 1 00 48 PM](https://user-images.githubusercontent.com/15069288/233174412-61a8b32d-9988-4250-adcb-4560c455c71a.png)

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-63`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
