### PR TITLE
Check for undefined focusable elements in setFocus

### DIFF
--- a/src/lib/utilities/focus-trap.ts
+++ b/src/lib/utilities/focus-trap.ts
@@ -34,10 +34,10 @@ export const focusTrap = (node: HTMLElement, enabled: boolean) => {
     firstFocusable = focusable[0];
     lastFocusable = focusable[focusable.length - 1];
 
-    if (!fromObserver) firstFocusable.focus();
+    if (!fromObserver) firstFocusable?.focus();
 
-    firstFocusable.addEventListener('keydown', onKeydown);
-    lastFocusable.addEventListener('keydown', onKeydown);
+    firstFocusable?.addEventListener('keydown', onKeydown);
+    lastFocusable?.addEventListener('keydown', onKeydown);
   };
 
   const cleanUp = () => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Fix `Cannot read properties of undefined (reading 'addEventListener')` errors in `setFocus`.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Steps to repro. [firstFocusable](https://github.com/temporalio/ui/blob/main/src/lib/utilities/focus-trap.ts#L39) as `undefined`:
* On a modal where the cancel/confirm buttons are the only focusable elements (e.g. `Request Cancellation`) 
* Select confirm > both buttons should be disabled while the request completes (leaving no focusable elements)

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
