### PR TITLE
Fix Schedule link in scheduled workflows

### DIFF
--- a/src/fixtures/workflow.scheduled.json
+++ b/src/fixtures/workflow.scheduled.json
@@ -1,0 +1,61 @@
+{
+  "executionConfig": {
+    "taskQueue": {
+      "name": "child-workflow-continue-as-new",
+      "kind": "Normal"
+    },
+    "workflowExecutionTimeout": "0s",
+    "workflowRunTimeout": "300s",
+    "defaultWorkflowTaskTimeout": "20s"
+  },
+  "workflowExecutionInfo": {
+    "execution": {
+      "workflowId": "child_workflow:24240710-e6a1-4541-91b9-9f117bc407f4",
+      "runId": "4da1552a-97b7-46f5-8df0-8a09caaf5951"
+    },
+    "type": {
+      "name": "workflow.retry-workflow.ext"
+    },
+    "startTime": "2023-02-01T21:33:20.020052838Z",
+    "closeTime": "2023-02-01T21:33:21.033103713Z",
+    "status": "ContinuedAsNew",
+    "historyLength": "7",
+    "parentNamespaceId": "7635a64b-dd16-407e-a7d3-9e72a97a51ba",
+    "parentExecution": {
+      "workflowId": "parent-workflow_3eaa9ff1-3927-461d-94b4-271631094c8d",
+      "runId": "24240710-e6a1-4541-91b9-9f117bc407f4"
+    },
+    "executionTime": "2022-07-01T20:22:50.015107253Z",
+    "memo": {
+      "fields": {}
+    },
+    "searchAttributes": {
+      "indexedFields": {
+        "TemporalScheduledById": {
+          "metadata": {
+            "encoding": "anNvbi9wbGFpbg==",
+            "type": "S2V5d29yZA=="
+          },
+          "data": "InNpZ25hbC1ldmVyeS0zMCI="
+        }
+      }
+    },
+    "autoResetPoints": {
+      "points": [
+        {
+          "binaryChecksum": "e56c0141e58df0bd405138565d0526f9",
+          "runId": "babf5e35-3a61-48c2-8738-a19293205282",
+          "firstWorkflowTaskCompletedId": "4",
+          "createTime": "2022-07-01T20:22:49.014356253Z",
+          "expireTime": "2022-07-11T20:22:49.015107253Z",
+          "resettable": true
+        }
+      ]
+    },
+    "taskQueue": "canary-task-queue",
+    "stateTransitionCount": "6"
+  },
+  "pendingActivities": [],
+  "pendingChildren": [],
+  "pendingWorkflowTask": null
+}

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -46,7 +46,7 @@ const toArray = (payloads: Payload | Payload[]): Payload[] => {
 export function decodePayload(
   payload: Payload,
   // This could decode to any object. So we either use the payload object passed in or decode it
-): Payload {
+): unknown | Payload | null {
   if (payload === null) {
     return payload;
   }

--- a/src/lib/utilities/get-workflow-relationships.test.ts
+++ b/src/lib/utilities/get-workflow-relationships.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { toWorkflowExecution } from '$lib/models/workflow-execution';
 
+import { decodePayload } from './decode-payload';
 import { getWorkflowRelationships } from './get-workflow-relationships';
 
 import childEvents from '$fixtures/events.children.json';
@@ -15,6 +16,7 @@ import continuedAsNewWorkflow from '$fixtures/workflow.continued-as-new.json';
 import failedWorkflow from '$fixtures/workflow.failed.json';
 import pendingChildrenWorkflow from '$fixtures/workflow.pending-children.json';
 import runningWorkflow from '$fixtures/workflow.running.json';
+import scheduledWorkflow from '$fixtures/workflow.scheduled.json';
 import timedOutWorkflow from '$fixtures/workflow.timed-out.json';
 
 describe('getWorkflowRelationships', () => {
@@ -245,5 +247,31 @@ describe('getWorkflowRelationships', () => {
         namespaces.namespaces,
       ).next,
     ).toBe(newExecutionRunId);
+  });
+
+  it('should return the decoded scheduleID for a scheduled workflows', () => {
+    const workflowScheduledId = decodePayload(
+      scheduledWorkflow?.workflowExecutionInfo?.searchAttributes?.indexedFields
+        ?.TemporalScheduledById,
+    );
+    expect(
+      getWorkflowRelationships(
+        toWorkflowExecution(scheduledWorkflow),
+        completedEventHistory,
+        completedEvents,
+        namespaces.namespaces,
+      ).scheduleId,
+    ).toBe(workflowScheduledId);
+  });
+
+  it('should return empty string for a non-scheduled workflows', () => {
+    expect(
+      getWorkflowRelationships(
+        toWorkflowExecution(completedWorkflow),
+        completedEventHistory,
+        completedEvents,
+        namespaces.namespaces,
+      ).scheduleId,
+    ).toBe('');
   });
 });

--- a/src/lib/utilities/get-workflow-relationships.ts
+++ b/src/lib/utilities/get-workflow-relationships.ts
@@ -94,8 +94,13 @@ export const getWorkflowRelationships = (
   const previous =
     workflowExecutionStartedEvent?.attributes?.continuedExecutionRunId;
 
-  const scheduleId = workflowExecutionStartedEvent?.attributes?.searchAttributes
-    ?.indexedFields?.TemporalScheduledById as string;
+  let scheduleId = '';
+  const temporalScheduledById =
+    workflow?.searchAttributes?.indexedFields?.TemporalScheduledById;
+
+  if (typeof temporalScheduledById === 'string') {
+    scheduleId = temporalScheduledById;
+  }
 
   const hasRelationships = !!(
     parent ||


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Previously we were using the already decoded WorkflowStarted event to grab the ScheduleId for the relationships table. Now that we don't decode event history payloads until used in the PayloadDecoded, the link was no longer valid since it wasn't decoded. I switched to finding the link by using the ScheduleId in the workflow info since that is decoded by default. Added unit tests as well.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
