### PR TITLE
Add backgrounds to buttons and text areas

### DIFF
--- a/src/lib/holocene/button.stories.svelte
+++ b/src/lib/holocene/button.stories.svelte
@@ -103,6 +103,8 @@
 <script lang="ts">
   import { action } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
+
+  import { shouldNotBeTransparent } from './test-utilities';
 </script>
 
 <Template let:args>
@@ -111,17 +113,21 @@
 
 <Story name="Primary" args={{}} />
 
-<Story name="Secondary" args={{ variant: 'Secondary' }} />
+<Story
+  name="Secondary"
+  args={{ variant: 'secondary' }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('button'))}
+/>
 
-<Story name="Destructive" args={{ variant: 'Destructive' }} />
+<Story name="Destructive" args={{ variant: 'destructive' }} />
 
-<Story name="Ghost" args={{ variant: 'Ghost' }} />
+<Story name="Ghost" args={{ variant: 'ghost' }} />
 
-<Story name="Extra Small" args={{ size: 'Extra Small' }} />
+<Story name="Extra Small" args={{ size: 'xs' }} />
 
-<Story name="Small" args={{ size: 'Small' }} />
+<Story name="Small" args={{ size: 'sm' }} />
 
-<Story name="Large" args={{ size: 'Large' }} />
+<Story name="Large" args={{ size: 'lg' }} />
 
 <Story name="Loading" args={{ loading: true }} />
 
@@ -163,7 +169,8 @@
 
 <Story
   name="Secondary (Dark)"
-  args={{ variant: 'Secondary' }}
+  args={{ variant: 'secondary' }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('button'))}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -173,7 +180,7 @@
 
 <Story
   name="Destructive (Dark)"
-  args={{ variant: 'Destructive' }}
+  args={{ variant: 'destructive' }}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -183,7 +190,7 @@
 
 <Story
   name="Ghost (Dark)"
-  args={{ variant: 'Ghost' }}
+  args={{ variant: 'ghost' }}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -193,7 +200,7 @@
 
 <Story
   name="Extra Small (Dark)"
-  args={{ size: 'Extra Small' }}
+  args={{ size: 'xs' }}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -203,7 +210,7 @@
 
 <Story
   name="Small (Dark)"
-  args={{ size: 'Small' }}
+  args={{ size: 'sm' }}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -213,7 +220,7 @@
 
 <Story
   name="Large (Dark)"
