### PR TITLE
Add support for parent namespace in Relationship link

### DIFF
--- a/src/fixtures/workflow.continued-as-new.json
+++ b/src/fixtures/workflow.continued-as-new.json
@@ -1,22 +1,61 @@
 {
-  "name": "SampleChildWorkflow",
-  "id": "child_workflow:24240710-e6a1-4541-91b9-9f117bc407f4",
-  "runId": "4da1552a-97b7-46f5-8df0-8a09caaf5951",
-  "startTime": "2023-02-01T21:33:20.020052838Z",
-  "endTime": "2023-02-01T21:33:21.033103713Z",
-  "status": "ContinuedAsNew",
-  "historyEvents": "5",
-  "url": "/workflows/child_workflow:24240710-e6a1-4541-91b9-9f117bc407f4/4da1552a-97b7-46f5-8df0-8a09caaf5951",
-  "taskQueue": "child-workflow-continue-as-new",
+  "executionConfig": {
+    "taskQueue": {
+      "name": "child-workflow-continue-as-new",
+      "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "300s",
+    "defaultWorkflowTaskTimeout": "20s"
+  },
+  "workflowExecutionInfo": {
+    "execution": {
+      "workflowId": "child_workflow:24240710-e6a1-4541-91b9-9f117bc407f4",
+      "runId": "4da1552a-97b7-46f5-8df0-8a09caaf5951"
+    },
+    "type": {
+      "name": "workflow.retry-workflow.ext"
+    },
+    "startTime": "2023-02-01T21:33:20.020052838Z",
+    "closeTime": "2023-02-01T21:33:21.033103713Z",
+    "status": "ContinuedAsNew",
+    "historyLength": "7",
+    "parentNamespaceId": "7635a64b-dd16-407e-a7d3-9e72a97a51ba",
+    "parentExecution": {
+      "workflowId": "parent-workflow_3eaa9ff1-3927-461d-94b4-271631094c8d",
+      "runId": "24240710-e6a1-4541-91b9-9f117bc407f4"
+    },
+    "executionTime": "2022-07-01T20:22:50.015107253Z",
+    "memo": {
+      "fields": {}
+    },
+    "searchAttributes": {
+      "indexedFields": {
+        "TemporalChangeVersion": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "S2V5d29yZA=="
+          },
+          "data": "WyJpbml0aWFsIHZlcnNpb24tMyJd"
+        }
+      }
+    },
+    "autoResetPoints": {
+      "points": [
+        {
+          "binaryChecksum": "e56c0141e58df0bd405138565d0526f9",
+          "runId": "babf5e35-3a61-48c2-8738-a19293205282",
+          "firstWorkflowTaskCompletedId": "4",
+          "createTime": "2022-07-01T20:22:49.014356253Z",
+          "expireTime": "2022-07-11T20:22:49.015107253Z",
+          "resettable": true
+        }
+      ]
+    },
+    "taskQueue": "canary-task-queue",
+    "stateTransitionCount": "6"
+  },
   "pendingActivities": [],
   "pendingChildren": [],
-  "parentNamespaceId": "7635a64b-dd16-407e-a7d3-9e72a97a51ba",
-  "parent": {
-    "workflowId": "parent-workflow_3eaa9ff1-3927-461d-94b4-271631094c8d",
-    "runId": "24240710-e6a1-4541-91b9-9f117bc407f4"
-  },
-  "stateTransitionCount": "4",
-  "isRunning": false,
-  "defaultWorkflowTaskTimeout": "10s",
-  "canBeTerminated": false
+  "pendingWorkflowTask": null
 }

