### PR TITLE
Apply selected timezone to datetime filters

### DIFF
--- a/src/lib/components/workflow/filter-search/datetime-filter.svelte
+++ b/src/lib/components/workflow/filter-search/datetime-filter.svelte
@@ -8,6 +8,7 @@
     formatISO,
     startOfDay,
   } from 'date-fns';
+  import { zonedTimeToUtc } from 'date-fns-tz';
   import { getContext } from 'svelte';
 
   import Button from '$lib/holocene/button.svelte';
@@ -23,15 +24,13 @@
   import TimePicker from '$lib/holocene/time-picker.svelte';
   import { translate } from '$lib/i18n/translate';
   import { supportsAdvancedVisibility } from '$lib/stores/advanced-visibility';
-  import { getLocalTime } from '$lib/utilities/format-date';
+  import { getTimezone, timeFormat } from '$lib/stores/time-format';
   import { toDate } from '$lib/utilities/to-duration';
 
   import ConditionalMenu from './conditional-menu.svelte';
   import { FILTER_CONTEXT, type FilterContext } from './index.svelte';
 
   const { filter, handleSubmit } = getContext<FilterContext>(FILTER_CONTEXT);
-
-  const localTime = getLocalTime() || translate('common.local');
 
   $: isTimeRange = $filter.conditional === 'BETWEEN';
 
@@ -96,11 +95,17 @@
         second: endSecond,
       });
 
+      const timezone = getTimezone($timeFormat);
+      const formattedStartTime = formatISO(
+        zonedTimeToUtc(startDateWithTime, timezone),
+      );
+      const formattedEndTime = formatISO(
+        zonedTimeToUtc(endDateWithTime, timezone),
+      );
+
       const value = useBetweenDateTimeQuery
-        ? `BETWEEN "${formatISO(startDateWithTime)}" AND "${formatISO(
-            endDateWithTime,
-          )}"`
-        : formatISO(startDateWithTime);
+        ? `BETWEEN "${formattedStartTime}" AND "${formattedEndTime}"`
+        : formattedStartTime;
 
       $filter.value = value;
 
@@ -261,7 +266,7 @@
       <MenuItem centered disabled class="!pt-0">
         <Icon name="clock" aria-hidden="true" />
         {translate('common.based-on-time-preface')}
-        {localTime}
+        {$timeFormat}
       </MenuItem>
     </Menu>
   </MenuContainer>

--- a/src/lib/components/workflow/filter-search/datetime-filter.svelte
+++ b/src/lib/components/workflow/filter-search/datetime-filter.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
   import { writable, type Writable } from 'svelte/store';
 
-  import {
-    addHours,
-    addMinutes,
-    addSeconds,
-    formatISO,
-    startOfDay,
-  } from 'date-fns';
+  import { addHours, addMinutes, addSeconds, startOfDay } from 'date-fns';
   import { zonedTimeToUtc } from 'date-fns-tz';
   import { getContext } from 'svelte';
 
@@ -96,12 +90,15 @@
       });
 
       const timezone = getTimezone($timeFormat);
-      const formattedStartTime = formatISO(
-        zonedTimeToUtc(startDateWithTime, timezone),
-      );
-      const formattedEndTime = formatISO(
-        zonedTimeToUtc(endDateWithTime, timezone),
-      );
+      const formattedStartTime = zonedTimeToUtc(
+        startDateWithTime,
+        timezone,
+      ).toISOString();
+
+      const formattedEndTime = zonedTimeToUtc(
+        endDateWithTime,
+        timezone,
+      ).toISOString();
 
       const value = useBetweenDateTimeQuery
         ? `BETWEEN "${formattedStartTime}" AND "${formattedEndTime}"`

