### PR TITLE
Add WorkflowExecutionUpdate group

### DIFF
--- a/src/fixtures/all-event-types.json
+++ b/src/fixtures/all-event-types.json
@@ -100,13 +100,19 @@
     "version": "0",
     "taskId": "29866296",
     "workflowTaskScheduledEventAttributes": {
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
       "startToCloseTimeout": "20s",
       "attempt": 1
     },
     "attributes": {
       "type": "workflowTaskScheduledEventAttributes",
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
       "startToCloseTimeout": "20 seconds",
       "attempt": 1
     },
@@ -179,14 +185,18 @@
     "upsertWorkflowSearchAttributesEventAttributes": {
       "workflowTaskCompletedEventId": "4",
       "searchAttributes": {
-        "indexedFields": { "TemporalChangeVersion": ["initial version-3"] }
+        "indexedFields": {
+          "TemporalChangeVersion": ["initial version-3"]
+        }
       }
     },
     "attributes": {
       "type": "upsertWorkflowSearchAttributesEventAttributes",
       "workflowTaskCompletedEventId": "4",
       "searchAttributes": {
-        "indexedFields": { "TemporalChangeVersion": ["initial version-3"] }
+        "indexedFields": {
+          "TemporalChangeVersion": ["initial version-3"]
+        }
       }
     },
     "category": "command",
@@ -206,14 +216,21 @@
         "change-id": {
           "payloads": [
             {
-              "metadata": { "encoding": "anNvbi9wbGFpbg==" },
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
               "data": "ImluaXRpYWwgdmVyc2lvbiI="
             }
           ]
         },
         "version": {
           "payloads": [
-            { "metadata": { "encoding": "anNvbi9wbGFpbg==" }, "data": "Mw==" }
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "Mw=="
+            }
           ]
         }
       },
@@ -228,14 +245,21 @@
         "change-id": {
           "payloads": [
             {
-              "metadata": { "encoding": "anNvbi9wbGFpbg==" },
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
               "data": "ImluaXRpYWwgdmVyc2lvbiI="
             }
           ]
         },
         "version": {
           "payloads": [
-            { "metadata": { "encoding": "anNvbi9wbGFpbg==" }, "data": "Mw==" }
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "Mw=="
+            }
           ]
         }
       },
@@ -255,15 +279,22 @@
     "version": "0",
     "taskId": "29866290",
     "workflowExecutionStartedEventAttributes": {
-      "workflowType": { "name": "workflow.advanced-visibility" },
+      "workflowType": {
+        "name": "workflow.advanced-visibility"
+      },
       "parentWorkflowNamespace": "canary",
       "parentWorkflowExecution": {
         "workflowId": "temporal.fixture.timed-out.workflow.id",
         "runId": "78cba607-189e-41fe-a31b-a2b6061babaa"
       },
       "parentInitiatedEventId": "11",
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
-      "input": { "payloads": ["1656683778738403300", "canary"] },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
+      "input": {
+        "payloads": ["1656683778738403300", "canary"]
+      },
       "workflowExecutionTimeout": "0s",
       "workflowRunTimeout": "1200s",
       "workflowTaskTimeout": "20s",
@@ -281,10 +312,14 @@
       "firstWorkflowTaskBackoff": "0s",
       "memo": null,
       "searchAttributes": {
-        "indexedFields": { "CustomKeywordField": "childWorkflowValue" }
+        "indexedFields": {
+          "CustomKeywordField": "childWorkflowValue"
+        }
       },
       "prevAutoResetPoints": null,
-      "header": { "fields": {} },
+      "header": {
+        "fields": {}
+      },
       "parentInitiatedEventVersion": "0"
     },
     "attributes": {
@@ -296,8 +331,13 @@
         "runId": "78cba607-189e-41fe-a31b-a2b6061babaa"
       },
       "parentInitiatedEventId": "11",
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
-      "input": { "payloads": ["1656683778738403300", "canary"] },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
+      "input": {
+        "payloads": ["1656683778738403300", "canary"]
+      },
       "workflowExecutionTimeout": "",
       "workflowRunTimeout": "20 minutes",
       "workflowTaskTimeout": "20 seconds",
@@ -315,10 +355,14 @@
       "firstWorkflowTaskBackoff": "",
       "memo": null,
       "searchAttributes": {
-        "indexedFields": { "CustomKeywordField": "childWorkflowValue" }
+        "indexedFields": {
+          "CustomKeywordField": "childWorkflowValue"
+        }
       },
       "prevAutoResetPoints": null,
