### PR TITLE
config: allow multiple cors origins

### DIFF
--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -21,7 +21,11 @@ cors:
   cookieInsecure: {{ default .Env.TEMPORAL_CSRF_COOKIE_INSECURE "false" }}
   allowOrigins:
     # override framework's default that allows all origins "*"
-    - {{ default .Env.TEMPORAL_CORS_ORIGINS "http://localhost:8080" }}
+    {{- if .Env.TEMPORAL_CORS_ORIGINS }} {{ range $seed := (split .Env.TEMPORAL_CORS_ORIGINS ",") }}
+    - {{ . }} {{ end }}
+    {{- else}}
+    - "http://localhost:8080"
+    {{- end }}
 tls:
   caFile: {{ default .Env.TEMPORAL_TLS_CA "" }}
   certFile: {{ default .Env.TEMPORAL_TLS_CERT "" }}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This config template change allows multiple CORS origins to be supplied via an comma separated env var.

Requested from: https://temporalio.slack.com/archives/CTTJCPZQE/p1692349771226649

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

Tested manually through:

```
dockerize -template ./config-template.yaml:./config/docker.yaml
```

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
