### PR TITLE
Small tweaks to Holocene components for self serve signup

### DIFF
--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -10,7 +10,7 @@
 
   interface $$Props extends HTMLInputAttributes {
     checked?: boolean;
-    label: string;
+    label?: string;
     labelHidden?: boolean;
     theme?: 'dark' | 'light';
     indeterminate?: boolean;
@@ -22,7 +22,7 @@
 
   export let id = '';
   export let checked = false;
-  export let label: string;
+  export let label = '';
   export let labelHidden = false;
   export let theme: 'dark' | 'light' = 'light';
   export let indeterminate = false;
@@ -95,9 +95,11 @@
       {/if}
     </span>
 
-    <span class="label" class:sr-only={labelHidden}>
-      {label}
-    </span>
+    <slot name="label">
+      <span class="label" class:sr-only={labelHidden}>
+        {label}
+      </span>
+    </slot>
   </label>
 </div>
 

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -16,6 +16,7 @@
   const dispatch = createEventDispatcher<{
     change: T | string;
     filter: string;
+    close: T | string;
   }>();
 
   type ExtendedInputEvent = Event & {
@@ -131,6 +132,12 @@
   const closeList = () => {
     if (!$open) return;
     $open = false;
+    dispatch('close', selectedOption);
+    resetValueAndOptions();
+  };
+
+  const handleMenuClose = () => {
+    dispatch('close', selectedOption);
     resetValueAndOptions();
   };
 
@@ -246,7 +253,7 @@
   };
 </script>
 
-<MenuContainer {open} on:close={resetValueAndOptions}>
+<MenuContainer {open} on:close={handleMenuClose}>
   <label
     class="combobox-label {theme}"
     class:sr-only={labelHidden}

--- a/src/lib/holocene/menu/menu-container.svelte
+++ b/src/lib/holocene/menu/menu-container.svelte
@@ -30,8 +30,10 @@
   const dispatch = createEventDispatcher<{ close: undefined }>();
 
   const closeMenu = () => {
-    dispatch('close');
-    $open = false;
+    if ($open) {
+      dispatch('close');
+      $open = false;
+    }
   };
 
   setContext<MenuContext>(MENU_CONTEXT, {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
- Support label slot in checkbox. This is so that links (or any other markup) can be rendered in the checkbox label
<img width="574" alt="Screenshot 2024-02-14 at 10 32 15 AM" src="https://github.com/temporalio/ui/assets/11775628/efe8406d-a542-4aea-89af-401b8e73a320">

- Add close event to combobox. This is so that we have an event to catch when the menu is closed _without_ the user having selected a value (i.e. they open the list of options by focusing the combobox, but then click away). This is useful to add inline errors to the combobox when a value is required.
- Only dispatch close even from `<MenuContainer />` if menu is open

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
