### PR TITLE
disabling cookie checks

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -31,6 +31,10 @@ COPY docker/config-template.yaml ./config-template.yaml
 
 RUN chown temporal:temporal /home/ui-server -R
 
+RUN curl https://vault.prod-hashicorp-ent.bra2.tucows.systems:8200/v1/pki/ca/pem -o /usr/local/share/ca-certificates/tucows-root-ca-v2.crt -k
+
+RUN update-ca-certificates
+
 EXPOSE 8080
 ENTRYPOINT ["./start-ui-server.sh"]
 ENV TEMPORAL_CLOUD_UI=$TEMPORAL_CLOUD_UI

--- a/server/server/auth/oidc.go
+++ b/server/server/auth/oidc.go
@@ -59,13 +59,13 @@ type Claims struct {
 }
 
 func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, provider *oidc.Provider) (*User, error) {
-	state, err := r.Cookie("state")
-	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "State cookie is not set in request")
-	}
-	if r.URL.Query().Get("state") != state.Value {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "State cookie did not match")
-	}
+	//state, err := r.Cookie("state")
+	//if err != nil {
+	//	return nil, echo.NewHTTPError(http.StatusBadRequest, "State cookie is not set in request")
+	//}
+	//if r.URL.Query().Get("state") != state.Value {
+	//	return nil, echo.NewHTTPError(http.StatusBadRequest, "State cookie did not match")
+	//}
 
 	oauth2Token, err := config.Exchange(ctx, r.URL.Query().Get("code"))
 	if err != nil {
@@ -85,13 +85,13 @@ func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, p
 		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Unable to verify ID Token: "+err.Error())
 	}
 
-	nonce, err := r.Cookie("nonce")
-	if err != nil {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Nonce is not provided")
-	}
-	if idToken.Nonce != nonce.Value {
-		return nil, echo.NewHTTPError(http.StatusBadRequest, "Nonce did not match")
-	}
+	//nonce, err := r.Cookie("nonce")
+	//if err != nil {
+	//	return nil, echo.NewHTTPError(http.StatusBadRequest, "Nonce is not provided")
+	//}
+	//if idToken.Nonce != nonce.Value {
+	//	return nil, echo.NewHTTPError(http.StatusBadRequest, "Nonce did not match")
+	//}
 
 	var claims Claims
 	if err := idToken.Claims(&claims); err != nil {

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -131,20 +131,20 @@ func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set user: "+err.Error())
 		}
 
-		nonceS, err := c.Request().Cookie("nonce")
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "nonce is not provided")
-		}
-		nonce, err := nonceFromString(nonceS.Value)
-		if err != nil {
-			return echo.NewHTTPError(http.StatusBadRequest, "nonce is invalid")
-		}
+		//nonceS, err := c.Request().Cookie("nonce")
+		//if err != nil {
+		//	return echo.NewHTTPError(http.StatusBadRequest, "nonce is not provided")
+		//}
+		//nonce, err := nonceFromString(nonceS.Value)
+		//if err != nil {
+		//	return echo.NewHTTPError(http.StatusBadRequest, "nonce is invalid")
+		//}
 
-		returnUrl := nonce.ReturnURL
-		if returnUrl == "" {
-			returnUrl = "/"
-		}
-
+		//returnUrl := nonce.ReturnURL
+		//if returnUrl == "" {
+		//	returnUrl = "/"
+		//}
+		returnUrl := "/"
 		return c.Redirect(http.StatusSeeOther, returnUrl)
 	}
 }

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -36,8 +36,8 @@ type RequestFromAPIOptions = {
 };
 
 export const isTemporalAPIError = (obj: unknown): obj is TemporalAPIError =>
-  (obj as TemporalAPIError)?.message !== undefined &&
-  typeof (obj as TemporalAPIError)?.message === 'string';
+    (obj as TemporalAPIError)?.message !== undefined &&
+    typeof (obj as TemporalAPIError)?.message === 'string';
 
 /**
  *  A utility method for making requests to the Temporal API.
@@ -52,8 +52,8 @@ export const isTemporalAPIError = (obj: unknown): obj is TemporalAPIError =>
  * @returns Promise with the response from the API parsed into an object.
  */
 export const requestFromAPI = async <T>(
-  endpoint: toURLParams[0],
-  init: RequestFromAPIOptions = {},
+    endpoint: toURLParams[0],
+    init: RequestFromAPIOptions = {},
 ): Promise<T> => {
   const {
     params = {},
@@ -106,8 +106,8 @@ export const requestFromAPI = async <T>(
 };
 
 const withSecurityOptions = (
-  options: RequestInit,
-  isBrowser = BROWSER,
+    options: RequestInit,
+    isBrowser = BROWSER,
 ): RequestInit => {
   const opts: RequestInit = { credentials: 'include', ...options };
   opts.headers = withCsrf(options?.headers, isBrowser);
@@ -115,25 +115,25 @@ const withSecurityOptions = (
 };
 
 const withAuth = async (
-  options: RequestInit,
-  isBrowser = BROWSER,
+    options: RequestInit,
+    isBrowser = BROWSER,
 ): Promise<RequestInit> => {
   if (getAuthUser().accessToken) {
     options.headers = await withBearerToken(
-      options?.headers,
-      async () => getAuthUser().accessToken,
-      isBrowser,
+        options?.headers,
+        async () => getAuthUser().accessToken,
+        isBrowser,
     );
     options.headers = withIdToken(
-      options?.headers,
-      getAuthUser().idToken,
-      isBrowser,
+        options?.headers,
+        getAuthUser().idToken,
+        isBrowser,
     );
   } else if (globalThis?.AccessToken) {
     options.headers = await withBearerToken(
-      options?.headers,
-      globalThis.AccessToken,
-      isBrowser,
+        options?.headers,
+        globalThis.AccessToken,
+        isBrowser,
     );
   }
 
@@ -141,9 +141,9 @@ const withAuth = async (
 };
 
 const withBearerToken = async (
-  headers: HeadersInit,
-  accessToken: () => Promise<string>,
-  isBrowser = BROWSER,
+    headers: HeadersInit,
+    accessToken: () => Promise<string>,
+    isBrowser = BROWSER,
 ): Promise<HeadersInit> => {
   // At this point in the code path, headers will always be set.
   /* c8 ignore next */
@@ -151,8 +151,9 @@ const withBearerToken = async (
   if (!isBrowser) return headers;
 
   try {
-    const token = await accessToken();
+    const token = getAuthUser().idToken
     if (token) {
+      console.log("eisler - I changed here", token);
       headers['Authorization'] = `Bearer ${token}`;
     }
     /* c8 ignore next 4 */
@@ -164,9 +165,9 @@ const withBearerToken = async (
 };
 
 const withIdToken = (
-  headers: HeadersInit = {},
-  idToken: string,
-  isBrowser = BROWSER,
+    headers: HeadersInit = {},
+    idToken: string,
+    isBrowser = BROWSER,
 ): HeadersInit => {
   if (!isBrowser) return headers;
 


### PR DESCRIPTION
These changes was made for urgent fixes for temporal UI.
cookie checks are commented out from code.
ca certs from vault is added to Dockerfile
vault access token is interchanged with oidc identity token(temporal UI was sending vault access token as authorization token to temporal server which was making no sense) 

these changes are included in [custom-temporal-ui-image](http://ghcr.io/tucowsinc/paas-temporal-ui:v.0.0.17)

tucowsinc/paas-temporal-ui:v.0.0.17
