### PR TITLE
Allow decoding Event History Download through the UI

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -49,6 +49,5 @@ codec:
   endpoint:
   passAccessToken: false
   includeCredentials: false
-  decodeEventHistoryDownload: true
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For

--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -51,7 +51,6 @@ codec:
   endpoint: {{ default .Env.TEMPORAL_CODEC_ENDPOINT "" }}
   passAccessToken: {{ default .Env.TEMPORAL_CODEC_PASS_ACCESS_TOKEN "false" }}
   includeCredentials: {{ default .Env.TEMPORAL_CODEC_INCLUDE_CREDENTIALS "false" }}
-  decodeEventHistoryDownload: {{ default .Env.TEMPORAL_CODEC_DECODE_EVENT_HISTORY_DOWNLOAD "false" }}
 
 forwardHeaders: {{ if .Env.TEMPORAL_FORWARD_HEADERS }} {{ range $seed := (split .Env.TEMPORAL_FORWARD_HEADERS ",") }}
   - {{ . }} {{ end }} {{ end }}

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -46,10 +46,9 @@ type Auth struct {
 }
 
 type CodecResponse struct {
-	Endpoint                   string
-	PassAccessToken            bool
-	IncludeCredentials         bool
-	DecodeEventHistoryDownload bool
+	Endpoint           string
+	PassAccessToken    bool
+	IncludeCredentials bool
 }
 
 type SettingsResponse struct {
@@ -123,10 +122,9 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 			FeedbackURL:                 cfg.FeedbackURL,
 			NotifyOnNewVersion:          cfg.NotifyOnNewVersion,
 			Codec: &CodecResponse{
-				Endpoint:                   cfg.Codec.Endpoint,
-				PassAccessToken:            cfg.Codec.PassAccessToken,
-				IncludeCredentials:         cfg.Codec.IncludeCredentials,
-				DecodeEventHistoryDownload: cfg.Codec.DecodeEventHistoryDownload,
+				Endpoint:           cfg.Codec.Endpoint,
+				PassAccessToken:    cfg.Codec.PassAccessToken,
+				IncludeCredentials: cfg.Codec.IncludeCredentials,
 			},
 			Version:                   version.UIVersion,
 			DisableWriteActions:       cfg.DisableWriteActions,

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -111,10 +111,9 @@ type (
 	}
 
 	Codec struct {
-		Endpoint                   string `yaml:"endpoint"`
-		PassAccessToken            bool   `yaml:"passAccessToken"`
-		IncludeCredentials         bool   `yaml:"includeCredentials"`
-		DecodeEventHistoryDownload bool   `yaml:"decodeEventHistoryDownload"`
+		Endpoint           string `yaml:"endpoint"`
+		PassAccessToken    bool   `yaml:"passAccessToken"`
+		IncludeCredentials bool   `yaml:"includeCredentials"`
 	}
 
 	Filesystem struct {

--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -175,7 +175,7 @@
       getTimelineOptions($workflowRun.workflow),
     );
     const reverseHistory =
-      $eventFilterSort === 'descending' && $eventViewType !== 'compact';
+      $eventFilterSort === 'descending' && $eventViewType === 'feed';
     const sortedHistory = reverseHistory
       ? [...history].reverse()
       : [...history];

--- a/src/lib/components/event/payload-decoder.svelte
+++ b/src/lib/components/event/payload-decoder.svelte
@@ -20,6 +20,8 @@
   export let value: PotentiallyDecodable | EventAttribute | WorkflowEvent;
   export let key = '';
 
+  $: keyedValue = key && value?.[key] ? value[key] : value;
+  $: decodedValue = stringifyWithBigInt(keyedValue);
   $: endpoint = getCodecEndpoint($page.data.settings);
   $: passAccessToken = getCodecPassAccessToken($page.data.settings);
   $: includeCredentials = getCodecIncludeCredentials($page.data.settings);
@@ -51,15 +53,13 @@
         decodedValue = stringifyWithBigInt(decodedAttributes);
       }
     } catch (e) {
-      return stringifyWithBigInt(value);
+      console.error('Could not decode payloads');
     }
   };
 
   onMount(() => {
     decodePayloads();
   });
