### PR TITLE
Account for non-enumerable properties in has util

### DIFF
--- a/src/lib/utilities/has.test.ts
+++ b/src/lib/utilities/has.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { has, hasAnyKeys } from './has';
+import { has, hasAnyProperties } from './has';
 
 describe('has', () => {
   it('returns true if an object has a key', () => {
@@ -50,30 +50,35 @@ describe('has', () => {
   });
 });
 
-describe('hasAnyKeys', () => {
-  it('returns true if an object has keys', () => {
+describe('hasAnyProperties', () => {
+  it('returns true if an object has enumerable properties', () => {
     const source = { foo: 123 };
-    expect(hasAnyKeys(source)).toBe(true);
+    expect(hasAnyProperties(source)).toBe(true);
+  });
+
+  it('returns true if an object has non-enumerable properties', () => {
+    const error = new Error();
+    expect(hasAnyProperties(error)).toBe(true);
   });
 
   it('returns false if an object has no keys', () => {
     const source = {};
-    expect(hasAnyKeys(source)).toBe(false);
+    expect(hasAnyProperties(source)).toBe(false);
   });
 
   it('should return false if given null', () => {
-    expect(hasAnyKeys(null)).toBe(false);
+    expect(hasAnyProperties(null)).toBe(false);
   });
 
   it('should return false if given undefined', () => {
-    expect(hasAnyKeys(undefined)).toBe(false);
+    expect(hasAnyProperties(undefined)).toBe(false);
   });
 
   it('should return false if given a number', () => {
-    expect(hasAnyKeys(3)).toBe(false);
+    expect(hasAnyProperties(3)).toBe(false);
   });
 
   it('should return false if given a boolean', () => {
-    expect(hasAnyKeys(true)).toBe(false);
+    expect(hasAnyProperties(true)).toBe(false);
   });
 });

--- a/src/lib/utilities/has.ts
+++ b/src/lib/utilities/has.ts
@@ -4,16 +4,16 @@ export const has = <K extends Readonly<string[]>, V = unknown>(
   target: unknown,
   ...properties: K
 ): target is Record<K[number], V> => {
-  if (!hasAnyKeys(target)) return false;
+  if (!hasAnyProperties(target)) return false;
   for (const property of properties) {
     if (!Object.prototype.hasOwnProperty.call(target, property)) return false;
   }
   return true;
 };
 
-export const hasAnyKeys = (
+export const hasAnyProperties = (
   obj: unknown,
 ): obj is ReturnType<typeof isObject> => {
   if (!isObject(obj)) return false;
-  return !!Object.keys(obj).length;
+  return !!Object.getOwnPropertyNames(obj).length;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Use `Object.getOwnPropertyNames()` instead of `Object.keys()` in the `has` util to account for instances where an object might have non-enumerable properties (e.g. `new Error()`).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
