### PR TITLE
Fix button so that it can't accept an `href` prop if disabled

### DIFF
--- a/src/lib/holocene/button.story.svelte
+++ b/src/lib/holocene/button.story.svelte
@@ -18,21 +18,41 @@
   export let Hst: HST;
 </script>
 
-<Hst.Story>
-  <div class="flex items-center justify-center p-4">
-    <Button
-      {variant}
-      {size}
-      {borderModifier}
-      {borderRadiusModifier}
-      {disabled}
-      {loading}
-      {href}
-      {leadingIcon}
-      {trailingIcon}
-      {count}>Click Me</Button
-    >
-  </div>
+<Hst.Story title="button">
+  <Hst.Variant title="A Regular Button">
+    <div class="flex items-center justify-center p-4">
+      <Button
+        {variant}
+        {size}
+        {borderModifier}
+        {borderRadiusModifier}
+        {disabled}
+        {loading}
+        {leadingIcon}
+        {trailingIcon}
+        {count}>Click Me</Button
+      >
+    </div>
+  </Hst.Variant>
+
+  <Hst.Variant title="A Button with an href">
+    <div class="flex items-center justify-center p-4">
+      <Button
+        href="https://temporal.io"
+        target="_blank"
+        {variant}
+        {size}
+        {borderModifier}
+        {borderRadiusModifier}
+        {loading}
+        {leadingIcon}
+        {trailingIcon}
+        {count}
+      >
+        A Link
+      </Button>
+    </div>
+  </Hst.Variant>
 
   <svelte:fragment slot="controls">
     <Hst.Select

--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -81,6 +81,7 @@
     HTMLAnchorAttributes & {
       href: string;
       target?: HTMLAnchorAttributes['target'];
+      disabled: never;
     };
 
   type ButtonStyles = VariantProps<typeof buttonStyles>;
@@ -106,7 +107,7 @@
   this={href ? 'a' : 'button'}
   {target}
   {href}
-  {disabled}
+  disabled={href ? null : disabled}
   {id}
   role="button"
   type="button"

--- a/src/lib/pages/schedules.svelte
+++ b/src/lib/pages/schedules.svelte
@@ -53,10 +53,9 @@
       {namespace}
     </p>
   </div>
-  {#if hasSchedules}
+  {#if hasSchedules && !createDisabled}
     <Button
       data-testid="create-schedule"
-      disabled={createDisabled}
       href={routeForScheduleCreate({ namespace })}
     >
       {translate('schedules', 'create')}
@@ -124,10 +123,9 @@
             >Temporal CLI</Link
           >.
         </p>
-        {#if !error}
+        {#if !error && !createDisabled}
           <Button
             data-testid="create-schedule"
-            disabled={createDisabled}
             href={routeForScheduleCreate({ namespace })}
           >
             {translate('schedules', 'create')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We allow `<Button />` to accept an `href` prop, which will render an Anchor element that is styled to look like a button. Anchor elements cannot be disabled, so this PR fixes `<Button />` to make the `disabled` prop type `never` when `href` is specified.

Also fixes the schedules list page, which is the only place in OSS we were were disabling link buttons.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
