### PR TITLE
use batch reset even for batch of 1

### DIFF
--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -34,7 +34,6 @@
   import BatchResetConfirmationModal from '$lib/components/workflow/client-actions/batch-reset-confirmation-modal.svelte';
   import BatchTerminateConfirmationModal from '$lib/components/workflow/client-actions/batch-terminate-confirmation-modal.svelte';
   import CancelConfirmationModal from '$lib/components/workflow/client-actions/cancel-confirmation-modal.svelte';
-  import ResetConfirmationModal from '$lib/components/workflow/client-actions/reset-confirmation-modal.svelte';
   import TerminateConfirmationModal from '$lib/components/workflow/client-actions/terminate-confirmation-modal.svelte';
   import WorkflowFilterSearch from '$lib/components/workflow/filter-search/index.svelte';
   import WorkflowCountRefresh from '$lib/components/workflow/workflow-count-refresh.svelte';
@@ -85,7 +84,6 @@
   let batchResetConfirmationModalOpen = false;
   let terminateConfirmationModalOpen = false;
   let cancelConfirmationModalOpen = false;
-  let resetConfirmationModalOpen = false;
   const allSelected = writable<boolean>(false);
   const pageSelected = writable<boolean>(false);
   const selectedWorkflows = writable<WorkflowExecution[]>([]);
@@ -115,9 +113,7 @@
   };
 
   const openBatchResetConfirmationModal = () => {
-    $selectedWorkflows.length > 1
-      ? (batchResetConfirmationModalOpen = true)
-      : (resetConfirmationModalOpen = true);
+    batchResetConfirmationModalOpen = true;
   };
 
   const handleSelectAll = (workflows: WorkflowExecution[]) => {
@@ -186,13 +182,6 @@
   {namespace}
   workflow={$selectedWorkflows[0]}
   bind:open={cancelConfirmationModalOpen}
-/>
-
-<ResetConfirmationModal
-  {refresh}
-  {namespace}
-  workflow={$selectedWorkflows[0]}
-  bind:open={resetConfirmationModalOpen}
 />
 
 <header class="flex flex-col gap-2">


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
In #1909 I refactored the batch Terminate and Cancel code to call the API for Terminating and Canceling a single workflow if only 1 workflows was selected for a batch operation. I followed this same approach when I implemented batch Reset in #1957, however, the API for Resetting a single workflow requires an Event ID, and we don't have the event history on the workflows summary page. Therefore, I opted to use the batch API for batch Resets, even when the batch size is 1.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