-
-  let decodedValue = '';
 </script>
 
 <slot {decodedValue} />

--- a/src/lib/components/event/payload-decoder.svelte
+++ b/src/lib/components/event/payload-decoder.svelte
@@ -20,8 +20,9 @@
   export let value: PotentiallyDecodable | EventAttribute | WorkflowEvent;
   export let key = '';
 
-  $: keyedValue = key && value?.[key] ? value[key] : value;
-  $: decodedValue = stringifyWithBigInt(keyedValue);
+  let keyedValue = key && value?.[key] ? value[key] : value;
+  let decodedValue = stringifyWithBigInt(keyedValue);
+
   $: endpoint = getCodecEndpoint($page.data.settings);
   $: passAccessToken = getCodecPassAccessToken($page.data.settings);
   $: includeCredentials = getCodecIncludeCredentials($page.data.settings);

--- a/src/lib/components/top-nav.svelte
+++ b/src/lib/components/top-nav.svelte
@@ -28,7 +28,8 @@
     (pathNameSplit.includes('workflows') ||
       pathNameSplit.includes('schedules') ||
       pathNameSplit.includes('batch-operations') ||
-      pathNameSplit.includes('task-queues'));
+      pathNameSplit.includes('task-queues') ||
+      pathNameSplit.includes('import'));
 
   let showProfilePic = true;
 

