### PR TITLE
Throttle refresh of workflow to 5 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "json-beautify": "^1.1.1",
     "json-bigint": "^1.0.0",
     "just-debounce": "^1.1.0",
+    "just-throttle": "^4.2.0",
     "lodash.groupby": "^4.6.0",
     "remark-stringify": "^10.0.3",
     "sanitize-html": "^2.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   just-debounce:
     specifier: ^1.1.0
     version: 1.1.0
+  just-throttle:
+    specifier: ^4.2.0
+    version: 4.2.0
   lodash.groupby:
     specifier: ^4.6.0
     version: 4.6.0
@@ -10701,6 +10704,10 @@ packages:
 
   /just-debounce@1.1.0:
     resolution: {integrity: sha512-qpcRocdkUmf+UTNBYx5w6dexX5J31AKK1OmPwH630a83DdVVUIngk55RSAiIGpQyoH0dlr872VHfPjnQnK1qDQ==}
+    dev: false
+
+  /just-throttle@4.2.0:
+    resolution: {integrity: sha512-/iAZv1953JcExpvsywaPKjSzfTiCLqeguUTE6+VmK15mOcwxBx7/FHrVvS4WEErMR03TRazH8kcBSHqMagYIYg==}
     dev: false
 
   /keycharm@0.4.0:


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Set a throttle to 5 seconds when new events come in to refresh the workflow execution to get new pending activities and status. This is the sweet spot to prevent too many refreshes that can cause relationships/stack trace to rerender quickly and also to prevent overfetching.

Add better logic to abort polling when sort or labs mode change.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