-      "header": { "fields": {} },
+      "header": {
+        "fields": {}
+      },
       "parentInitiatedEventVersion": "0"
     },
     "classification": "Started",
@@ -410,9 +454,16 @@
     "taskId": "29867308",
     "activityTaskScheduledEventAttributes": {
       "activityId": "13",
-      "activityType": { "name": "activity.advanced-visibility" },
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
-      "header": { "fields": {} },
+      "activityType": {
+        "name": "activity.advanced-visibility"
+      },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
+      "header": {
+        "fields": {}
+      },
       "input": {
         "payloads": [
           "1656683782883152600",
@@ -439,8 +490,13 @@
       "type": "activityTaskScheduledEventAttributes",
       "activityId": "13",
       "activityType": "activity.advanced-visibility",
-      "taskQueue": { "name": "canary-task-queue", "kind": "Normal" },
-      "header": { "fields": {} },
+      "taskQueue": {
+        "name": "canary-task-queue",
+        "kind": "Normal"
+      },
+      "header": {
+        "fields": {}
+      },
       "input": {
         "payloads": [
           "1656683782883152600",
@@ -475,7 +531,10 @@
     "eventType": "TimerFired",
     "version": "0",
     "taskId": "29867299",
-    "timerFiredEventAttributes": { "timerId": "8", "startedEventId": "8" },
+    "timerFiredEventAttributes": {
+      "timerId": "8",
+      "startedEventId": "8"
+    },
     "attributes": {
       "type": "timerFiredEventAttributes",
       "timerId": "8",
@@ -600,10 +659,14 @@
         "runId": "3cbbf515-36da-43b9-a1f3-18a7ec031ddd"
       },
       "signalName": "signalToTrigger",
-      "input": { "payloads": ["signalValue"] },
+      "input": {
+        "payloads": ["signalValue"]
+      },
       "control": "25",
       "childWorkflowOnly": false,
-      "header": { "fields": {} }
+      "header": {
+        "fields": {}
+      }
     },
     "attributes": {
       "type": "signalExternalWorkflowExecutionInitiatedEventAttributes",
@@ -614,10 +677,14 @@
         "runId": "3cbbf515-36da-43b9-a1f3-18a7ec031ddd"
       },
       "signalName": "signalToTrigger",
-      "input": { "payloads": ["signalValue"] },
+      "input": {
+        "payloads": ["signalValue"]
+      },
       "control": "25",
       "childWorkflowOnly": false,
-      "header": { "fields": {} }
+      "header": {
+        "fields": {}
+      }
     },
     "classification": "Initiated",
     "category": "signal",
@@ -633,16 +700,24 @@
     "taskId": "32096693",
     "workflowExecutionSignaledEventAttributes": {
       "signalName": "signalBeforeReset",
-      "input": { "payloads": ["signalValue"] },
+      "input": {
+        "payloads": ["signalValue"]
+      },
       "identity": "history-service",
-      "header": { "fields": {} }
+      "header": {
+        "fields": {}
+      }
     },
     "attributes": {
       "type": "workflowExecutionSignaledEventAttributes",
       "signalName": "signalBeforeReset",
-      "input": { "payloads": ["signalValue"] },
+      "input": {
+        "payloads": ["signalValue"]
+      },
       "identity": "history-service",
-      "header": { "fields": {} }
+      "header": {
+        "fields": {}
+      }
     },
     "classification": "Signaled",
     "category": "signal",
@@ -756,5 +831,96 @@
     "id": "14",
     "name": "ActivityTaskTimedOut",
     "timestamp": "2022-07-01 UTC 14:00:29.94"
+  },
+  "WorkflowExecutionUpdateAccepted": {
+    "eventId": "13",
+    "eventTime": "2023-09-11T13:29:00.588588Z",
+    "eventType": "WorkflowExecutionUpdateAccepted",
+    "version": "0",
+    "taskId": "1048706",
+    "workerMayIgnore": false,
+    "workflowExecutionUpdateAcceptedEventAttributes": {
+      "protocolInstanceId": "31440fef-27ba-4393-bb59-debabc23b77d",
+      "acceptedRequestMessageId": "31440fef-27ba-4393-bb59-debabc23b77d/request",
+      "acceptedRequestSequencingEventId": "10",
+      "acceptedRequest": {
+        "meta": {
+          "updateId": "31440fef-27ba-4393-bb59-debabc23b77d",
+          "identity": "29187@Alexs-MacBook-Pro.local@"
+        },
+        "input": {
+          "header": {
+            "fields": {}
+          },
+          "name": "set-to-account",
+          "args": {
+            "payloads": ["Piggy Bank"]
+          }
+        }
+      }
+    },
+    "name": "WorkflowExecutionUpdateAccepted",
+    "id": "13",
+    "timestamp": "2023-09-11 UTC 13:29:00.58",
+    "category": "update",
+    "attributes": {
+      "type": "workflowExecutionUpdateAcceptedEventAttributes",
+      "protocolInstanceId": "31440fef-27ba-4393-bb59-debabc23b77d",
+      "acceptedRequestMessageId": "31440fef-27ba-4393-bb59-debabc23b77d/request",
+      "acceptedRequestSequencingEventId": "10",
+      "acceptedRequest": {
+        "meta": {
+          "updateId": "31440fef-27ba-4393-bb59-debabc23b77d",
+          "identity": "29187@MacBook-Pro.local@"
+        },
+        "input": {
+          "header": {
+            "fields": {}
+          },
+          "name": "set-to-account",
+          "args": {
+            "payloads": ["Piggy Bank"]
+          }
+        }
+      }
+    }
+  },
+  "WorkflowExecutionUpdateCompleted": {
+    "eventId": "14",
+    "eventTime": "2023-09-11T13:29:00.588642Z",
+    "eventType": "WorkflowExecutionUpdateCompleted",
+    "version": "0",
+    "taskId": "1048707",
+    "workerMayIgnore": false,
+    "workflowExecutionUpdateCompletedEventAttributes": {
+      "meta": {
+        "updateId": "31440fef-27ba-4393-bb59-debabc23b77d",
+        "identity": ""
+      },
+      "acceptedEventId": "13",
+      "outcome": {
+        "success": {
+          "payloads": [null]
+        }
+      }
+    },
+    "name": "WorkflowExecutionUpdateCompleted",
+    "id": "14",
+    "timestamp": "2023-09-11 UTC 13:29:00.58",
+    "classification": "Completed",
+    "category": "update",
+    "attributes": {
+      "type": "workflowExecutionUpdateCompletedEventAttributes",
+      "meta": {
+        "updateId": "31440fef-27ba-4393-bb59-debabc23b77d",
+        "identity": ""
+      },
+      "acceptedEventId": "13",
+      "outcome": {
+        "success": {
+          "payloads": [null]
+        }
+      }
+    }
   }
 }

--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -395,6 +395,14 @@
     color: #652b19;
   }
 
