### PR TITLE
Add hidden/optional dark mode

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,7 @@ type Vitest = import('vitest');
 interface ImportMetaEnv {
   readonly VITE_TEMPORAL_UI_BUILD_TARGET: string;
   readonly VITE_API: string;
+  readonly VITE_DARK_MODE: boolean;
 }
 
 interface ImportMeta {

--- a/src/lib/utilities/dark-mode/dark-mode.svelte
+++ b/src/lib/utilities/dark-mode/dark-mode.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { darkMode } from './dark-mode';
+</script>
+
+<svelte:body use:darkMode />

--- a/src/lib/utilities/dark-mode/dark-mode.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.ts
@@ -8,7 +8,6 @@ const useDarkMode = persistStore(
 
 export const darkMode = (node: HTMLElement) => {
   useDarkMode.subscribe((value) => {
-    console.log({ darkMode: value });
     if (value) {
       node.classList.add('dark');
     } else {

--- a/src/lib/utilities/dark-mode/dark-mode.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.ts
@@ -1,0 +1,18 @@
+import { persistStore } from '$lib/stores/persist-store';
+
+const useDarkMode = persistStore(
+  'dark mode',
+  !!import.meta.env.VITE_DARK_MODE,
+  true,
+);
+
+export const darkMode = (node: HTMLElement) => {
+  useDarkMode.subscribe((value) => {
+    console.log({ darkMode: value });
+    if (value) {
+      node.classList.add('dark');
+    } else {
+      node.classList.remove('dark');
+    }
+  });
+};

--- a/src/lib/utilities/dark-mode/index.ts
+++ b/src/lib/utilities/dark-mode/index.ts
@@ -1,0 +1,3 @@
+import DarkMode from './dark-mode.svelte';
+
+export default DarkMode;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -15,6 +15,7 @@
   import { lastUsedNamespace, namespaces } from '$lib/stores/namespaces';
   import { toaster } from '$lib/stores/toaster';
   import type { NamespaceListItem } from '$lib/types/global';
+  import DarkMode from '$lib/utilities/dark-mode';
   import {
     routeForArchivalWorkfows,
     routeForBatchOperations,
@@ -103,7 +104,9 @@
   });
 </script>
 
+<DarkMode />
 <SkipNavigation />
+
 <div class="flex w-screen flex-row">
   <Toaster
     closeButtonLabel={translate('common.close')}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -4,6 +4,7 @@ const temporalColors = require('./colors.cjs');
 /** @type {import('tailwindcss').Config} */
 const config = {
   content: ['./src/**/*.{html,js,svelte,ts}'],
+  darkMode: 'class',
   theme: {
     colors: temporalColors,
     textColor: ({ theme }) => theme('colors'),


### PR DESCRIPTION
Adds an environmental variable, `VITE_DARK_MODE` and `"dark mode"` local storage variable for opting in the work-in-progress dark mode.
