### PR TITLE
Make View Search Input toggle sticky

### DIFF
--- a/src/lib/components/workflow/filter-search/index.svelte
+++ b/src/lib/components/workflow/filter-search/index.svelte
@@ -25,6 +25,7 @@
   import { translate } from '$lib/i18n/translate';
   import type { WorkflowFilter } from '$lib/models/workflow-filters';
   import { workflowFilters } from '$lib/stores/filters';
+  import { searchInputViewOpen } from '$lib/stores/filters';
   import { refresh } from '$lib/stores/workflows';
   import {
     getFocusedElementId,
@@ -57,8 +58,6 @@
 
   $: searchParamQuery = $page.url.searchParams.get('query');
   $: showClearAllButton = $workflowFilters.length && !$filter.attribute;
-
-  let viewAdvancedSearchInput = false;
 
   setContext<FilterContext>(FILTER_CONTEXT, {
     filter,
@@ -139,7 +138,7 @@
 
 <div class="flex grow flex-col">
   <div class="flex grow flex-col gap-4 sm:flex-row sm:items-center">
-    {#if viewAdvancedSearchInput}
+    {#if $searchInputViewOpen}
       <WorkflowAdvancedSearch />
     {:else}
       <div
@@ -218,7 +217,7 @@
       label={translate('workflows.view-search-input')}
       labelPosition="left"
       id="view-search-input"
-      bind:checked={viewAdvancedSearchInput}
+      bind:checked={$searchInputViewOpen}
       on:change={() => {
         resetFilter();
       }}

--- a/src/lib/stores/filters.ts
+++ b/src/lib/stores/filters.ts
@@ -33,6 +33,12 @@ export const persistedTimeFilter = persistStore<WorkflowFilter>(
   true,
 );
 
+export const searchInputViewOpen = persistStore<boolean>(
+  'searchInputView',
+  false,
+  true,
+);
+
 export const workflowFilters = writable<WorkflowFilter[]>(
   [],
   updateWorkflowFilters,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
`View Search Input` toggle state is persisted so that after changing pages and navigating back or switching Namespaces the view is still set to the search input.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1050" alt="Screenshot 2023-11-08 at 5 35 34 PM" src="https://github.com/temporalio/ui/assets/15069288/75d8df30-f0ab-4774-bcc9-38158a37c3f0">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [ ] Verify the `View Search Input` toggle is persisted when
   - changing namespaces
   - navigating to different pages and then back to `Workflows`
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
