### PR TITLE
Make Start/End Time Filter Sticky

### DIFF
--- a/cypress/integration/workflow-executions.spec.js
+++ b/cypress/integration/workflow-executions.spec.js
@@ -94,7 +94,7 @@ describe('Workflow Executions List', () => {
         ).as('workflow-api');
       });
 
-      it('should keep single workflow filter after navigating away and back to workflow list', () => {
+      it('should keep single workflow filter after navigating to workflow history and back to workflow list', () => {
         cy.get('#execution-status-filter')
           .find('option:selected')
           .should('have.value', 'null');

--- a/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
+++ b/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
@@ -15,7 +15,11 @@
   import Select from '$lib/holocene/select/select.svelte';
   import Option from '$lib/holocene/select/option.svelte';
   import SimpleSplitButton from '$lib/holocene/simple-split-button.svelte';
-  import { workflowFilters, workflowSorts } from '$lib/stores/filters';
+  import {
+    persistedTimeFilter,
+    workflowFilters,
+    workflowSorts,
+  } from '$lib/stores/filters';
   import DatePicker from '$lib/holocene/date-picker.svelte';
   import Button from '$lib/holocene/button.svelte';
   import TimePicker from '$lib/holocene/time-picker.svelte';
@@ -53,9 +57,18 @@
       value = 'All Time';
       timeField = 'StartTime';
     } else {
-      value = custom ? 'Custom' : timeFilter.value;
+      value =
+        custom || !columnOrderedDurations.includes(timeFilter?.value)
+          ? 'Custom'
+          : timeFilter.value;
       timeField = timeFilter.attribute as string;
     }
+
+    const shouldUpdateTimeFilter =
+      !timeFilter ||
+      columnOrderedDurations.includes(timeFilter?.value) ||
+      timeFilter?.customDate;
+    if (shouldUpdateTimeFilter) $persistedTimeFilter = timeFilter;
   };
 
   $: timeFilter, setTimeValues();

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -11,7 +11,12 @@
     workflowsSearchParams,
   } from '$lib/stores/workflows';
   import { lastUsedNamespace } from '$lib/stores/namespaces';
-  import { workflowFilters, workflowSorts } from '$lib/stores/filters';
+  import {
+    persistedTimeFilter,
+    workflowFilters,
+    workflowSorts,
+  } from '$lib/stores/filters';
+  import { updateQueryParamsFromFilter } from '$lib/utilities/query/to-list-workflow-filters';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
   import Pagination from '$lib/holocene/pagination.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -50,13 +55,20 @@
     }
   }
 
+  const persistTimeFilter = () => {
+    if (!query && !$workflowFilters.length && $persistedTimeFilter) {
+      $workflowFilters = [$persistedTimeFilter];
+      updateQueryParamsFromFilter($page.url, $workflowFilters, $workflowSorts);
+    }
+  };
+
+  $: $page.params.namespace, persistTimeFilter();
+
   onMount(() => {
     $lastUsedNamespace = $page.params.namespace;
     if (query) {
       // Set filters from inital page load query if it exists
       $workflowFilters = toListWorkflowFilters(query);
-    } else {
-      $workflowFilters = [];
     }
   });
 

--- a/src/lib/stores/filters.ts
+++ b/src/lib/stores/filters.ts
@@ -2,6 +2,7 @@ import type {
   WorkflowFilter,
   WorkflowSort,
 } from '$lib/models/workflow-filters';
+import { persistStore } from '$lib/stores/persist-store';
 import { writable, derived, get } from 'svelte/store';
 import { page } from '$app/stores';
 import type { StartStopNotifier } from 'svelte/store';
@@ -36,10 +37,17 @@ const updateSorts: StartStopNotifier<WorkflowSort[]> = (set) => {
   });
 };
 
+export const persistedTimeFilter = persistStore<WorkflowFilter>(
+  'workflowDateTimeFilter',
+  undefined,
+  true,
+);
+
 export const workflowFilters = writable<WorkflowFilter[]>(
   [],
   updateWorkflowFilters,
 );
+
 export const workflowSorts = writable<WorkflowSort[]>([], updateSorts);
 
 const updateEventCategoryFilter: StartStopNotifier<string | null> = (set) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Time preference (e.g. last `15 Minutes`, `3 Days`, `All Time`…) is persisted so that when accessing Temporal or switching Namespaces, it applies the time preference on the `Recent Workflows` page.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [ ] Verify time filter is persisted when
   - changing namespaces
   - navigating to recent workflows 
- [ ] Verify the time filter is properly applied in the 
   - time filter dropdown
   - manual search input
   - url
- [ ] Verify the time filter is **not** applied if the user
   - enters a custom manual search
   - navigates to a workflow url with a query
  
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-14`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