--- a/src/lib/components/workflow/filter-search/filter-list.svelte
+++ b/src/lib/components/workflow/filter-search/filter-list.svelte
@@ -88,7 +88,7 @@
   {#each visibleFilters as workflowFilter, i (`${workflowFilter.attribute}-${i}`)}
     {@const { attribute, value, conditional, customDate } = workflowFilter}
     {#if attribute}
-      <div in:fade>
+      <div in:fade data-testid="{workflowFilter.attribute}-{i}">
         <Chip
           removeButtonLabel={translate('workflows.remove-filter-label', {
             attribute,

--- a/src/lib/stores/time-format.test.ts
+++ b/src/lib/stores/time-format.test.ts
@@ -2,7 +2,7 @@ import { get } from 'svelte/store';
 
 import { describe, expect, test } from 'vitest';
 
-import { relativeTime, timeFormat } from './time-format';
+import { getTimezone, relativeTime, timeFormat } from './time-format';
 
 describe('time format store', () => {
   test('should return UTC as the default timeFormat', () => {
@@ -10,5 +10,16 @@ describe('time format store', () => {
   });
   test('should return false as the default for relativeTime', () => {
     expect(get(relativeTime)).toBe(false);
+  });
+});
+
+describe('getTimezone', () => {
+  test('should return the first zone for the specified time format in the Timezones object', () => {
+    expect(getTimezone('Pacific Daylight Time')).toBe('America/Los_Angeles');
+    expect(getTimezone('Greenwich Mean Time')).toBe('Africa/Abidjan');
+  });
+
+  test('should return the time format if the time format does not exist in the Timezones object', () => {
+    expect(getTimezone('UTC')).toBe('UTC');
   });
 });

--- a/src/lib/stores/time-format.ts
+++ b/src/lib/stores/time-format.ts
@@ -1155,3 +1155,7 @@ export const TimezoneOptions: TimeFormatOptions = Object.entries(Timezones)
     if (b.label > a.label) return -1;
     return 0;
   });
+
+export const getTimezone = (timeFormat: TimeFormat): string => {
+  return Timezones[timeFormat]?.zones[0] ?? timeFormat;
+};

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -7,9 +7,9 @@ import {
 import * as dateTz from 'date-fns-tz'; // `build` script fails on importing some of named CommonJS modules
 
 import {
+  getTimezone,
   type TimeFormat,
   TimezoneOptions,
-  Timezones,
 } from '$lib/stores/time-format';
 
 import { isTimestamp, timestampToDate, type ValidTime } from './format-time';
@@ -55,7 +55,7 @@ export function formatDate(
           : formatDistanceToNow(parsed) + ` ${relativeLabel}`;
       return dateTz.format(parsed, format);
     }
-    const timezone = Timezones[timeFormat]?.zones[0] ?? timeFormat;
+    const timezone = getTimezone(timeFormat);
     return dateTz.formatInTimeZone(parsed, timezone, format);
   } catch (e) {
     console.error('Error formatting date:', e);

--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -154,7 +154,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       combineDropdownFilters(filters),
       supportsAdvancedVisibility,
     );
-    expect(query).toBe('StartTime > "2019-12-30T00:00:00Z"');
+    expect(query).toBe('StartTime > "2019-12-30T00:00:00.000Z"');
   });
 
   it('should convert two filters, one as datetime filter', () => {
@@ -180,7 +180,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       supportsAdvancedVisibility,
     );
     expect(query).toBe(
-      'WorkflowType="cronWorkflow" AND StartTime > "2019-12-30T00:00:00Z"',
+      'WorkflowType="cronWorkflow" AND StartTime > "2019-12-30T00:00:00.000Z"',
     );
   });
 });

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -2,7 +2,6 @@ import { get } from 'svelte/store';
 
 import type { WorkflowFilter } from '$lib/models/workflow-filters';
 import { supportsAdvancedVisibility } from '$lib/stores/advanced-visibility';
-import { labsMode } from '$lib/stores/labs-mode';
 import type { SearchAttributes } from '$lib/types/workflows';
 
 import { isDuration, isDurationString, toDate, tomorrow } from '../to-duration';
