### PR TITLE
bump version in package.json to v2.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "engines": {
     "pnpm": ">=8.6.0",
     "node": ">=18.15.0"

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -133,9 +133,7 @@
 />
 
 <div class="pagination relative mb-8 flex flex-col gap-4">
-  <div
-    class="flex flex-col items-end justify-end gap-4 lg:flex-row lg:items-start"
-  >
+  <div class="flex flex-col items-end justify-end gap-4 lg:justify-start">
     <div class="w-full">
       <slot name="action-top-left" />
     </div>


### PR DESCRIPTION
* Release version v2.22.2
* Fix spacing on `Pagination` at smaller breakpoint

| Before | After |
|--|--|
|<img width="962" alt="Screenshot 2024-01-19 at 12 44 46 PM" src="https://github.com/temporalio/ui/assets/15069288/627180f5-3c89-4ef3-b101-c9bfaa4fa05a">|<img width="957" alt="Screenshot 2024-01-19 at 12 50 19 PM" src="https://github.com/temporalio/ui/assets/15069288/17d265bc-0f80-4232-bdac-3b066c1ad74a">|