### PR TITLE
[DT-1011] Fix cannot read properties of null (reading 'close')

### DIFF
--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -78,7 +78,6 @@
           reason,
         });
     scheduleFetch = fetchSchedule(parameters, fetch);
-    pauseConfirmationModal.close();
     reason = '';
   };
 </script>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
`pauseConfirmationModal.close()` was being called after an `await unpauseSchedule` or `await pauseSchedule`.

A user could navigate away during this time causing `pauseConfirmationModal` to be `undefined`.

`fetchSchedule` is also being called, which causes the page to reload and therefore makes `pauseConfirmationModal.close()` unnecessary. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [ ] Verify (with throttling) there is no error if selecting `pause`/`unpause` and immediately navigating to a different page 
- [ ] Verify the modal does not stay open after selecting `pause`/`unpause` and the schedule is updated as expected

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-1011`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