-  args={{ size: 'Large' }}
+  args={{ size: 'lg' }}
   parameters={{
     themes: {
       themeOverride: 'dark',

--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -36,7 +36,7 @@
           primary:
             'bg-interactive border-interactive text-white hover:text-white hover:bg-interactive-hover hover:border-interactive-hover focus-visible:bg-interactive-hover focus-visible:border-white dark:focus-visible:border-black focus-visible:shadow-focus focus-visible:shadow-primary/70',
           secondary:
-            'border-secondary text-primary focus-visible:shadow-focus focus-visible:shadow-primary/70 hover:surface-interactive-secondary hover:border-interactive-secondary dark:hover:border-transparent focus-visible:surface-interactive-secondary focus-visible:border-white dark:focus-visible:border-black',
+            'border-secondary surface-input text-primary focus-visible:shadow-focus focus-visible:shadow-primary/70 hover:surface-interactive-secondary hover:border-interactive-secondary dark:hover:border-transparent focus-visible:surface-interactive-secondary focus-visible:border-white dark:focus-visible:border-black',
           destructive:
             'border-danger bg-danger text-primary hover:bg-red-400 hover:border-red-400 focus-visible:shadow-focus focus-visible:shadow-danger/50 focus-visible:border-white dark:focus-visible:border-red-400/50 dark:focus-visible:bg-red-400',
           ghost:

--- a/src/lib/holocene/checkbox.stories.svelte
+++ b/src/lib/holocene/checkbox.stories.svelte
@@ -35,6 +35,8 @@
 <script lang="ts">
   import { action } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
+
+  import { shouldNotBeTransparent } from './test-utilities';
 </script>
 
 <Template let:args>
@@ -46,7 +48,10 @@
   />
 </Template>
 
-<Story name="Default" />
+<Story
+  name="Default"
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('checkbox'))}
+/>
 
 <Story name="Disabled" args={{ disabled: true }} />
 

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -85,6 +85,7 @@
       {id}
       {value}
       type="checkbox"
+      class="surface-input"
       bind:checked
       {disabled}
       {required}

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -178,7 +178,7 @@
   }
 
   .input-container {
-    @apply surface-primary relative box-border inline-flex h-10 w-full items-center rounded border border-subtle text-sm focus-within:shadow-focus focus-within:shadow-primary/50 focus-within:outline-none dark:bg-transparent;
+    @apply surface-input relative box-border inline-flex h-10 w-full items-center rounded border border-subtle text-sm focus-within:shadow-focus focus-within:shadow-primary/50 focus-within:outline-none dark:bg-transparent;
 
     &.error,
     &.invalid {

--- a/src/lib/holocene/menu/menu-button.svelte
+++ b/src/lib/holocene/menu/menu-button.svelte
@@ -162,7 +162,7 @@
   }
 
   .secondary {
-    @apply border-secondary text-primary hover:surface-interactive-secondary focus-visible:surface-interactive-secondary hover:border-interactive-secondary  focus-visible:border-white focus-visible:shadow-focus focus-visible:shadow-primary/70 dark:hover:border-transparent dark:focus-visible:border-black;
+    @apply surface-input border-secondary text-primary hover:surface-interactive-secondary focus-visible:surface-interactive-secondary hover:border-interactive-secondary  focus-visible:border-white focus-visible:shadow-focus focus-visible:shadow-primary/70 dark:hover:border-transparent dark:focus-visible:border-black;
 
     &:disabled {
       @apply bg-slate-50;

--- a/src/lib/holocene/menu/menu.stories.svelte
+++ b/src/lib/holocene/menu/menu.stories.svelte
@@ -46,6 +46,8 @@
 <script lang="ts">
   import { action } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
+
+  import { shouldNotBeTransparent } from '../test-utilities';
 </script>
 
 <Template let:args let:context>
@@ -68,7 +70,11 @@
 
 <Story name="Primary" args={{ variant: 'primary' }} />
 
-<Story name="Secondary" args={{ variant: 'secondary' }} />
+<Story
+  name="Secondary"
+  args={{ variant: 'secondary' }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('button'))}
+/>
 
 <Story name="Ghost" args={{ variant: 'ghost' }} />
 

--- a/src/lib/holocene/radio-input/radio-input.stories.svelte
+++ b/src/lib/holocene/radio-input/radio-input.stories.svelte
@@ -36,6 +36,8 @@
 
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
+  import { shouldNotBeTransparent } from '../test-utilities';
+
   const loremIpsum =
     'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus. Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices diam. Maecenas ligula massa, varius a, semper congue, euismod non, mi. Proin porttitor, orci nec nonummy molestie, enim est eleifend mi, non fermentum diam nisl sit amet erat. Duis semper. Duis arcu massa, scelerisque vitae, consequat in, pretium a, enim. Pellentesque congue. Ut in risus volutpat libero pharetra tempor. Cras vestibulum bibendum augue. Praesent egestas leo in pede. Praesent blandit odio eu enim. Pellentesque sed dui ut augue blandit sodales. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aliquam nibh. Mauris ac mauris sed pede pellentesque fermentum. Maecenas adipiscing ante non diam sodales hendrerit.';
 </script>
@@ -46,9 +48,16 @@
   </RadioGroup>
 </Template>
 
-<Story name="Checked" />
+<Story
+  name="Checked"
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('radio'))}
+/>
 
-<Story name="Unchecked" args={{ value: 'unchecked' }} />
+<Story
+  name="Unchecked"
+  args={{ value: 'unchecked' }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('radio'))}
+/>
 
 <Story name="Checked and Disabled" args={{ disabled: true }} />
 
