### PR TITLE
Update Modal component with open and error props

### DIFF
--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -63,23 +63,17 @@
 
   const hideTerminationModal = () => {
     reason = '';
-    error = '';
-    terminateConfirmationModalOpen = false;
   };
 
   const hideSignalModal = () => {
     signalInput = '';
     signalName = '';
-    error = '';
-    signalConfirmationModalOpen = false;
   };
 
   const hideResetModal = () => {
     resetReapplyType = ResetReapplyType.Unspecified;
     resetId = undefined;
     resetReason = undefined;
-    error = '';
-    resetConfirmationModalOpen = false;
   };
 
   const handleSuccessfulTermination = async () => {
@@ -299,8 +293,8 @@
   data-testid="reset-confirmation-modal"
   confirmText={translate('confirm')}
   cancelText={translate('cancel')}
-  {error}
-  open={resetConfirmationModalOpen}
+  bind:error
+  bind:open={resetConfirmationModalOpen}
   on:confirmModal={reset}
   on:cancelModal={hideResetModal}
   confirmDisabled={!resetId}
@@ -319,15 +313,11 @@
   data-testid="cancel-confirmation-modal"
   confirmText={translate('confirm')}
   cancelText={translate('cancel')}
-  {error}
-  open={cancelConfirmationModalOpen}
+  bind:error
+  bind:open={cancelConfirmationModalOpen}
   {loading}
   confirmType="destructive"
   on:confirmModal={cancel}
-  on:cancelModal={() => {
-    cancelConfirmationModalOpen = false;
-    error = '';
-  }}
 >
   <h3 slot="title">{translate('workflows', 'cancel-modal-title')}</h3>
   <svelte:fragment slot="content">
@@ -339,8 +329,8 @@
 <Modal
   id="terminate-confirmation-modal"
   data-testid="terminate-confirmation-modal"
-  {error}
-  open={terminateConfirmationModalOpen}
+  bind:error
+  bind:open={terminateConfirmationModalOpen}
   confirmText={translate('workflows', 'terminate')}
   cancelText={translate('cancel')}
   confirmType="destructive"
@@ -365,8 +355,8 @@
 <Modal
   id="signal-confirmation-modal"
   data-testid="signal-confirmation-modal"
-  {error}
-  open={signalConfirmationModalOpen}
+  bind:error
+  bind:open={signalConfirmationModalOpen}
   confirmText={translate('submit')}
   cancelText={translate('cancel')}
   confirmDisabled={!signalName}

--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -45,10 +45,11 @@
   let reason = '';
   let signalInput = '';
   let signalName = '';
-  let cancelConfirmationModal: Modal;
-  let terminateConfirmationModal: Modal;
-  let resetConfirmationModal: Modal;
-  let signalConfirmationModal: Modal;
+  let cancelConfirmationModalOpen = false;
+  let terminateConfirmationModalOpen = false;
+  let resetConfirmationModalOpen = false;
+  let signalConfirmationModalOpen = false;
+  let error = '';
   let resetReapplyType: ResetReapplyType = ResetReapplyType.Unspecified;
   let resetId: string;
   let resetReason: string;
@@ -62,21 +63,27 @@
 
   const hideTerminationModal = () => {
     reason = '';
+    error = '';
+    terminateConfirmationModalOpen = false;
   };
 
   const hideSignalModal = () => {
     signalInput = '';
     signalName = '';
+    error = '';
+    signalConfirmationModalOpen = false;
   };
 
   const hideResetModal = () => {
     resetReapplyType = ResetReapplyType.Unspecified;
     resetId = undefined;
     resetReason = undefined;
+    error = '';
+    resetConfirmationModalOpen = false;
   };
 
   const handleSuccessfulTermination = async () => {
-    terminateConfirmationModal?.close();
+    terminateConfirmationModalOpen = false;
     $refresh = Date.now();
     toaster.push({
       id: 'workflow-termination-success-toast',
@@ -84,14 +91,13 @@
     });
   };
 
-  const handleTerminationError = (error: NetworkError) => {
+  const handleTerminationError = (err: NetworkError) => {
     reason = '';
-    terminateConfirmationModal?.setError(
-      error?.message ?? translate('unknown-error'),
-    );
+    error = err?.message ?? translate('unknown-error');
   };
 
   const terminate = () => {
+    error = '';
     if (!workflow.canBeTerminated) return;
     terminateWorkflow({
       workflow,
@@ -109,23 +115,22 @@
 
   const cancel = async () => {
     loading = true;
+    error = '';
     try {
       await cancelWorkflow({
         namespace,
         workflowId: workflow.id,
         runId: workflow.runId,
       });
-      cancelConfirmationModal?.close();
+      cancelConfirmationModalOpen = false;
       loading = false;
       $refresh = Date.now();
       toaster.push({
         id: 'workflow-cancelation-success-toast',
         message: translate('workflows', 'cancel-success'),
       });
-    } catch (error) {
-      cancelConfirmationModal?.setError(
-        error?.message ?? translate('unknown-error'),
-      );
+    } catch (err) {
+      error = err?.message ?? translate('unknown-error');
     }
   };
 
@@ -134,6 +139,7 @@
   };
 
   const signal = async () => {
+    error = '';
     try {
       await signalWorkflow({
         namespace,
@@ -142,22 +148,21 @@
         signalInput,
         signalName,
       });
-      signalConfirmationModal?.close();
+      signalConfirmationModalOpen = false;
       $refresh = Date.now();
       toaster.push({
         message: translate('workflows', 'signal-success'),
         id: 'workflow-signal-success-toast',
       });
-    } catch (error) {
-      signalConfirmationModal?.setError(
-        error?.message ?? translate('unknown-error'),
-      );
+    } catch (err) {
+      error = err?.message ?? translate('unknown-error');
     }
 
     hideSignalModal();
   };
 
   const reset = async () => {
+    error = '';
     try {
       const response = await resetWorkflow({
         namespace,
@@ -178,12 +183,10 @@
           [workflow.runId]: response.runId,
         }));
       }
-      resetConfirmationModal?.close();
+      resetConfirmationModalOpen = false;
       $refresh = Date.now();
-    } catch (error) {
-      resetConfirmationModal?.setError(
-        error?.message ?? translate('unknown-error'),
-      );
+    } catch (err) {
+      error = err?.message ?? translate('unknown-error');
     }
     hideResetModal();
   };
@@ -222,21 +225,21 @@
   $: workflowActions = [
     {
       label: translate('workflows', 'reset'),
-      onClick: () => resetConfirmationModal.open(),
+      onClick: () => (resetConfirmationModalOpen = true),
       testId: 'reset-button',
       allowed: resetAllowed,
       tooltip: resetAllowed ? '' : resetTooltipText,
     },
     {
       label: translate('workflows', 'signal'),
-      onClick: () => signalConfirmationModal.open(),
+      onClick: () => (signalConfirmationModalOpen = true),
       testId: 'signal-button',
       allowed: signalEnabled,
       tooltip: signalEnabled ? '' : translate('workflows', 'signal-disabled'),
     },
     {
       label: translate('workflows', 'terminate'),
-      onClick: () => terminateConfirmationModal.open(),
+      onClick: () => (terminateConfirmationModalOpen = true),
       testId: 'terminate-button',
       allowed: terminateEnabled,
       destructive: true,
@@ -259,7 +262,7 @@
     position="right"
     disabled={actionsDisabled}
     primaryActionDisabled={!cancelEnabled || cancelInProgress}
-    on:click={() => cancelConfirmationModal.open()}
+    on:click={() => (cancelConfirmationModalOpen = true)}
     label={translate('workflows', 'request-cancellation')}
     menuLabel={translate('workflows', 'workflow-actions')}
   >
@@ -284,7 +287,7 @@
       aria-label={translate('workflows', 'reset')}
       disabled={!resetAllowed}
       variant="primary"
-      on:click={() => resetConfirmationModal.open()}
+      on:click={() => (resetConfirmationModalOpen = true)}
     >
       {translate('workflows', 'reset')}
     </Button>
@@ -296,7 +299,8 @@
   data-testid="reset-confirmation-modal"
   confirmText={translate('confirm')}
   cancelText={translate('cancel')}
-  bind:this={resetConfirmationModal}
+  {error}
+  open={resetConfirmationModalOpen}
   on:confirmModal={reset}
   on:cancelModal={hideResetModal}
   confirmDisabled={!resetId}
@@ -315,10 +319,15 @@
   data-testid="cancel-confirmation-modal"
   confirmText={translate('confirm')}
   cancelText={translate('cancel')}
-  bind:this={cancelConfirmationModal}
+  {error}
+  open={cancelConfirmationModalOpen}
   {loading}
   confirmType="destructive"
   on:confirmModal={cancel}
+  on:cancelModal={() => {
+    cancelConfirmationModalOpen = false;
+    error = '';
+  }}
 >
   <h3 slot="title">{translate('workflows', 'cancel-modal-title')}</h3>
   <svelte:fragment slot="content">
@@ -330,7 +339,8 @@
 <Modal
   id="terminate-confirmation-modal"
   data-testid="terminate-confirmation-modal"
-  bind:this={terminateConfirmationModal}
+  {error}
+  open={terminateConfirmationModalOpen}
   confirmText={translate('workflows', 'terminate')}
   cancelText={translate('cancel')}
   confirmType="destructive"
@@ -355,7 +365,8 @@
 <Modal
   id="signal-confirmation-modal"
   data-testid="signal-confirmation-modal"
-  bind:this={signalConfirmationModal}
+  {error}
+  open={signalConfirmationModalOpen}
   confirmText={translate('submit')}
   cancelText={translate('cancel')}
   confirmDisabled={!signalName}

--- a/src/lib/components/workflow/batch-operation-confirmation-modal.svelte
+++ b/src/lib/components/workflow/batch-operation-confirmation-modal.svelte
@@ -42,22 +42,16 @@
       reason: formatReason({ action, reason, email: $authUser.email }),
     });
   };
-
-  const handleCancelModal = () => {
-    error = '';
-    isOpen = false;
-  };
 </script>
 
 <Modal
   id="batch-operation-confirmation-modal"
-  open={isOpen}
-  {error}
+  bind:open={isOpen}
+  bind:error
   data-testid="batch-{actionText}-confirmation"
   confirmType="destructive"
   cancelText={translate('cancel')}
   {confirmText}
-  on:cancelModal={handleCancelModal}
   on:confirmModal={handleConfirmModal}
 >
   <h3 slot="title">

--- a/src/lib/components/workflow/batch-operation-confirmation-modal.svelte
+++ b/src/lib/components/workflow/batch-operation-confirmation-modal.svelte
@@ -13,10 +13,16 @@
   export let actionableWorkflowsLength: number;
   export let query: string;
 
-  let modal: Modal;
-  export const open = () => modal.open();
-  export const close = () => modal.close();
-  export const setError = (error: string) => modal.setError(error);
+  let reason: string = '';
+  let isOpen = false;
+  let error = '';
+
+  export const open = () => {
+    reason = '';
+    isOpen = true;
+  };
+  export const close = () => (isOpen = false);
+  export const setError = (err: string) => (error = err);
 
   const dispatch = createEventDispatcher<{
     confirm: { reason: string };
@@ -30,22 +36,23 @@
 
   $: placeholder = getPlacholder(action, $authUser.email);
 
-  let reason: string = '';
-
   const handleConfirmModal = () => {
+    error = '';
     dispatch('confirm', {
       reason: formatReason({ action, reason, email: $authUser.email }),
     });
   };
 
   const handleCancelModal = () => {
-    reason = '';
+    error = '';
+    isOpen = false;
   };
 </script>
 
 <Modal
   id="batch-operation-confirmation-modal"
-  bind:this={modal}
+  open={isOpen}
+  {error}
   data-testid="batch-{actionText}-confirmation"
   confirmType="destructive"
   cancelText={translate('cancel')}

--- a/src/lib/holocene/modal.story.svelte
+++ b/src/lib/holocene/modal.story.svelte
@@ -8,25 +8,32 @@
 
   export let Hst: HST;
   let deleteConfirm: string;
-  let modal: Modal;
   let loading = false;
+  let basicModalOpen = false;
+  let formModalOpen = false;
+  let formModalError = '';
 
   let shouldError = false;
   let errorText =
     'Quo sint nisi nostrum quis nesciunt est. Delectus adipisci reiciendis nihil fuga libero exercitationem. Distinctio nihil sit et consequatur sit quia. Quia aut et temporibus doloremque veritatis corporis.';
-  const openModal = () => {
-    modal.open();
-  };
 
   const handleConfirm = () => {
     logEvent('Confirm', {});
+    basicModalOpen = false;
+    formModalOpen = false;
+    deleteConfirm = '';
   };
 
   const handleCancel = () => {
     logEvent('Cancel', {});
+    basicModalOpen = false;
+    formModalOpen = false;
+    formModalError = '';
+    deleteConfirm = '';
   };
 
   const makeFakeApiRequest = async () => {
+    formModalError = '';
     try {
       loading = true;
       await new Promise<void>((resolve, reject) => {
@@ -36,9 +43,9 @@
           setTimeout(resolve, 250);
         }
       });
-      modal?.close();
+      formModalOpen = false;
     } catch {
-      modal?.setError(errorText);
+      formModalError = errorText;
     } finally {
       loading = false;
     }
@@ -47,15 +54,19 @@
 
 <Hst.Story>
   <Hst.Variant title="A Basic Confirmation Modal">
-    <Button on:click={openModal}>Open Modal</Button>
+    <Button
+      on:click={() => {
+        basicModalOpen = true;
+      }}>Open Modal</Button
+    >
     <Modal
-      bind:this={modal}
       id="basic-modal"
       confirmType="destructive"
       confirmText="Delete"
       cancelText="Cancel"
       on:confirmModal={handleConfirm}
       on:cancelModal={handleCancel}
+      open={basicModalOpen}
     >
       <h3 slot="title">Delete User</h3>
       <p slot="content">
@@ -64,16 +75,21 @@
     </Modal>
   </Hst.Variant>
   <Hst.Variant title="A Modal with a Form">
-    <Button on:click={openModal}>Open Modal</Button>
+    <Button
+      on:click={() => {
+        formModalOpen = true;
+      }}>Open Modal</Button
+    >
     <Modal
       id="form-modal"
-      bind:this={modal}
       confirmType="destructive"
       confirmText="Delete"
       cancelText="Cancel"
       {loading}
       on:cancelModal={handleCancel}
       on:confirmModal={makeFakeApiRequest}
+      open={formModalOpen}
+      error={formModalError}
     >
       <h3 slot="title">Delete Namespace</h3>
       <div slot="content" class="flex flex-col gap-2">

--- a/src/lib/holocene/modal.story.svelte
+++ b/src/lib/holocene/modal.story.svelte
@@ -20,15 +20,11 @@
   const handleConfirm = () => {
     logEvent('Confirm', {});
     basicModalOpen = false;
-    formModalOpen = false;
     deleteConfirm = '';
   };
 
   const handleCancel = () => {
     logEvent('Cancel', {});
-    basicModalOpen = false;
-    formModalOpen = false;
-    formModalError = '';
     deleteConfirm = '';
   };
 
@@ -44,6 +40,7 @@
         }
       });
       formModalOpen = false;
