### PR TITLE
Map default columns to the namespace column store

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -25,6 +25,7 @@
   $: empty = workflows.length === 0;
   $: pinnedColumns = columns.filter((column) => column.pinned);
   $: otherColumns = columns.filter((column) => !column.pinned);
+  $: totalColumnCount = pinnedColumns.length + otherColumns.length;
 
   const openCustomizationDrawer = () => {
     customizationDrawerOpen = true;
@@ -37,7 +38,7 @@
 
 <div class="workflows-summary-configurable-table">
   <TableWrapper noPinnedColumns={pinnedColumns.length === 0}>
-    <Table pinned {empty} columns={pinnedColumns}>
+    <Table pinned {empty} {totalColumnCount} columns={pinnedColumns}>
       <TableHeaderRow pinned {workflows} {pinnedColumns} {empty} slot="headers">
         {#each pinnedColumns as column}
           <TableHeaderCell {column} />
@@ -51,7 +52,12 @@
         </TableRow>
       {/each}
     </Table>
-    <Table {empty} columns={otherColumns} slot="unpinned-columns">
+    <Table
+      {empty}
+      {totalColumnCount}
+      columns={otherColumns}
+      slot="unpinned-columns"
+    >
       <TableHeaderRow
         onClickConfigure={openCustomizationDrawer}
         {workflows}

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -19,7 +19,7 @@
 
   $: ({ namespace } = $page.params);
   $: columns = $workflowTableColumns?.[namespace] ?? [];
-  $: empty = workflows.length === 0 || columns.length === 0;
+  $: empty = workflows.length === 0;
   $: pinnedColumns = columns.filter((column) => column.pinned);
   $: otherColumns = columns.filter((column) => !column.pinned);
 

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { workflowTableColumns } from '$lib/stores/workflow-table-columns';
+  import {
+    getDefaultColumns,
+    workflowTableColumns,
+  } from '$lib/stores/workflow-table-columns';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import Drawer from '$lib/holocene/drawer.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -18,7 +21,7 @@
   let customizationDrawerOpen: boolean = false;
 
   $: ({ namespace } = $page.params);
-  $: columns = $workflowTableColumns?.[namespace] ?? [];
+  $: columns = $workflowTableColumns?.[namespace] ?? getDefaultColumns();
   $: empty = workflows.length === 0;
   $: pinnedColumns = columns.filter((column) => column.pinned);
   $: otherColumns = columns.filter((column) => !column.pinned);

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table.svelte
@@ -8,6 +8,7 @@
 
   export let pinned = false;
   export let columns: WorkflowHeader[];
+  export let totalColumnCount: number;
   export let empty: boolean;
 </script>
 
@@ -35,7 +36,7 @@
           />
         </td>
       </tr>
-    {:else if !pinned && columns.length === 0}
+    {:else if !pinned && totalColumnCount === 0}
       <tr>
         <td colspan={columns.length + 1}>
           <EmptyState title="No column headers are in view">

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -76,7 +76,7 @@ const DEFAULT_AVAILABLE_COLUMNS: WorkflowHeader[] = [
   { label: 'Task Queue', pinned: false },
 ];
 
-const getDefaultColumns = (): WorkflowHeader[] => {
+export const getDefaultColumns = (): WorkflowHeader[] => {
   let columns: WorkflowHeader[];
   try {
     // try to get the list of columns that was stored last time they interacted

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -106,13 +106,27 @@ export const workflowTableColumns: Readable<State> = derived(
   [namespaces, persistedWorkflowTableColumns],
   ([$namespaces, $persistedWorkflowTableColumns]) => {
     const state: State = {};
+
+    const useOrAddDefaultTableColumnsToNamespace = (
+      columns: State,
+      namespace: string,
+    ) => {
+      if (!columns?.[namespace]?.length) {
+        columns[namespace] = [...getDefaultColumns()];
+        return columns[namespace];
+      }
+      return columns[namespace];
+    };
+
     return (
       $namespaces?.reduce(
         (namespaceToColumnsMap, { namespaceInfo: { name } }) => {
           return {
             ...namespaceToColumnsMap,
-            [name]:
-              $persistedWorkflowTableColumns?.[name] ?? getDefaultColumns(),
+            [name]: useOrAddDefaultTableColumnsToNamespace(
+              $persistedWorkflowTableColumns,
+              name,
+            ),
           };
         },
         state,

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -84,9 +84,10 @@ export const getDefaultColumns = (): WorkflowHeader[] => {
     const stringifiedOldColumns = window.localStorage.getItem(
       'workflow-table-columns',
     );
+    const parsedOldColumns = JSON.parse(stringifiedOldColumns);
 
-    if (stringifiedOldColumns) {
-      columns = JSON.parse(stringifiedOldColumns);
+    if (stringifiedOldColumns && parsedOldColumns?.length) {
+      columns = parsedOldColumns;
     } else {
       columns = DEFAULT_COLUMNS;
     }


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
There are possible edge cases depending on the state of a user's localStorage where $persistedWorkflowTableColumns[namespace] could return an empty array. This plus the check for empty column length for empty prop led to weird situations where it showed 'No Workflows' when there was workflows.

The solution is to check for !columns?.[namespace]?.length, and if false, set columns[namespace] to the default columns.

A side effect of this solution is that if you try to remove all columns, it will reset to the default columns (which I think is an okay behavior)

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
