### PR TITLE
Fix gradient on skeleton loader for light mode

### DIFF
--- a/src/lib/holocene/skeleton/index.svelte
+++ b/src/lib/holocene/skeleton/index.svelte
@@ -7,7 +7,7 @@
 
 <div
   class={merge(
-    'background-animate w-full rounded-full bg-gradient-to-r from-slate-600 via-slate-700 to-slate-800',
+    'background-animate w-full rounded-full bg-gradient-to-r from-slate-100 via-slate-200 to-slate-300 dark:bg-gradient-to-r dark:from-slate-600 dark:via-slate-700 dark:to-slate-800',
     className,
   )}
 />


### PR DESCRIPTION
Add gradient back to skeleton loader on light mode
<img width="825" alt="Screenshot 2024-04-01 at 10 59 26 AM" src="https://github.com/temporalio/ui/assets/68283157/1f9a6385-f63b-460d-a487-b99fd827208e">
<img width="837" alt="Screenshot 2024-04-01 at 10 59 32 AM" src="https://github.com/temporalio/ui/assets/68283157/abd4227b-3f3c-4f8e-8791-c783098901ca">