--- a/src/lib/components/workflow/input-and-results.svelte
+++ b/src/lib/components/workflow/input-and-results.svelte
@@ -29,7 +29,8 @@
 
   const parsePayloads = (c: string): unknown[] => {
     try {
-      return parseWithBigInt(c);
+      const data = parseWithBigInt(c);
+      return Array.isArray(data) ? parseWithBigInt(c) : [];
     } catch {
       return [];
     }

--- a/src/lib/components/workflow/workflow-json-navigator.svelte
+++ b/src/lib/components/workflow/workflow-json-navigator.svelte
@@ -3,6 +3,7 @@
   import RangeInput from '$lib/holocene/input/range-input.svelte';
   import Loading from '$lib/holocene/loading.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { fromEventToRawEvent } from '$lib/models/event-history';
   import type { WorkflowEvents } from '$lib/types/events';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
@@ -84,7 +85,10 @@
   </div>
   {#if decodeEventHistory}
     {#key [index, decodeEventHistory]}
-      <PayloadDecoder value={events[index - 1]} let:decodedValue>
+      <PayloadDecoder
+        value={fromEventToRawEvent(events[index - 1])}
+        let:decodedValue
+      >
         <CodeBlock
           content={decodedValue}
           testId="event-history-json"
@@ -96,7 +100,11 @@
   {:else}
     {#key index}
       <CodeBlock
-        content={stringifyWithBigInt(events[index - 1], undefined, 2)}
+        content={stringifyWithBigInt(
+          fromEventToRawEvent(events[index - 1]),
+          undefined,
+          2,
+        )}
         testId="event-history-json"
         copyIconTitle={translate('common.copy-icon-title')}
         copySuccessIconTitle={translate('common.copy-success-icon-title')}

--- a/src/lib/components/workflow/workflow-json-navigator.svelte
+++ b/src/lib/components/workflow/workflow-json-navigator.svelte
@@ -4,13 +4,13 @@
   import Loading from '$lib/holocene/loading.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fromEventToRawEvent } from '$lib/models/event-history';
+  import { decodeEventHistory } from '$lib/stores/events';
   import type { WorkflowEvents } from '$lib/types/events';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   import PayloadDecoder from '../event/payload-decoder.svelte';
 
   export let events: WorkflowEvents = [];
-  export let decodeEventHistory: boolean;
 
   let index = 1;
 
@@ -83,8 +83,8 @@
     </div>
     <slot name="decode" />
   </div>
-  {#if decodeEventHistory}
-    {#key [index, decodeEventHistory]}
+  {#if $decodeEventHistory}
+    {#key [index, $decodeEventHistory]}
       <PayloadDecoder
         value={fromEventToRawEvent(events[index - 1])}
         let:decodedValue

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -146,4 +146,5 @@ export const Strings = {
   'auto-refresh': 'Auto refresh',
   'auto-refresh-tooltip': '{{ interval }} second page refresh',
   'view-more': 'View More...',
+  download: 'Download',
 } as const;

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -59,5 +59,5 @@ export const Strings = {
     failed: 'Failed',
     terminated: 'Terminated',
   },
-  'decode-event-history-download': 'Decode Event History Payloads',
+  'decode-event-history': 'Decode Event History',
 } as const;

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -59,4 +59,5 @@ export const Strings = {
     failed: 'Failed',
     terminated: 'Terminated',
   },
+  'decode-event-history-download': 'Decode Event History Payloads',
 } as const;

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -10,8 +10,10 @@
   import WorkflowSummary from '$lib/components/workflow/workflow-summary.svelte';
   import WorkflowTypedError from '$lib/components/workflow/workflow-typed-error.svelte';
   import Accordion from '$lib/holocene/accordion.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
+  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fetchAllEvents } from '$lib/services/events-service';
   import {
@@ -31,6 +33,8 @@
 
   $: ({ namespace, workflow: workflowId, run: runId } = $page.params);
   let showShortcuts = false;
+  let showDownloadPrompt = false;
+  let decodeEventHistory = true;
 
   $: workflowEvents =
     getWorkflowStartedCompletedAndTaskFailedEvents($eventHistory);
@@ -74,6 +78,17 @@
       $page.url.searchParams.delete('page');
     }
     $eventViewType = view;
+  };
+
+  const onDownloadClick = () => {
+    showDownloadPrompt = false;
+    exportHistory({
+      namespace: decodeURIForSvelte($page.params.namespace),
+      workflowId: decodeURIForSvelte($workflowRun.workflow?.id),
+      runId: decodeURIForSvelte($workflowRun.workflow?.runId),
+      settings: $page.data.settings,
+      decodeEventHistory,
+    });
   };
 </script>
 
@@ -145,13 +160,8 @@
           <ToggleButton
             icon="download"
             data-testid="download"
-            on:click={() =>
-              exportHistory({
-                namespace: decodeURIForSvelte($page.params.namespace),
-                workflowId: decodeURIForSvelte($workflowRun.workflow?.id),
-                runId: decodeURIForSvelte($workflowRun.workflow?.runId),
-                settings: $page.data.settings,
-              })}>{translate('workflows.download')}</ToggleButton
+            on:click={() => (showDownloadPrompt = true)}
+            >{translate('workflows.download')}</ToggleButton
           >
         </ToggleButtons>
       </div>
@@ -164,3 +174,26 @@
     onClose={() => (showShortcuts = false)}
   />
 </div>
+
+<Modal
+  id="download-history"
+  large
+  bind:open={showDownloadPrompt}
+  confirmType="primary"
+  confirmText={translate('common.download')}
+  cancelText={translate('common.cancel')}
+  on:confirmModal={() => onDownloadClick()}
+  on:cancelModal={() => (showDownloadPrompt = false)}
+>
+  <h3 slot="title">
+    {translate('common.download-json')}
+  </h3>
+  <div slot="content" class="flex flex-col gap-4">
+    <ToggleSwitch
+      label={translate('events.decode-event-history-download')}
+      id="decode-event-history"
+      bind:checked={decodeEventHistory}
+      data-testid="decode-event-history-toggle"
+    />
+  </div>
+</Modal>

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -190,7 +190,7 @@
   </h3>
   <div slot="content" class="flex flex-col gap-4">
     <ToggleSwitch
-      label={translate('events.decode-event-history-download')}
+      label={translate('events.decode-event-history')}
       id="decode-event-history"
       bind:checked={decodeEventHistory}
       data-testid="decode-event-history-toggle"

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -62,7 +62,7 @@
       namespace,
       workflowId,
       runId,
-      sort: view === 'compact' ? 'ascending' : sort,
+      sort: view === 'feed' ? sort : 'ascending',
     });
   };
 

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -21,7 +21,11 @@
     type EventSortOrder,
     eventViewType,
   } from '$lib/stores/event-view';
