### PR TITLE
Show none for next retry for canceled pending activities

### DIFF
--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -89,8 +89,10 @@
                     <div class="pending-activity-detail">
                       <h4 class="pending-activity-detail-header">Next Retry</h4>
                       <Badge type={failed ? 'error' : 'default'}>
-                        {toTimeDifference(pendingActivity.scheduledTime) ||
-                          'None'}
+                        {toTimeDifference({
+                          date: pendingActivity.scheduledTime,
+                          negativeDefault: 'None',
+                        })}
                       </Badge>
                     </div>
                   {/if}

--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -89,7 +89,8 @@
                     <div class="pending-activity-detail">
                       <h4 class="pending-activity-detail-header">Next Retry</h4>
                       <Badge type={failed ? 'error' : 'default'}>
-                        {toTimeDifference(pendingActivity.scheduledTime)}
+                        {toTimeDifference(pendingActivity.scheduledTime) ||
+                          'None'}
                       </Badge>
                     </div>
                   {/if}

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -64,7 +64,10 @@
                 <li class="event-table-row">
                   <h4>Next Retry</h4>
                   <Badge type="error">
-                    {toTimeDifference(details.scheduledTime) || 'None'}
+                    {toTimeDifference({
+                      date: details.scheduledTime,
+                      negativeDefault: 'None',
+                    })}
                   </Badge>
                 </li>
               {/if}

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -64,7 +64,7 @@
                 <li class="event-table-row">
                   <h4>Next Retry</h4>
                   <Badge type="error">
-                    {toTimeDifference(details.scheduledTime)}
+                    {toTimeDifference(details.scheduledTime) || 'None'}
                   </Badge>
                 </li>
               {/if}

--- a/src/lib/utilities/to-time-difference.test.ts
+++ b/src/lib/utilities/to-time-difference.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { toTimeDifference } from './to-time-difference';
+
+describe('toTimeDifference', () => {
+  it('should correctly parse a Timestamp', () => {
+    const now = 1649867374630;
+    const date = '2022-04-13T16:29:35.630571Z';
+    expect(toTimeDifference(date, now)).toEqual('1s');
+  });
+
+  it('should correctly parse a negative difference', () => {
+    const now = 1683060815883;
+    const date = '2022-04-13T16:29:35.630571Z';
+    expect(toTimeDifference(date, now)).toEqual('');
+  });
+
+  it('should correctly parse an invalid date', () => {
+    expect(toTimeDifference(null)).toEqual('');
+    expect(toTimeDifference('')).toEqual('');
+    expect(toTimeDifference(undefined)).toEqual('');
+    expect(toTimeDifference('date')).toEqual('');
+  });
+});

--- a/src/lib/utilities/to-time-difference.test.ts
+++ b/src/lib/utilities/to-time-difference.test.ts
@@ -2,22 +2,30 @@ import { describe, expect, it } from 'vitest';
 import { toTimeDifference } from './to-time-difference';
 
 describe('toTimeDifference', () => {
+  const negativeDefault = 'None';
+
   it('should correctly parse a Timestamp', () => {
     const now = 1649867374630;
     const date = '2022-04-13T16:29:35.630571Z';
-    expect(toTimeDifference(date, now)).toEqual('1s');
+    expect(toTimeDifference({ date, now, negativeDefault })).toEqual('1s');
   });
 
   it('should correctly parse a negative difference', () => {
     const now = 1683060815883;
     const date = '2022-04-13T16:29:35.630571Z';
-    expect(toTimeDifference(date, now)).toEqual('');
+    expect(toTimeDifference({ date, now })).toEqual('-33193440.253s');
+  });
+
+  it('should correctly parse a negative difference with a default', () => {
+    const now = 1683060815883;
+    const date = '2022-04-13T16:29:35.630571Z';
+    expect(toTimeDifference({ date, now, negativeDefault })).toEqual('None');
   });
 
   it('should correctly parse an invalid date', () => {
-    expect(toTimeDifference(null)).toEqual('');
-    expect(toTimeDifference('')).toEqual('');
-    expect(toTimeDifference(undefined)).toEqual('');
-    expect(toTimeDifference('date')).toEqual('');
+    expect(toTimeDifference({ date: null })).toEqual('');
+    expect(toTimeDifference({ date: '' })).toEqual('');
+    expect(toTimeDifference({ date: undefined })).toEqual('');
+    expect(toTimeDifference({ date: 'date' })).toEqual('');
   });
 });

--- a/src/lib/utilities/to-time-difference.ts
+++ b/src/lib/utilities/to-time-difference.ts
@@ -1,11 +1,13 @@
-export const toTimeDifference = (date: unknown, now = Date.now()): string => {
+import type { Timestamp } from '$lib/types';
+
+export const toTimeDifference = (date: Timestamp, now = Date.now()): string => {
   if (!date) return '';
   const start = String(date);
 
   try {
     const scheduled = Number(new Date(start));
     const timeFromNow = (scheduled - now) / 1000;
-    return !isNaN(timeFromNow) ? `${timeFromNow}s` : '';
+    return !isNaN(timeFromNow) && timeFromNow > 0 ? `${timeFromNow}s` : '';
   } catch (error) {
     return '';
   }

--- a/src/lib/utilities/to-time-difference.ts
+++ b/src/lib/utilities/to-time-difference.ts
@@ -1,13 +1,26 @@
 import type { Timestamp } from '$lib/types';
 
-export const toTimeDifference = (date: Timestamp, now = Date.now()): string => {
+export const toTimeDifference = ({
+  date,
+  now = Date.now(),
+  negativeDefault,
+}: {
+  date: Timestamp;
+  now?: number;
+  negativeDefault?: string;
+}): string => {
   if (!date) return '';
   const start = String(date);
 
   try {
     const scheduled = Number(new Date(start));
     const timeFromNow = (scheduled - now) / 1000;
-    return !isNaN(timeFromNow) && timeFromNow > 0 ? `${timeFromNow}s` : '';
+
+    if (negativeDefault && timeFromNow < 0) {
+      return negativeDefault;
+    }
+
+    return !isNaN(timeFromNow) ? `${timeFromNow}s` : '';
   } catch (error) {
     return '';
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
On canceled pending activities, the time for `Next Retry` is negative. This PR make it so it shows `None` instead.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1017" alt="Screenshot 2023-05-02 at 4 41 24 PM" src="https://user-images.githubusercontent.com/15069288/235800945-340ad975-8266-406f-a3b5-3cf31e941735.png">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
