### PR TITLE
Add check for statusCode in Error component

### DIFF
--- a/src/lib/holocene/error.svelte
+++ b/src/lib/holocene/error.svelte
@@ -3,17 +3,16 @@
   import { afterNavigate } from '$app/navigation';
   import { BROWSER } from 'esm-env';
   import { page } from '$app/stores';
-
-  import { isNetworkError } from '$lib/utilities/is-network-error';
-  import type { NetworkError } from '$lib/types/global';
+  import { has } from '$lib/utilities/has';
 
   import Link from '$lib/holocene/link.svelte';
+  import type { NetworkError } from '$lib/types/global';
 
   export let error: App.Error | NetworkError = null;
   export let status = 500;
   let message = error?.message || '';
 
-  if (isNetworkError(error)) {
+  if (has(error, 'statusCode')) {
     status = error.statusCode;
   }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Checks for `statusCode` on an `error` in the `Error` Holocene component instead of `isNetworkError` in order to update the `status`. There were instances (specifically in Cloud) where an error didn't meet all the criteria for a network error but did have a `statusCode` which led to the `Error` showing `500` for errors with a different status code.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
![Screenshot 2023-06-14 at 11 52 03 AM](https://github.com/temporalio/ui/assets/15069288/16417e4f-3bf5-4b13-8763-7e1e9bf11035)

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
