### PR TITLE
Fix Copyable Link styling

### DIFF
--- a/src/lib/components/workflow/first-previous-next-workflow-table.svelte
+++ b/src/lib/components/workflow/first-previous-next-workflow-table.svelte
@@ -25,7 +25,7 @@
     <th>{translate('workflows.next-execution')}</th>
   </TableHeaderRow>
   <TableRow>
-    <td class="w-1/3 hover:text-blue-700 hover:underline">
+    <td class="w-1/3">
       {#if first}
         <Link
           href={routeForEventHistory({
@@ -43,7 +43,7 @@
         </Link>
       {/if}
     </td>
-    <td class="w-1/3 hover:text-blue-700 hover:underline">
+    <td class="w-1/3">
       {#if previous}
         <Link
           href={routeForEventHistory({
@@ -61,7 +61,7 @@
         </Link>
       {/if}
     </td>
-    <td class="w-1/3 hover:text-blue-700 hover:underline">
+    <td class="w-1/3">
       {#if next}
         <Link
           href={routeForEventHistory({


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Removes blue underline from the Copyable links under the relationships tab. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
Before: 
<img width="1174" alt="Screenshot 2024-04-02 at 10 30 48 AM" src="https://github.com/temporalio/ui/assets/42048868/814d783b-9472-44b4-928d-bb03a58c3358">

After:
<img width="1036" alt="Screenshot 2024-04-17 at 11 01 44 PM" src="https://github.com/temporalio/ui/assets/42048868/904dd12d-ed6a-4b75-8649-f7128ed33d54">

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Issue(s) closed <!-- add issue number here -->
DT-1987
