### PR TITLE
Fix absolute time filtering for Local timezone

### DIFF
--- a/src/lib/stores/time-format.test.ts
+++ b/src/lib/stores/time-format.test.ts
@@ -19,6 +19,10 @@ describe('getTimezone', () => {
     expect(getTimezone('Greenwich Mean Time')).toBe('Africa/Abidjan');
   });
 
+  test('should return the local timezone if the time format is local', () => {
+    expect(getTimezone('local')).toBe('UTC');
+  });
+
   test('should return the time format if the time format does not exist in the Timezones object', () => {
     expect(getTimezone('UTC')).toBe('UTC');
   });

--- a/src/lib/stores/time-format.ts
+++ b/src/lib/stores/time-format.ts
@@ -1,4 +1,5 @@
 import { persistStore } from '$lib/stores/persist-store';
+import { getLocalTimezone } from '$lib/utilities/format-date';
 
 export const timeFormat = persistStore('timeFormat', 'UTC' as TimeFormat);
 export const relativeTime = persistStore('relativeTime', false);
@@ -1157,5 +1158,6 @@ export const TimezoneOptions: TimeFormatOptions = Object.entries(Timezones)
   });
 
 export const getTimezone = (timeFormat: TimeFormat): string => {
+  if (timeFormat === 'local') return getLocalTimezone();
   return Timezones[timeFormat]?.zones[0] ?? timeFormat;
 };

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -81,8 +81,12 @@ export function formatUTCOffset(
   if (offset < 0) return `${utc}-${formattedOffset}`;
 }
 
+export function getLocalTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}
+
 export function getLocalTime(): string {
-  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const localTimezone = getLocalTimezone();
   const localOption = TimezoneOptions.find(
     ({ zones }) => zones?.includes(localTimezone),
   );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Account for local timezone option in `getTimezone`.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Set timezone to `Local`
- Select a datetime filter (e.g. `StartTime`) > `Select Time` > `Absolute` > `Apply`
   - [ ] Verify the filter is applied and works as expected 
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