@@ -54,7 +53,7 @@ const toFilterQueryStatement = (
 
   if (isDuration(value) || isDurationString(value)) {
     if (archived || get(supportsAdvancedVisibility)) {
-      return `${queryKey} ${labsMode ? conditional : '>'} "${toDate(value)}"`;
+      return `${queryKey} ${conditional} "${toDate(value)}"`;
     }
     return `${queryKey} BETWEEN "${toDate(value)}" AND "${tomorrow()}"`;
   }

--- a/src/lib/utilities/query/list-workflow-query.test.ts
+++ b/src/lib/utilities/query/list-workflow-query.test.ts
@@ -40,7 +40,7 @@ describe('toListWorkflowQuery', () => {
   });
 
   it('should convert an timeRange with a Duration as a value', () => {
-    const twentyFourHoursEarlier = '2019-12-31T00:00:00Z';
+    const twentyFourHoursEarlier = '2019-12-31T00:00:00.000Z';
 
     const supportsAdvancedVisibility = isVersionNewer('1.20', '1.19');
     const query = toListWorkflowQuery(
@@ -51,7 +51,7 @@ describe('toListWorkflowQuery', () => {
   });
 
   it('should convert an timeRange with a Duration as a value when archived', () => {
-    const twentyFourHoursEarlier = '2019-12-31T00:00:00Z';
+    const twentyFourHoursEarlier = '2019-12-31T00:00:00.000Z';
 
     const query = toListWorkflowQuery({ timeRange: { days: 1 } }, true);
 

--- a/src/lib/utilities/to-duration.test.ts
+++ b/src/lib/utilities/to-duration.test.ts
@@ -102,14 +102,14 @@ describe('toDate', () => {
   });
 
   it('should produce a date based on a duration', () => {
-    const ninetyDaysEarlier = '2019-10-03T00:00:00Z';
+    const ninetyDaysEarlier = '2019-10-03T00:00:00.000Z';
 
     const result = toDate({ days: 90 });
     expect(result).toBe(ninetyDaysEarlier);
   });
 
   it('should produce a date based on a duration string', () => {
-    const ninetyDaysEarlier = '2019-10-03T00:00:00Z';
+    const ninetyDaysEarlier = '2019-10-03T00:00:00.000Z';
 
     const result = toDate('90 days');
     expect(result).toBe(ninetyDaysEarlier);
@@ -127,11 +127,11 @@ describe('tomorrow', () => {
   });
 
   it('should create a date 24 hours in the future', () => {
-    expect(tomorrow()).toBe('2020-01-02T00:00:00Z');
+    expect(tomorrow()).toBe('2020-01-02T00:00:00.000Z');
   });
 
   it('should create a date 24 hours in the future from an argument', () => {
-    expect(tomorrow(new Date('2022-07-01'))).toBe('2022-07-02T00:00:00Z');
+    expect(tomorrow(new Date('2022-07-01'))).toBe('2022-07-02T00:00:00.000Z');
   });
 });
 

--- a/src/lib/utilities/to-duration.ts
+++ b/src/lib/utilities/to-duration.ts
@@ -1,4 +1,4 @@
-import { add, formatISO, intervalToDuration, parseISO, sub } from 'date-fns';
+import { add, intervalToDuration, parseISO, sub } from 'date-fns';
 
 import { isObject, isString } from './is';
 
@@ -68,7 +68,7 @@ export const isDurationString = (value: unknown): value is string => {
 };
 
 export const tomorrow = (date = new Date()): string => {
-  return formatISO(add(date, { hours: 24 }));
+  return add(date, { hours: 24 }).toISOString();
 };
 
 export const toDuration = (value: string): Duration => {
@@ -107,7 +107,7 @@ export const toDate = (timeRange: Duration | string): string => {
   const duration =
     typeof timeRange === 'string' ? toDuration(timeRange) : timeRange;
 
-  return formatISO(sub(new Date(), duration));
+  return sub(new Date(), duration).toISOString();
 };
 
 export const fromDate = (

--- a/tests/integration/filter-search.spec.ts
+++ b/tests/integration/filter-search.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  mockClusterApi,
+  mockWorkflowApis,
+  mockWorkflowsApis,
+  waitForWorkflowsApis,
+} from '~/test-utilities/mock-apis';
+
+test.beforeEach(async ({ page }) => {
+  await mockWorkflowsApis(page);
+  await mockWorkflowApis(page);
+
+  await mockClusterApi(page, {
+    visibilityStore: 'elasticsearch',
+    persistenceStore: 'postgres,elasticsearch',
+  });
+
+  page.goto('/namespaces/default/workflows');
+
+  await waitForWorkflowsApis(page);
+});
+
+test('it should update the datetime filter based on the selected timezone', async ({
+  page,
+}) => {
+  await page.getByTestId('timezones-menu-button').click();
+  await page.getByTestId('top-nav').getByPlaceholder('Search').fill('PDT');
+  await page.getByText('Pacific Daylight Time (PDT) UTC-07:00').click();
+
+  await page.getByRole('button', { name: 'Filter' }).click();
+  await page.getByText('CloseTime').click();
+  await page.getByRole('menuitem', { name: 'After' }).click();
+  await page.getByLabel('Absolute', { exact: true }).check();
+  await page.getByLabel('hrs', { exact: true }).fill('5');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await page.getByTestId('manual-search-toggle').click();
+
+  let filter = await page.getByTestId('CloseTime-0').innerText();
+  expect(filter).toContain('05:00 AM');
+
+  let query = await page.locator('#manual-search').inputValue();
+  expect(query).toContain('13:00:00.000Z');
+
+  await page.getByTestId('timezones-menu-button').click();
+  await page.getByTestId('top-nav').getByPlaceholder('Search').fill('MDT');
+  await page.getByText('Mountain Daylight Time (MDT) UTC-06:00').click();
+
+  filter = await page.getByTestId('CloseTime-0').innerText();
+  expect(filter).toContain('06:00 AM');
+
+  query = await page.locator('#manual-search').inputValue();
+  expect(query).toContain('13:00:00.000Z');
+});

--- a/tests/integration/workflows-list-time-frames.spec.ts
+++ b/tests/integration/workflows-list-time-frames.spec.ts
@@ -15,42 +15,42 @@ const timeFrames = [
   {
     period: '15 minutes',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T11%3A45%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T17%3A45%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '1 hour',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T11%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T17%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '3 hours',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T09%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-19T15%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '24 hours',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-18T12%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-18T18%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '3 days',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-16T12%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-16T18%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '7 days',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-12T12%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-09-12T18%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '30 days',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-08-20T12%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-08-20T18%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
   {
     period: '90 days',
     query:
-      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-06-21T12%3A00%3A00-06%3A00%22+AND+%222012-09-20T12%3A00%3A00-06%3A00%22',
+      'http://localhost:3333/namespaces/default/workflows?search=basic&query=StartTime+BETWEEN+%222012-06-21T18%3A00%3A00.000Z%22+AND+%222012-09-20T18%3A00%3A00.000Z%22',
   },
 ];
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When selecting a timezone, a user should be able to select a datetime filter based on that timezone.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

![Screenshot 2023-11-08 at 9 39 58 AM](https://github.com/temporalio/ui/assets/15069288/b3aef199-2b43-4c9b-b1ee-bf5984839aa4)
### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [x] Verify when selecting an `Absolute` date with a non-local timezone selected
   - the filter "chip" should show the correct time (based on the timezone)
   - the search input and query param show the time in UTC
   - the filter should work as expected
- [x] Verify when selecting a `Relative` date with a non-local timezone selected
   - the filter "chip" should show the correct time (based on the timezone)
   - the search input and query param show the time in UTC
   - the filter should work as expected
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-1377`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
