### PR TITLE
Create new URLSearchParams and use goto when updating query params

### DIFF
--- a/src/lib/components/event/event-category-filter.svelte
+++ b/src/lib/components/event/event-category-filter.svelte
@@ -27,34 +27,33 @@
     options = options.filter(({ option }) => option !== 'update');
   }
 
-  $: _value = $page.url?.searchParams?.get(parameter);
+  $: visibleOption = options.find(
+    ({ option }) => option === $page.url?.searchParams?.get(parameter),
+  );
+  $: $eventCategoryFilter = visibleOption?.option?.toString() ?? undefined;
 
-  $: {
+  const onOptionClick = (value: string) => {
     updateQueryParameters({
       parameter: parameter,
-      value: _value,
+      value,
       url: $page.url,
-    }).then((v) => {
-      const visibleOption = options.find(({ option }) => option === v);
-      _value = visibleOption?.option?.toString() ?? null;
-      $eventCategoryFilter = _value;
     });
-  }
-
-  const onOptionClick = (option: string) => {
-    _value = option;
   };
 </script>
 
-<DropdownMenu value={_value} icon="filter" testId="event-category-filter">
+<DropdownMenu
+  value={$eventCategoryFilter}
+  icon="filter"
+  testId="event-category-filter"
+>
   <svelte:fragment slot="label">
     {label}
   </svelte:fragment>
   <div class="w-56">
     {#each options as { label, option } (option)}
-      <div class="option" class:active={_value === option}>
+      <div class="option" class:active={$eventCategoryFilter === option}>
         <div class="check active">
-          {#if _value === option}
+          {#if $eventCategoryFilter === option}
             <Icon name="checkmark" />
           {/if}
         </div>

--- a/src/lib/stores/filters.ts
+++ b/src/lib/stores/filters.ts
@@ -47,7 +47,7 @@ const updateEventCategoryFilter: StartStopNotifier<string | null> = (set) => {
   });
 };
 
-export const eventCategoryFilter = writable<string | null>(
-  null,
+export const eventCategoryFilter = writable<string | undefined>(
+  undefined,
   updateEventCategoryFilter,
 );

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -2,113 +2,165 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { gotoOptions, updateQueryParameters } from './update-query-parameters';
 
-const url = new URL('https://temporal.io');
-
 describe('updateQueryParameters', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should call the set method on the query when a value is provided', () => {
+  it('should call `goto` with the correct path when no value is provided', () => {
+    const url = new URL('https://temporal.io');
     const parameter = 'parameter';
-    const value = 'value';
-    const goto = () => Promise.resolve();
-
-    const spy = vi.spyOn(url.searchParams, 'set');
-
-    updateQueryParameters({ parameter, value, url, goto });
-
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith(parameter, value);
-  });
-
-  it('should call the delete method on the query when no value is provided', () => {
-    const parameter = 'parameter';
-    const goto = () => Promise.resolve();
-
-    const spy = vi.spyOn(url.searchParams, 'delete');
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, url, goto });
 
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith(parameter);
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/');
+    expect(options).toEqual(gotoOptions);
   });
 
-  it('should call the delete method on the query when an empty string is provided', () => {
+  it('should call `goto` with the correct path when an empty string is provided', () => {
+    const url = new URL('https://temporal.io');
     const parameter = 'parameter';
     const value = '';
-    const goto = () => Promise.resolve();
-
-    const spy = vi.spyOn(url.searchParams, 'delete');
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith(parameter);
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/');
+    expect(options).toEqual(gotoOptions);
   });
 
-  it('should call the delete method on the query when null is provided', () => {
+  it('should call `goto` with the correct path when an emmpty string is provided and there are other params', () => {
+    const url = new URL('https://temporal.io/?other=value');
     const parameter = 'parameter';
-    const value = null as unknown as string;
-    const goto = () => Promise.resolve();
+    const value = '';
 
-    const spy = vi.spyOn(url.searchParams, 'delete');
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith(parameter);
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?other=value');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should call `goto` with the correct path when null is provided', () => {
+    const url = new URL('https://temporal.io');
+    const parameter = 'parameter';
+    const value = null as unknown as string;
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should call `goto` with the correct path when null is provided and there are other params', () => {
+    const url = new URL('https://temporal.io/?other=value');
+    const parameter = 'parameter';
+    const value = null as unknown as string;
+
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?other=value');
+    expect(options).toEqual(gotoOptions);
   });
 
   it('should call `goto` with the correct path', () => {
+    const url = new URL('https://temporal.io');
     const parameter = 'parameter';
     const value = 'value';
     const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    const [{ href }, options] = goto.mock.calls[0];
+    const [href, options] = goto.mock.calls[0];
 
-    expect(href).toBe('https://temporal.io/?parameter=value');
+    expect(href).toBe('/?parameter=value');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should call `goto` with the correct path when there are other params', () => {
+    const url = new URL('https://temporal.io/?other=value');
+    const parameter = 'parameter';
+    const value = 'value';
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?other=value&parameter=value');
     expect(options).toEqual(gotoOptions);
   });
 
   it('should call `goto` with the correct path when query parameters already exist', () => {
     const parameter = 'parameter';
-    const value = 'newvalue';
+    const value = 'value';
+    const url = new URL(`https://temporal.io/?${parameter}=oldvalue`);
     const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    const [{ href }, options] = goto.mock.calls[0];
+    const [href, options] = goto.mock.calls[0];
 
-    expect(href).toBe('https://temporal.io/?parameter=newvalue');
+    expect(href).toBe('/?parameter=value');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should call `goto` with the correct path for the updated param when there are other params', () => {
+    const parameter = 'parameter';
+    const value = 'value';
+    const url = new URL(
+      `https://temporal.io/?${parameter}=oldvalue&other=value`,
+    );
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?other=value&parameter=value');
     expect(options).toEqual(gotoOptions);
   });
 
   it('should call `goto` with without the "?" if the query params are empty', () => {
+    const url = new URL('https://temporal.io');
     const parameter = 'parameter';
     const value = null as unknown as string;
     const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto });
 
-    const [{ href }, options] = goto.mock.calls[0];
+    const [href, options] = goto.mock.calls[0];
 
-    expect(href).toBe('https://temporal.io/');
+    expect(href).toBe('/');
     expect(options).toEqual(gotoOptions);
   });
 
   it('should set the parameter to an empty string if allowEmpty is set', () => {
+    const url = new URL('https://temporal.io');
     const parameter = 'parameter';
     const value = '';
     const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
 
     updateQueryParameters({ parameter, value, url, goto, allowEmpty: true });
 
-    const [{ href }, options] = goto.mock.calls[0];
+    const [href, options] = goto.mock.calls[0];
 
-    expect(href).toBe('https://temporal.io/?parameter=');
+    expect(href).toBe('/?parameter=');
     expect(options).toEqual(gotoOptions);
   });
 });

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -1,9 +1,6 @@
-import { get } from 'svelte/store';
-
 import { BROWSER } from 'esm-env';
 
-import { invalidate, goto as navigateTo } from '$app/navigation';
-import { page } from '$app/stores';
+import { goto as navigateTo } from '$app/navigation';
 
 type UpdateQueryParams = {
   parameter: string;
@@ -11,7 +8,6 @@ type UpdateQueryParams = {
   url: URL;
   goto?: typeof navigateTo;
   allowEmpty?: boolean;
-  invalidate?: typeof invalidate;
 };
 
 export const gotoOptions = {
@@ -27,24 +23,25 @@ export const updateQueryParameters = async ({
   allowEmpty = false,
 }: UpdateQueryParams): Promise<typeof value> => {
   const next = String(value);
+  const params = {};
+  url.searchParams.forEach((value, key) => {
+    if (key !== parameter) {
+      params[key] = value;
+    }
+  });
+  const newQuery = new URLSearchParams(params);
 
   if (value) {
-    url.searchParams.set(parameter, next);
+    newQuery.set(parameter, next);
   } else if (allowEmpty) {
-    url.searchParams.set(parameter, '');
-  } else {
-    url.searchParams.delete(parameter);
+    newQuery.set(parameter, '');
   }
 
-  if (BROWSER && url.href !== window.location.href) {
-    const namespace = get(page)?.params?.namespace;
-    const workflowsPath = `/namespaces/${namespace}/workflows`;
+  if (BROWSER) {
+    const query = newQuery?.toString();
+    const newUrl = query ? `${url.pathname}?${query}` : url.pathname;
 
-    if (url.pathname === workflowsPath) {
-      await invalidate((url) => url.pathname === workflowsPath);
-    }
-
-    goto(url, gotoOptions);
+    goto(newUrl, gotoOptions);
   }
 
   return value;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Changes to query parameters were not triggering a `$page` store update. This meant derived stores based on url search params (like `pageSize` in `api-pagination`) where not updated and therefore the page did not reflect the changes in the query parameters.

Since [$page](https://kit.svelte.dev/docs/modules#$app-stores-page) is a readable store, instead of mutating `$page.url.searchParams` directly, we can create new `URLSearchParams` and then navigate to the updated URL using [goto](https://kit.svelte.dev/docs/modules#$app-stores-page). This triggers an update to the url in the `$page` store and ensures derived stores based on the `$page` store are updated.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
* `DT-1322`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
