### PR TITLE
Fetch child workflows with ParentWorkflowId if Temporal server v1.23+

### DIFF
--- a/src/lib/components/workflow/live-child-workflows-table.svelte
+++ b/src/lib/components/workflow/live-child-workflows-table.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+
+  import Link from '$lib/holocene/link.svelte';
+  import Pagination from '$lib/holocene/pagination.svelte';
+  import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';
+  import TableRow from '$lib/holocene/table/table-row.svelte';
+  import Table from '$lib/holocene/table/table.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import type { WorkflowExecution } from '$lib/types/workflows';
+  import { routeForEventHistory } from '$lib/utilities/route-for';
+
+  import WorkflowStatus from '../workflow-status.svelte';
+
+  export let children: WorkflowExecution[] = [];
+
+  $: ({ namespace } = $page.params);
+</script>
+
+<Pagination
+  items={children}
+  let:visibleItems
+  aria-label={translate('workflows.child-workflows')}
+  pageSizeSelectLabel={translate('common.per-page')}
+  previousButtonLabel={translate('common.previous')}
+  nextButtonLabel={translate('common.next')}
+>
+  <div slot="pagination-top" />
+  <Table class="w-full">
+    <caption class="sr-only" slot="caption"
+      >{translate('workflows.child-workflows')}</caption
+    >
+    <TableHeaderRow slot="headers">
+      <th class="max-md:hidden">{translate('common.status')}</th>
+      <th class="max-lg:hidden">{translate('common.type')}</th>
+      <th>{translate('workflows.child-id')}</th>
+      <th>{translate('workflows.child-run-id')}</th>
+    </TableHeaderRow>
+    {#each visibleItems as child}
+      <TableRow>
+        <td class="max-md:hidden">
+          <WorkflowStatus status={child.status} />
+        </td>
+        <td class="max-lg:hidden">
+          {child.name}
+        </td>
+        <td class="hover:text-blue-700 hover:underline">
+          <Link
+            href={routeForEventHistory({
+              namespace,
+              workflow: child.id,
+              run: child.runId,
+            })}
+          >
+            {child.id}
+          </Link>
+        </td>
+        <td class="hover:text-blue-700 hover:underline">
+          <Link
+            href={routeForEventHistory({
+              namespace,
+              workflow: child.id,
+              run: child.runId,
+            })}
+          >
+            {child.runId}
+          </Link>
+        </td>
+      </TableRow>
+    {/each}
+  </Table>
+</Pagination>

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -1,19 +1,45 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+
   import { page } from '$app/stores';
 
   import ChildWorkflowsTable from '$lib/components/workflow/child-workflows-table.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { fetchAllWorkflows } from '$lib/services/workflow-service';
+  import { isCloud } from '$lib/stores/advanced-visibility';
   import { fullEventHistory } from '$lib/stores/events';
   import { namespaces } from '$lib/stores/namespaces';
+  import { temporalVersion } from '$lib/stores/versions';
   import { workflowRun } from '$lib/stores/workflow-run';
+  import type { WorkflowExecution } from '$lib/types/workflows';
   import { getWorkflowRelationships } from '$lib/utilities/get-workflow-relationships';
+  import { minimumVersionRequired } from '$lib/utilities/version-check';
 
   import FirstPreviousNextWorkflowTable from './first-previous-next-workflow-table.svelte';
+  import LiveChildWorkflowsTable from './live-child-workflows-table.svelte';
   import ParentWorkflowTable from './parent-workflow-table.svelte';
   import SchedulerTable from './scheduler-table.svelte';
 
   $: ({ workflow: workflowId, namespace } = $page.params);
   $: ({ workflow } = $workflowRun);
+
+  $: canFetchLiveChildren =
+    $isCloud || minimumVersionRequired('1.23', $temporalVersion);
+
+  onMount(async () => {
+    if (canFetchLiveChildren) {
+      try {
+        const { workflows } = await fetchAllWorkflows(namespace, {
+          query: `ParentWorkflowId = "${workflowId}"`,
+        });
+        liveChildren = workflows;
+      } catch (e) {
+        // Use the getWorkflowRelationships children in case of failure
+      }
+    }
+  });
+
+  let liveChildren: WorkflowExecution[] = [];
 
   $: workflowRelationships = getWorkflowRelationships(
     workflow,
@@ -52,7 +78,9 @@
         />
       {/if}
     </div>
-    {#if hasChildren}
+    {#if liveChildren.length}
+      <LiveChildWorkflowsTable children={liveChildren} />
+    {:else if hasChildren}
       <ChildWorkflowsTable
         {children}
         pendingChildren={$workflowRun.workflow.pendingChildren}

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -9,7 +9,9 @@ import {
   toWorkflowExecution,
   toWorkflowExecutions,
 } from '$lib/models/workflow-execution';
+import { isCloud } from '$lib/stores/advanced-visibility';
 import { authUser } from '$lib/stores/auth-user';
+import { temporalVersion } from '$lib/stores/versions';
 import type { ResetWorkflowRequest } from '$lib/types';
 import type {
   ValidWorkflowEndpoints,
@@ -36,7 +38,10 @@ import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
 import type { ErrorCallback } from '$lib/utilities/request-from-api';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { base, pathForApi, routeForApi } from '$lib/utilities/route-for-api';
-import { isVersionNewer } from '$lib/utilities/version-check';
+import {
+  isVersionNewer,
+  minimumVersionRequired,
+} from '$lib/utilities/version-check';
 import { formatReason } from '$lib/utilities/workflow-actions';
 
 export type GetWorkflowExecutionRequest = NamespaceScopedRequest & {
@@ -380,4 +385,23 @@ export async function fetchWorkflowForSchedule(
     onError,
     handleError: onError,
   }).then(toWorkflowExecution);
+}
+
+export async function fetchAllChildWorkflows(
+  namespace: string,
+  workflowId: string,
+): Promise<WorkflowExecution[]> {
+  const canFetchLiveChildren =
+    get(isCloud) || minimumVersionRequired('1.23', get(temporalVersion));
+  if (!canFetchLiveChildren) {
+    return [];
+  }
+  try {
+    const { workflows } = await fetchAllWorkflows(namespace, {
+      query: `ParentWorkflowId = "${workflowId}"`,
+    });
+    return workflows;
+  } catch (e) {
+    return [];
+  }
 }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
In the Relationships tab, child workflows can show stale statuses due to the parent completing. The completed parent won't update it's pending children, it's a snapshot at the time of completion.

With v1.23, we can now query workflows with ParentWorkflowId. This allows us to show current status of children regardless of the parent status.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
This shows the difference in the two tables after terminating the workflow. The live children table correctly shows the Terminated child workflow status. The old table shows it still running.

<img width="1728" alt="Screen Shot 2024-04-17 at 12 45 13 PM" src="https://github.com/temporalio/ui/assets/7967403/7f494499-f914-4d56-a883-fbd1683a577a">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
