### PR TITLE
Add includeMillisecondsForUnderSecond for formatDate to show ms for under a second

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
@@ -84,7 +84,11 @@
         relative: $relativeTime,
       })}
     {:else if label === 'Execution Duration'}
-      {formatDistance({ start: workflow.startTime, end: workflow.endTime })}
+      {formatDistance({
+        start: workflow.startTime,
+        end: workflow.endTime,
+        includeMillisecondsForUnderSecond: true,
+      })}
     {:else if label === 'History Length'}
       {parseInt(workflow.historyEvents, 10) > 0 ? workflow.historyEvents : ''}
     {:else if isCustomSearchAttribute(label) && workflowIncludesSearchAttribute(workflow, label)}

--- a/src/lib/utilities/format-time.test.ts
+++ b/src/lib/utilities/format-time.test.ts
@@ -174,6 +174,56 @@ describe('getDuration', () => {
     expect(distance).toBe('263ms');
     expect(abbvDistancer).toBe('263ms');
   });
+  it('should get only milliseconds of a start and end date less than a second apart with includeMillisecondsForUnderSecond', () => {
+    const start = '2022-04-13T16:29:35.630571Z';
+    const end = '2022-04-13T16:29:35.893821Z';
+    const duration = getDuration({ start, end });
+    const distance = formatDistance({
+      start,
+      end,
+      includeMillisecondsForUnderSecond: true,
+    });
+    const abbvDistancer = formatDistanceAbbreviated({
+      start,
+      end,
+      includeMillisecondsForUnderSecond: true,
+    });
+    expect(duration).toStrictEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      months: 0,
+      seconds: 0,
+      years: 0,
+    });
+    expect(distance).toBe('263ms');
+    expect(abbvDistancer).toBe('263ms');
+  });
+  it('should not get milliseconds of a start and end date more than a second apart with includeMillisecondsForUnderSecond', () => {
+    const start = '2022-04-13T16:29:33.630571Z';
+    const end = '2022-04-13T16:29:35.893821Z';
+    const duration = getDuration({ start, end });
+    const distance = formatDistance({
+      start,
+      end,
+      includeMillisecondsForUnderSecond: true,
+    });
+    const abbvDistancer = formatDistanceAbbreviated({
+      start,
+      end,
+      includeMillisecondsForUnderSecond: true,
+    });
+    expect(duration).toStrictEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      months: 0,
+      seconds: 2,
+      years: 0,
+    });
+    expect(distance).toBe('2 seconds');
+    expect(abbvDistancer).toBe('2s');
+  });
 });
 
 describe('fromSecondsToMinutesAndSeconds', () => {

--- a/src/lib/utilities/format-time.ts
+++ b/src/lib/utilities/format-time.ts
@@ -131,15 +131,20 @@ export function formatDistance({
   start,
   end,
   includeMilliseconds = false,
+  includeMillisecondsForUnderSecond = false,
 }: {
   start: ValidTime | undefined | null;
   end: ValidTime | undefined | null;
   includeMilliseconds?: boolean;
+  includeMillisecondsForUnderSecond?: boolean;
 }): string {
   const duration = getDuration({ start, end });
   const distance = formatDuration(duration);
   const msDuration = getMillisecondDuration({ start, end });
-  if (includeMilliseconds && msDuration) {
+
+  if (!distance && msDuration && includeMillisecondsForUnderSecond) {
+    return `${msDuration}ms`.trim();
+  } else if (includeMilliseconds && msDuration) {
     return `${distance} ${msDuration}ms`.trim();
   } else {
     return distance;
@@ -150,16 +155,21 @@ export function formatDistanceAbbreviated({
   start,
   end,
   includeMilliseconds = false,
+  includeMillisecondsForUnderSecond = false,
 }: {
   start: ValidTime | undefined | null;
   end: ValidTime | undefined | null;
   includeMilliseconds?: boolean;
+  includeMillisecondsForUnderSecond?: boolean;
 }): string {
   const duration = getDuration({ start, end });
   const distance = formatDuration(duration, ' ');
   const formattedDistance = formatDistanceToSingleLetters(distance);
   const msDuration = getMillisecondDuration({ start, end });
-  if (includeMilliseconds && msDuration) {
+
+  if (!distance && msDuration && includeMillisecondsForUnderSecond) {
+    return `${msDuration}ms`.trim();
+  } else if (includeMilliseconds && msDuration) {
     return `${formattedDistance} ${msDuration}ms`.trim();
   } else {
     return formattedDistance;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add option to show ms for formatDate but only for durations under 1 second. Previously any duration under a second would show an empty string, which is confusing for short, completed workflows.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1724" alt="Screen Shot 2023-10-18 at 8 20 36 PM" src="https://github.com/temporalio/ui/assets/7967403/cb87e31b-4127-477f-acb4-191b20e54029">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
