### PR TITLE
Flip the order to always use globalThis.AccessToken first if it exists

### DIFF
--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -126,7 +126,13 @@ const withAuth = async (
   options: RequestInit,
   isBrowser = BROWSER,
 ): Promise<RequestInit> => {
-  if (getAuthUser().accessToken) {
+  if (globalThis?.AccessToken) {
+    options.headers = await withBearerToken(
+      options?.headers,
+      globalThis.AccessToken,
+      isBrowser,
+    );
+  } else if (getAuthUser().accessToken) {
     options.headers = await withBearerToken(
       options?.headers,
       async () => getAuthUser().accessToken,
@@ -135,12 +141,6 @@ const withAuth = async (
     options.headers = withIdToken(
       options?.headers,
       getAuthUser().idToken,
-      isBrowser,
-    );
-  } else if (globalThis?.AccessToken) {
-    options.headers = await withBearerToken(
-      options?.headers,
-      globalThis.AccessToken,
       isBrowser,
     );
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Always use globalThis.AccessToken if it exists so we can get new access tokens after they expire

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
