### PR TITLE
[DT-1004] Make title an optional prop in Alert component

### DIFF
--- a/src/lib/holocene/alert.story.svelte
+++ b/src/lib/holocene/alert.story.svelte
@@ -63,7 +63,7 @@
     />
   </Hst.Variant>
   <Hst.Variant title="An Alert without a Title">
-    <Alert icon="error" intent="error" title="">
+    <Alert icon="error" intent="error">
       <p>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut cupiditate
         exercitationem quia quibusdam excepturi rem saepe dolore quas, odit vero

--- a/src/lib/holocene/alert.svelte
+++ b/src/lib/holocene/alert.svelte
@@ -5,14 +5,14 @@
 
   interface $$Props extends HTMLAttributes<HTMLDivElement> {
     intent: 'warning' | 'error' | 'success' | 'info';
-    title: string;
+    title?: string;
     icon?: IconName;
     bold?: boolean;
     'data-testid'?: string;
   }
 
   export let intent: 'warning' | 'error' | 'success' | 'info';
-  export let title: string;
+  export let title = '';
   export let icon: IconName = null;
   export let bold = false;
 
@@ -32,7 +32,9 @@
     </div>
   {/if}
   <div class="ml-1">
-    <h5 class="font-semibold leading-6">{title}</h5>
+    <h5 class="font-semibold leading-6" class:hidden={!title}>
+      {title}
+    </h5>
     {#if $$slots.default}
       <div class="content">
         <slot />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Make title an optional prop in the Holocene `Alert` component since not all `Alert`s have a `title`.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
![Screenshot 2023-05-19 at 10 22 54 AM](https://github.com/temporalio/ui/assets/15069288/9e4e0401-b3fd-4894-9b1b-1e3c977b2e3b)

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-1004`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
