### PR TITLE
Clear the activeIndex when going to next/previous page in event history

### DIFF
--- a/src/lib/stores/pagination.test.ts
+++ b/src/lib/stores/pagination.test.ts
@@ -389,6 +389,16 @@ describe('pagination', () => {
     expect(get(store).activeRowIndex).toBe(0);
   });
 
+  it('by default should not set active row index', () => {
+    const store = pagination(oneHundredResolutions, 5);
+
+    expect(get(store).activeRowIndex).toBe(undefined);
+
+    store.setActiveRowIndex();
+
+    expect(get(store).activeRowIndex).toBe(undefined);
+  });
+
   it('should set active row index', () => {
     const store = pagination(oneHundredResolutions, 5);
 

--- a/src/lib/stores/pagination.test.ts
+++ b/src/lib/stores/pagination.test.ts
@@ -348,7 +348,7 @@ describe('pagination', () => {
     expect(get(store).activeRowIndex).toBe(1);
   });
 
-  it('should set active row to current row item on next ', () => {
+  it('should set active row to undefined on next page', () => {
     const store = pagination(oneHundredResolutions, 5);
 
     for (let i = 0; i < 4; i++) {
@@ -359,7 +359,7 @@ describe('pagination', () => {
 
     store.next();
 
-    expect(get(store).activeRowIndex).toBe(3);
+    expect(get(store).activeRowIndex).toBe(undefined);
   });
 
   it('should set active row to last row item on next if next page has less items', () => {

--- a/src/lib/stores/pagination.ts
+++ b/src/lib/stores/pagination.ts
@@ -16,7 +16,7 @@ type PaginationMethods<T> = {
   findPage: (fn: (item: T) => boolean) => number;
   nextRow: () => void;
   previousRow: () => void;
-  setActiveRowIndex: (activeRowIndex: number) => void;
+  setActiveRowIndex: (activeRowIndex: number | undefined) => void;
 };
 
 type PaginationStore<T> = PaginationMethods<T> &
@@ -132,6 +132,7 @@ export const pagination = <T>(
   };
 
   const next = () => {
+    setActiveRowIndex();
     index.update((index) => {
       const nextIndex = index + get(pageSize);
       if (outOfBounds(nextIndex, items)) return index;
@@ -140,6 +141,7 @@ export const pagination = <T>(
   };
 
   const previous = () => {
+    setActiveRowIndex();
     index.update((index) => {
       const nextStart = index - get(pageSize);
       return getIndex(nextStart, items);
@@ -179,7 +181,8 @@ export const pagination = <T>(
     return getPageForIndex(i, get(pageSize));
   };
 
-  const setActiveRowIndex = (nextIndex: number) => {
+  const setActiveRowIndex = (nextIndex: number | undefined = undefined) => {
+    if (nextIndex === undefined) activeRowIndex.set(nextIndex);
     const pageItemSize = items.slice(
       get(index),
       get(index) + get(pageSize),


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If you expanded an event in the event history table, and then went to the next/previous page, it would keep the same index open which is confusing. When next/previous page is trigger, clear the activeIndex (set to undefined).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
