### PR TITLE
Fix query param for requests containing a Run ID

### DIFF
--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -56,7 +56,7 @@ export const fetchRawEvents = async ({
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(route, {
         token,
         request: fetch,
-        params: { runId: runId },
+        params: { 'execution.runId': runId },
       });
     },
     { onStart, onUpdate, onComplete },
@@ -81,7 +81,7 @@ export const fetchAllEvents = async ({
       return requestFromAPI<GetWorkflowExecutionHistoryResponse>(route, {
         token,
         request: fetch,
-        params: { runId: runId },
+        params: { 'execution.runId': runId },
       });
     },
     { onStart, onUpdate, onComplete },
@@ -107,7 +107,7 @@ export const fetchPartialRawEvents = async ({
       route,
       {
         request: fetch,
-        params: { maximumPageSize: '20', runId: runId },
+        params: { maximumPageSize: '20', 'execution.runId': runId },
       },
     );
 
@@ -167,7 +167,7 @@ export async function getPaginatedEvents({
         request: fetch,
         params: {
           nextPageToken: token,
-          runId: runId,
+          'execution.runId': runId,
         },
       });
 

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -213,7 +213,9 @@ export async function fetchWorkflow(
   });
   return requestFromAPI(route, {
     request,
-    params: { runId: parameters.runId },
+    params: {
+      'execution.runId': parameters.runId,
+    },
   }).then(toWorkflowExecution);
 }
 
@@ -234,7 +236,7 @@ export async function terminateWorkflow({
     },
     notifyOnError: false,
     params: {
-      runId: workflow.runId,
+      'execution.runId': workflow.runId,
     },
   });
 }
@@ -255,7 +257,7 @@ export async function cancelWorkflow(
       method: 'POST',
     },
     params: {
-      runId,
+      'execution.runId': runId,
     },
   });
 }
@@ -313,7 +315,7 @@ export async function signalWorkflow({
           payloads,
         },
         params: {
-          runId,
+          'execution.runId': runId,
         },
       }),
     },
@@ -354,7 +356,7 @@ export async function resetWorkflow({
       body: stringifyWithBigInt(body),
     },
     params: {
-      runId,
+      'execution.runId': runId,
     },
   });
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
In #1700 we accidentally introduced a query param that is not compatible with the new protos. `runId` should be `execution.runId`
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
