### PR TITLE
[DT-1060] Fix incorrect link to Schedule in search results

### DIFF
--- a/src/lib/components/schedule/schedules-table-row.svelte
+++ b/src/lib/components/schedule/schedules-table-row.svelte
@@ -37,14 +37,13 @@
     );
   };
 
-  const getRoute = () =>
-    routeForSchedule({
-      namespace,
-      scheduleId: schedule?.scheduleId as string,
-    });
+  $: route = routeForSchedule({
+    namespace,
+    scheduleId: schedule?.scheduleId as string,
+  });
 </script>
 
-<TableRow href={getRoute()} class="schedule-row">
+<TableRow href={route} class="schedule-row">
   <td class="cell">
     <WorkflowStatus status={schedule?.info?.paused ? 'Paused' : 'Running'} />
   </td>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

When searching for a schedule in the UI and then clicking on a result that wasn't in the same location in the table, the link was for the schedule that was previously at that index. 

This PR makes the `href` for each table row reactive to so that when the schedule changes it is updated correctly.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Create several Schedules (with different names)
   - [ ] Verify clicking on a Schedule in the `Schedules` list view takes you to the correct Schedule details page
- Enter a specific Schedule name in the search (one that isn't the first Schedule listed)
   - [ ] Verify clicking on the Schedule takes you to the correct Schedule details page

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-1060`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
