### PR TITLE
Add maxLength to Textarea

### DIFF
--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -1,4 +1,22 @@
 <script lang="ts">
+  import type { HTMLTextareaAttributes } from 'svelte/elements';
+
+  type $$Props = HTMLTextareaAttributes & {
+    disabled?: boolean;
+    error?: string;
+    isValid?: boolean;
+    placeholder?: string;
+    rows?: number;
+    spellcheck?: boolean;
+    value: string;
+    label: string;
+    labelHidden?: boolean;
+    id: string;
+    required?: boolean;
+    description?: string;
+    maxLength?: number;
+  };
+
   export let disabled = false;
   export let error = '';
   export let isValid = true;
@@ -11,6 +29,7 @@
   export let id: string;
   export let required = false;
   export let description = '';
+  export let maxLength = 0;
 
   let className = '';
   export { className as class };
@@ -21,22 +40,38 @@
   {#if description}
     <p class="text-sm">{description}</p>
   {/if}
-  <textarea
-    class="min-h-fit w-full rounded border border-gray-900 py-2 px-3 font-mono text-sm"
-    class:error={!isValid}
-    {id}
-    bind:value
-    {disabled}
-    {placeholder}
-    {rows}
-    {spellcheck}
-    on:input
-    on:change
-    on:focus
-    on:blur
-    on:keydown|stopPropagation
-  />
-  <div class="error-msg" aria-live={isValid ? 'off' : 'assertive'}>
+  <div class="relative">
+    <textarea
+      class="min-h-fit w-full rounded border border-gray-900 py-2 px-3 font-mono text-sm"
+      class:error={!isValid}
+      {id}
+      bind:value
+      {disabled}
+      {placeholder}
+      {rows}
+      {spellcheck}
+      on:input
+      on:change
+      on:focus
+      on:blur
+      on:keydown|stopPropagation
+      maxlength={maxLength > 0 ? maxLength : undefined}
+    />
+    {#if maxLength && !disabled}
+      <span class="count">
+        <span
+          class="text-blue-700"
+          class:warn={maxLength - value?.length <= 5}
+          class:error={maxLength === value?.length}>{value?.length ?? 0}</span
+        >&nbsp;/&nbsp;{maxLength}
+      </span>
+    {/if}
+  </div>
+  <div
+    class="error-msg"
+    class:min-width={maxLength}
+    aria-live={isValid ? 'off' : 'assertive'}
+  >
     {#if !isValid}
       {#if error}
         <p>{error}</p>
@@ -60,6 +95,26 @@
   }
 
   .error-msg {
-    @apply border-danger font-primary text-sm font-normal text-danger;
+    @apply break-words border-danger font-primary text-sm font-normal text-danger;
+  }
+
+  .error-msg.min-width {
+    @apply w-[calc(100%-6rem)];
+  }
+
+  .count {
+    @apply invisible absolute -bottom-5 right-0 font-secondary text-sm font-medium text-primary;
+  }
+
+  .count > .warn {
+    @apply text-orange-600;
+  }
+
+  .count > .error {
+    @apply text-red-700;
+  }
+
+  textarea:focus + .count {
+    @apply visible;
   }
 </style>

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -95,7 +95,7 @@
   }
 
   .error-msg {
-    @apply break-words border-danger font-primary text-sm font-normal text-danger;
+    @apply min-h-[1.25rem] break-words border-danger font-primary text-sm font-normal text-danger;
   }
 
   .error-msg.min-width {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add `maxLength` prop for Holocene `Textarea` component. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="732" alt="Screenshot 2023-11-17 at 4 42 52 PM" src="https://github.com/temporalio/ui/assets/15069288/1489e9df-dca8-494c-83ef-b5895ec6bade">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- [x] Verify a `Textarea` with a `maxLength`
   - Shows up as expected (count should be orange within 5 characters and red when it reaches max)
   - Doesn't allow additional characters
   - Still shows an error message as expected (with no overlap of the count)

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
