### PR TITLE
Only show scroll to bottom when there is event history, better lines on Event Details

### DIFF
--- a/src/lib/components/lines-and-dots/svg/box.svelte
+++ b/src/lib/components/lines-and-dots/svg/box.svelte
@@ -30,8 +30,6 @@
   }
 
   .active {
-    stroke: #ebebeb;
-    stroke-width: 3;
     fill: #1e293b;
   }
 

--- a/src/lib/components/lines-and-dots/svg/event-detail-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/event-detail-row.svelte
@@ -60,8 +60,9 @@
     fill="#465977"
   />
 {/if}
+<Box point={[x, eventY]} {width} height={fontSizeRatio} fill="#1E293B" />
 <Text
-  point={[x + 0.5 * fontSizeRatio, eventY + 0.75 * fontSizeRatio]}
+  point={[x + 0.5 * fontSizeRatio, eventY + 0.66 * fontSizeRatio]}
   fontSize="13px"
   fontWeight="300"
   >{event.id}<tspan dx={5}>{spaceBetweenCapitalLetters(event?.name)}</tspan
@@ -117,7 +118,17 @@
   />
 {/each}
 <Line
+  startPoint={[x - 1.5, eventY]}
+  endPoint={[x + width, eventY]}
+  strokeWidth={3}
+/>
+<Line
   startPoint={[x, eventY + getEventDetailsBoxHeight(event)]}
   endPoint={[x + width, eventY + getEventDetailsBoxHeight(event)]}
+  strokeWidth={3}
+/>
+<Line
+  startPoint={[x, eventY]}
+  endPoint={[x, eventY + getEventDetailsBoxHeight(event)]}
   strokeWidth={3}
 />

--- a/src/lib/components/lines-and-dots/svg/event-details-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/event-details-row.svelte
@@ -57,7 +57,7 @@
       />
     {/each}
   {:else}
-    <EventDetailRow {event} {canvasWidth} {x} {y} />
+    <EventDetailRow active {event} {canvasWidth} {x} {y} />
   {/if}
 </g>
 

--- a/src/lib/holocene/scroll-to-container.svelte
+++ b/src/lib/holocene/scroll-to-container.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import ScrollToBottom from '$lib/holocene/scroll-to-bottom.svelte';
   import ScrollToTop from '$lib/holocene/scroll-to-top.svelte';
+  import { fullEventHistory } from '$lib/stores/events';
 
   export let scrollToTopHidden = true;
   export let scrollToBottomHidden = false;
@@ -10,7 +11,9 @@
 
 <div id="scroll-container" class={$$props.class}>
   <ScrollToTop hidden={scrollToTopHidden} {onScrollToTopClick} />
-  <ScrollToBottom hidden={scrollToBottomHidden} {onScrollToBottomClick} />
+  {#if $fullEventHistory.length}
+    <ScrollToBottom hidden={scrollToBottomHidden} {onScrollToBottomClick} />
+  {/if}
 </div>
 
 <style lang="postcss">


### PR DESCRIPTION
…active box on event details

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Scroll to bottom should only show (for now) on event history pages.

Better lines on event details row

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" alt="Screen Shot 2024-04-08 at 8 56 39 AM" src="https://github.com/temporalio/ui/assets/7967403/228c2491-93cd-4f59-87f2-b2a0463a28fc">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->


## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