@@ -95,12 +104,14 @@
 <Story
   name="Checked (Dark)"
   parameters={{ themes: { themeOverride: 'dark' } }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('radio'))}
 />
 
 <Story
   name="Unchecked (Dark)"
   args={{ value: 'unchecked' }}
   parameters={{ themes: { themeOverride: 'dark' } }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('radio'))}
 />
 
 <Story

--- a/src/lib/holocene/radio-input/radio-input.svelte
+++ b/src/lib/holocene/radio-input/radio-input.svelte
@@ -36,6 +36,7 @@
     <input
       bind:group={$group}
       type="radio"
+      class="surface-input"
       aria-describedby="{id}-description"
       {name}
       {value}
@@ -68,7 +69,7 @@
   }
 
   input[type='radio'] {
-    @apply relative box-content h-4 w-4 min-w-[16px] cursor-pointer appearance-none rounded-full border-2 border-subtle bg-transparent outline outline-4 outline-transparent dark:text-black;
+    @apply relative box-content h-4 w-4 min-w-[16px] cursor-pointer appearance-none rounded-full border-2 border-subtle outline outline-4 outline-transparent dark:text-black;
 
     &::after {
       @apply absolute left-1 top-1 h-0 w-0 scale-0 rounded-full bg-interactive transition-transform content-[''];

--- a/src/lib/holocene/test-utilities.ts
+++ b/src/lib/holocene/test-utilities.ts
@@ -1,0 +1,14 @@
+import type { Story } from '@storybook/addon-svelte-csf';
+import { expect, within } from '@storybook/test';
+
+type PlayFunction = Story['$$prop_def']['play'];
+
+export const shouldNotBeTransparent = (
+  fn: (canvas: ReturnType<typeof within>) => PlayFunction,
+) => {
+  return ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const element = fn(canvas);
+    expect(element).not.toHaveStyle({ backgroundColor: 'rgba(0,0,0,0)' });
+  };
+};

--- a/src/lib/holocene/textarea.stories.svelte
+++ b/src/lib/holocene/textarea.stories.svelte
@@ -41,6 +41,8 @@
 <script lang="ts">
   import { action } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
+
+  import { shouldNotBeTransparent } from './test-utilities';
 </script>
 
 <Template let:args>
@@ -54,7 +56,10 @@
   />
 </Template>
 
-<Story name="Default" />
+<Story
+  name="Default"
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('textbox'))}
+/>
 
 <Story name="Disabled" args={{ disabled: true }} />
 
@@ -75,6 +80,7 @@
 <Story
   name="Default (Dark)"
   parameters={{ themes: { themeOverride: 'dark' } }}
+  play={shouldNotBeTransparent((canvas) => canvas.getByRole('textbox'))}
 />
 
 <Story

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -42,7 +42,7 @@
   {/if}
   <div class="relative">
     <textarea
-      class=" min-h-fit w-full rounded-lg border-2 border-subtle bg-transparent px-3 py-2 font-mono text-sm focus-visible:border-information focus-visible:shadow-[0_0_0_4px_rgb(97,115,243,0.7)] focus-visible:outline-none enabled:hover:border-information"
+      class="surface-input min-h-fit w-full rounded-lg border-2 border-subtle px-3 py-2 font-mono text-sm focus-visible:border-information focus-visible:shadow-[0_0_0_4px_rgb(97,115,243,0.7)] focus-visible:outline-none enabled:hover:border-information"
       class:error={!isValid}
       {id}
       bind:value

--- a/src/lib/theme/plugin.ts
+++ b/src/lib/theme/plugin.ts
@@ -134,6 +134,10 @@ const temporal = plugin(
         backgroundColor: css('--color-surface-secondary-active'),
         color: css('--color-text-primary'),
       },
+      '.surface-input': {
+        backgroundColor: css('--color-surface-primary'),
+        color: css('--color-text-primary'),
+      },
       '.surface-interactive': {
         backgroundColor: css('--color-surface-interactive'),
         color: css('--color-text-primary'),


### PR DESCRIPTION
- Fixes issue where secondary buttons and text areas had transparent backgrounds
- Also adds backgrounds to checkboxes and radio inputs
- Adds tests to stories to check for a regression
- Adds `surface-input` class to the theme plugin