+  :global(.vis-item.vis-range.update) {
+    background-color: #f3e8ff;
+    border-color: #581c87;
+    border-radius: 9999px;
+    border-width: 2px;
+    color: #581c87;
+  }
+
   :global(.bar-content) {
     display: flex;
     gap: 2px;

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -91,10 +91,6 @@
   $: initialItem = currentEvents?.[0];
   $: items = getEventsOrGroups(currentEvents, category);
   $: updating = currentEvents.length && !$fullEventHistory.length;
-
-  $: {
-    console.log('GROUPS: ', items);
-  }
 </script>
 
 <Pagination

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  
+
   import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
   import EventSummaryTable from '$lib/components/event/event-summary-table.svelte';
   import Pagination from '$lib/holocene/pagination.svelte';
@@ -23,9 +23,8 @@
     IterableEvent,
   } from '$lib/types/events';
   import { isLocalActivityMarkerEvent } from '$lib/utilities/is-event-type';
-  
+
   import EventEmptyRow from './event-empty-row.svelte';
-  
 
   export let compact = false;
 
@@ -92,6 +91,10 @@
   $: initialItem = currentEvents?.[0];
   $: items = getEventsOrGroups(currentEvents, category);
   $: updating = currentEvents.length && !$fullEventHistory.length;
+
+  $: {
+    console.log('GROUPS: ', items);
+  }
 </script>
 
 <Pagination

