### PR TITLE
Allow decodePayload to return full payload with data instead of only data

### DIFF
--- a/src/lib/components/event/payload-decoder.svelte
+++ b/src/lib/components/event/payload-decoder.svelte
@@ -43,6 +43,7 @@
         $page.params.namespace,
         settings,
         $authUser.accessToken,
+        true,
       );
       const decodedAttributes = decodePayloadAttributes(
         convertedAttributes,

--- a/src/lib/components/event/payload-decoder.svelte
+++ b/src/lib/components/event/payload-decoder.svelte
@@ -43,7 +43,6 @@
         $page.params.namespace,
         settings,
         $authUser.accessToken,
-        true,
       );
       const decodedAttributes = decodePayloadAttributes(
         convertedAttributes,

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -86,7 +86,7 @@ const JsonObjectEncodedWithConstructor = {
 const JsonObjectDecoded = { Transformer: 'OptimusPrime' };
 const JsonObjectDecodedWithConstructor = { ConstructorOutput: 'OptimusPrime' };
 
-describe('decodePayload', () => {
+describe('decodePayload with default returnDataOnly', () => {
   it('Should not decode a payload with encoding binary/encrypted', () => {
     expect(decodePayload(WebDecodePayload)).toEqual(WebDecodePayload);
   });
@@ -108,6 +108,46 @@ describe('decodePayload', () => {
   it('Should decode a json payload with constructor keyword with encoding json/plain', () => {
     expect(decodePayload(JsonObjectEncodedWithConstructor)).toEqual(
       JsonObjectDecodedWithConstructor,
+    );
+  });
+});
+
+describe('decodePayload with returnDataOnly = false', () => {
+  it('Should not decode a payload with encoding binary/encrypted', () => {
+    expect(decodePayload(WebDecodePayload, false)).toEqual(WebDecodePayload);
+  });
+  it('Should not decode a payload with encoding binary/null', () => {
+    const fullDecodedPayload = { ...BinaryNullEncodedNoData, data: null };
+    expect(decodePayload(BinaryNullEncodedNoData, false)).toEqual(
+      fullDecodedPayload,
+    );
+  });
+  it('Should decode a payload with encoding json/plain', () => {
+    const fullDecodedPayload = { ...JsonPlainEncoded, data: Base64Decoded };
+    expect(decodePayload(JsonPlainEncoded, false)).toEqual(fullDecodedPayload);
+  });
+  it('Should decode a payload with encoding json/foo', () => {
+    const fullDecodedPayload = { ...JsonFooEncoded, data: Base64Decoded };
+    expect(decodePayload(JsonFooEncoded, false)).toEqual(fullDecodedPayload);
+  });
+  it('Should decode a payload with encoding json/protobuf', () => {
+    const fullDecodedPayload = { ...ProtobufEncoded, data: Base64Decoded };
+    expect(decodePayload(ProtobufEncoded, false)).toEqual(fullDecodedPayload);
+  });
+  it('Should decode a json payload with encoding json/plain', () => {
+    const fullDecodedPayload = {
+      ...JsonObjectEncoded,
+      data: JsonObjectDecoded,
+    };
+    expect(decodePayload(JsonObjectEncoded, false)).toEqual(fullDecodedPayload);
+  });
+  it('Should decode a json payload with constructor keyword with encoding json/plain', () => {
+    const fullDecodedPayload = {
+      ...JsonObjectEncoded,
+      data: JsonObjectDecodedWithConstructor,
+    };
+    expect(decodePayload(JsonObjectEncodedWithConstructor, false)).toEqual(
+      fullDecodedPayload,
     );
   });
 });

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -194,7 +194,7 @@ export const cloneAllPotentialPayloadsWithCodec = async (
   namespace: string,
   settings: Settings,
   accessToken: string,
-  returnDataOnly: boolean,
+  returnDataOnly: boolean = true,
 ): Promise<PotentiallyDecodable | EventAttribute | WorkflowEvent | null> => {
   if (!anyAttributes) return anyAttributes;
 

--- a/src/lib/utilities/export-history.ts
+++ b/src/lib/utilities/export-history.ts
@@ -32,14 +32,17 @@ const decodePayloads = async (event: HistoryEvent, settings: Settings) => {
     },
   };
 
+  // Keep download in payload structure
+  const returnDataOnly = false;
   try {
     const convertedAttributes = await cloneAllPotentialPayloadsWithCodec(
       event,
       get(page).params.namespace,
       settingsWithLocalConfig,
       get(authUser).accessToken,
+      returnDataOnly,
     );
-    return decodePayloadAttributes(convertedAttributes);
+    return decodePayloadAttributes(convertedAttributes, returnDataOnly);
   } catch (e) {
     return event;
   }


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
For users that choose to decode payloads when downloading the event history, if they were to use the Replayer with the history, it would not work. This is because we change the payload structure to return only the data instead of keeping the payload structure. This is to make the UI present the data in a much easier to read format.

I've added a boolean to not return the decodePayload value as only data, but instead replace the data key with the decoded data and keep the payload structure.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
