### PR TITLE
Fix Timeline history sort and Icon Button height issue

### DIFF
--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -157,8 +157,9 @@
     if (history.length && timeline) {
       const reverseHistory =
         $eventFilterSort === 'descending' && $eventViewType !== 'compact';
+      const historyCopy = [...history];
       const eventGroups = groupEvents(
-        reverseHistory ? history.reverse() : history,
+        reverseHistory ? historyCopy.reverse() : history,
       );
       const { groups, items } = createGroupItems(
         eventGroups,

--- a/src/lib/holocene/icon-button.svelte
+++ b/src/lib/holocene/icon-button.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { HTMLButtonAttributes } from 'svelte/elements';
-  
+
   import Icon from '$lib/holocene/icon/icon.svelte';
   import type { IconName } from '$lib/holocene/icon/paths';
 
@@ -26,7 +26,7 @@
 >
   {#if icon}
     <div class="flex items-center justify-center gap-2 {classes}">
-      <Icon name={icon} class="h-fit" />
+      <Icon name={icon} class="h-auto" />
       <slot />
     </div>
   {:else}


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When labs mode was on and reverse sort selected on Feed view, the event history would still show up 1-9 order. This was because I was reversing the history directly in the Timeline component instead of creating a copy of history and reversing. This fixes that.

Also fixes icon-button height issue for Safari

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
