### PR TITLE
Allow decoding event history for download and for JSON view

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -48,5 +48,6 @@ codec:
   endpoint:
   passAccessToken: false
   includeCredentials: false
+  decodeEventHistoryDownload: true
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For

--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -46,7 +46,7 @@ codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
   includeCredentials: {{ default .Env.TEMPORAL_CODEC_INCLUDE_CREDENTIALS "false" }}
-  decodeEventHistoryDownload: {{ default .Env.TEMPORAL_CODEC_DECODE_EVENT_HISTORY_DOWNLOAD "true" }}
+  decodeEventHistoryDownload: {{ default .Env.TEMPORAL_CODEC_DECODE_EVENT_HISTORY_DOWNLOAD "false" }}
 
 forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }} {{ end }} {{ end }}

--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -46,5 +46,7 @@ codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
   includeCredentials: {{ default .Env.TEMPORAL_CODEC_INCLUDE_CREDENTIALS "false" }}
+  decodeEventHistoryDownload: {{ default .Env.TEMPORAL_CODEC_DECODE_EVENT_HISTORY_DOWNLOAD "true" }}
+
 forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }} {{ end }} {{ end }}

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -45,9 +45,10 @@ type Auth struct {
 }
 
 type CodecResponse struct {
-	Endpoint           string
-	PassAccessToken    bool
-	IncludeCredentials bool
+	Endpoint                   string
+	PassAccessToken            bool
+	IncludeCredentials         bool
+	DecodeEventHistoryDownload bool
 }
 
 type SettingsResponse struct {
@@ -120,9 +121,10 @@ func GetSettings(cfgProvier *config.ConfigProviderWithRefresh) func(echo.Context
 			FeedbackURL:                 cfg.FeedbackURL,
 			NotifyOnNewVersion:          cfg.NotifyOnNewVersion,
 			Codec: &CodecResponse{
-				Endpoint:           cfg.Codec.Endpoint,
-				PassAccessToken:    cfg.Codec.PassAccessToken,
-				IncludeCredentials: cfg.Codec.IncludeCredentials,
+				Endpoint:                   cfg.Codec.Endpoint,
+				PassAccessToken:            cfg.Codec.PassAccessToken,
+				IncludeCredentials:         cfg.Codec.IncludeCredentials,
+				DecodeEventHistoryDownload: cfg.Codec.DecodeEventHistoryDownload,
 			},
 			Version:                   version.UIVersion,
 			DisableWriteActions:       cfg.DisableWriteActions,

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -109,9 +109,10 @@ type (
 	}
 
 	Codec struct {
-		Endpoint           string `yaml:"endpoint"`
-		PassAccessToken    bool   `yaml:"passAccessToken"`
-		IncludeCredentials bool   `yaml:"includeCredentials"`
+		Endpoint                   string `yaml:"endpoint"`
+		PassAccessToken            bool   `yaml:"passAccessToken"`
+		IncludeCredentials         bool   `yaml:"includeCredentials"`
+		DecodeEventHistoryDownload bool   `yaml:"decodeEventHistoryDownload"`
 	}
 
 	Filesystem struct {

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -20,6 +20,8 @@
   import EventShortcutKeys from '$lib/components/event/event-shortcut-keys.svelte';
 
   import type { EventView } from '$lib/types/events';
+  import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
+  import { authUser } from '$lib/stores/auth-user';
 
   let showShortcuts = false;
 
@@ -102,9 +104,11 @@
             data-testid="download"
             on:click={() =>
               exportHistory({
-                namespace: $page.params.namespace,
-                workflowId: $workflowRun.workflow?.id,
-                runId: $workflowRun.workflow?.runId,
+                namespace: decodeURIForSvelte($page.params.namespace),
+                workflowId: decodeURIForSvelte($workflowRun.workflow?.id),
+                runId: decodeURIForSvelte($workflowRun.workflow?.runId),
+                settings: $page.data.settings,
+                accessToken: $authUser?.accessToken,
               })}>Download</ToggleButton
           >
         </ToggleButtons>

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -36,7 +36,7 @@
     <label
       for="decode-event-history"
       class="flex items-center gap-4 font-secondary text-sm"
-      >View Decoded Event History<ToggleSwitch
+      >View decoded event history<ToggleSwitch
         id="decode-event-history"
         bind:checked={decodeEventHistory}
         data-testid="decode-event-history-toggle"

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -3,21 +3,45 @@
 
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Loading from '$lib/holocene/loading.svelte';
-  import { fetchRawEvents } from '$lib/services/events-service';
+  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
+  import { fetchAllEvents, fetchRawEvents } from '$lib/services/events-service';
+  import { authUser } from '$lib/stores/auth-user';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 
   const { namespace, workflow: workflowId, run: runId } = $page.params;
 
-  const events = fetchRawEvents({
-    namespace: decodeURIForSvelte(namespace),
-    workflowId: decodeURIForSvelte(workflowId),
-    runId: decodeURIForSvelte(runId),
-    sort: 'ascending',
-  });
+  let decodeEventHistory = true;
+
+  $: events = decodeEventHistory
+    ? fetchAllEvents({
+        namespace: decodeURIForSvelte(namespace),
+        workflowId: decodeURIForSvelte(workflowId),
+        runId: decodeURIForSvelte(runId),
+        settings: $page.data.settings,
+        accessToken: $authUser?.accessToken,
+        sort: 'ascending',
+      })
+    : fetchRawEvents({
+        namespace: decodeURIForSvelte(namespace),
+        workflowId: decodeURIForSvelte(workflowId),
+        runId: decodeURIForSvelte(runId),
+        sort: 'ascending',
+      });
 </script>
 
 {#await events}
   <Loading />
 {:then events}
+  <div class="flex justify-end">
+    <label
+      for="decode-event-history"
+      class="flex items-center gap-4 font-secondary text-sm"
+      >View Decoded Event History<ToggleSwitch
+        id="decode-event-history"
+        bind:checked={decodeEventHistory}
+        data-testid="decode-event-history-toggle"
+      />
+    </label>
+  </div>
   <CodeBlock content={events} data-testid="event-history-json" />
 {/await}

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -27,6 +27,8 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
       endpoint: settingsResponse?.Codec?.Endpoint,
       passAccessToken: settingsResponse?.Codec?.PassAccessToken,
       includeCredentials: settingsResponse?.Codec?.IncludeCredentials,
+      decodeEventHistoryDownload:
+        settingsResponse?.Codec?.DecodeEventHistoryDownload,
     },
     defaultNamespace: settingsResponse?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
     disableWriteActions: !!settingsResponse?.DisableWriteActions || false,

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -48,6 +48,7 @@ export type Settings = {
     endpoint?: string;
     passAccessToken?: boolean;
     includeCredentials?: boolean;
+    decodeEventHistoryDownload?: boolean;
   };
   defaultNamespace: string;
   disableWriteActions: boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -184,6 +184,7 @@ export type SettingsResponse = {
     Endpoint: string;
     PassAccessToken?: boolean;
     IncludeCredentials?: boolean;
+    DecodeEventHistoryDownload?: boolean;
   };
   DefaultNamespace: string;
   DisableWriteActions: boolean;


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add env var TEMPORAL_CODEC_DECODE_EVENT_HISTORY_DOWNLOAD which allows users to download the event history decoded instead of in the raw format (encoded). This env var is set to true in the development.yaml but false in config-template.yaml.

Add a toggle switch to view event history decoded in the JSON view. Default is set to view decoded.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" alt="Screen Shot 2023-05-09 at 9 41 25 AM" src="https://github.com/temporalio/ui/assets/7967403/dc0588fd-46be-4525-b911-910362bc6a5f">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
