### PR TITLE
[DT-1423] Send signal input payload to data encoder

### DIFF
--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -32,7 +32,7 @@
 >
   {#if typeof value === 'object'}
     <div
-      class="flex w-full flex-wrap items-center justify-between pr-1 xl:flex-nowrap xl:gap-4"
+      class="flex w-full flex-wrap items-center justify-between gap-1 pr-1 xl:flex-nowrap xl:gap-4"
     >
       <p class="min-w-fit text-sm">
         {format(key)}

--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -158,11 +158,10 @@
         message: translate('workflows', 'signal-success'),
         id: 'workflow-signal-success-toast',
       });
+      hideSignalModal();
     } catch (err) {
       error = err?.message ?? translate('unknown-error');
     }
-
-    hideSignalModal();
   };
 
   const reset = async () => {

--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -19,6 +19,11 @@
   } from '$lib/services/workflow-service';
   import { authUser } from '$lib/stores/auth-user';
   import { coreUserStore } from '$lib/stores/core-user';
+  import {
+    codecEndpoint,
+    includeCredentials,
+    passAccessToken,
+  } from '$lib/stores/data-encoder-config';
   import { resetEvents } from '$lib/stores/events';
   import { resetWorkflows } from '$lib/stores/reset-workflows';
   import { settings } from '$lib/stores/settings';
@@ -137,6 +142,15 @@
         runId: workflow.runId,
         signalInput,
         signalName,
+        settings: {
+          ...$page.data.settings,
+          codec: {
+            endpoint: $codecEndpoint,
+            includeCredentials: $includeCredentials,
+            passAccessToken: $passAccessToken,
+          },
+        },
+        accessToken: $authUser.accessToken,
       });
       signalConfirmationModalOpen = false;
       $refresh = Date.now();

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -128,7 +128,7 @@
   });
 
   const setView = () => {
-    if (view && !editable) {
+    if (view && (!editable || (editable && !value))) {
       const newState = createEditorState(value);
       view.setState(newState);
     }

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -137,4 +137,6 @@ export const Strings = {
   timeline: 'Timeline',
   'equal-to': 'Equal to',
   'not-equal-to': 'Not equal to',
+  'encode-failed': 'Data encoding failed',
+  'decode-failed': 'Data decoding failed',
 } as const;

--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -13,11 +13,13 @@ export async function convertPayloadsWithCodec({
   namespace,
   settings,
   accessToken,
+  encode = false,
 }: {
   payloads: PotentialPayloads;
   namespace: string;
   settings: Settings;
   accessToken: string;
+  encode?: boolean;
 }): Promise<PotentialPayloads> {
   const endpoint = settings?.codec?.endpoint;
   const passAccessToken = settings?.codec?.passAccessToken;
@@ -51,7 +53,7 @@ export async function convertPayloadsWithCodec({
       };
 
   const encoderResponse: Promise<PotentialPayloads> = fetch(
-    endpoint + '/decode',
+    endpoint + (encode ? '/encode' : '/decode'),
     requestOptions,
   )
     .then((r) => r.json())

--- a/src/lib/stores/data-encoder-config.ts
+++ b/src/lib/stores/data-encoder-config.ts
@@ -2,6 +2,7 @@ import { writable } from 'svelte/store';
 
 import { persistStore } from '$lib/stores/persist-store';
 import type { DataEncoderStatus } from '$lib/types/global';
+import { has } from '$lib/utilities/has';
 
 export const codecEndpoint = persistStore('endpoint', null, true);
 
@@ -26,8 +27,16 @@ export const overrideRemoteCodecConfiguration = persistStore<boolean>(
 export const lastDataEncoderStatus =
   writable<DataEncoderStatus>('notRequested');
 
-export function setLastDataEncoderFailure(): void {
+export const lastDataEncoderError = writable<string>('');
+
+export function setLastDataEncoderFailure(error?: unknown): void {
   lastDataEncoderStatus.set('error');
+
+  if (error && has(error, 'message') && typeof error.message === 'string') {
+    lastDataEncoderError.set(error.message);
+  } else {
+    lastDataEncoderError.set('');
+  }
 }
 
 export function setLastDataEncoderSuccess(): void {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When sending a Signal through the UI, the input payload is sent to the `/encode` endpoint if a codec endpoint is configured. If not, the payload is base64 encoded. Once encoded, the payload is sent as part of the api request. If there is an error when the payload is sent to `/encode`, there is an error message (`Data encoding failed`) and the signal request is not sent.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists
- [ ] Verify a signal input is base64 encoded if there is no codec endpoint configured
- [ ] Verify a signal input is encoded if there is a codec endpoint configured
- [ ] Verify there is an error message if the input can not be encoded
- [ ] Verify the name and input are cleared when the signal modal is closed

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1423`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