--- a/src/fixtures/workflow.pending-children.json
+++ b/src/fixtures/workflow.pending-children.json
@@ -1,13 +1,57 @@
 {
-  "name": "SampleParentWorkflow",
-  "id": "parent-workflow_b84f7ba9-e645-4324-b300-77028d21c116",
-  "runId": "e50934b8-fad0-414c-93dd-d260a2476bc0",
-  "startTime": "2023-02-01T20:49:11.358822126Z",
-  "endTime": "null",
-  "status": "Running",
-  "historyEvents": "9",
-  "url": "/workflows/parent-workflow_b84f7ba9-e645-4324-b300-77028d21c116/e50934b8-fad0-414c-93dd-d260a2476bc0",
-  "taskQueue": "child-workflow-continue-as-new",
+  "executionConfig": {
+    "taskQueue": {
+      "name": "child-workflow-continue-as-new",
+      "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "300s",
+    "defaultWorkflowTaskTimeout": "20s"
+  },
+  "workflowExecutionInfo": {
+    "execution": {
+      "workflowId": "parent-workflow_b84f7ba9-e645-4324-b300-77028d21c116",
+      "runId": "e50934b8-fad0-414c-93dd-d260a2476bc0"
+    },
+    "type": {
+      "name": "workflow.retry-workflow.ext"
+    },
+    "startTime": "2023-02-01T20:49:11.358822126Z",
+    "closeTime": null,
+    "status": "Running",
+    "historyLength": "7",
+    "parentNamespaceId": "",
+    "parentExecution": null,
+    "executionTime": "2022-07-01T20:22:50.015107253Z",
+    "memo": {
+      "fields": {}
+    },
+    "searchAttributes": {
+      "indexedFields": {
+        "TemporalChangeVersion": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "S2V5d29yZA=="
+          },
+          "data": "WyJpbml0aWFsIHZlcnNpb24tMyJd"
+        }
+      }
+    },
+    "autoResetPoints": {
+      "points": [
+        {
+          "binaryChecksum": "e56c0141e58df0bd405138565d0526f9",
+          "runId": "babf5e35-3a61-48c2-8738-a19293205282",
+          "firstWorkflowTaskCompletedId": "4",
+          "createTime": "2022-07-01T20:22:49.014356253Z",
+          "expireTime": "2022-07-11T20:22:49.015107253Z",
+          "resettable": true
+        }
+      ]
+    },
+    "taskQueue": "canary-task-queue",
+    "stateTransitionCount": "6"
+  },
   "pendingActivities": [],
   "pendingChildren": [
     {
@@ -18,10 +62,5 @@
       "parentClosePolicy": "Terminate"
     }
   ],
-  "parentNamespaceId": "",
-  "parent": null,
-  "stateTransitionCount": "6",
-  "isRunning": true,
-  "defaultWorkflowTaskTimeout": "10s",
-  "canBeTerminated": true
+  "pendingWorkflowTask": null
 }

--- a/src/lib/components/workflow/parent-workflow-table.svelte
+++ b/src/lib/components/workflow/parent-workflow-table.svelte
@@ -11,6 +11,7 @@
   import Link from '$lib/holocene/link.svelte';
 
   export let parent: WorkflowIdentifier;
+  export let parentNamespaceName: string | undefined;
   export let namespace: string;
 </script>
 
@@ -24,7 +25,7 @@
       <Link
         newTab
         href={routeForEventHistory({
-          namespace,
+          namespace: parentNamespaceName ?? namespace,
           workflow: parent.workflowId,
           run: parent.runId,
         })}

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { routeForEventHistory } from '$lib/utilities/route-for';
   import { workflowRun } from '$lib/stores/workflow-run';
 
   import Accordion from '$lib/holocene/accordion.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
-  import WorkflowDetail from '$lib/components/workflow/workflow-detail.svelte';
 
   import type { WorkflowIdentifier } from '$lib/types/workflows';
   import type { ChildWorkflowClosedEvent } from '$lib/utilities/get-workflow-relationships';
@@ -15,11 +13,12 @@
 
   export let hasChildren: boolean;
   export let hasRelationships: boolean;
-  export let first: string;
-  export let parent: WorkflowIdentifier;
+  export let first: string | undefined;
+  export let parent: WorkflowIdentifier | undefined;
+  export let parentNamespaceName: string | undefined;
   export let children: ChildWorkflowClosedEvent[];
-  export let next: string;
-  export let previous: string;
+  export let next: string | undefined;
+  export let previous: string | undefined;
 
   $: ({ workflow, namespace } = $page.params);
 </script>
