### PR TITLE
Don't reset filters after batch actions

### DIFF
--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -76,7 +76,6 @@
     bulkCancelByIDs,
     bulkTerminateByIDs,
   } from '$lib/services/batch-service';
-  import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
   import BatchOperationConfirmationModal from '$lib/components/workflow/batch-operation-confirmation-modal.svelte';
   import { Action } from '$lib/models/workflow-actions';
   import { supportsAdvancedVisibility } from '$lib/stores/advanced-visibility';

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -132,17 +132,6 @@
     $refresh = Date.now();
   };
 
-  const resetPageToDefaultState = () => {
-    $workflowFilters = [];
-    updateQueryParameters({
-      url: $page.url,
-      parameter: 'query',
-      value: '',
-      allowEmpty: true,
-    });
-    refreshWorkflows();
-  };
-
   const terminateWorkflows = async (event: CustomEvent<{ reason: string }>) => {
     const options = {
       namespace: $page.params.namespace,
@@ -169,7 +158,7 @@
         });
       }
       batchTerminateConfirmationModal?.close();
-      resetPageToDefaultState();
+      refreshWorkflows();
     } catch (error) {
       batchTerminateConfirmationModal?.setError(
         error?.message ?? translate('unknown-error'),
@@ -203,7 +192,7 @@
         });
       }
       batchCancelConfirmationModal?.close();
-      resetPageToDefaultState();
+      refreshWorkflows();
     } catch (error) {
       batchCancelConfirmationModal?.setError(
         error?.message ?? translate('unknown-error'),


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Keep the applied filters after batch actions in case users want to run them again.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
