### PR TITLE
DT-725 - make workflow ID and type links again

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
@@ -106,16 +106,6 @@
     dispatch('togglePage', { checked, ...(checked && { workflows }) });
   };
 
-  const goToWorkflow = (workflow: WorkflowExecution) => {
-    goto(
-      routeForEventHistory({
-        namespace,
-        workflow: workflow.id,
-        run: workflow.runId,
-      }),
-    );
-  };
-
   let resizableContainer: HTMLDivElement;
   let resizableContainerWidth: number = $pinnedColumnsWidth;
   let resizing: boolean = false;
@@ -229,9 +219,14 @@
       <tbody>
         {#if $workflowTableColumns.length > 0}
           {#each workflows as workflow}
+            {@const href = routeForEventHistory({
+              namespace,
+              workflow: workflow.id,
+              run: workflow.runId,
+            })}
             <tr
               class="workflow-summary-configurable-row pinned"
-              on:click={() => goToWorkflow(workflow)}
+              on:click={() => goto(href)}
             >
               {#if $supportsBulkActions}
                 <td>
@@ -245,7 +240,7 @@
                 </td>
               {/if}
               {#each pinnedColumns as column}
-                <WorkflowsSummaryTableBodyCell {column} {workflow} />
+                <WorkflowsSummaryTableBodyCell {href} {column} {workflow} />
               {/each}
             </tr>
           {/each}
@@ -285,12 +280,17 @@
       <tbody>
         {#if $workflowTableColumns.length > 0}
           {#each workflows as workflow}
+            {@const href = routeForEventHistory({
+              namespace,
+              workflow: workflow.id,
+              run: workflow.runId,
+            })}
             <tr
               class="workflow-summary-configurable-row"
-              on:click={() => goToWorkflow(workflow)}
+              on:click={() => goto(href)}
             >
               {#each otherColumns as column}
-                <WorkflowsSummaryTableBodyCell {column} {workflow} />
+                <WorkflowsSummaryTableBodyCell {href} {column} {workflow} />
               {/each}
               <td />
             </tr>

--- a/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-configurable-table.svelte
@@ -84,6 +84,17 @@
   $: pinnedColumns = $workflowTableColumns.filter((column) => column.pinned);
   $: otherColumns = $workflowTableColumns.filter((column) => !column.pinned);
 
+  const goToEventHistory = (event: MouseEvent, workflow: WorkflowExecution) => {
+    if (event.target instanceof HTMLAnchorElement) return;
+    goto(
+      routeForEventHistory({
+        namespace,
+        workflow: workflow.id,
+        run: workflow.runId,
+      }),
+    );
+  };
+
   const openCustomizationDrawer = () => {
     customizationDrawerOpen = true;
   };
@@ -219,14 +230,9 @@
       <tbody>
         {#if $workflowTableColumns.length > 0}
           {#each workflows as workflow}
-            {@const href = routeForEventHistory({
-              namespace,
-              workflow: workflow.id,
-              run: workflow.runId,
-            })}
             <tr
               class="workflow-summary-configurable-row pinned"
-              on:click={() => goto(href)}
+              on:click={(e) => goToEventHistory(e, workflow)}
             >
               {#if $supportsBulkActions}
                 <td>
@@ -240,7 +246,15 @@
                 </td>
               {/if}
               {#each pinnedColumns as column}
-                <WorkflowsSummaryTableBodyCell {href} {column} {workflow} />
+                <WorkflowsSummaryTableBodyCell
+                  href={routeForEventHistory({
+                    namespace,
+                    workflow: workflow.id,
+                    run: workflow.runId,
+                  })}
+                  {column}
+                  {workflow}
+                />
               {/each}
             </tr>
           {/each}
@@ -280,17 +294,20 @@
       <tbody>
         {#if $workflowTableColumns.length > 0}
           {#each workflows as workflow}
-            {@const href = routeForEventHistory({
-              namespace,
-              workflow: workflow.id,
-              run: workflow.runId,
-            })}
             <tr
               class="workflow-summary-configurable-row"
-              on:click={() => goto(href)}
+              on:click={(e) => goToEventHistory(e, workflow)}
             >
               {#each otherColumns as column}
-                <WorkflowsSummaryTableBodyCell {href} {column} {workflow} />
+                <WorkflowsSummaryTableBodyCell
+                  href={routeForEventHistory({
+                    namespace,
+                    workflow: workflow.id,
+                    run: workflow.runId,
+                  })}
+                  {column}
+                  {workflow}
+                />
               {/each}
               <td />
             </tr>

--- a/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-table-body-cell.svelte
@@ -22,6 +22,7 @@
 
   export let column: WorkflowHeader;
   export let workflow: WorkflowExecution;
+  export let href: string;
 
   $: ({ label } = column);
 
@@ -78,7 +79,7 @@
     on:mouseleave={hideFilterOrCopy}
     on:blur={hideFilterOrCopy}
   >
-    <span class="table-link">{cellContent}</span>
+    <a on:click|stopPropagation {href} class="table-link">{cellContent}</a>
     <FilterOrCopyButtons
       show={filterOrCopyButtonsVisible}
       content={cellContent}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/workflows-summary-table-body-cell.svelte
@@ -73,13 +73,13 @@
   </td>
 {:else if label === 'Type' || label === 'Workflow ID'}
   <td
-    class="workflows-summary-table-body-cell relative"
+    class="workflows-summary-table-body-cell filterable"
     on:mouseover={showFilterOrCopy}
     on:focus={showFilterOrCopy}
     on:mouseleave={hideFilterOrCopy}
     on:blur={hideFilterOrCopy}
   >
-    <a on:click|stopPropagation {href} class="table-link">{cellContent}</a>
+    <a {href} class="table-link">{cellContent}</a>
     <FilterOrCopyButtons
       show={filterOrCopyButtonsVisible}
       content={cellContent}
@@ -107,5 +107,9 @@
 <style lang="postcss">
   .workflows-summary-table-body-cell {
     @apply whitespace-nowrap px-2 h-10 text-sm;
+
+    &.filterable {
+      @apply relative pr-24;
+    }
   }
 </style>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The new configurable table introduced a regression in that the workflow ID and Type cells were changed to `<span />` elements instead of remaining `<a />` elements. This PR fixes that regression by making the cell content for those table cells links again.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
N/a
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
N/a
## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing*
- [ ] E2E tests added
- [ ] Unit tests added

`* working on adding regression tests in a future PR`
### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists
N/a
### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
closes #1324 
## Docs
N/a
### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
