### PR TITLE
Fix(query): add delimiter to the query keyword

### DIFF
--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -46,7 +46,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       },
     ];
     const query = toListWorkflowQueryFromFilters(filters);
-    expect(query).toBe('ExecutionStatus="Running"');
+    expect(query).toBe('`ExecutionStatus`="Running"');
   });
 
   it('should convert multiple ExecutionStatus filters', () => {
@@ -78,7 +78,7 @@ describe('toListWorkflowQueryFromFilters', () => {
     ];
     const query = toListWorkflowQueryFromFilters(combineFilters(filters));
     expect(query).toBe(
-      '(ExecutionStatus="Running" OR ExecutionStatus="Canceled" OR ExecutionStatus="Failed")',
+      '(`ExecutionStatus`="Running" OR `ExecutionStatus`="Canceled" OR `ExecutionStatus`="Failed")',
     );
   });
 
@@ -94,7 +94,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       },
     ];
     const query = toListWorkflowQueryFromFilters(filters);
-    expect(query).toBe('CustomBoolField=false');
+    expect(query).toBe('`CustomBoolField`=false');
   });
 
   it('should convert two different filters', () => {
@@ -117,7 +117,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       },
     ];
     const query = toListWorkflowQueryFromFilters(combineFilters(filters));
-    expect(query).toBe('ExecutionStatus="Running" AND WorkflowId="abcd"');
+    expect(query).toBe('`ExecutionStatus`="Running" AND `WorkflowId`="abcd"');
   });
 
   it('should convert three different filters', () => {
@@ -149,7 +149,7 @@ describe('toListWorkflowQueryFromFilters', () => {
     ];
     const query = toListWorkflowQueryFromFilters(combineFilters(filters));
     expect(query).toBe(
-      'ExecutionStatus="Running" AND WorkflowId="abcd" AND WorkflowType="cronWorkflow"',
+      '`ExecutionStatus`="Running" AND `WorkflowId`="abcd" AND `WorkflowType`="cronWorkflow"',
     );
   });
 
@@ -198,7 +198,7 @@ describe('toListWorkflowQueryFromFilters', () => {
       supportsAdvancedVisibility,
     );
     expect(query).toBe(
-      'WorkflowType="cronWorkflow" AND StartTime > "2019-12-30T00:00:00.000Z"',
+      '`WorkflowType`="cronWorkflow" AND StartTime > "2019-12-30T00:00:00.000Z"',
     );
   });
 });

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -82,10 +82,10 @@ const toFilterQueryStatement = (
   }
 
   if (isStartsWith(conditional)) {
-    return `${queryKey} ${conditional} ${formatValue(value, type)}`;
+    return `\`${queryKey}\` ${conditional} ${formatValue(value, type)}`;
   }
 
-  return `${queryKey}${conditional}${formatValue(value, type)}`;
+  return `\`${queryKey}\`${conditional}${formatValue(value, type)}`;
 };
 
 const toQueryStatementsFromFilters = (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

When send out a query of custom search attribute through the options on UI, the server will return back an error if the custom search attribute include hyphen (`-`), this is because hyphen is a reserved character for SQL, to send the query including such characters need to introduce delimiter backtik `` ` `` to escape.

This will address the open issue [here](https://github.com/temporalio/temporal/issues/5557) with the minimum change only on UI.

Here is another [PR](https://github.com/temporalio/temporal/pull/5747) for adding tests in server.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

N/A

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->


## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

Test it though a manual test. Will open another PR in server to include the test on the attribute name with hyphen in server.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