--- a/src/lib/models/event-groups/create-event-group.test.ts
+++ b/src/lib/models/event-groups/create-event-group.test.ts
@@ -144,4 +144,27 @@ describe('createEventGroup', () => {
   it('should ignore an event that should not create an event group', () => {
     expect(createEventGroup(completedEvent)).toBeUndefined();
   });
+
+  it('should create a group from a WorkflowExecutionUpdateAccepted event and add WorkflowTaskScheduled event to group', () => {
+    const workflowTaskEvent = {
+      id: '120',
+    } as unknown as WorkflowEvent;
+
+    const updateEvent = {
+      id: '123',
+      eventId: '123',
+      workflowExecutionUpdateAcceptedEventAttributes: {
+        acceptedRequestSequencingEventId: 120,
+      },
+    } as unknown as WorkflowEvent;
+
+    expect(
+      createEventGroup(updateEvent, [workflowTaskEvent, updateEvent])
+        .initialEvent.id,
+    ).toBe(workflowTaskEvent.id);
+    expect(
+      createEventGroup(updateEvent, [workflowTaskEvent, updateEvent]).eventList
+        .length,
+    ).toBe(2);
+  });
 });

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -67,7 +67,7 @@ const createGroupFor = <K extends keyof StartingEvents>(
   const groupEvents: EventGroup['events'] = new Map();
   const groupEventIds: EventGroup['eventIds'] = new Set();
 
-  if (isWorkflowExecutionUpdateAcceptedEvent(event)) {
+  if (initialEvent && isWorkflowExecutionUpdateAcceptedEvent(event)) {
     groupEvents.set(initialEvent.id, initialEvent);
     groupEvents.set(event.id, event);
     groupEventIds.add(initialEvent.id);

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -6,6 +6,7 @@ import type {
   StartChildWorkflowExecutionInitiatedEvent,
   TimerStartedEvent,
   WorkflowExecutionSignaledEvent,
+  WorkflowExecutionUpdateAcceptedEvent,
 } from '$lib/types/events';
 import {
   isActivityTaskScheduledEvent,
@@ -15,6 +16,7 @@ import {
   isStartChildWorkflowExecutionInitiatedEvent,
   isTimerStartedEvent,
   isWorkflowExecutionSignaledEvent,
+  isWorkflowExecutionUpdateAcceptedEvent,
 } from '$lib/utilities/is-event-type';
 
 import type { EventGroup } from './event-groups';
@@ -35,6 +37,7 @@ type StartingEvents = {
   SignalReceived: WorkflowExecutionSignaledEvent;
   LocalActivity: MarkerRecordedEvent;
   Marker: MarkerRecordedEvent;
+  Update: WorkflowExecutionUpdateAcceptedEvent;
 };
 
 const createGroupFor = <K extends keyof StartingEvents>(
@@ -106,4 +109,7 @@ export const createEventGroup = (event: CommonHistoryEvent): EventGroup => {
     }
     return createGroupFor<'Marker'>(event);
   }
+
+  if (isWorkflowExecutionUpdateAcceptedEvent(event))
+    return createGroupFor<'Update'>(event);
 };

--- a/src/lib/models/event-groups/get-group-id.test.ts
+++ b/src/lib/models/event-groups/get-group-id.test.ts
@@ -156,4 +156,13 @@ describe('getGroupId', () => {
     } as unknown as CommonHistoryEvent;
     expect(getGroupId(event)).toBe('42');
   });
+
+  it('should get the correct ID for WorkflowExecutionUpdateCompleted events', () => {
+    const event = {
+      workflowExecutionUpdateCompletedEventAttributes: {
+        acceptedEventId: 59,
+      },
+    } as unknown as CommonHistoryEvent;
+    expect(getGroupId(event)).toBe('59');
+  });
 });

