### PR TITLE
Adjust code selection color for better Safari support

### DIFF
--- a/src/lib/vendor/codemirror/theme.ts
+++ b/src/lib/vendor/codemirror/theme.ts
@@ -33,7 +33,7 @@ export const TEMPORAL_THEME = EditorView.theme(
       borderLeftColor: colors.white,
     },
     '&.cm-focused .cm-selectionBackground, ::selection': {
-      backgroundColor: colors.indigo['300'],
+      backgroundColor: colors.indigo['500'],
     },
     '.cm-gutters': {
       backgroundColor: colors.black,

--- a/src/lib/vendor/codemirror/theme.ts
+++ b/src/lib/vendor/codemirror/theme.ts
@@ -33,7 +33,7 @@ export const TEMPORAL_THEME = EditorView.theme(
       borderLeftColor: colors.white,
     },
     '&.cm-focused .cm-selectionBackground, ::selection': {
-      backgroundColor: colors.slate['700'],
+      backgroundColor: colors.indigo['300'],
     },
     '.cm-gutters': {
       backgroundColor: colors.black,


### PR DESCRIPTION
We received a bug support about Safari not showing the text selection color. Technically, it is showing it, but it uses a lot more transparency than Chrome. Adjusting the color slightly allows for a reasonable compromise between how Safari renders the color and how Chrome renders it.