### PR TITLE
Preserve datetime value on search

### DIFF
--- a/src/lib/utilities/format-date.test.ts
+++ b/src/lib/utilities/format-date.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { isValidDate } from './format-date';
+
+describe('isValidDate', () => {
+  it('should return true if the value is a valid Date', () => {
+    expect(isValidDate('2022-04-13T11:29:32.633009Z')).toBe(true);
+  });
+  it('should return false if the value is not a valid Date', () => {
+    expect(isValidDate('bogus')).toBe(false);
+    expect(isValidDate('')).toBe(false);
+  });
+});

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -1,6 +1,7 @@
 import {
   formatDistanceToNow,
   formatDistanceToNowStrict,
+  parseISO,
   parseJSON,
 } from 'date-fns';
 import * as dateTz from 'date-fns-tz'; // `build` script fails on importing some of named CommonJS modules
@@ -58,4 +59,9 @@ export function formatDateTime(
   } catch {
     return `about ${date} ${relativeLabel}`;
   }
+}
+
+export function isValidDate(date: string): boolean {
+  const d = parseISO(date);
+  return d instanceof Date && !isNaN(d.getTime());
 }

--- a/src/lib/utilities/query/to-list-workflow-filters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.test.ts
@@ -143,7 +143,7 @@ describe('toListWorkflowParameters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-18T17:45:18-06:00',
       },
     ];
     expect(result).toEqual(expectedFilters);
@@ -160,7 +160,7 @@ describe('toListWorkflowParameters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-18T17:45:18-06:00',
       },
     ];
     expect(result).toEqual(expectedFilters);
@@ -183,7 +183,7 @@ describe('toListWorkflowParameters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-18T17:45:18-06:00',
       },
     ];
     expect(result).toEqual(expectedFilters);
@@ -207,7 +207,7 @@ describe('toListWorkflowParameters', () => {
         conditional: '>',
         operator: 'AND',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-18T17:45:18-06:00',
       },
       {
         attribute: 'ExecutionStatus',
@@ -259,7 +259,7 @@ describe('toListWorkflowParameters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-18T17:45:18-06:00',
       },
     ];
     expect(result).toEqual(expectedFilters);
@@ -329,7 +329,7 @@ describe('combineDropdownFilters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-20T17:45:18-06:00',
       },
     ];
 
@@ -347,7 +347,7 @@ describe('combineDropdownFilters', () => {
         conditional: '>',
         operator: '',
         parenthesis: '',
-        value: '2 days',
+        value: '2022-04-20T17:45:18-06:00',
       },
     ]);
   });

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -1,4 +1,3 @@
-import { formatDuration } from 'date-fns';
 import debounce from 'just-debounce';
 
 import type { WorkflowFilter } from '$lib/models/workflow-filters';
@@ -6,10 +5,10 @@ import type { FilterParameters, SearchAttributes } from '$lib/types/workflows';
 import { toListWorkflowQueryFromFilters } from '$lib/utilities/query/filter-workflow-query';
 
 import { tokenize } from './tokenize';
+import { isValidDate } from '../format-date';
 import { isBetween, isConditional, isJoin, isParenthesis } from '../is';
-import { durationKeys, fromDate } from '../to-duration';
+import { durationKeys } from '../to-duration';
 import { updateQueryParameters } from '../update-query-parameters';
-
 type Tokens = string[];
 export type ParsedParameters = FilterParameters & { timeRange?: string };
 
@@ -72,14 +71,10 @@ export const toListWorkflowFilters = (
         filter.attribute = token;
         if (isDatetimeStatement(attributes[token])) {
           const start = getTwoAhead(tokens, index);
-
-          try {
-            const duration = fromDate(start);
-            const largestUnit = getLargestDurationUnit(duration);
-
-            filter.value = formatDuration(largestUnit);
-          } catch (error) {
-            console.error('Error parsing Datetime field from query', error);
+          if (isValidDate(start)) {
+            filter.value = start;
+          } else {
+            console.error('Error parsing Datetime field from query');
           }
         } else {
           filter.value = getTwoAhead(tokens, index);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The datetime value listed in the search input changes when other filters are added (e.g. enter in a `startTime` filter and then add an `ExecutionStatus` from the dropdown `Status` filter). This is because we have been converting that date into a duration (e.g. "15 minutes") and adding it to the `workflowFilters` store. 

This PR removes the logic that converts the date to a duration in `toListWorkflowFilters` and preserves the Date as the filter value.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Enter in a datetime value in the search input (e.g.  StartTime < "...")
   - [ ] Verify it works as expected
   - Do a hard refresh of the page
      - [ ] Verify it works as expected
   - Add another filter (e.g. select an `ExecutionStatus` from the `Status` dropdown filter)  
      - [ ] Verify it works as expected
- Select a relative datetime value from the time filter dropdown
   - [ ] Verify it works as expected
   - Do a hard refresh of the page
      - [ ] Verify it works as expected
   - Add another filter (e.g. select an `ExecutionStatus` from the `Status` dropdown filter)  
      - [ ] Verify it works as expected
- Enter in a custom datetime value from the time filter dropdown
   - [ ] Verify it works as expected
   - Do a hard refresh of the page
      - [ ] Verify it works as expected
   - Add another filter (e.g. select an `ExecutionStatus` from the `Status` dropdown filter)  
      - [ ] Verify it works as expected
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1311`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
