### PR TITLE
Clear page parameter when workflow list query updates

### DIFF
--- a/src/lib/components/workflow/filter-search/index.svelte
+++ b/src/lib/components/workflow/filter-search/index.svelte
@@ -26,6 +26,7 @@
   import type { WorkflowFilter } from '$lib/models/workflow-filters';
   import { workflowFilters } from '$lib/stores/filters';
   import { searchInputViewOpen } from '$lib/stores/filters';
+  import { currentPageKey } from '$lib/stores/pagination';
   import { refresh } from '$lib/stores/workflows';
   import {
     getFocusedElementId,
@@ -81,6 +82,7 @@
         parameter: 'query',
         value: searchQuery,
         allowEmpty: true,
+        clearParameters: [currentPageKey],
       });
     }
   }

--- a/src/lib/components/workflow/workflow-advanced-search.svelte
+++ b/src/lib/components/workflow/workflow-advanced-search.svelte
@@ -8,6 +8,7 @@
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
   import { workflowFilters } from '$lib/stores/filters';
+  import { currentPageKey } from '$lib/stores/pagination';
   import { searchAttributes } from '$lib/stores/search-attributes';
   import { refresh, workflowsQuery } from '$lib/stores/workflows';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
@@ -48,6 +49,7 @@
         parameter: 'query',
         value: manualSearchString,
         allowEmpty: true,
+        clearParameters: [currentPageKey],
       });
     }
   };

--- a/src/lib/holocene/table/paginated-table.svelte
+++ b/src/lib/holocene/table/paginated-table.svelte
@@ -121,7 +121,7 @@
       <div class="paginated-table-controls-center">
         {#each $store.pageShortcuts as page}
           {#if isNaN(page)}
-            <span>...</span>
+            <span class="text-primary">...</span>
           {:else}
             <Button
               variant="ghost"

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -20,7 +20,6 @@ export const hideWorkflowQueryErrors = derived(
 
 const namespace = derived([page], ([$page]) => $page.params.namespace);
 const query = derived([page], ([$page]) => $page.url.searchParams.get('query'));
-
 const parameters = derived(
   [
     namespace,

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -20,6 +20,7 @@ export const hideWorkflowQueryErrors = derived(
 
 const namespace = derived([page], ([$page]) => $page.params.namespace);
 const query = derived([page], ([$page]) => $page.url.searchParams.get('query'));
+
 const parameters = derived(
   [
     namespace,

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -1,6 +1,7 @@
 import debounce from 'just-debounce';
 
 import type { WorkflowFilter } from '$lib/models/workflow-filters';
+import { currentPageKey } from '$lib/stores/pagination';
 import type { FilterParameters, SearchAttributes } from '$lib/types/workflows';
 import { toListWorkflowQueryFromFilters } from '$lib/utilities/query/filter-workflow-query';
 
@@ -207,6 +208,7 @@ export const updateQueryParamsFromFilter = debounce(
       parameter: 'query',
       value: query,
       allowEmpty: false,
+      clearParameters: [currentPageKey],
     });
   },
   300,

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -163,6 +163,50 @@ describe('updateQueryParameters', () => {
     expect(href).toBe('/?parameter=');
     expect(options).toEqual(gotoOptions);
   });
+
+  it('should clear single clearParameter when on a page', () => {
+    const parameter = 'parameter';
+    const value = 'value';
+    const url = new URL(
+      `https://temporal.io/?${parameter}=oldvalue&other=value`,
+    );
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({
+      parameter,
+      value,
+      url,
+      goto,
+      clearParameters: ['other'],
+    });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?parameter=value');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should clear multiple clearParameters when on a page', () => {
+    const parameter = 'parameter';
+    const value = 'value';
+    const url = new URL(
+      `https://temporal.io/?${parameter}=oldvalue&other=value&page=3`,
+    );
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({
+      parameter,
+      value,
+      url,
+      goto,
+      clearParameters: ['page', 'other'],
+    });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?parameter=value');
+    expect(options).toEqual(gotoOptions);
+  });
 });
 
 describe('a sanity test for how URLs work in JavaScript', () => {

--- a/src/lib/utilities/update-query-parameters.ts
+++ b/src/lib/utilities/update-query-parameters.ts
@@ -8,6 +8,7 @@ type UpdateQueryParams = {
   url: URL;
   goto?: typeof navigateTo;
   allowEmpty?: boolean;
+  clearParameters?: string[];
 };
 
 export const gotoOptions = {
@@ -21,6 +22,7 @@ export const updateQueryParameters = async ({
   url,
   goto = navigateTo,
   allowEmpty = false,
+  clearParameters = [],
 }: UpdateQueryParams): Promise<typeof value> => {
   const next = String(value);
   const params = {};
@@ -35,6 +37,12 @@ export const updateQueryParameters = async ({
     newQuery.set(parameter, next);
   } else if (allowEmpty) {
     newQuery.set(parameter, '');
+  }
+
+  if (clearParameters.length) {
+    clearParameters.forEach((parameter) => {
+      newQuery.delete(parameter);
+    });
   }
 
   if (BROWSER) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When a user selected a page (say page 4) on the workflows list page and then selected a filter, the page would remain at 4. This PR clears the page param whenever the query changes so it will always start on page 1.

Also fix ... text color in bottom table footer.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