+      deleteConfirm = '';
     } catch {
       formModalError = errorText;
     } finally {
@@ -66,7 +63,7 @@
       cancelText="Cancel"
       on:confirmModal={handleConfirm}
       on:cancelModal={handleCancel}
-      open={basicModalOpen}
+      bind:open={basicModalOpen}
     >
       <h3 slot="title">Delete User</h3>
       <p slot="content">
@@ -88,8 +85,8 @@
       {loading}
       on:cancelModal={handleCancel}
       on:confirmModal={makeFakeApiRequest}
-      open={formModalOpen}
-      error={formModalError}
+      bind:open={formModalOpen}
+      bind:error={formModalError}
     >
       <h3 slot="title">Delete Namespace</h3>
       <div slot="content" class="flex flex-col gap-2">

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -18,6 +18,8 @@
     large?: boolean;
     loading?: boolean;
     'data-testid'?: string;
+    open: boolean;
+    error?: string;
   }
 
   export let hideConfirm = false;
@@ -29,24 +31,23 @@
   export let loading = false;
   export let hightlightNav = false;
   export let id: string;
-
-  let error: string;
-
-  export const open = () => modalElement.showModal();
-
-  export const close = () => {
-    error = '';
-    modalElement.close();
-  };
-
-  export const setError = (err: string) => {
-    error = err;
-  };
+  export let open: boolean;
+  export let error = '';
 
   let className = '';
   export { className as class };
 
   let modalElement: HTMLDialogElement;
