### PR TITLE
Fix alignment on checkbox; address accessibility concerns

### DIFF
--- a/src/lib/holocene/checkbox.stories.svelte
+++ b/src/lib/holocene/checkbox.stories.svelte
@@ -58,7 +58,7 @@
 
 <Story name="Required" args={{ required: true }} />
 
-<Story name="Error" args={{ error: 'Error' }} />
+<Story name="Invalid with Error" args={{ error: 'Error', valid: false }} />
 
 <Story name="Valid" args={{ valid: true }} />
 
@@ -122,8 +122,8 @@
 />
 
 <Story
-  name="Error (Dark)"
-  args={{ error: 'Error' }}
+  name="Invalid (Dark)"
+  args={{ valid: false }}
   parameters={{
     themes: {
       themeOverride: 'dark',
@@ -132,8 +132,8 @@
 />
 
 <Story
-  name="Valid (Dark)"
-  args={{ valid: true }}
+  name="Invalid with Error (Dark)"
+  args={{ error: 'Error', valid: false }}
   parameters={{
     themes: {
       themeOverride: 'dark',

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -119,7 +119,7 @@
 
 <style lang="postcss">
   .checkbox {
-    @apply flex cursor-pointer select-none items-start items-center gap-3 text-sm leading-[18px] text-primary;
+    @apply flex cursor-pointer select-none items-center gap-3 text-sm leading-[18px] text-primary;
 
     &.disabled {
       @apply cursor-not-allowed;

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -71,10 +71,11 @@
   data-testid={$$restProps['data-testid'] ?? null}
   on:click|stopPropagation
   on:keypress|stopPropagation
+  role="checkbox"
+  aria-checked={checked}
+  tabindex={-1}
 >
   <label
-    on:click
-    on:keypress
     class={merge('checkbox', 'text-primary', className)}
     class:hoverable={hoverable && !disabled}
     class:disabled
@@ -118,7 +119,7 @@
 
 <style lang="postcss">
   .checkbox {
-    @apply flex cursor-pointer select-none items-start gap-3 text-sm leading-[18px] text-primary;
+    @apply flex cursor-pointer select-none items-start items-center gap-3 text-sm leading-[18px] text-primary;
 
     &.disabled {
       @apply cursor-not-allowed;


### PR DESCRIPTION
Addresses the following accessibility warnings:

- A11y: `<div>` with click, keypress handlers must have an ARIA role
- A11y: Non-interactive element `<label>` should not be assigned mouse or keyboard event listeners.

### Before

![checkbox-before@2x](https://github.com/temporalio/ui/assets/251000/989ad5e0-e76a-4cef-ab04-6b962979a236)

### After

![checkbox-after@2x](https://github.com/temporalio/ui/assets/251000/5fc0f404-f30a-40df-a268-cfa00bff9bd4)
