### PR TITLE
Support duration strings for ExecutionDuration queries

### DIFF
--- a/src/lib/components/workflow/filter-search/duration-filter.svelte
+++ b/src/lib/components/workflow/filter-search/duration-filter.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+
+  import Input from '$lib/holocene/input/input.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import { isValidDurationQuery } from '$lib/utilities/to-duration';
+
+  import ConditionalMenu from './conditional-menu.svelte';
+  import { FILTER_CONTEXT, type FilterContext } from './index.svelte';
+
+  const { filter, handleSubmit } = getContext<FilterContext>(FILTER_CONTEXT);
+  let value = $filter.value;
+  let isValid = true;
+
+  const handleKeydown = (e: KeyboardEvent) => {
+    if (isValid && e.key === 'Enter' && value !== '') {
+      $filter.value = value.trim();
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const validateDuration = (event: Event & { target: HTMLInputElement }) => {
+    if (isValidDurationQuery(event.target.value.trim())) {
+      isValid = true;
+    } else {
+      isValid = false;
+    }
+  };
+</script>
+
+<ConditionalMenu inputId="duration-filter-search" noBorderLeft />
+<Input
+  label={$filter.attribute}
+  labelHidden
+  id="duration-filter-search"
+  type="search"
+  placeholder={`${translate('common.enter')} ${$filter.attribute}`}
+  icon="search"
+  class="w-full"
+  unroundLeft
+  bind:value
+  on:keydown={handleKeydown}
+  on:input={validateDuration}
+  valid={isValid}
+/>

--- a/src/lib/components/workflow/filter-search/duration-filter.svelte
+++ b/src/lib/components/workflow/filter-search/duration-filter.svelte
@@ -13,8 +13,9 @@
   let isValid = true;
 
   const handleKeydown = (e: KeyboardEvent) => {
-    if (isValid && e.key === 'Enter' && value !== '') {
-      $filter.value = value.trim();
+    const newValue = value.trim();
+    if (isValid && e.key === 'Enter' && newValue !== '') {
+      $filter.value = newValue;
       e.preventDefault();
       handleSubmit();
     }

--- a/src/lib/components/workflow/filter-search/duration-filter.svelte
+++ b/src/lib/components/workflow/filter-search/duration-filter.svelte
@@ -36,7 +36,9 @@
   labelHidden
   id="duration-filter-search"
   type="search"
-  placeholder={`${translate('common.enter')} ${$filter.attribute}`}
+  placeholder={`${translate('common.enter')} ${$filter.attribute} (${translate(
+    'workflows.duration-filter-placeholder',
+  )})`}
   icon="search"
   class="w-full"
   unroundLeft

--- a/src/lib/components/workflow/filter-search/index.svelte
+++ b/src/lib/components/workflow/filter-search/index.svelte
@@ -30,6 +30,7 @@
     getFocusedElementId,
     isBooleanFilter,
     isDateTimeFilter,
+    isDurationFilter,
     isNumberFilter,
     isStatusFilter,
     isTextFilter,
@@ -44,6 +45,7 @@
   import BooleanFilter from './boolean-filter.svelte';
   import CloseFilter from './close-filter-button.svelte';
   import DateTimeFilter from './datetime-filter.svelte';
+  import DurationFilter from './duration-filter.svelte';
   import FilterList from './filter-list.svelte';
   import NumberFilter from './number-filter.svelte';
   import SearchAttributeMenu from './search-attribute-menu.svelte';
@@ -164,6 +166,14 @@
         <div class="w-full" in:fly={{ x: -100, duration: 150 }}>
           <ListFilter />
         </div> -->
+        {:else if isDurationFilter($filter.attribute)}
+          <div
+            class="flex w-full items-center"
+            in:fly={{ x: -100, duration: 150 }}
+          >
+            <DurationFilter />
+            <CloseFilter />
+          </div>
         {:else if isNumberFilter($filter.attribute)}
           <div
             class="flex w-full items-center"

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -218,4 +218,6 @@ export const Strings = {
   'advanced-search': 'Advanced Search',
   'time-range': 'Time Range',
   'pending-activities-link': 'Show all Pending Activities',
+  'duration-filter-placeholder':
+    'e.g. "2h45m", "hh:mm:ss", or "1000" nanoseconds',
 } as const;

--- a/src/lib/utilities/query/filter-search.test.ts
+++ b/src/lib/utilities/query/filter-search.test.ts
@@ -7,6 +7,7 @@ import type { SearchAttributes } from '$lib/types/workflows';
 import {
   isBooleanFilter,
   isDateTimeFilter,
+  isDurationFilter,
   isListFilter,
   isNumberFilter,
   isStatusFilter,
@@ -78,6 +79,16 @@ describe('isNumberFilter', () => {
   it('should return false if the attribute is not an Int', () => {
     expect(isNumberFilter('WorkflowType', store)).toBe(false);
     expect(isNumberFilter('isStartTime', store)).toBe(false);
+  });
+});
+
+describe('isDurationFilter', () => {
+  it('should return true if the attribute is ExecutionDuration', () => {
+    expect(isDurationFilter('ExecutionDuration')).toBe(true);
+  });
+
+  it('should return false if the attribute is not ExecutionDuration', () => {
+    expect(isDurationFilter('CustomB')).toBe(false);
   });
 });
 

--- a/src/lib/utilities/query/filter-search.ts
+++ b/src/lib/utilities/query/filter-search.ts
@@ -25,6 +25,10 @@ export function isNumberFilter(
   return ['Int', 'Double'].includes(searchAttributeType);
 }
 
+export function isDurationFilter(attribute: string) {
+  return ['ExecutionDuration'].includes(attribute);
+}
+
 export function isDateTimeFilter(
   attribute: string,
   attributes = searchAttributes,

--- a/src/lib/utilities/to-duration.test.ts
+++ b/src/lib/utilities/to-duration.test.ts
@@ -7,6 +7,7 @@ import {
   isDuration,
   isDurationKey,
   isDurationString,
+  isValidDurationQuery,
   toDate,
   toDuration,
   tomorrow,
@@ -380,5 +381,65 @@ describe('durations', () => {
         "90 days",
       ]
     `);
+  });
+});
+
+describe('isValidDurationQuery', () => {
+  it('should return true if the value is a valid number (for nanoseconds)', () => {
+    expect(isValidDurationQuery('01')).toBe(true);
+    expect(isValidDurationQuery('-01')).toBe(true);
+    expect(isValidDurationQuery('1')).toBe(true);
+    expect(isValidDurationQuery('-1')).toBe(true);
+    expect(isValidDurationQuery('10')).toBe(true);
+    expect(isValidDurationQuery('-10')).toBe(true);
+  });
+
+  it('should return false if the value is not a valid number (for nanoseconds)', () => {
+    expect(isValidDurationQuery('test')).toBe(false);
+    expect(isValidDurationQuery('1e6t')).toBe(false);
+  });
+
+  it('should return true if the value is in a valid HH:MM:SS format', () => {
+    expect(isValidDurationQuery('00')).toBe(true);
+    expect(isValidDurationQuery('00:00:00')).toBe(true);
+    expect(isValidDurationQuery('0:00:00')).toBe(true);
+    expect(isValidDurationQuery('01:00:00')).toBe(true);
+    expect(isValidDurationQuery('90:00:00')).toBe(true);
+    expect(isValidDurationQuery('10000:00:00')).toBe(true);
+    expect(isValidDurationQuery('00:01:00')).toBe(true);
+    expect(isValidDurationQuery('00:59:00')).toBe(true);
+    expect(isValidDurationQuery('00:00:01')).toBe(true);
+    expect(isValidDurationQuery('00:00:59')).toBe(true);
+  });
+
+  it('should return false if the value is not in a valid HH:MM:SS format', () => {
+    expect(isValidDurationQuery('00:00')).toBe(false);
+    expect(isValidDurationQuery('00:60:00')).toBe(false);
+    expect(isValidDurationQuery('00:00:60')).toBe(false);
+  });
+
+  it('should return true if the value is in valid Golang duration format', () => {
+    expect(isValidDurationQuery('1000ns')).toBe(true);
+    expect(isValidDurationQuery('-1000ns')).toBe(true);
+    expect(isValidDurationQuery('2us')).toBe(true);
+    expect(isValidDurationQuery('-2us')).toBe(true);
+    expect(isValidDurationQuery('3µs')).toBe(true);
+    expect(isValidDurationQuery('-3µs')).toBe(true);
+    expect(isValidDurationQuery('4ms')).toBe(true);
+    expect(isValidDurationQuery('-4ms')).toBe(true);
+    expect(isValidDurationQuery('5s')).toBe(true);
+    expect(isValidDurationQuery('-5s')).toBe(true);
+    expect(isValidDurationQuery('60m')).toBe(true);
+    expect(isValidDurationQuery('-60m')).toBe(true);
+    expect(isValidDurationQuery('700h')).toBe(true);
+    expect(isValidDurationQuery('-700h')).toBe(true);
+    expect(isValidDurationQuery('2h30m')).toBe(true);
+  });
+
+  it('should return false if the value is not in a valid Golang duration format', () => {
+    expect(isValidDurationQuery('1 hour')).toBe(false);
+    expect(isValidDurationQuery('60min')).toBe(false);
+    expect(isValidDurationQuery('10 s')).toBe(false);
+    expect(isValidDurationQuery(' 100 ms')).toBe(false);
   });
 });

--- a/src/lib/utilities/to-duration.ts
+++ b/src/lib/utilities/to-duration.ts
@@ -128,3 +128,15 @@ export const fromSeconds = (seconds: string): Duration | undefined => {
 
   return intervalToDuration({ start: 0, end: milliseconds });
 };
+
+export const isValidDurationQuery = (value: string): boolean => {
+  const isValidNumber = !isNaN(Number(value));
+  const isValidGolangDuration =
+    /^-?\d+\S*$/.test(value) &&
+    ['ns', 'us', 'µs', 'ms', 's', 'm', 'h'].some((char) =>
+      value.endsWith(char),
+    );
+  const isValidTime = /^\d+:[0-5][0-9]:[0-5][0-9]$/.test(value);
+
+  return isValidNumber || isValidGolangDuration || isValidTime;
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
> [ExecutionDuration](https://docs.temporal.io/visibility#advanced-visibility) is stored as a number for nanoseconds in the database, but we also support duration strings such as ‘5m’ or ‘-2h’.  For users, it is much easier to use the duration string than calculate the duration as nanoseconds.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|--|--|
|![Screenshot 2023-11-07 at 12 42 03 PM](https://github.com/temporalio/ui/assets/15069288/96d8b2d4-336d-44c9-b628-396187c3781c)|<img width="790" alt="Screenshot 2023-11-07 at 12 42 58 PM" src="https://github.com/temporalio/ui/assets/15069288/325cc525-96ef-4fd3-bb4e-5227ef993528">|
| |<img width="795" alt="Screenshot 2023-11-07 at 12 43 39 PM" src="https://github.com/temporalio/ui/assets/15069288/1eed7b9e-dee1-4f5c-95a0-1f1987d2518a">|
| |<img width="790" alt="Screenshot 2023-11-07 at 12 33 36 PM" src="https://github.com/temporalio/ui/assets/15069288/0e873fc5-92f4-4351-b804-fc096840c3fe">|
| |<img width="790" alt="Screenshot 2023-11-07 at 12 33 57 PM" src="https://github.com/temporalio/ui/assets/15069288/9a88cd36-d6e7-4a5f-8708-b8d492cfd5a5">|
| |<img width="798" alt="Screenshot 2023-11-07 at 12 34 29 PM" src="https://github.com/temporalio/ui/assets/15069288/edbcf90b-6687-4fc2-bc13-8d9d3b866443">|


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [ ] Verify the filter for `ExecutionDuration` supports the following
    - a number (for nanoseconds)
    - a time in `HH:MM:SS` format
    - [Golang duration format](https://pkg.go.dev/time#ParseDuration)
- [ ] Verify the filter for `ExecutionDuration` input errors (and can not be submitted) if the input is not valid
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1543`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