+
+  $: open, toggleModal();
+
+  export const toggleModal = () => {
+    if (open) {
+      modalElement?.showModal();
+    } else {
+      modalElement?.close();
+    }
+  };
 
   const dispatch = createEventDispatcher<{
     cancelModal: undefined;
@@ -54,12 +55,10 @@
   }>();
 
   const handleCancel = () => {
-    close();
     dispatch('cancelModal');
   };
 
   const confirmModal = () => {
-    error = '';
     dispatch('confirmModal');
   };
 

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -56,6 +56,8 @@
 
   const handleCancel = () => {
     dispatch('cancelModal');
+    open = false;
+    error = '';
   };
 
   const confirmModal = () => {

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -87,6 +87,10 @@
     reason = '';
     pauseConfirmationModalOpen = false;
   };
+
+  const resetReason = () => {
+    reason = '';
+  };
 </script>
 
 {#await scheduleFetch}
@@ -206,7 +210,7 @@
     </div>
     <Modal
       id="pause-schedule-modal"
-      open={pauseConfirmationModalOpen}
+      bind:open={pauseConfirmationModalOpen}
       confirmType="primary"
       confirmText={schedule.schedule.state.paused
         ? translate('schedules', 'unpause')
@@ -214,10 +218,7 @@
       cancelText={translate('cancel')}
       confirmDisabled={!reason}
       on:confirmModal={() => handlePause(schedule)}
-      on:cancelModal={() => {
-        reason = '';
-        pauseConfirmationModalOpen = false;
-      }}
+      on:cancelModal={resetReason}
     >
       <h3 slot="title">
         {schedule.schedule.state.paused
@@ -249,17 +250,13 @@
     </Modal>
     <Modal
       id="delete-schedule-modal"
-      open={deleteConfirmationModalOpen}
-      {error}
+      bind:open={deleteConfirmationModalOpen}
+      bind:error
       confirmType="destructive"
       confirmText={translate('delete')}
       cancelText={translate('cancel')}
       on:confirmModal={handleDelete}
-      on:cancelModal={() => {
-        error = '';
-        reason = '';
-        deleteConfirmationModalOpen = false;
-      }}
+      on:cancelModal={resetReason}
     >
       <h3 slot="title">{translate('schedules', 'delete-modal-title')}</h3>
       <div slot="content">

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -19,11 +19,11 @@
   );
 
   export const openBatchCancelConfirmationModal = () => {
-    batchCancelConfirmationModal.open();
+    batchCancelConfirmationModal?.open();
   };
 
   export const openBatchTerminateConfirmationModal = () => {
-    batchTerminateConfirmationModal.open();
+    batchTerminateConfirmationModal?.open();
   };
 
   export const handleSelectAll = (workflows: WorkflowExecution[]) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Pass `open` and `error` props to the Modal Holocene component instead of having to add optional chaining if we call `setError` or `close` after an async function.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
> * `Cancel` should close the modal and clear an errors
> * `Confirm` should clear any errors and either close the modal (success) or display an error (failure)
> * Any inputs on the modal should be cleared on close
   - [ ] Verify the `BatchOperationConfirmationModal` works as expected
   - [ ] Verify the various `WorkflowActions` modals work as expected
   - [ ] Verify the Schedule pause and delete modals work as expected

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1056`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
