### PR TITLE
Remove duplicate authorization header forwarding

### DIFF
--- a/server/server/server.go
+++ b/server/server/server.go
@@ -57,6 +57,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	authMiddleware := server_options.WithAPIMiddleware(([]api.Middleware{
 		headers.WithForwardHeaders(
 			[]string{
+				// NOTE: Authorization header is forwarded by grpc-gateway
 				auth.AuthorizationExtrasHeader,
 			}),
 	}))

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -57,7 +57,6 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 	authMiddleware := server_options.WithAPIMiddleware(([]api.Middleware{
 		headers.WithForwardHeaders(
 			[]string{
-				echo.HeaderAuthorization,
 				auth.AuthorizationExtrasHeader,
 			}),
 	}))


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭
As desicribed and demonstrated in #1365, the current ui-server middleware injects duplicate authorization metadata into frontend grpc requests. The behavior is caused by two pieces of middleware adding the authorization header from the incoming API request to the outgoing grpc request metadata:

1. The grpc-gateway [here](https://github.com/temporalio/grpc-gateway/blob/ea4029e1bec8672694afe8cabc98e450414dee9b/runtime/context.go#L123-L125)
2. The header forwarding metadataAnnotator injected by the ui-server [here](https://github.com/temporalio/ui/blob/d77b9231562fb00e19c915dc241dd1140a96b332/server/server/server.go#L60)

This PR prefers the grpc-gateway handle the authorization header and configures the ui-server metadataAnnotator accordingly.

One small adjustment to the repro steps called out in #1365, auth does not need to be enabled to observe this issue. The middleware configuration causing this behavior is not externally configurable. Any frontend grpc request generated by ui-sever will have two authorization entries in the metadata if the incoming API request includes an authorization header.

### Screenshots (if applicable) 📸
N/A

### Design Considerations 🎨
N/A

## Testing 🧪 

### How was this tested 👻 

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ 

1. While debugging in ui-server mode, set a breakpoint at [grpc-gateway/runtime/context.go:168](https://github.com/temporalio/grpc-gateway/blob/ea4029e1bec8672694afe8cabc98e450414dee9b/runtime/context.go#L168)
2. Make a request (**_which includes an authorization header_**) to one of the API endpoints 
    * `/api/namespaces/v1?`, for example
3. Inspect `md` when stopped at the breakpoint set in step <span>#</span>1
    * With the current code, notice authorization has two elements. This are the duplicate authorization entries.
![image](https://github.com/temporalio/ui/assets/23125233/097d5099-aeb3-47b2-9bce-5de16b11769a)
    * With this MR, authorization has a single element
![image](https://github.com/temporalio/ui/assets/23125233/d489b826-ae0e-42de-9d12-5200778ad7e3)

## Checklists
N/A
### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed
closes #1365 

## Docs

### Any docs updates needed?
N/A
