### PR TITLE
Dont use itemsPerPage on child workflow table, remove runId key

### DIFF
--- a/src/lib/components/workflow/child-workflows-table.svelte
+++ b/src/lib/components/workflow/child-workflows-table.svelte
@@ -40,7 +40,6 @@
 
 <Pagination
   items={formattedAll}
-  itemsPerPage={10}
   let:visibleItems
   aria-label={translate('workflows.child-workflows')}
   pageSizeSelectLabel={translate('common.per-page')}
@@ -58,7 +57,7 @@
       <th>{translate('workflows.child-id')}</th>
       <th>{translate('workflows.child-run-id')}</th>
     </TableHeaderRow>
-    {#each visibleItems as child (child.runId)}
+    {#each visibleItems as child}
       <TableRow>
         <td class="max-md:hidden">
           <WorkflowStatus status={child.status} />


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When a workflow has children and you try to change the perPage dropdown on the event history, it would be instantly overridden by the child workflow itemsPerPage = 10, which would then default it back to 100. I believe this bug was hidden from us until the latest Sveltekit update. This means the child workflow table will show 100 by default, which is significantly more than before. I think this is acceptable because it's in an Accordion so it's easy to collapse and you can see a lot more children without having to paginate.

So moral of the story... don't use multiple pagination tables on the same without having the same itemsPerPage/options. They will override each other with updated query params.

I also removed the key in the child workflow table in the rare case when multiple runId's are an empty string when they aren't yet assigned one.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
