### PR TITLE
Add dark mode support for Storybook

### DIFF
--- a/.storybook/dark-mode.css
+++ b/.storybook/dark-mode.css
@@ -1,0 +1,3 @@
+.sb-show-main.dark {
+  background: #111827;
+}

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,43 +1,41 @@
 import type { Preview } from '@storybook/svelte';
+
 import '../src/app.css';
+import './dark-mode.css';
+
+import DarkMode, { useDarkMode } from '../src/lib/utilities/dark-mode';
 
 const preview: Preview = {
+  decorators: [
+    (_, { globals }) => {
+      useDarkMode.set(globals.theme === 'dark');
+      return { Component: DarkMode };
+    },
+  ],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     backgrounds: {
-      default: 'primary',
-      values: [
-        {
-          name: 'space-black',
-          value: '#141414',
-        },
-        {
-          name: 'off-white',
-          value: '#f8f8f7',
-        },
-        {
-          name: 'black',
-          value: '#000',
-        },
-        {
-          name: 'white',
-          value: '#fff',
-        },
-        {
-          name: 'light',
-          value: '#f4f4f5',
-        },
-        {
-          name: 'dark',
-          value: '#18181b',
-        },
-      ],
+      disable: true,
     },
     controls: {
       matchers: {
         color: /(background|color)$/i,
         date: /Date$/,
       },
+    },
+  },
+};
+
+export const globalTypes = {
+  theme: {
+    name: 'Toggle Theme',
+    description: 'Global theme for components',
+    defaultValue: 'light',
+    toolbar: {
+      icon: 'circlehollow',
+      items: ['light', 'dark'],
+      showName: true,
+      dynamicTitle: true,
     },
   },
 };

--- a/src/lib/utilities/dark-mode/dark-mode.svelte
+++ b/src/lib/utilities/dark-mode/dark-mode.svelte
@@ -3,3 +3,4 @@
 </script>
 
 <svelte:body use:darkMode />
+<slot />

--- a/src/lib/utilities/dark-mode/dark-mode.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.ts
@@ -1,6 +1,6 @@
 import { persistStore } from '$lib/stores/persist-store';
 
-const useDarkMode = persistStore(
+export const useDarkMode = persistStore(
   'dark mode',
   !!import.meta.env.VITE_DARK_MODE,
   true,

--- a/src/lib/utilities/dark-mode/index.ts
+++ b/src/lib/utilities/dark-mode/index.ts
@@ -1,3 +1,4 @@
 import DarkMode from './dark-mode.svelte';
 
 export default DarkMode;
+export { useDarkMode } from './dark-mode';


### PR DESCRIPTION
Adds a toggle for dark mode in Storybook.

<img width="752" alt="image" src="https://github.com/temporalio/ui/assets/251000/2089f802-f9d1-4bcb-aaf1-856b04a82d25">
