### PR TITLE
Abort polling if different runId, better styles of event details row

### DIFF
--- a/src/lib/components/lines-and-dots/svg/event-detail-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/event-detail-row.svelte
@@ -52,18 +52,19 @@
   $: textStartingY = eventY + 1.5 * fontSizeRatio;
 </script>
 
-{#if active}
-  <Box
-    point={[x, eventY]}
-    {width}
-    height={getEventDetailsBoxHeight(event)}
-    fill="#465977"
-  />
-{/if}
-<Box point={[x, eventY]} {width} height={fontSizeRatio} fill="#1E293B" />
+<Box
+  point={[x, eventY]}
+  {width}
+  height={1.25 * fontSizeRatio}
+  fill={active ? '#465977' : ''}
+/>
+<Line
+  startPoint={[x, eventY + 1.25 * fontSizeRatio]}
+  endPoint={[x + width, eventY + 1.25 * fontSizeRatio]}
+  strokeWidth={2}
+/>
 <Text
   point={[x + 0.5 * fontSizeRatio, eventY + 0.66 * fontSizeRatio]}
-  fontSize="13px"
   fontWeight="300"
   >{event.id}<tspan dx={5}>{spaceBetweenCapitalLetters(event?.name)}</tspan
   ></Text
@@ -73,7 +74,7 @@
     point={[canvasWidth - 1.5 * radius, eventY + 0.6 * fontSizeRatio]}
     textAnchor="end"
   >
-    <tspan fill="#aebed9" font-size="12px">
+    <tspan fill="#aebed9" font-size="13px">
       {formatDate(event?.eventTime, $timeFormat, {
         relative: $relativeTime,
       })}</tspan
@@ -120,15 +121,15 @@
 <Line
   startPoint={[x - 1.5, eventY]}
   endPoint={[x + width, eventY]}
-  strokeWidth={3}
+  strokeWidth={2}
 />
 <Line
   startPoint={[x, eventY + getEventDetailsBoxHeight(event)]}
   endPoint={[x + width, eventY + getEventDetailsBoxHeight(event)]}
-  strokeWidth={3}
+  strokeWidth={2}
 />
 <Line
   startPoint={[x, eventY]}
   endPoint={[x, eventY + getEventDetailsBoxHeight(event)]}
-  strokeWidth={3}
+  strokeWidth={2}
 />

--- a/src/lib/components/lines-and-dots/svg/event-details-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/event-details-row.svelte
@@ -17,6 +17,7 @@
   export let canvasWidth: number;
   export let x = 0;
   export let index: number;
+  export let primary = true;
 
   const { height } = HistoryConfig;
 
@@ -31,7 +32,12 @@
   $: width = canvasWidth / 2;
 </script>
 
-<g role="button" tabindex="0" class="relative cursor-pointer">
+<g
+  role="button"
+  tabindex="0"
+  class="relative cursor-pointer"
+  opacity={primary ? '1' : '.6'}
+>
   <Box point={[x, y]} {width} height={boxHeight} classification="active" />
   {#if group}
     {#if group.pendingActivity}

--- a/src/lib/components/lines-and-dots/svg/history-graph.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph.svelte
@@ -89,6 +89,7 @@
       group={allGroups.find((group) => group.eventIds.has(id))}
       index={visibleHistory.indexOf(history.find((event) => event.id === id))}
       {canvasWidth}
+      primary={activeEvents[activeEvents.length - 1] === id}
     />
   {/each}
   <svg

--- a/src/lib/components/lines-and-dots/svg/pending-detail-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/pending-detail-row.svelte
@@ -40,7 +40,7 @@
     point={[x, eventY]}
     {width}
     height={getPendingEventDetailHeight(event)}
-    fill={retrying ? '#FF9B70' : '#a78bfa'}
+    fill={retrying ? '#FFE4D4' : '#E0EAFF'}
   />
 {/if}
 <Text

--- a/src/lib/holocene/main-content-container.svelte
+++ b/src/lib/holocene/main-content-container.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import {
+    clearActives,
     endIndex,
     indexPageSize,
     startIndex,
@@ -31,6 +32,7 @@
   function onScrollToBottomClick() {
     const historyLength = $filteredEventHistory?.length;
     if (historyLength) {
+      clearActives();
       $endIndex = historyLength;
       $startIndex = $endIndex - indexPageSize;
     }

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -137,12 +137,9 @@
     runId,
   );
 
-  onMount(() => {
-    const sort = $page.url.searchParams.get('sort');
-    if (sort) $eventFilterSort = sort as EventSortOrder;
-  });
+  $: runId, clearWorkflowData();
 
-  onDestroy(() => {
+  const clearWorkflowData = () => {
     $timelineEvents = null;
     $workflowRun = initialWorkflowRun;
     $fullEventHistory = [];
@@ -151,6 +148,15 @@
     if (eventHistoryController) {
       eventHistoryController.abort();
     }
+  };
+
+  onMount(() => {
+    const sort = $page.url.searchParams.get('sort');
+    if (sort) $eventFilterSort = sort as EventSortOrder;
+  });
+
+  onDestroy(() => {
+    clearWorkflowData();
   });
 </script>
 


### PR DESCRIPTION
…on, event group styling updates, add opacity on non-primary (last clicked) event groups.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Make sure to abort poll if navigating to another runId so history is cleared.
Better styles for event row details and add opacity to non-primary events.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
