### PR TITLE
Truncate long IDs in Recent Workflows table

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/filterable-table-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/filterable-table-cell.svelte
@@ -22,6 +22,7 @@
     workflow: workflow.id,
     run: workflow.runId,
   });
+  $: displayValue = truncateValue(value);
 
   const onRowFilterClick = () => {
     const filter = $workflowFilters.find((f) => f.attribute === attribute);
@@ -43,9 +44,22 @@
 
     updateQueryParamsFromFilter($page.url, $workflowFilters);
   };
+
+  const truncateValue = (val: string) => {
+    return val?.length > 100
+      ? val.slice(0, 53) + '....' + val.slice(val.length - 54, val.length - 1)
+      : val;
+  };
 </script>
 
-<a {href} class="table-link">{value}</a>
+<a
+  {href}
+  class="table-link"
+  on:blur={() => (displayValue = truncateValue(value))}
+  on:mouseout={() => (displayValue = truncateValue(value))}
+  on:focus={() => (displayValue = value)}
+  on:mouseover={() => (displayValue = value)}>{displayValue}</a
+>
 <FilterOrCopyButtons
   copyIconTitle={translate('copy-icon-title')}
   copySuccessIconTitle={translate('copy-success-icon-title')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Some Workflow IDs can be very long and take up a lot of space on the `Recent Workflows` table. This PR truncates IDs longer than 100 characters, but still reveals the full ID on hover.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1710" alt="Screenshot 2023-08-17 at 3 38 07 PM" src="https://github.com/temporalio/ui/assets/15069288/01eb41cc-43c5-4673-9553-f548bb4ce158">
<img width="1715" alt="Screenshot 2023-08-17 at 3 38 34 PM" src="https://github.com/temporalio/ui/assets/15069288/62e85dc9-597e-4e17-8add-a3e842f947d6">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
