### PR TITLE
Prevent duplicate ids in Timeline

### DIFF
--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -98,7 +98,7 @@
       });
     }
 
-    eventGroups.forEach((group, i) => {
+    eventGroups.forEach((group, index) => {
       const initialEvent = group.initialEvent;
       const lastEvent = group?.lastEvent;
       const groupPendingActivity =
@@ -108,7 +108,7 @@
       if (groupPendingActivity && isRunning) {
         items.add({
           id: `pending-${groupPendingActivity.activityId}`,
-          group: group.id,
+          group: `group-${index}`,
           start: initialEvent.eventTime,
           end: Date.now(),
           content: renderPendingAttempts(
@@ -120,8 +120,8 @@
         });
       } else {
         items.add({
-          id: `event-range-${initialEvent.id}`,
-          group: group.id,
+          id: `group-${index}-items`,
+          group: `group-${index}`,
           start: initialEvent.eventTime,
           data: group,
           content:
@@ -134,10 +134,11 @@
           editable: false,
         });
       }
+
       groups.add({
-        id: group.id,
+        id: `group-${index}`,
         content: renderGroupName(group),
-        order: i,
+        order: index,
       });
     });
     return { items, groups };


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
In some cases such as Update, event groups can share the same id (have the same initial event).

I've changed from using event ids as the Item/Group ids to using the index to prevent duplicate ids. We can't trust event group ids will be unique (initial or last event ids).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
