### PR TITLE
Remove width for inputs to grow for suffix and max length

### DIFF
--- a/src/lib/components/schedule/schedules-interval-view.svelte
+++ b/src/lib/components/schedule/schedules-interval-view.svelte
@@ -41,58 +41,50 @@
   <p>
     {translate('schedules.interval-view-description')}
   </p>
-  <div class="flex flex-row items-center gap-2">
-    <div class="w-24">
-      <Input
-        id="days"
-        label={translate('common.days')}
-        labelHidden
-        bind:value={days}
-        placeholder="00"
-        suffix={translate('common.days')}
-        maxLength={3}
-        error={error(days)}
-      />
-    </div>
-    <div>:</div>
-    <div class="w-24">
-      <Input
-        id="hour-interval"
-        label={translate('common.hours-abbreviated')}
-        labelHidden
-        bind:value={hour}
-        placeholder="00"
-        suffix={translate('common.hours-abbreviated')}
-        maxLength={2}
-        error={error(hour)}
-      />
-    </div>
-    <div>:</div>
-    <div class="w-24">
-      <Input
-        id="minute-interval"
-        label={translate('common.minutes-abbreviated')}
-        labelHidden
-        bind:value={minute}
-        placeholder="00"
-        suffix={translate('common.minutes-abbreviated')}
-        maxLength={2}
-        error={error(minute)}
-      />
-    </div>
-    <div>:</div>
-    <div class="w-24">
-      <Input
-        id="second"
-        label={translate('common.seconds-abbreviated')}
-        labelHidden
-        bind:value={second}
-        placeholder="00"
-        suffix={translate('common.seconds-abbreviated')}
-        maxLength={2}
-        error={error(second)}
-      />
-    </div>
+  <div class="flex flex-col items-center gap-2 lg:flex-row">
+    <Input
+      id="days"
+      label={translate('common.days')}
+      labelHidden
+      bind:value={days}
+      placeholder="00"
+      suffix={translate('common.days')}
+      maxLength={3}
+      error={error(days)}
+    />
+    <div class="hidden lg:block">:</div>
+    <Input
+      id="hour-interval"
+      label={translate('common.hours-abbreviated')}
+      labelHidden
+      bind:value={hour}
+      placeholder="00"
+      suffix={translate('common.hours-abbreviated')}
+      maxLength={2}
+      error={error(hour)}
+    />
+    <div class="hidden lg:block">:</div>
+    <Input
+      id="minute-interval"
+      label={translate('common.minutes-abbreviated')}
+      labelHidden
+      bind:value={minute}
+      placeholder="00"
+      suffix={translate('common.minutes-abbreviated')}
+      maxLength={2}
+      error={error(minute)}
+    />
+    <div class="hidden lg:block">:</div>
+    <Input
+      id="second"
+      label={translate('common.seconds-abbreviated')}
+      labelHidden
+      bind:value={second}
+      placeholder="00"
+      suffix={translate('common.seconds-abbreviated')}
+      maxLength={2}
+      error={error(second)}
+    />
   </div>
   <h3 class="mt-4 text-lg font-medium">
     {translate('schedules.offset-heading')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
With the !suffix checked removed from Input in https://github.com/temporalio/ui/pull/1797, the ScheduleForm is too small for both suffix and max length. Remove the width from the inputs and make it flex-col for better responsiveness as well.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
