### PR TITLE
Fix workflow counts fetching logic by using query param instead of st…

### DIFF
--- a/src/lib/components/workflow/workflow-count-all.svelte
+++ b/src/lib/components/workflow/workflow-count-all.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Spinner from '$lib/holocene/icon/svg/spinner.svelte';
   import { translate } from '$lib/i18n/translate';
   import { loading, updating } from '$lib/stores/workflows';
 
@@ -7,11 +6,12 @@
 </script>
 
 <div class="font-base flex text-center text-sm leading-4">
-  <p data-testid="workflow-count" data-loaded={!$loading && !$updating}>
-    {#if $loading || $updating}
-      <Spinner class="h-4 w-4 animate-spin" />
-    {:else if count >= 0}
-      {count.toLocaleString()} {translate('workflows').toLocaleLowerCase()}
-    {/if}
+  <p
+    class="flex items-center"
+    data-testid="workflow-count"
+    data-loaded={!$loading && !$updating}
+  >
+    {count.toLocaleString()}
+    {translate('workflows').toLocaleLowerCase()}
   </p>
 </div>

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -58,6 +58,7 @@
   import WorkflowAdvancedSearch from '$lib/components/workflow/workflow-advanced-search.svelte';
   import WorkflowCounts from '$lib/components/workflow/workflow-counts.svelte';
   import WorkflowsSummaryConfigurableTable from '$lib/components/workflow/workflows-summary-configurable-table.svelte';
+  import Spinner from '$lib/holocene/icon/svg/spinner.svelte';
   import IconButton from '$lib/holocene/icon-button.svelte';
   import LabsModeGuard from '$lib/holocene/labs-mode-guard.svelte';
   import Link from '$lib/holocene/link.svelte';
@@ -214,8 +215,11 @@
 <header class="flex flex-col">
   <div class="flex items-center justify-between">
     <div>
-      <h1 class="text-2xl" data-cy="workflows-title">
+      <h1 class="flex items-center text-2xl" data-cy="workflows-title">
         <Translate namespace="workflows" key="recent-workflows" />
+        {#if $loading || $updating}
+          <Spinner class="h-8 w-8 animate-spin" />
+        {/if}
       </h1>
       <div class="flex items-center gap-2 text-sm">
         {#if $workflowCount?.totalCount >= 0 && $supportsAdvancedVisibility && !$groupByCountEnabled}

--- a/src/lib/services/workflow-counts.ts
+++ b/src/lib/services/workflow-counts.ts
@@ -1,9 +1,6 @@
 import { noop } from 'svelte/internal';
 
-import type { WorkflowFilter } from '$lib/models/workflow-filters';
 import type { CountWorkflowExecutionsResponse } from '$lib/types/workflows';
-import { toListWorkflowQueryFromFilters } from '$lib/utilities/query/filter-workflow-query';
-import { combineFilters } from '$lib/utilities/query/to-list-workflow-filters';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
@@ -56,22 +53,23 @@ export const fetchWorkflowCount = async (
 
 type WorkflowCountByExecutionStatusOptions = {
   namespace: string;
-  filters: WorkflowFilter[];
+  query: string;
 };
 
 export const fetchWorkflowCountByExecutionStatus = async ({
   namespace,
-  filters,
+  query,
 }: WorkflowCountByExecutionStatusOptions): Promise<CountWorkflowExecutionsResponse> => {
   try {
     const groupByClause = 'GROUP BY ExecutionStatus';
     const countRoute = routeForApi('workflows.count', {
       namespace,
     });
-    const query = toListWorkflowQueryFromFilters(combineFilters(filters));
     const { count, groups } =
       await requestFromAPI<CountWorkflowExecutionsResponse>(countRoute, {
-        params: { query: `${query} ${groupByClause}` },
+        params: {
+          query: query ? `${query} ${groupByClause}` : `${groupByClause}`,
+        },
         notifyOnError: false,
       });
     return { count, groups };


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Switch to using query param for fetching counts and not using $workflowFilter store. This allows the counts to be accurate on a hard refresh of page. 

Also, don't show the Counts row in the UI when loading. Add spinner but keep consistent height of Counts row when empty. Less flashing of badges and a cleaner UX.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
https://github.com/temporalio/ui/assets/7967403/566cabb5-8390-4528-8d57-b89a5c274df2



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
