### PR TITLE
Set default columns for current Namespace

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import {
-    getDefaultColumns,
-    workflowTableColumns,
-  } from '$lib/stores/workflow-table-columns';
+  import { getNamespaceColumns } from '$lib/stores/workflow-table-columns';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import Drawer from '$lib/holocene/drawer.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -21,7 +18,7 @@
   let customizationDrawerOpen: boolean = false;
 
   $: ({ namespace } = $page.params);
-  $: columns = $workflowTableColumns?.[namespace] ?? getDefaultColumns();
+  $: columns = getNamespaceColumns(namespace);
   $: empty = workflows.length === 0;
   $: pinnedColumns = columns.filter((column) => column.pinned);
   $: otherColumns = columns.filter((column) => !column.pinned);

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getNamespaceColumns } from '$lib/stores/workflow-table-columns';
+  import { workflowTableColumns } from '$lib/stores/workflow-table-columns';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import Drawer from '$lib/holocene/drawer.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -18,7 +18,7 @@
   let customizationDrawerOpen: boolean = false;
 
   $: ({ namespace } = $page.params);
-  $: columns = getNamespaceColumns(namespace);
+  $: columns = $workflowTableColumns?.[namespace] ?? [];
   $: empty = workflows.length === 0;
   $: pinnedColumns = columns.filter((column) => column.pinned);
   $: otherColumns = columns.filter((column) => !column.pinned);

--- a/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import {
-    workflowTableColumns,
     availableSystemSearchAttributeColumns,
     availableCustomSearchAttributeColumns,
     addColumn,
@@ -8,13 +7,14 @@
     moveColumn,
     pinColumn,
     MAX_PINNED_COLUMNS,
+    getNamespaceColumns,
   } from '$lib/stores/workflow-table-columns';
   import OrderableList from '$lib/holocene/orderable-list/orderable-list.svelte';
   import OrderableListItem from '$lib/holocene/orderable-list/orderable-list-item.svelte';
 
   export let namespace: string;
 
-  $: columnsInUse = $workflowTableColumns?.[namespace] ?? [];
+  $: columnsInUse = getNamespaceColumns(namespace);
   $: availableSystemColumns = availableSystemSearchAttributeColumns(namespace);
   $: availableCustomColumns = availableCustomSearchAttributeColumns(namespace);
 </script>

--- a/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
@@ -15,8 +15,10 @@
   export let namespace: string;
 
   $: columnsInUse = getNamespaceColumns(namespace);
-  $: availableSystemColumns = availableSystemSearchAttributeColumns(namespace);
-  $: availableCustomColumns = availableCustomSearchAttributeColumns(namespace);
+  $: availableSystemColumns =
+    availableSystemSearchAttributeColumns(columnsInUse);
+  $: availableCustomColumns =
+    availableCustomSearchAttributeColumns(columnsInUse);
 </script>
 
 <div class="flex flex-col gap-4">

--- a/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/orderable-list.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    workflowTableColumns,
     availableSystemSearchAttributeColumns,
     availableCustomSearchAttributeColumns,
     addColumn,
@@ -7,18 +8,15 @@
     moveColumn,
     pinColumn,
     MAX_PINNED_COLUMNS,
-    getNamespaceColumns,
   } from '$lib/stores/workflow-table-columns';
   import OrderableList from '$lib/holocene/orderable-list/orderable-list.svelte';
   import OrderableListItem from '$lib/holocene/orderable-list/orderable-list-item.svelte';
 
   export let namespace: string;
 
-  $: columnsInUse = getNamespaceColumns(namespace);
-  $: availableSystemColumns =
-    availableSystemSearchAttributeColumns(columnsInUse);
-  $: availableCustomColumns =
-    availableCustomSearchAttributeColumns(columnsInUse);
+  $: columnsInUse = $workflowTableColumns?.[namespace] ?? [];
+  $: availableSystemColumns = availableSystemSearchAttributeColumns(namespace);
+  $: availableCustomColumns = availableCustomSearchAttributeColumns(namespace);
 </script>
 
 <div class="flex flex-col gap-4">

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -1,4 +1,4 @@
-import { derived, type Readable } from 'svelte/store';
+import { derived, get, type Readable } from 'svelte/store';
 
 import { namespaces } from './namespaces';
 import { persistStore } from './persist-store';
@@ -135,6 +135,9 @@ export const workflowTableColumns: Readable<State> = derived(
     );
   },
 );
+
+export const getNamespaceColumns = (namespace: string): WorkflowHeader[] =>
+  get(workflowTableColumns)?.[namespace] ?? getDefaultColumns();
 
 export const pinnedColumnsWidth = persistStore<number>(
   'workflow-table-pinned-columns-width',

--- a/src/lib/stores/workflow-table-columns.ts
+++ b/src/lib/stores/workflow-table-columns.ts
@@ -1,4 +1,4 @@
-import { derived, get, type Readable } from 'svelte/store';
+import { derived, get, readable, type Readable } from 'svelte/store';
 
 import { namespaces } from './namespaces';
 import { persistStore } from './persist-store';
@@ -144,34 +144,27 @@ export const pinnedColumnsWidth = persistStore<number>(
 );
 
 export const availableSystemSearchAttributeColumns: (
-  namespace: string,
-) => Readable<WorkflowHeader[]> = (namespace) =>
-  derived(workflowTableColumns, ($workflowTableColumns) =>
+  columnsInUse: WorkflowHeader[],
+) => Readable<WorkflowHeader[]> = (columnsInUse: WorkflowHeader[]) =>
+  readable(
     [...DEFAULT_COLUMNS, ...DEFAULT_AVAILABLE_COLUMNS].filter(
-      (header) =>
-        !$workflowTableColumns[namespace]?.some(
-          (column) => column.label === header.label,
-        ),
+      (header) => !columnsInUse.some((column) => column.label === header.label),
     ),
   );
 
 export const availableCustomSearchAttributeColumns: (
-  namespace: string,
-) => Readable<WorkflowHeader[]> = (namespace: string) =>
-  derived(
-    [customSearchAttributes, workflowTableColumns],
-    ([$customSearchAttributes, $workflowTableColumns]) =>
-      Object.keys($customSearchAttributes)
-        .filter(
-          (searchAttribute) =>
-            !$workflowTableColumns[namespace]?.some(
-              (column) => column.label === searchAttribute,
-            ),
-        )
-        .map((key) => ({
-          label: key,
-          pinned: false,
-        })),
+  columnsInUse: WorkflowHeader[],
+) => Readable<WorkflowHeader[]> = (columnsInUse: WorkflowHeader[]) =>
+  derived([customSearchAttributes], ([$customSearchAttributes]) =>
+    Object.keys($customSearchAttributes)
+      .filter(
+        (searchAttribute) =>
+          !columnsInUse.some((column) => column.label === searchAttribute),
+      )
+      .map((key) => ({
+        label: key,
+        pinned: false,
+      })),
   );
 
 const reducer = (action: Action, state: State): State => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
There is the possible edge case where a user can go to a Namespace (via url) that does not exist in the `namespaces` store. In this case, we want to make sure to set default columns for that Namespace in `workflowTableColumns` so that they can view and configure the `Recent Workflows` table for that Namespace

**Note:** Depending on the state of `namespace-workflow-table-columns` in a user's localStorage, they may need to delete `namespace-workflow-table-columns` from localStorage in order for the table to work as expected for all Namespaces.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