-  import { eventHistory, fullEventHistory } from '$lib/stores/events';
+  import {
+    decodeEventHistory,
+    eventHistory,
+    fullEventHistory,
+  } from '$lib/stores/events';
   import { namespaces } from '$lib/stores/namespaces';
   import { refresh, workflowRun } from '$lib/stores/workflow-run';
   import type { EventView } from '$lib/types/events';
@@ -34,7 +38,6 @@
   $: ({ namespace, workflow: workflowId, run: runId } = $page.params);
   let showShortcuts = false;
   let showDownloadPrompt = false;
-  let decodeEventHistory = true;
 
   $: workflowEvents =
     getWorkflowStartedCompletedAndTaskFailedEvents($eventHistory);
@@ -87,7 +90,7 @@
       workflowId: decodeURIForSvelte($workflowRun.workflow?.id),
       runId: decodeURIForSvelte($workflowRun.workflow?.runId),
       settings: $page.data.settings,
-      decodeEventHistory,
+      decodeEventHistory: $decodeEventHistory,
     });
   };
 </script>
@@ -192,7 +195,7 @@
     <ToggleSwitch
       label={translate('events.decode-event-history')}
       id="decode-event-history"
-      bind:checked={decodeEventHistory}
+      bind:checked={$decodeEventHistory}
       data-testid="decode-event-history-toggle"
     />
   </div>

--- a/src/lib/models/event-history/index.ts
+++ b/src/lib/models/event-history/index.ts
@@ -111,3 +111,14 @@ export const isEvent = (event: unknown): event is WorkflowEvent => {
   if (has(event, 'eventType')) return true;
   return false;
 };
+
+export const fromEventToRawEvent = (event: WorkflowEvent): HistoryEvent => {
+  const workflowEvent = { ...event };
+  delete workflowEvent.name;
+  delete workflowEvent.id;
+  delete workflowEvent.timestamp;
+  delete workflowEvent.classification;
+  delete workflowEvent.category;
+  delete workflowEvent.attributes;
+  return workflowEvent;
+};

--- a/src/lib/models/event-history/to-event-history.test.ts
+++ b/src/lib/models/event-history/to-event-history.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { HistoryEvent } from '$lib/types/events';
 import type { Settings } from '$lib/types/global';
 
-import { getEventAttributes, toEventHistory } from '.';
+import { fromEventToRawEvent, getEventAttributes, toEventHistory } from '.';
 
 import eventsFixture from '$fixtures/raw-events.descending.completed.json';
 import settingsFixture from '$fixtures/settings.json';
@@ -191,6 +191,30 @@ describe('toEventHistory', () => {
       const [event] = events;
 
       expect(event[property]).toBeDefined();
+    });
+  }
+});
+
+describe('fromEventToRawEvent', () => {
+  const additionalProperties = [
+    'attributes',
+    'classification',
+    'category',
+    'id',
+    'name',
+    'timestamp',
+  ];
+
+  for (const property of additionalProperties) {
+    it(`should remove a[n] ${property} property`, async () => {
+      const events = await toEventHistory(
+        eventsFixture.history.events as unknown as HistoryEvent[],
+      );
+
+      const [event] = events;
+      const rawEvent = fromEventToRawEvent(event);
+
+      expect(rawEvent[property]).toBeUndefined();
     });
   }
 });

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import WorkflowJsonNavigator from '$lib/components/workflow/workflow-json-navigator.svelte';
   import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
+  import { translate } from '$lib/i18n/translate';
   import { fullEventHistory } from '$lib/stores/events';
 
   let decodeEventHistory = true;
@@ -9,7 +10,7 @@
 <WorkflowJsonNavigator events={$fullEventHistory} {decodeEventHistory}>
   <ToggleSwitch
     slot="decode"
-    label="View decoded event history"
+    label={translate('events.decode-event-history')}
     id="decode-event-history"
     bind:checked={decodeEventHistory}
     data-testid="decode-event-history-toggle"

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -2,17 +2,15 @@
   import WorkflowJsonNavigator from '$lib/components/workflow/workflow-json-navigator.svelte';
   import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { fullEventHistory } from '$lib/stores/events';
