### PR TITLE
Use activityId instead of event.id for finding pending activities

### DIFF
--- a/src/lib/components/event/event-history-timeline.svelte
+++ b/src/lib/components/event/event-history-timeline.svelte
@@ -22,7 +22,10 @@
     EventTypeCategory,
   } from '$lib/types/events';
   import { capitalize } from '$lib/utilities/format-camel-case';
-  import { isLocalActivityMarkerEvent } from '$lib/utilities/is-event-type';
+  import {
+    isActivityTaskScheduledEvent,
+    isLocalActivityMarkerEvent,
+  } from '$lib/utilities/is-event-type';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   import { getTimelineOptions } from './event-history-timeline-helpers';
@@ -104,7 +107,11 @@
       const lastEvent = group?.lastEvent;
       const groupPendingActivity =
         $workflowRun?.workflow?.pendingActivities.find((activity) =>
-          group.eventList.find((e) => e.id === activity.activityId),
+          group.eventList.find(
+            (e) =>
+              isActivityTaskScheduledEvent(e) &&
+              e.attributes.activityId === activity.activityId,
+          ),
         );
       if (groupPendingActivity && isRunning) {
         items.add({


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Use the attributes.activityId for finding the matching pending activity in the Timeline instead of the eventId. 

The eventId does not always match the activityId of a pending activity, but the attributes.activityId does.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
