### PR TITLE
Add onClick to Tab, fix presets, sort recent runs, remove required on name field

### DIFF
--- a/src/lib/components/schedule/schedule-recent-runs.svelte
+++ b/src/lib/components/schedule/schedule-recent-runs.svelte
@@ -12,11 +12,23 @@
 
   export let recentRuns: ScheduleActionResult[] = [];
   export let namespace: string;
+
+  const sortRecentRuns = (recentRuns: ScheduleActionResult[]) => {
+    return (
+      recentRuns
+        ?.sort(
+          (a, b) =>
+            new Date(b.actualTime as string).getTime() -
+            new Date(a.actualTime as string).getTime(),
+        )
+        ?.slice(0, 5) ?? []
+    );
+  };
 </script>
 
 <Panel>
   <h2 class="mb-4 text-2xl">Recent Runs</h2>
-  {#each recentRuns.slice(0, 5) as run (run?.startWorkflowResult?.workflowId)}
+  {#each sortRecentRuns(recentRuns) as run (run?.startWorkflowResult?.workflowId)}
     {#await fetchWorkflowForSchedule({ namespace, workflowId: decodeURIForSvelte(run.startWorkflowResult.workflowId), runId: run.startWorkflowResult.runId }, fetch) then workflow}
       <div class="row">
         <div class="w-28">

--- a/src/lib/components/schedule/schedules-calendar-view.svelte
+++ b/src/lib/components/schedule/schedules-calendar-view.svelte
@@ -45,12 +45,37 @@
   <h2 class="mb-4 text-2xl">Frequency</h2>
   <TabList label="Schedule Tabs" class="flex flex-wrap gap-6">
     {#if schedule}
-      <Tab label="Existing" id="existing-tab" panelId="existing-panel" />
+      <Tab
+        label="Existing"
+        id="existing-tab"
+        panelId="existing-panel"
+        onClick={() => (preset = 'existing')}
+      />
     {/if}
-    <Tab label="Interval" id="interval-tab" panelId="interval-panel" />
-    <Tab label="Days of the Week" id="daily-tab" panelId="daily-panel" />
-    <Tab label="Days of the Month" id="monthly-tab" panelId="monthly-panel" />
-    <Tab label="String" id="string-tab" panelId="string-panel" />
+    <Tab
+      label="Interval"
+      id="interval-tab"
+      panelId="interval-panel"
+      onClick={() => (preset = 'interval')}
+    />
+    <Tab
+      label="Days of the Week"
+      id="daily-tab"
+      panelId="daily-panel"
+      onClick={() => (preset = 'week')}
+    />
+    <Tab
+      label="Days of the Month"
+      id="monthly-tab"
+      panelId="monthly-panel"
+      onClick={() => (preset = 'month')}
+    />
+    <Tab
+      label="String"
+      id="string-tab"
+      panelId="string-panel"
+      onClick={() => (preset = 'string')}
+    />
   </TabList>
   <div class="mt-4 flex w-full flex-wrap gap-6">
     {#if schedule}

--- a/src/lib/components/schedule/schedules-time-view.svelte
+++ b/src/lib/components/schedule/schedules-time-view.svelte
@@ -50,7 +50,6 @@
     <div class="w-24">
       <Input
         id="minute"
-        required
         bind:value={minute}
         placeholder="00"
         suffix="min"

--- a/src/lib/holocene/tab/tab.svelte
+++ b/src/lib/holocene/tab/tab.svelte
@@ -3,6 +3,7 @@
   import type { HTMLButtonAttributes, HTMLAttributes } from 'svelte/elements';
   import { isNull } from '$lib/utilities/is';
   import { type TabContext, TABS } from './tabs.svelte';
+  import { noop } from 'svelte/internal';
 
   type OwnProps = {
     label: string;
@@ -12,6 +13,7 @@
     panelId?: string;
     disabled?: boolean;
     active?: boolean;
+    onClick?: () => void;
   };
 
   type $$Props =
@@ -24,6 +26,7 @@
   export let panelId: string = null;
   export let disabled = false;
   export let active: boolean = null;
+  export let onClick: () => void = noop;
 
   const { registerTab, selectTab, activeTab } = getContext<TabContext>(TABS);
 
@@ -33,6 +36,7 @@
 
   const handleClick = () => {
     selectTab(id);
+    onClick && onClick();
   };
 </script>
 


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
I think we lost an onClick prop with the Tab which was used to set the preset value for Schedules (thus edit/create Schedules didn't respect the preset). @rossedfort open to something else if you have something better.

Also in this PR, remove required prop from Minute field since it is not required, and sort recent runs on the Schedule View page by most recent.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
