### PR TITLE
stay on batch operations page when switching namespaces

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -69,11 +69,24 @@
   };
 
   function getCurrentHref(namespace: string) {
-    const onSchedulesPage = $page.url.pathname.endsWith('schedules');
-    const href = onSchedulesPage
-      ? routeForSchedules({ namespace })
-      : routeForWorkflows({ namespace });
-    return href;
+    const namespacePages = [
+      {
+        subPath: 'schedules',
+        fullRoute: routeForSchedules({ namespace }),
+      },
+      {
+        subPath: 'batch-operations',
+        fullRoute: routeForBatchOperations({ namespace }),
+      },
+    ];
+
+    for (const { subPath, fullRoute } of namespacePages) {
+      if ($page.url.pathname.endsWith(subPath)) {
+        return fullRoute;
+      }
+    }
+
+    return routeForWorkflows({ namespace });
   }
 
   const logout = () => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When switching namespaces, if the user is currently on the batch-operations (or schedules) page, we should keep them on that page in the new namespace
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
