### PR TITLE
Add utility to get associated pending activity using activityId and not event id

### DIFF
--- a/src/lib/components/lines-and-dots/constants.ts
+++ b/src/lib/components/lines-and-dots/constants.ts
@@ -16,6 +16,7 @@ import {
   formatGroupAttributes,
   formatPendingAttributes,
 } from '$lib/utilities/format-event-attributes';
+import { isAssociatedPendingActivity } from '$lib/utilities/pending-activities';
 
 export const DetailsChildTimelineHeight = 200;
 
@@ -382,7 +383,7 @@ export const getEventDetailsBoxHeight = (
   );
 
   let pendingActivityHeight = 0;
-  if (pendingActivity && event.id === pendingActivity.id) {
+  if (isAssociatedPendingActivity(event, pendingActivity)) {
     pendingActivityHeight = getPendingEventDetailHeight(pendingActivity);
   }
   const codeBlockHeight = codeBlockAttributes.length * staticCodeBlockHeight;

--- a/src/lib/components/lines-and-dots/constants.ts
+++ b/src/lib/components/lines-and-dots/constants.ts
@@ -152,12 +152,8 @@ const isConsecutiveGroup = (group: EventGroup): boolean => {
 const getOpenGroups = (
   event: WorkflowEvent | PendingActivity,
   groups: EventGroups,
-  pendingActivity?: PendingActivity,
 ): number => {
   const group = groups.find((g) => g.eventIds.has(event.id));
-  if (!group.pendingActivity && pendingActivity) {
-    group.pendingActivity = pendingActivity;
-  }
   if (group.level !== undefined) return group.level;
 
   const pendingGroups = groups
@@ -232,11 +228,10 @@ export const getNextDistanceAndOffset = (
     return { nextDistance, offset };
   }
 
-  const pendingActivity = group.pendingActivity;
   const currentIndex = group.eventList.indexOf(event);
   const nextEvent = group.eventList[currentIndex + 1];
   if (event.category !== 'workflow') {
-    offset = getOpenGroups(event, groups, pendingActivity);
+    offset = getOpenGroups(event, groups);
   }
 
   if (!nextEvent && !group.isPending) {

--- a/src/lib/components/lines-and-dots/svg/event-details-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/event-details-row.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { EventGroup } from '$lib/models/event-groups/event-groups';
   import type { WorkflowEvent } from '$lib/types/events';
+  import { isAssociatedPendingActivity } from '$lib/utilities/pending-activities';
 
   import {
     getEventDetailsBoxHeight,
@@ -46,7 +47,7 @@
         {canvasWidth}
         {x}
         {y}
-        active={event.id === group.pendingActivity.id}
+        active={isAssociatedPendingActivity(event, group.pendingActivity)}
       />
     {/if}
     {#each group.eventList as e, index}

--- a/src/lib/components/lines-and-dots/svg/history-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row.svelte
@@ -68,9 +68,6 @@
     {#if group && group.displayName && showDetails}<tspan dx={3}
         >{group.displayName}</tspan
       >{/if}
-    <!-- <tspan dx={3}
-      ><HistoryRowPayloadDetail {...getSingleAttributeForEvent(event)} /></tspan
-    > -->
   </Text>
   {#if showTimestamp}
     <Text point={[canvasWidth - 1.5 * radius, y]} textAnchor="end">

--- a/src/lib/models/event-groups/index.ts
+++ b/src/lib/models/event-groups/index.ts
@@ -5,6 +5,7 @@ import type {
   WorkflowEvent,
 } from '$lib/types/events';
 import { has } from '$lib/utilities/has';
+import { getPendingActivity } from '$lib/utilities/pending-activities';
 
 import {
   createEventGroup,
@@ -46,10 +47,7 @@ export const groupEvents = (
   const createGroups = (event: CommonHistoryEvent) => {
     const id = getGroupId(event);
     const group = createEventGroup(event, events);
-
-    const pendingActivity = pendingActivities.find(
-      (p) => p.activityId === event.id && event.category === 'activity',
-    );
+    const pendingActivity = getPendingActivity(event, pendingActivities);
 
     if (group) {
       groups[group.id] = group;

--- a/src/lib/utilities/pending-activities.test.ts
+++ b/src/lib/utilities/pending-activities.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { toEvent } from '$lib/models/event-history';
+
+import {
+  getPendingActivity,
+  isAssociatedPendingActivity,
+} from './pending-activities';
+
+import pendingActivityWorkflow from '$fixtures/workflow.pending-activities.json';
+
+const getScheduledEvent = (activityId: string) =>
+  toEvent({
+    eventId: '12',
+    eventTime: '2024-04-10T13:15:26.790496Z',
+    eventType: 'EVENT_TYPE_ACTIVITY_TASK_SCHEDULED',
+    taskId: '1048648',
+    activityTaskScheduledEventAttributes: {
+      activityId: activityId,
+      activityType: {
+        name: 'fun-activity',
+      },
+      taskQueue: {
+        name: 'demo',
+        kind: 'TASK_QUEUE_KIND_NORMAL',
+      },
+      header: {},
+      input: {
+        payloads: [],
+      },
+      scheduleToCloseTimeout: '0s',
+      scheduleToStartTimeout: '0s',
+      startToCloseTimeout: '1s',
+      heartbeatTimeout: '0s',
+      workflowTaskCompletedEventId: '10',
+      retryPolicy: {
+        initialInterval: '1s',
+        backoffCoefficient: 2,
+        maximumInterval: '5s',
+      },
+      useCompatibleVersion: true,
+    },
+  });
+
+describe('getPendingActivity', () => {
+  it('should return pending activity if the event has activityId of same pending activityId', () => {
+    const pendingActivities = pendingActivityWorkflow.pendingActivities;
+    expect(getPendingActivity(getScheduledEvent('1'), pendingActivities)).toBe(
+      pendingActivities[0],
+    );
+  });
+
+  it('should return undefined if the event has different activityId of pending activityId', () => {
+    const pendingActivities = pendingActivityWorkflow.pendingActivities;
+    expect(getPendingActivity(getScheduledEvent('23'), pendingActivities)).toBe(
+      undefined,
+    );
+  });
+});
+
+describe('isAssociatedPendingActivity', () => {
+  it('should return true if the event has matching activityId of pending activity', () => {
+    const pendingActivities = pendingActivityWorkflow.pendingActivities;
+    expect(
+      isAssociatedPendingActivity(getScheduledEvent('1'), pendingActivities[0]),
+    ).toBe(true);
+  });
+
+  it('should return undefined if the event has different activityId of pending activityId', () => {
+    const pendingActivities = pendingActivityWorkflow.pendingActivities;
+    expect(
+      isAssociatedPendingActivity(getScheduledEvent('1'), pendingActivities[1]),
+    ).toBe(false);
+  });
+
+  it('should return undefined if the event has different activityId of pending activityId', () => {
+    const pendingActivities = pendingActivityWorkflow.pendingActivities;
+    expect(
+      isAssociatedPendingActivity(
+        getScheduledEvent('16'),
+        pendingActivities[0],
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/utilities/pending-activities.ts
+++ b/src/lib/utilities/pending-activities.ts
@@ -1,0 +1,30 @@
+import type { PendingActivity } from '$lib/types/events';
+import type { WorkflowEvent } from '$lib/types/events';
+
+import { isActivityTaskScheduledEvent } from './is-event-type';
+
+export const getPendingActivity = (
+  event: WorkflowEvent,
+  pendingActivities: PendingActivity[],
+): PendingActivity | undefined => {
+  let pendingActivity: PendingActivity | undefined;
+
+  if (isActivityTaskScheduledEvent(event)) {
+    pendingActivity = pendingActivities.find(
+      (p) => p.activityId === event.attributes.activityId,
+    );
+
+    return pendingActivity;
+  }
+};
+
+export const isAssociatedPendingActivity = (
+  event: WorkflowEvent,
+  pendingActivity: PendingActivity | undefined,
+): boolean => {
+  if (isActivityTaskScheduledEvent(event) && pendingActivity) {
+    return pendingActivity.activityId === event.attributes.activityId;
+  }
+
+  return false;
+};

--- a/src/lib/utilities/pending-activities.ts
+++ b/src/lib/utilities/pending-activities.ts
@@ -13,9 +13,9 @@ export const getPendingActivity = (
     pendingActivity = pendingActivities.find(
       (p) => p.activityId === event.attributes.activityId,
     );
-
-    return pendingActivity;
   }
+
+  return pendingActivity;
 };
 
 export const isAssociatedPendingActivity = (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
To correctly associate pending activity, use activityScheduledEvent and attributes.eventId instead of event.id

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
