### PR TITLE
Fix misalignment of table rows when scrolling is always on

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-wrapper.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-wrapper.svelte
@@ -58,7 +58,7 @@
 
 <style lang="postcss">
   .workflows-summary-table-wrapper {
-    @apply flex overflow-y-visible;
+    @apply overflow-y-visible;
 
     &.pinned {
       @apply shrink-0 overflow-x-hidden rounded-l-lg max-md:max-w-[50%] max-md:overflow-x-scroll max-w-fit min-w-[40px];


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If you set your OS settings to scrolling always, the scrollbar at the bottom of the unpinned columns creates a mismatch in row heights and makes them unaligned. Removed the flex class fixes it by growing the last row in the pinned columns to match the height of the last row + scrollbar in the unpinned columns.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
Before
<img width="1727" alt="Screen Shot 2023-06-08 at 10 21 09 AM" src="https://github.com/temporalio/ui/assets/7967403/4d083dbc-58e4-4b44-88ff-d628f3cfaf81">

After
<img width="1725" alt="Screen Shot 2023-06-08 at 10 21 22 AM" src="https://github.com/temporalio/ui/assets/7967403/321a8ad5-6903-4db9-8498-ac77aa402fc8">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Tested in all browsers, responsiveness

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
