### PR TITLE
Make history graph visual width dynamic based with max of canvasWidth / 4

### DIFF
--- a/src/lib/components/lines-and-dots/constants.ts
+++ b/src/lib/components/lines-and-dots/constants.ts
@@ -216,6 +216,7 @@ export const getVisualWidth = (
   maxWidth: number,
 ) => {
   let maxOffset = 0;
+  if (!history.length) return maxWidth;
   history.forEach((event) => {
     const group = groups.find((g) => g.eventIds.has(event.id));
     if (group) {

--- a/src/lib/components/lines-and-dots/constants.ts
+++ b/src/lib/components/lines-and-dots/constants.ts
@@ -210,6 +210,24 @@ export const activeEventsHeightAboveGroup = (
     .reduce((acc, height) => acc + height, 0);
 };
 
+export const getVisualWidth = (
+  history: WorkflowEvents,
+  groups: EventGroups,
+  maxWidth: number,
+) => {
+  let maxOffset = 0;
+  history.forEach((event) => {
+    const group = groups.find((g) => g.eventIds.has(event.id));
+    if (group) {
+      const offset = getOpenGroups(event, groups);
+      if (offset > maxOffset) {
+        maxOffset = offset;
+      }
+    }
+  });
+  return Math.min(maxWidth, (maxOffset + 2) * 2 * HistoryConfig.radius);
+};
+
 export const getNextDistanceAndOffset = (
   history: WorkflowEvents,
   event: WorkflowEvent,

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -49,8 +49,8 @@
 
   const strokeWidth = radius / 2;
 
-  $: width = (canvasWidth / 4) * zoomLevel;
-  $: horizontalOffset = (offset / 1.5) * 3 * radius;
+  $: width = canvasWidth * zoomLevel;
+  $: horizontalOffset = offset * 2 * radius;
   $: nextIsPending = group?.lastEvent.id === event?.id && group.isPending;
   $: eventInViewBox = horizontalOffset <= width;
   $: isActive =

--- a/src/lib/components/lines-and-dots/svg/history-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row.svelte
@@ -16,6 +16,7 @@
   export let activeEvents: string[] = [];
 
   export let canvasWidth: number;
+  export let visualWidth: number;
   export let index: number;
 
   const { height, radius } = HistoryConfig;
@@ -30,7 +31,6 @@
       ? 'retry'
       : 'pending'
     : event.classification;
-  $: visualWidth = canvasWidth / 4;
   $: detailsWidth = canvasWidth - visualWidth;
 </script>
 

--- a/src/lib/components/lines-and-dots/svg/history-graph.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph.svelte
@@ -9,7 +9,11 @@
   } from '$lib/stores/active-events';
   import type { WorkflowEvents } from '$lib/types/events';
 
-  import { getEventDetailsBoxHeight, HistoryConfig } from '../constants';
+  import {
+    getEventDetailsBoxHeight,
+    getVisualWidth,
+    HistoryConfig,
+  } from '../constants';
 
   import EventDetailsRow from './event-details-row.svelte';
   import HistoryGraphRowVisual from './history-graph-row-visual.svelte';
@@ -60,7 +64,7 @@
     visibleHistory.length * height + activeDetailsHeight + height,
     400,
   );
-  $: visualWidth = canvasWidth / 4;
+  $: visualWidth = getVisualWidth(history, allGroups, canvasWidth / 4);
 </script>
 
 <svg
@@ -79,6 +83,7 @@
       group={allGroups.find((g) => g.eventIds.has(event.id))}
       {activeEvents}
       {canvasWidth}
+      {visualWidth}
       {index}
     />
   {/each}
@@ -103,7 +108,7 @@
         group={allGroups.find((g) => g.eventIds.has(event.id))}
         groups={allGroups}
         {history}
-        {canvasWidth}
+        canvasWidth={visualWidth}
         {activeEvents}
         {zoomLevel}
         {index}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
To create more space for row information, make the visual width on the History view dynamic based on groups.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" alt="Screen Shot 2024-04-11 at 1 00 03 PM" src="https://github.com/temporalio/ui/assets/7967403/23d0a9ee-33c4-4923-85eb-89efa426b29b">
<img width="1728" alt="Screen Shot 2024-04-11 at 1 12 02 PM" src="https://github.com/temporalio/ui/assets/7967403/862e5887-7466-477f-b3e7-aba620b22cef">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
