### PR TITLE
Add UTC time to last heartbeat time

### DIFF
--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -67,9 +67,15 @@
                     <h4 class="pending-activity-detail-header">
                       {translate('workflows', 'last-heartbeat')}
                     </h4>
-                    {formatDate(pendingActivity.lastHeartbeatTime, 'relative', {
-                      relativeStrict: true,
-                    })}
+                    {`${formatDate(
+                      pendingActivity.lastHeartbeatTime,
+                    )} (${formatDate(
+                      pendingActivity.lastHeartbeatTime,
+                      'relative',
+                      {
+                        relativeStrict: true,
+                      },
+                    )})`}
                   </div>
                   <div class="pending-activity-detail">
                     <h4 class="pending-activity-detail-header">

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -118,10 +118,13 @@
             <li class="event-table-row">
               <h4>{translate('workflows', 'last-heartbeat')}</h4>
               <p>
-                {(formatDate(details.lastHeartbeatTime, 'relative'),
-                {
-                  relativeStrict: true,
-                })}
+                {`${formatDate(details.lastHeartbeatTime)} (${formatDate(
+                  details.lastHeartbeatTime,
+                  'relative',
+                  {
+                    relativeStrict: true,
+                  },
+                )})`}
               </p>
             </li>
             <li class="event-table-row">


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Adds a precise UTC timestamp down to the second (in addition to displaying "x seconds ago").

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="905" alt="Screenshot 2023-07-25 at 12 30 07 PM" src="https://github.com/temporalio/ui/assets/15069288/283d9a22-0e85-4fe1-bdfd-c9b9b9989b03">
<img width="725" alt="Screenshot 2023-07-25 at 12 28 54 PM" src="https://github.com/temporalio/ui/assets/15069288/afc2f0af-be8b-4662-b2fe-6fc94852688d">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1287`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
