### PR TITLE
Fix "Worklfow terminated" typo

### DIFF
--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -80,7 +80,7 @@ export const Strings = {
     'Signaling workflows is not enabled, please contact your administrator for assistance.',
   'terminate-disabled':
     'Terminating workflows is not enabled, please contact your adminstrator for assistance.',
-  'terminate-success': 'Worklfow terminated.',
+  'terminate-success': 'Workflow terminated.',
   'cancel-success': 'Workflow canceled.',
   'signal-success': 'Workflow signaled.',
   'reset-modal-title': 'Reset Workflow',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

When terminating a workflow, you get a toast "Worklfow terminated". This pull request fixes the typo so that it says "Workflow terminated" instead.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

n/a

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

Did not test as this is a trivial string tweak

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
No