### PR TITLE
Set broadcastToAll to false for eventViewType

### DIFF
--- a/src/lib/stores/event-view.ts
+++ b/src/lib/stores/event-view.ts
@@ -13,7 +13,7 @@ export const autoRefreshWorkflow = persistStore<'on' | 'off'>(
   'off',
 );
 
-export const eventViewType = persistStore<EventView>('eventView', 'feed', true);
+export const eventViewType = persistStore<EventView>('eventView', 'feed');
 
 export const expandAllEvents = persistStore('expandAllEvents', 'false');
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Sets `broadcastToAll` to `false` for `eventViewType` so that users can view different event views in different browser tabs.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->
- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Open multiple workflow detail pages in separate tabs
- Change the `Event History` view (`History`, `Compact`, `JSON`) in the various tabs
   - [ ] Verify the view is not updated based on the view selected in other tabs 
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