-
-  let decodeEventHistory = true;
+  import { decodeEventHistory, fullEventHistory } from '$lib/stores/events';
 </script>
 
-<WorkflowJsonNavigator events={$fullEventHistory} {decodeEventHistory}>
+<WorkflowJsonNavigator events={$fullEventHistory}>
   <ToggleSwitch
     slot="decode"
     label={translate('events.decode-event-history')}
     id="decode-event-history"
-    bind:checked={decodeEventHistory}
+    bind:checked={$decodeEventHistory}
     data-testid="decode-event-history-toggle"
   />
 </WorkflowJsonNavigator>

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -27,8 +27,6 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
       endpoint: settingsResponse?.Codec?.Endpoint,
       passAccessToken: settingsResponse?.Codec?.PassAccessToken,
       includeCredentials: settingsResponse?.Codec?.IncludeCredentials,
-      decodeEventHistoryDownload:
-        settingsResponse?.Codec?.DecodeEventHistoryDownload,
     },
     defaultNamespace: settingsResponse?.DefaultNamespace || 'default', // API returns an empty string if default namespace is not configured
     disableWriteActions: !!settingsResponse?.DisableWriteActions || false,

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -13,6 +13,7 @@ import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { isResetEvent } from '$lib/utilities/is-event-type';
 
 import { eventFilterSort } from './event-view';
