### PR TITLE
Add Caller-Type to http headers, allow in ui-server, update tests

### DIFF
--- a/server/server/server.go
+++ b/server/server/server.go
@@ -84,6 +84,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 		AllowHeaders: []string{
 			echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept,
 			echo.HeaderXCSRFToken, echo.HeaderAuthorization, auth.AuthorizationExtrasHeader,
+			"Caller-Type",
 		},
 		AllowCredentials: true,
 	}))

--- a/src/lib/services/namespaces-service.test.ts
+++ b/src/lib/services/namespaces-service.test.ts
@@ -45,7 +45,9 @@ describe('fetchNamespaces', () => {
       'http://localhost:8233/api/v1/namespaces?',
       {
         credentials: 'include',
-        headers: {},
+        headers: {
+          'Caller-Type': 'operator',
+        },
       },
     );
   });

--- a/src/lib/utilities/request-from-api.test.ts
+++ b/src/lib/utilities/request-from-api.test.ts
@@ -61,7 +61,9 @@ describe('requestFromAPI', () => {
 
   const options = {
     credentials: 'include',
-    headers: {},
+    headers: {
+      'Caller-Type': 'operator',
+    },
   };
 
   const fetchMock = <T = unknown>(
@@ -102,6 +104,7 @@ describe('requestFromAPI', () => {
       ...options,
       headers: {
         'X-CSRF-TOKEN': token,
+        'Caller-Type': 'operator',
       },
     });
   });

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -187,6 +187,7 @@ const withIdToken = (
 
 const withCsrf = (headers: HeadersInit, isBrowser = BROWSER): HeadersInit => {
   if (!headers) headers = {};
+  headers['Caller-Type'] = 'operator';
   if (!isBrowser) return headers;
 
   const csrfCookie = '_csrf=';

--- a/src/lib/utilities/request-from-api.with-access-token.test.ts
+++ b/src/lib/utilities/request-from-api.with-access-token.test.ts
@@ -13,7 +13,9 @@ type MockResponse<T = unknown> = {
 
 const options = {
   credentials: 'include',
-  headers: {},
+  headers: {
+    'Caller-Type': 'operator',
+  },
 };
 
 const endpoint = '/api/endpoint';


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
To prioritize web requests, add Caller-Type='operator' to all requests.

Allow the header in ui-server and update unit tests.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1702" alt="Screen Shot 2023-09-13 at 11 37 11 AM" src="https://github.com/temporalio/ui/assets/7967403/a84166f6-e581-4644-8d9f-baf5520a5a10">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