--- a/src/lib/models/event-groups/get-group-id.ts
+++ b/src/lib/models/event-groups/get-group-id.ts
@@ -11,6 +11,7 @@ import {
   isChildWorkflowExecutionTerminatedEvent,
   isTimerCanceledEvent,
   isTimerFiredEvent,
+  isWorkflowExecutionUpdateCompletedEvent,
 } from '$lib/utilities/is-event-type';
 
 export const getGroupId = (event: CommonHistoryEvent): string => {
@@ -63,6 +64,12 @@ export const getGroupId = (event: CommonHistoryEvent): string => {
 
   if (isTimerCanceledEvent(event)) {
     return String(event.timerCanceledEventAttributes.startedEventId);
+  }
+
+  if (isWorkflowExecutionUpdateCompletedEvent(event)) {
+    return String(
+      event.workflowExecutionUpdateCompletedEventAttributes.acceptedEventId,
+    );
   }
 
   return event.id;

--- a/src/lib/models/event-groups/get-group-name.ts
+++ b/src/lib/models/event-groups/get-group-name.ts
@@ -8,6 +8,7 @@ import {
   isStartChildWorkflowExecutionInitiatedEvent,
   isTimerStartedEvent,
   isWorkflowExecutionSignaledEvent,
+  isWorkflowExecutionUpdateAcceptedEvent,
 } from '$lib/utilities/is-event-type';
 
 export const getEventGroupName = (event: CommonHistoryEvent): string => {
@@ -43,5 +44,9 @@ export const getEventGroupName = (event: CommonHistoryEvent): string => {
 
   if (isStartChildWorkflowExecutionInitiatedEvent(event)) {
     return `Child Workflow: ${event.startChildWorkflowExecutionInitiatedEventAttributes?.workflowType?.name}`;
+  }
+
+  if (isWorkflowExecutionUpdateAcceptedEvent(event)) {
+    return `${event.workflowExecutionUpdateAcceptedEventAttributes?.acceptedRequest?.input?.name}`;
   }
 };

--- a/src/lib/models/event-groups/group-events.test.ts
+++ b/src/lib/models/event-groups/group-events.test.ts
@@ -234,4 +234,20 @@ describe('getEventGroupName', () => {
       'Child Workflow: Workflow Name',
     );
   });
+
+  it('should get the name of a WorkflowExecutionUpdateAcceptedEvent', () => {
+    const workflowUpdateAcceptedEvent = {
+      workflowExecutionUpdateAcceptedEventAttributes: {
+        acceptedRequest: {
+          input: {
+            name: 'Start the update',
+          },
+        },
+      },
+    } as unknown as CommonHistoryEvent;
+
+    expect(getEventGroupName(workflowUpdateAcceptedEvent)).toBe(
+      'Start the update',
+    );
+  });
 });

--- a/src/lib/models/event-groups/index.ts
+++ b/src/lib/models/event-groups/index.ts
@@ -25,7 +25,7 @@ export const groupEvents = (
 
   for (const event of events) {
     const id = getGroupId(event);
-    const group = createEventGroup(event);
+    const group = createEventGroup(event, events);
 
     if (group) {
       groups[group.id] = group;

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -220,6 +220,8 @@ export type ExternalWorkflowExecutionSignaledEvent =
   EventWithAttributes<'externalWorkflowExecutionSignaledEventAttributes'>;
 export type UpsertWorkflowSearchAttributesEvent =
   EventWithAttributes<'upsertWorkflowSearchAttributesEventAttributes'>;
+export type WorkflowExecutionUpdateAcceptedEvent =
+  EventWithAttributes<'workflowExecutionUpdateAcceptedEventAttributes'>;
 export type WorkflowExecutionUpdateCompletedEvent =
   EventWithAttributes<'workflowExecutionUpdateCompletedEventAttributes'>;
 

--- a/src/lib/utilities/is-event-type.ts
+++ b/src/lib/utilities/is-event-type.ts
@@ -41,6 +41,7 @@ import type {
   WorkflowExecutionStartedEvent,
   WorkflowExecutionTerminatedEvent,
   WorkflowExecutionTimedOutEvent,
+  WorkflowExecutionUpdateAcceptedEvent,
   WorkflowExecutionUpdateCompletedEvent,
   WorkflowTaskCompletedEvent,
   WorkflowTaskFailedEvent,
@@ -410,7 +411,12 @@ export const isLocalActivityMarkerEvent = (
   return true;
 };
 
-const isWorkflowExecutionUpdateCompletedEvent =
+export const isWorkflowExecutionUpdateAcceptedEvent =
+  hasAttributes<WorkflowExecutionUpdateAcceptedEvent>(
+    'workflowExecutionUpdateAcceptedEventAttributes',
+  );
+
+export const isWorkflowExecutionUpdateCompletedEvent =
   hasAttributes<WorkflowExecutionUpdateCompletedEvent>(
     'workflowExecutionUpdateCompletedEventAttributes',
   );


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We want to show WorkflowUpdate event groups in the Compact view and in the Timeline view. This is helpful to show when updates occur and the latency of the Update with the group.

It is a special case in our event group logic, in that we insert the WorkflowTaskScheduled event as the initial event in the group when we find the WorklowExecutionUpdateAccepted event.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1716" alt="Screen Shot 2023-09-11 at 9 05 58 AM" src="https://github.com/temporalio/ui/assets/7967403/71d3104f-0690-4051-b4b5-68f95efbf561">

<img width="1618" alt="Screen Shot 2023-09-11 at 9 27 38 AM" src="https://github.com/temporalio/ui/assets/7967403/61cbf691-d673-4fd2-a4d1-eede4f4b877e">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