+import { persistStore } from './persist-store';
 
 const namespace = derived([page], ([$page]) => {
   if ($page.params.namespace) {
@@ -86,4 +87,10 @@ export const fullEventHistory = writable<WorkflowEvents>([]);
 
 export const resetEvents = derived(fullEventHistory, (events) =>
   events.filter(isResetEvent),
+);
+
+export const decodeEventHistory = persistStore<boolean>(
+  'decodeEventHistory',
+  true,
+  true,
 );

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -79,7 +79,6 @@ export type Settings = {
     endpoint?: string;
     passAccessToken?: boolean;
     includeCredentials?: boolean;
-    decodeEventHistoryDownload?: boolean;
   };
   defaultNamespace: string;
   disableWriteActions: boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -204,7 +204,6 @@ export type SettingsResponse = {
     Endpoint: string;
     PassAccessToken?: boolean;
     IncludeCredentials?: boolean;
-    DecodeEventHistoryDownload?: boolean;
   };
   DefaultNamespace: string;
   DisableWriteActions: boolean;

--- a/src/lib/utilities/export-history.ts
+++ b/src/lib/utilities/export-history.ts
@@ -63,13 +63,14 @@ export const exportHistory = async ({
   workflowId,
   runId,
   settings,
+  decodeEventHistory,
 }: {
   namespace: string;
   workflowId: string;
   runId: string;
-  settings?: Settings;
+  settings: Settings;
+  decodeEventHistory: boolean;
 }) => {
-  const decodeEventHistory = settings?.codec?.decodeEventHistoryDownload;
   try {
     const rawEvents = await fetchRawEvents({
       namespace,

--- a/src/lib/utilities/export-history.ts
+++ b/src/lib/utilities/export-history.ts
@@ -1,7 +1,62 @@
-import { fetchAllEvents, fetchRawEvents } from '$lib/services/events-service';
+import { get } from 'svelte/store';
+
+import { page } from '$app/stores';
+
+import { fetchRawEvents } from '$lib/services/events-service';
+import { authUser } from '$lib/stores/auth-user';
+import type { HistoryEvent } from '$lib/types/events';
 import type { Settings } from '$lib/types/global';
 
+import {
+  cloneAllPotentialPayloadsWithCodec,
+  decodePayloadAttributes,
+} from './decode-payload';
+import {
+  getCodecEndpoint,
+  getCodecIncludeCredentials,
+  getCodecPassAccessToken,
+} from './get-codec';
 import { stringifyWithBigInt } from './parse-with-big-int';
+
+const decodePayloads = async (event: HistoryEvent, settings: Settings) => {
+  const endpoint = getCodecEndpoint(settings);
+  const passAccessToken = getCodecPassAccessToken(settings);
+  const includeCredentials = getCodecIncludeCredentials(settings);
+  const settingsWithLocalConfig = {
+    ...settings,
+    codec: {
+      ...settings?.codec,
+      endpoint,
+      passAccessToken,
+      includeCredentials,
+    },
+  };
+
+  try {
+    const convertedAttributes = await cloneAllPotentialPayloadsWithCodec(
+      event,
+      get(page).params.namespace,
+      settingsWithLocalConfig,
+      get(authUser).accessToken,
+    );
+    return decodePayloadAttributes(convertedAttributes);
+  } catch (e) {
+    return event;
+  }
+};
+
+function download(
+  events: HistoryEvent[],
+  fileName: string,
+  contentType: string,
+) {
+  const content = stringifyWithBigInt({ events }, null, 2);
+  const a = document.createElement('a');
+  const file = new Blob([content], { type: contentType });
+  a.href = URL.createObjectURL(file);
+  a.download = fileName;
+  a.click();
+}
 
 export const exportHistory = async ({
   namespace,
@@ -15,28 +70,25 @@ export const exportHistory = async ({
   settings?: Settings;
 }) => {
   const decodeEventHistory = settings?.codec?.decodeEventHistoryDownload;
-  const events = decodeEventHistory
-    ? await fetchAllEvents({
-        namespace,
-        workflowId,
-        runId,
-        sort: 'ascending',
-      })
-    : await fetchRawEvents({
-        namespace,
-        workflowId,
-        runId,
-        sort: 'ascending',
-      });
+  try {
+    const rawEvents = await fetchRawEvents({
+      namespace,
+      workflowId,
+      runId,
+      sort: 'ascending',
+    });
 
-  const content = stringifyWithBigInt({ events }, null, 2);
-  download(content, `${runId}/events.json`, 'text/plain');
-
-  function download(content: string, fileName: string, contentType: string) {
-    const a = document.createElement('a');
-    const file = new Blob([content], { type: contentType });
-    a.href = URL.createObjectURL(file);
-    a.download = fileName;
-    a.click();
+    if (decodeEventHistory) {
+      const decodedEvents = [];
+      for (const event of rawEvents) {
+        const decodedEvent = await decodePayloads(event, settings);
+        decodedEvents.push(decodedEvent);
+      }
+      download(decodedEvents, `${runId}/events.json`, 'text/plain');
+    } else {
+      download(rawEvents, `${runId}/events.json`, 'text/plain');
+    }
+  } catch (e) {
+    console.error('Could not download event history');
   }
 };

--- a/src/lib/utilities/get-codec.test.ts
+++ b/src/lib/utilities/get-codec.test.ts
@@ -27,7 +27,6 @@ const defaultSettings = {
     endpoint: '',
     passAccessToken: false,
     includeCredentials: false,
-    decodeEventHistoryDownload: false,
   },
   version: '2.15.0',
   disableWriteActions: false,

--- a/src/routes/(app)/import/events/[namespace]/[workflow]/[run]/history/json/+page.svelte
+++ b/src/routes/(app)/import/events/[namespace]/[workflow]/[run]/history/json/+page.svelte
@@ -3,4 +3,4 @@
   import { importEvents } from '$lib/stores/import-events';
 </script>
 
-<WorkflowJsonNavigator events={$importEvents} decodeEventHistory={false} />
+<WorkflowJsonNavigator events={$importEvents} />

--- a/tests/test-utilities/mocks/settings.ts
+++ b/tests/test-utilities/mocks/settings.ts
@@ -17,7 +17,6 @@ const defaultSettings = {
     Endpoint: '',
     PassAccessToken: false,
     IncludeCredentials: false,
-    DecodeEventHistoryDownload: false,
   },
   Version: '2.15.0',
   DisableWriteActions: false,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Previously we had an env var to allow downloading decoded event histories. This PR removes that env var and replaces it with a toggle from the UI. Decoding is defaulted on.

This also strips the extra UI attributes we add (id, name, classification, timestamp, category, attributes) from downloaded event histories and JSON view events.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1724" alt="Screen Shot 2023-10-23 at 1 52 42 PM" src="https://github.com/temporalio/ui/assets/7967403/6a501e0d-d702-4835-9718-8ad8f36048e8">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
