### PR TITLE
Use namespace attribute in Child Workflow link if it exists

### DIFF
--- a/src/lib/components/event/event-details-row-expanded.svelte
+++ b/src/lib/components/event/event-details-row-expanded.svelte
@@ -84,7 +84,7 @@
           <Link
             newTab
             href={routeForEventHistory({
-              namespace,
+              namespace: attributes?.namespace || namespace,
               workflow: attributes.workflowExecutionWorkflowId,
               run: attributes.workflowExecutionRunId,
             })}

--- a/src/lib/components/workflow/child-workflows-table.svelte
+++ b/src/lib/components/workflow/child-workflows-table.svelte
@@ -9,8 +9,6 @@
   import type { WorkflowExecution } from '$lib/types/workflows';
   import type { ChildWorkflowClosedEvent } from '$lib/utilities/get-workflow-relationships';
   import WorkflowStatus from '../workflow-status.svelte';
-  import type { WorkflowExecutionStatus } from '$lib/types';
-  import { goto } from '$app/navigation';
   import Link from '$lib/holocene/link.svelte';
 
   export let children: ChildWorkflowClosedEvent[] = [];
@@ -18,7 +16,12 @@
   export let namespace: string;
 
   $: formattedPending = pendingChildren.map((c) => {
-    return { runId: c.runId, workflowId: c.workflowId, status: 'Running' };
+    return {
+      runId: c.runId,
+      workflowId: c.workflowId,
+      status: 'Running',
+      namespace,
+    };
   });
 
   $: formattedCompleted = children.map((c) => {
@@ -26,6 +29,7 @@
       runId: c.attributes.workflowExecution.runId,
       workflowId: c.attributes.workflowExecution.workflowId,
       status: c.classification,
+      namespace: c.attributes?.namespace || namespace,
     };
   });
 
@@ -54,7 +58,7 @@
           <Link
             newTab
             href={routeForEventHistory({
-              namespace,
+              namespace: child.namespace,
               workflow: child.workflowId,
               run: child.runId,
             })}

--- a/src/lib/utilities/format-event-attributes.ts
+++ b/src/lib/utilities/format-event-attributes.ts
@@ -20,6 +20,7 @@ export type CombinedAttributes = EventAttribute & {
   firstExecutionRunId?: string;
   continuedExecutionRunId?: string;
   newExecutionRunId?: string;
+  namespace?: string;
 };
 
 const keysToOmit: Readonly<Set<string>> = new Set(['header']);


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We use the current namespace for links to child workflows. If a child workflow has a different namespace than the current namespace, it will result in a 404. 

This PR looks up the history event namespace attribute and uses it if it exists to link to that child workflow.

Related to https://github.com/temporalio/ui/pull/1350


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
#1297 

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
