### PR TITLE
[DT-1014] Fix cannot read properties of null (reading 'setError')

### DIFF
--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -70,7 +70,7 @@
   };
 
   const handleSuccessfulTermination = async () => {
-    terminateConfirmationModal.close();
+    terminateConfirmationModal?.close();
     $refresh = Date.now();
     toaster.push({
       id: 'workflow-termination-success-toast',
@@ -80,7 +80,7 @@
 
   const handleTerminationError = (error: NetworkError) => {
     reason = '';
-    terminateConfirmationModal.setError(
+    terminateConfirmationModal?.setError(
       error?.message ?? 'An unknown error occurred.',
     );
   };
@@ -104,7 +104,7 @@
         workflowId: workflow.id,
         runId: workflow.runId,
       });
-      cancelConfirmationModal.close();
+      cancelConfirmationModal?.close();
       loading = false;
       $refresh = Date.now();
       toaster.push({
@@ -112,7 +112,7 @@
         message: 'Workflow canceled.',
       });
     } catch (error) {
-      cancelConfirmationModal.setError(
+      cancelConfirmationModal?.setError(
         error?.message ?? 'An unknown error occurred.',
       );
     }
@@ -131,14 +131,14 @@
         signalInput,
         signalName,
       });
-      signalConfirmationModal.close();
+      signalConfirmationModal?.close();
       $refresh = Date.now();
       toaster.push({
         message: 'Workflow signaled.',
         id: 'workflow-signal-success-toast',
       });
     } catch (error) {
-      signalConfirmationModal.setError(
+      signalConfirmationModal?.setError(
         error?.message ?? 'An unknown error occurred.',
       );
     }
@@ -163,10 +163,10 @@
           [workflow.runId]: response.runId,
         }));
       }
-      resetConfirmationModal.close();
+      resetConfirmationModal?.close();
       $refresh = Date.now();
     } catch (error) {
-      resetConfirmationModal.setError(
+      resetConfirmationModal?.setError(
         error?.message ?? 'An unknown error occurred.',
       );
     }

--- a/src/lib/holocene/modal.story.svelte
+++ b/src/lib/holocene/modal.story.svelte
@@ -37,9 +37,9 @@
           setTimeout(resolve, 250);
         }
       });
-      modal.close();
+      modal?.close();
     } catch {
-      modal.setError(errorText);
+      modal?.setError(errorText);
     } finally {
       loading = false;
     }

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -52,15 +52,17 @@
 
   const handleDelete = async () => {
     try {
-      deleteConfirmationModal.close();
       $loading = true;
       await deleteSchedule({ namespace, scheduleId });
+      deleteConfirmationModal?.close();
       setTimeout(() => {
         $loading = false;
         goto(routeForSchedules({ namespace }));
       }, 2000);
     } catch (e) {
-      deleteConfirmationModal.setError(`Cannot delete schedule. ${e?.message}`);
+      deleteConfirmationModal?.setError(
+        `Cannot delete schedule. ${e?.message}`,
+      );
       $loading = false;
     }
   };

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -162,10 +162,10 @@
           id: 'batch-terminate-success-toast',
         });
       }
-      batchTerminateConfirmationModal.close();
+      batchTerminateConfirmationModal?.close();
       resetPageToDefaultState();
     } catch (error) {
-      batchTerminateConfirmationModal.setError(
+      batchTerminateConfirmationModal?.setError(
         error?.message ?? 'An unknown error occurred.',
       );
     }
@@ -196,10 +196,10 @@
           id: 'batch-cancel-success-toast',
         });
       }
-      batchCancelConfirmationModal.close();
+      batchCancelConfirmationModal?.close();
       resetPageToDefaultState();
     } catch (error) {
-      batchCancelConfirmationModal.setError(
+      batchCancelConfirmationModal?.setError(
         error?.message ?? 'An unknown error occurred.',
       );
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
`modal.setError()` is being called after an async function. A user can navigate away during this time causing the modal to be `undefined`. 

This PR adds optional chaining to check if the modal is `undefined`.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-1014`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
