### PR TITLE
Add trailing-slash utility and use on codec server endpoint

### DIFF
--- a/src/lib/components/data-encoder-settings.svelte
+++ b/src/lib/components/data-encoder-settings.svelte
@@ -26,6 +26,7 @@
 <script lang="ts">
   import RadioGroup from '$lib/holocene/radio-input/radio-group.svelte';
   import RadioInput from '$lib/holocene/radio-input/radio-input.svelte';
+  import { trimTrailingSlash } from '$lib/utilities/trim-trailing-slash';
 
   let endpoint = $codecEndpoint ?? '';
   let passToken = $passAccessToken ?? false;
@@ -61,7 +62,7 @@
 
   const onConfirm = () => {
     error = '';
-    $codecEndpoint = endpoint;
+    $codecEndpoint = trimTrailingSlash(endpoint);
     $passAccessToken = passToken;
     $includeCredentials = includeCreds;
     $viewDataEncoderSettings = false;

--- a/src/lib/utilities/trim-trailing-slash.test.ts
+++ b/src/lib/utilities/trim-trailing-slash.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { trimTrailingSlash } from './trim-trailing-slash';
+
+describe('trimTrailingSlash', () => {
+  it('should remove trailing slash from a string', () => {
+    expect(trimTrailingSlash('http://cats.meow/')).toEqual('http://cats.meow');
+  });
+  it('should return original string if no trailing slash', () => {
+    expect(trimTrailingSlash('http://cats.meow')).toEqual('http://cats.meow');
+  });
+});

--- a/src/lib/utilities/trim-trailing-slash.ts
+++ b/src/lib/utilities/trim-trailing-slash.ts
@@ -1,0 +1,3 @@
+export const trimTrailingSlash = (x: string): string => {
+  return x.endsWith('/') ? x.slice(0, -1) : x;
+};

--- a/src/lib/utilities/trim-trailing-slash.ts
+++ b/src/lib/utilities/trim-trailing-slash.ts
@@ -1,3 +1,3 @@
 export const trimTrailingSlash = (x: string): string => {
-  return x.endsWith('/') ? x.slice(0, -1) : x;
+  return x.replace(/\/+$/, '');
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If a user enters `https://something-of-a-url.com/` for their codec, the decode endpoint would incorrectly be `https://something-of-a-url.com//decode`. This trims it for that case.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
