### PR TITLE
Parse custom datetime in toListWorkflowFilters

### DIFF
--- a/src/lib/utilities/query/to-list-workflow-filters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.test.ts
@@ -17,6 +17,8 @@ const workflowTypeQuery = 'WorkflowType="World"';
 const workflowQuery1 = 'WorkflowId="Hello" AND WorkflowType="World"';
 const startTimeQuery = 'StartTime > "2022-04-18T17:45:18-06:00"';
 const closeTimeQuery = 'CloseTime > "2022-04-18T17:45:18-06:00"';
+const betweenTimeQuery =
+  'StartTime BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"';
 const workflowQuery2 =
   'WorkflowType="World" AND StartTime > "2022-04-18T17:45:18-06:00"';
 const workflowQuery3 =
@@ -165,6 +167,26 @@ describe('toListWorkflowParameters', () => {
     ];
     expect(result).toEqual(expectedFilters);
   });
+
+  it('should parse a query BETWEEN two times', () => {
+    vi.useFakeTimers().setSystemTime(
+      parseISO('2022-04-20T17:45:18-06:00').getTime(),
+    );
+    const result = toListWorkflowFilters(betweenTimeQuery, attributes);
+    const expectedFilters = [
+      {
+        attribute: 'StartTime',
+        conditional: '',
+        operator: '',
+        parenthesis: '',
+        value:
+          'BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"',
+        customDate: true,
+      },
+    ];
+    expect(result).toEqual(expectedFilters);
+  });
+
   it('should parse a query with a workflowType and startTime', () => {
     vi.useFakeTimers().setSystemTime(
       parseISO('2022-04-20T17:45:18-06:00').getTime(),
@@ -184,6 +206,35 @@ describe('toListWorkflowParameters', () => {
         operator: '',
         parenthesis: '',
         value: '2022-04-18T17:45:18-06:00',
+      },
+    ];
+    expect(result).toEqual(expectedFilters);
+  });
+
+  it('should parse a query with a workflowId and BETWEEN two times', () => {
+    vi.useFakeTimers().setSystemTime(
+      parseISO('2022-04-20T17:45:18-06:00').getTime(),
+    );
+    const result = toListWorkflowFilters(
+      `${workflowIdQuery} AND ${betweenTimeQuery}`,
+      attributes,
+    );
+    const expectedFilters = [
+      {
+        attribute: 'WorkflowId',
+        conditional: '=',
+        operator: 'AND',
+        parenthesis: '',
+        value: 'Hello',
+      },
+      {
+        attribute: 'StartTime',
+        conditional: '',
+        operator: '',
+        parenthesis: '',
+        value:
+          'BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"',
+        customDate: true,
       },
     ];
     expect(result).toEqual(expectedFilters);
@@ -274,6 +325,40 @@ describe('toListWorkflowParameters', () => {
   it('should console error if given an invalid start time', () => {
     const spy = vi.spyOn(console, 'error');
     toListWorkflowFilters('StartTime = "bogus"', attributes);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should not throw if given an invalid time in a BETWEEN query', () => {
+    expect(() => {
+      toListWorkflowFilters(
+        'StartTime BETWEEN "bogus" AND "2023-07-28T06:00:00-00:00"',
+        attributes,
+      );
+    }).not.toThrow();
+
+    expect(() => {
+      toListWorkflowFilters(
+        'StartTime BETWEEN "2023-07-28T00:00:00-00:00" AND "bogus"',
+        attributes,
+      );
+    }).not.toThrow();
+  });
+
+  it('should console error if given an invalid start time in a BETWEEN query', () => {
+    const spy = vi.spyOn(console, 'error');
+    toListWorkflowFilters(
+      'StartTime BETWEEN "bogus" AND "2023-07-28T06:00:00-00:00"',
+      attributes,
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should console error if given an invalid end time in a BETWEEN query', () => {
+    const spy = vi.spyOn(console, 'error');
+    toListWorkflowFilters(
+      'StartTime BETWEEN "2023-07-28T00:00:00-00:00" AND "bogus"',
+      attributes,
+    );
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -36,7 +36,7 @@ export const getLargestDurationUnit = (duration: Duration): Duration => {
 
 const isDatetimeStatement = is('Datetime');
 
-export const emptyFilter = () => ({
+export const emptyFilter = (): WorkflowFilter => ({
   attribute: '',
   value: '',
   operator: '',
@@ -71,7 +71,19 @@ export const toListWorkflowFilters = (
         filter.attribute = token;
         if (isDatetimeStatement(attributes[token])) {
           const start = getTwoAhead(tokens, index);
-          if (isValidDate(start)) {
+          const hasValidStartTime = isValidDate(start);
+
+          if (isBetween(tokens[index + 1])) {
+            const end = tokens[index + 4];
+            const hasValidEndTime = isValidDate(end);
+
+            if (hasValidStartTime && hasValidEndTime) {
+              filter.value = `BETWEEN "${start}" AND "${end}"`;
+              filter.customDate = true;
+            } else {
+              console.error('Error parsing Datetime field from query');
+            }
+          } else if (hasValidStartTime) {
             filter.value = start;
           } else {
             console.error('Error parsing Datetime field from query');


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
A custom datetime filter (e.g. `StartTime BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"`)  in the search input for `Recent Workflows` was not being parsed correctly in `toListWorkflowFilters`. This meant when adding another filter (e.g. `Workflow ID`) the BETWEEN and end time part of the search query was not preserved.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Add a custom time filter
- Add another filter (e.g. `WorkflowId`)
   - Verify the query in the search input is as expected and `BETWEEN` is preserved

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1327`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
