### PR TITLE
Fix reverse sort timeline issue and compact table view

### DIFF
--- a/src/lib/components/event/event-group-details.svelte
+++ b/src/lib/components/event/event-group-details.svelte
@@ -16,11 +16,6 @@
 
 <div class="w-full border-gray-700 lg:w-1/3 lg:border-r-2">
   <Table class="w-full table-fixed pb-2" variant="simple">
-    <caption class="sr-only" slot="caption"
-      >{translate('events', 'event-group', {
-        eventName: eventGroup.name,
-      })}</caption
-    >
     {#each [...eventGroup.events].reverse() as [id, eventInGroup] (id)}
       <tr
         class="row"

--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -37,11 +37,11 @@
     });
     return `<div class="flex gap-1 items-center justify-between"><div class="bar-content"><p>${name}</p></div><div class="flex gap-1 items-center">${retryIcon}${attempt.toString()}</div></div>`;
   }
-  const createGroupItems = (eventGroups, isRunning) => {
+  const createGroupItems = (eventGroups, isRunning, sortedHistory) => {
     const items = new DataSet([]);
     const groups = new DataSet([]);
-    const firstEvent = history[0];
-    const finalEvent = history[history.length - 1];
+    const firstEvent = sortedHistory[0];
+    const finalEvent = sortedHistory[sortedHistory.length - 1];
     if ($workflowRun?.workflow?.status) {
       groups.add({
         id: 'workflow',
@@ -157,13 +157,14 @@
     if (history.length && timeline) {
       const reverseHistory =
         $eventFilterSort === 'descending' && $eventViewType !== 'compact';
-      const historyCopy = [...history];
-      const eventGroups = groupEvents(
-        reverseHistory ? historyCopy.reverse() : history,
-      );
+      const sortedHistory = reverseHistory
+        ? [...history].reverse()
+        : [...history];
+      const eventGroups = groupEvents(sortedHistory);
       const { groups, items } = createGroupItems(
         eventGroups,
         $workflowRun?.workflow?.isRunning,
+        sortedHistory,
       );
       setVizItems(items, groups);
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When in reverse sort, the top timeline item that represents the workflow execution would have the incorrect start and end times, which would create an issue with 'Zoom to Fit'.

Also removed the <caption> element in the compact view table to fix spacing issue.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