@@ -44,7 +43,7 @@
     {#if hasRelationships}
       <div class="flex w-full flex-wrap gap-4">
         {#if parent}
-          <ParentWorkflowTable {parent} {namespace} />
+          <ParentWorkflowTable {parent} {parentNamespaceName} {namespace} />
         {/if}
         {#if first || previous || next}
           <FirstPreviousNextWorkflowTable

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -6,6 +6,7 @@
   import { exportHistory } from '$lib/utilities/export-history';
   import { workflowRun } from '$lib/stores/workflow-run';
   import { eventHistory, fullEventHistory } from '$lib/stores/events';
+  import { namespaces } from '$lib/stores/namespaces';
 
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
@@ -29,6 +30,7 @@
     workflow,
     $eventHistory,
     $fullEventHistory,
+    $namespaces,
   );
 
   const onViewClick = (view: EventView) => {

--- a/src/lib/utilities/get-workflow-relationships.test.ts
+++ b/src/lib/utilities/get-workflow-relationships.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { getWorkflowRelationships } from './get-workflow-relationships';
+import { toWorkflowExecution } from '$lib/models/workflow-execution';
 
 import completedEvents from '$fixtures/events.completed.json';
 import continuedAsNewEvents from '$fixtures/events.continued-as-new.json';
@@ -13,6 +14,7 @@ import failedWorkflow from '$fixtures/workflow.failed.json';
 import pendingChildrenWorkflow from '$fixtures/workflow.pending-children.json';
 import runningWorkflow from '$fixtures/workflow.running.json';
 import timedOutWorkflow from '$fixtures/workflow.timed-out.json';
+import namespaces from '$fixtures/namespaces.json';
 
 describe('getWorkflowRelationships', () => {
   const completedEventHistory = {
@@ -27,9 +29,10 @@ describe('getWorkflowRelationships', () => {
   it('hasChildren should return true if there are pending children', () => {
     expect(
       getWorkflowRelationships(
-        pendingChildrenWorkflow,
+        toWorkflowExecution(pendingChildrenWorkflow),
         completedEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).hasChildren,
     ).toBe(true);
   });
@@ -37,33 +40,48 @@ describe('getWorkflowRelationships', () => {
   it('hasChildren should return true if there are pending children and non-pending children', () => {
     expect(
       getWorkflowRelationships(
-        pendingChildrenWorkflow,
+        toWorkflowExecution(pendingChildrenWorkflow),
         completedEventHistory,
         childEvents,
+        namespaces.namespaces,
       ).hasChildren,
     ).toBe(true);
     expect(
       getWorkflowRelationships(
-        pendingChildrenWorkflow,
+        toWorkflowExecution(pendingChildrenWorkflow),
         completedEventHistory,
         childEvents,
+        namespaces.namespaces,
       ).children.length,
     ).toBe(15);
+  });
+
+  it('parentNamespaceName should return undefined if parentNamespaceId does not match namespaces list', () => {
+    expect(
+      getWorkflowRelationships(
+        toWorkflowExecution(pendingChildrenWorkflow),
+        completedEventHistory,
+        childEvents,
+        namespaces.namespaces,
+      ).parentNamespaceName,
+    ).toBe(undefined);
   });
 
   it('hasChildren should return true if there are no pending children and non-pending children', () => {
     expect(
       getWorkflowRelationships(
-        runningWorkflow,
+        toWorkflowExecution(runningWorkflow),
         completedEventHistory,
         childEvents,
+        namespaces.namespaces,
       ).hasChildren,
     ).toBe(true);
     expect(
       getWorkflowRelationships(
-        runningWorkflow,
+        toWorkflowExecution(runningWorkflow),
         completedEventHistory,
         childEvents,
+        namespaces.namespaces,
       ).children.length,
     ).toBe(15);
   });
@@ -71,11 +89,23 @@ describe('getWorkflowRelationships', () => {
   it('hasRelationships should return false if there are is not a parent, pending children, first, previous, or next', () => {
     expect(
       getWorkflowRelationships(
-        runningWorkflow,
+        toWorkflowExecution(runningWorkflow),
         completedEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).hasChildren,
     ).toBe(false);
+  });
+
+  it('parentNamespaceName should return namespace name if parentNamespaceId does match namespaces list', () => {
+    expect(
+      getWorkflowRelationships(
+        toWorkflowExecution(runningWorkflow),
+        completedEventHistory,
+        completedEvents,
+        namespaces.namespaces,
+      ).parentNamespaceName,
+    ).toBe('canary');
   });
 
   it('should return the firstExecutionRunId for first on a workflowExecutionStartedEvent', () => {
@@ -87,9 +117,10 @@ describe('getWorkflowRelationships', () => {
 
     expect(
       getWorkflowRelationships(
-        continuedAsNewWorkflow,
+        toWorkflowExecution(continuedAsNewWorkflow),
         continuedAsNewEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).first,
     ).toBe(firstExecutionRunId);
   });
@@ -105,19 +136,22 @@ describe('getWorkflowRelationships', () => {
     );
     expect(
       getWorkflowRelationships(
-        continuedAsNewWorkflowCopy,
+        toWorkflowExecution(continuedAsNewWorkflowCopy),
         continuedAsNewEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).first,
     ).toBe(firstExecutionRunId);
 
-    continuedAsNewWorkflowCopy.runId = firstExecutionRunId;
+    continuedAsNewWorkflowCopy.workflowExecutionInfo.execution.runId =
+      firstExecutionRunId;
 
     expect(
       getWorkflowRelationships(
-        continuedAsNewWorkflowCopy,
+        toWorkflowExecution(continuedAsNewWorkflowCopy),
         continuedAsNewEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).first,
     ).toBe(undefined);
   });
@@ -130,9 +164,10 @@ describe('getWorkflowRelationships', () => {
       workflowExecutionStartedEvent?.attributes?.continuedExecutionRunId;
     expect(
       getWorkflowRelationships(
-        continuedAsNewWorkflow,
+        toWorkflowExecution(continuedAsNewWorkflow),
         continuedAsNewEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).previous,
     ).toBe(continuedExecutionRunId);
   });
@@ -146,9 +181,10 @@ describe('getWorkflowRelationships', () => {
 
     expect(
       getWorkflowRelationships(
-        continuedAsNewWorkflow,
+        toWorkflowExecution(continuedAsNewWorkflow),
         continuedAsNewEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).next,
     ).toBe(newExecutionRunId);
   });
@@ -162,9 +198,10 @@ describe('getWorkflowRelationships', () => {
 
     expect(
       getWorkflowRelationships(
-        completedWorkflow,
+        toWorkflowExecution(completedWorkflow),
         completedEventHistory,
         completedEvents,
+        namespaces.namespaces,
       ).next,
     ).toBe(newExecutionRunId);
   });
@@ -178,12 +215,13 @@ describe('getWorkflowRelationships', () => {
 
     expect(
       getWorkflowRelationships(
-        timedOutWorkflow,
+        toWorkflowExecution(timedOutWorkflow),
         {
           start: timedOutEvents,
           end: timedOutEvents,
         },
         completedEvents,
+        namespaces.namespaces,
       ).next,
     ).toBe(newExecutionRunId);
   });
@@ -197,12 +235,13 @@ describe('getWorkflowRelationships', () => {
 
     expect(
       getWorkflowRelationships(
-        failedWorkflow,
+        toWorkflowExecution(failedWorkflow),
         {
           start: failedEvents,
           end: failedEvents,
         },
         completedEvents,
+        namespaces.namespaces,
       ).next,
     ).toBe(newExecutionRunId);
   });

--- a/src/lib/utilities/get-workflow-relationships.ts
+++ b/src/lib/utilities/get-workflow-relationships.ts
@@ -19,6 +19,8 @@ import type {
   WorkflowEvents,
 } from '$lib/types/events';
 import type { WorkflowExecution } from '$lib/types/workflows';
+import type { DescribeNamespaceResponse } from '$lib/types';
+import type { WorkflowIdentifier } from '$lib/types/workflows';
 
 const getNewExecutionId = (events: WorkflowEvents): string | undefined => {
   for (const event of events) {
@@ -48,16 +50,32 @@ export const isChildWorkflowClosedEvent = (event) => {
   );
 };
 
+type WorkflowRelationships = {
+  hasRelationships: boolean;
+  hasChildren: boolean;
+  children: ChildWorkflowClosedEvent[];
+  first: string | undefined;
+  previous: string | undefined;
+  parent: WorkflowIdentifier | undefined;
+  parentNamespaceName: string | undefined;
+  next: string | undefined;
+};
+
 export const getWorkflowRelationships = (
   workflow: WorkflowExecution | null,
   eventHistory: StartAndEndEventHistory,
   fullEventHistory: WorkflowEvents,
-) => {
+  namespaces: DescribeNamespaceResponse[],
+): WorkflowRelationships => {
   const children = fullEventHistory.filter((event) =>
     isChildWorkflowClosedEvent(event),
   ) as ChildWorkflowClosedEvent[];
   const hasChildren = !!workflow?.pendingChildren.length || !!children.length;
   const parent = workflow?.parent;
+
+  const parentNamespaceName = namespaces?.find((namespace) => {
+    return namespace.namespaceInfo.id === workflow.parentNamespaceId;
+  })?.namespaceInfo?.name;
 
   const workflowExecutionStartedEvent = eventHistory.start.find(
     isWorkflowExecutionStartedEvent,
@@ -89,6 +107,7 @@ export const getWorkflowRelationships = (
     first,
     previous,
     parent,
+    parentNamespaceName,
     next: newExecutionRunId,
   };
 };


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Currently we always link a parent workflow to the current namespace in the Relationships accordion. So if a parent workflow has a different namespace than it's child, it will result in a 404 page.

This PR fixes that behavior to look for the parent namespace name and fallback to the current namespace if it doesn't exist.

I also updated all the fixtures to be consistent with API results and updated the tests to use toWorkflowExecution to accurately type the json. Included 2 new unit tests for parentNamespaceName.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
