### PR TITLE
Fix FilterSelect focus outline with tabs

### DIFF
--- a/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
+++ b/src/lib/components/workflow/dropdown-filter/workflow-datetime-filter.svelte
@@ -265,14 +265,14 @@
   <MenuContainer>
     <MenuButton
       class="p-2 bg-white border border-primary rounded-r h-10 w-32"
-      id="datetime"
-      controls="datetime-menu"
+      id="datetime-filter"
+      controls="datetime-filter-menu"
       hasIndicator
       icon="clock"
     >
       {capitalize($timeFormat)}
     </MenuButton>
-    <Menu id="datetime-menu">
+    <Menu id="datetime-filter-menu">
       <MenuItem on:click={() => ($timeFormat = 'relative')}
         >{translate('relative')}</MenuItem
       >

--- a/src/lib/holocene/primitives/menu/menu-item.svelte
+++ b/src/lib/holocene/primitives/menu/menu-item.svelte
@@ -80,7 +80,7 @@
   }
 
   .menu-item {
-    @apply w-full cursor-pointer list-none bg-white p-4 font-secondary text-sm font-medium text-primary hover:bg-gray-50 first-of-type:rounded-t last-of-type:rounded-b focus:outline-none focus-visible:bg-blue-50 focus-visible:outline-blue-700 focus-visible:outline focus-visible:-outline-offset-2;
+    @apply w-full cursor-pointer list-none bg-white p-4 font-secondary text-sm font-medium text-primary hover:bg-gray-50 first-of-type:rounded-t last-of-type:rounded-b focus:outline-none focus-visible:outline focus-visible:bg-blue-50 focus-visible:outline-blue-700 focus-visible:-outline-offset-2;
   }
 
   .dark {

--- a/src/lib/holocene/select/filter-select.svelte
+++ b/src/lib/holocene/select/filter-select.svelte
@@ -31,7 +31,7 @@
   {id}
   bind:value={_value}
   {...$$props}
-  class="border-[1px] border-gray-900 outline-none"
+  class="border-[1px] border-gray-900 outline-none focus-visible:outline focus-visible:outline-blue-700"
 >
   <slot>
     {#each options.map((o) => o.toString()) as option}


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Tabbing through workflow list, you think the controls lose focus but the pagination select doesn't have an outline when focused. Adding the `focus-visible:outline focus-visible:outline-blue-700` classes show the user the select is in focus.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1724" alt="Screen Shot 2023-06-08 at 12 30 32 PM" src="https://github.com/temporalio/ui/assets/7967403/c4d455a7-571b-4d36-aa95-8d36880fe15a">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
