### PR TITLE
Remove overflow to show tooltips

### DIFF
--- a/src/lib/holocene/navigation/nav-row.svelte
+++ b/src/lib/holocene/navigation/nav-row.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <li
-  class="{link ? '' : classes} overflow-hidden"
+  class={link ? '' : classes}
   class:noFilter
   class:wrap
   class:button={handleClick !== null}


### PR DESCRIPTION
 ## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The overflow issue with the `<li> <button>` combo was fixed and we don't want this overflow-hidden so tooltips show up when collapsed.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
