### PR TITLE
Fix negative page numbers in Pagination component

### DIFF
--- a/src/lib/stores/pagination.test.ts
+++ b/src/lib/stores/pagination.test.ts
@@ -483,6 +483,10 @@ describe('getStartingIndexForPage', () => {
     expect(getStartingIndexForPage(100, 20, oneHundredResolutions)).toBe(80);
   });
 
+  it('should return 0 for the something out of bounds if the total number of items is less than itemsPerPage', () => {
+    expect(getStartingIndexForPage(3, 101, oneHundredResolutions)).toBe(0);
+  });
+
   it('should return 0 if given a negative number for the page', () => {
     expect(getStartingIndexForPage(-10, 20, oneHundredResolutions)).toBe(0);
   });

--- a/src/lib/stores/pagination.ts
+++ b/src/lib/stores/pagination.ts
@@ -46,8 +46,10 @@ export const getStartingIndexForPage = (
   if (isNaN(page)) return 0;
 
   if (page <= 1) return 0;
-  if (page > getTotalPages(itemsPerPage, items))
-    return items.length - itemsPerPage;
+  if (page > getTotalPages(itemsPerPage, items)) {
+    const index = items.length - itemsPerPage;
+    return index > 0 ? index : 0;
+  }
 
   return Math.floor(itemsPerPage * (page - 1));
 };


### PR DESCRIPTION
… page is out of bounds

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
`getStartingIndexForPage` was returning a negative index if the total number of `items` was less than `itemsPerPage` when a page was out of bounds.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="518" alt="Screenshot 2023-06-28 at 5 07 47 PM" src="https://github.com/temporalio/ui/assets/15069288/fb9bbd66-4f6b-4f3b-a4a7-dd4dee7e87f4">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
