### PR TITLE
Don't close menu on space press

### DIFF
--- a/e2e/tests/workflow-navigation.spec.ts
+++ b/e2e/tests/workflow-navigation.spec.ts
@@ -61,6 +61,34 @@ test('Top Navigation current namespace is present and has other namespaces to se
   );
 });
 
+test('Top Navigation current namespace is present and has other namespaces to search and stays open with space press', async ({
+  page,
+}) => {
+  await mockNamespacesApi(page);
+  await setLocalStorage('viewedFeatureTags', JSON.stringify(['topNav']), page);
+
+  await expect(page.getByTestId('namespace-select-button')).toBeVisible();
+  await expect(
+    page.getByTestId('data-encoder-status-configured'),
+  ).toBeVisible();
+
+  await page.getByTestId('namespace-select-button').click();
+  await expect(page.getByPlaceholder('Search')).toBeFocused();
+  await expect(page.getByRole('link', { name: 'default' })).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'some-other-namespace' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'temporal-system' }),
+  ).not.toBeVisible();
+
+  await page.getByPlaceholder('Search').type('some other namespace');
+  await expect(page.getByRole('link', { name: 'default' })).not.toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'some-other-namespace' }),
+  ).not.toBeVisible();
+});
+
 test('Top Navigation current namespace is not present on non-namespace specific pages', async ({
   page,
 }) => {

--- a/src/lib/holocene/primitives/menu/trigger-menu.ts
+++ b/src/lib/holocene/primitives/menu/trigger-menu.ts
@@ -33,7 +33,7 @@ export const triggerMenu = (
   };
 
   const handleKeyUp = (event: KeyboardEvent) => {
-    if (event.key === 'Escape' || event.key === 'Enter' || event.key === ' ') {
+    if (event.key === 'Escape' || event.key === 'Enter') {
       node.dispatchEvent(new CustomEvent('close-menu'));
     }
   };


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The trigger-menu onKeyUp listener closed the menu on Space. While this is convenient for users, I think it will cause more issues than its value. More and more modal and dropdown buttons will require inputs that use space, and a user can still use Escape or Enter to close the menu.

Added a test for this situation as well. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

https://user-images.githubusercontent.com/7967403/234884778-298c8385-f99c-4d1c-b096-4ae946be7395.mov



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
