### PR TITLE
Fix UTC date on Schedule Backfill

### DIFF
--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -42,7 +42,7 @@
   import { refresh, workflowCount } from '$lib/stores/workflows';
   import type { OverlapPolicy } from '$lib/types/schedule';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
-  import { formatDate } from '$lib/utilities/format-date';
+  import { formatDate, getUTCString } from '$lib/utilities/format-date';
   import {
     routeForScheduleEdit,
     routeForSchedules,
@@ -207,32 +207,6 @@
 
   $: backfillConfirmationModalOpen && updateDefaultBackfillTimes();
 
-  const applyTimeSelection = (): {
-    startTime: string;
-    endTime: string;
-  } => {
-    const startTimeUTC = Date.UTC(
-      startDate.getFullYear(),
-      startDate.getMonth(),
-      startDate.getDay(),
-      Number(startHour),
-      Number(startMinute),
-      Number(startSecond),
-    );
-    const startTime = new Date(startTimeUTC).toISOString();
-    const endTimeUTC = Date.UTC(
-      endDate.getFullYear(),
-      endDate.getMonth(),
-      endDate.getDay(),
-      Number(endHour),
-      Number(endMinute),
-      Number(endSecond),
-    );
-    const endTime = new Date(endTimeUTC).toISOString();
-
-    return { startTime, endTime };
-  };
-
   const closeBackfillModal = () => {
     backfillConfirmationModalOpen = false;
     viewMoreBackfillOptions = false;
@@ -241,7 +215,19 @@
 
   const handleBackfill = async () => {
     scheduleUpdating = true;
-    const { startTime, endTime } = applyTimeSelection();
+
+    const startTime = getUTCString({
+      date: startDate,
+      hour: startHour,
+      minute: startMinute,
+      second: startSecond,
+    });
+    const endTime = getUTCString({
+      date: endDate,
+      hour: endHour,
+      minute: endMinute,
+      second: endSecond,
+    });
 
     await backfillRequest({
       namespace,

--- a/src/lib/utilities/format-date.test.ts
+++ b/src/lib/utilities/format-date.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   formatDate,
   formatUTCOffset,
   getLocalTime,
   getSelectedTimezone,
+  getUTCString,
   isValidDate,
 } from './format-date';
 
@@ -143,5 +144,33 @@ describe('getSelectedTimezone', () => {
 
   it('should return the time format if there is no matching timezone found', () => {
     expect(getSelectedTimezone('UTC')).toBe('UTC');
+  });
+});
+
+describe('getUTCString', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01').getTime());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should default to 00:00 for the current date', () => {
+    expect(getUTCString()).toBe('2020-01-01T00:00:00.000Z');
+  });
+
+  it('should return a string with hours, minutes, and seconds set', () => {
+    expect(getUTCString({ hour: 1, minute: 1, second: 1 })).toBe(
+      '2020-01-01T01:01:01.000Z',
+    );
+    expect(getUTCString({ hour: 1, minute: 61, second: 1 })).toBe(
+      '2020-01-01T02:01:01.000Z',
+    );
+    expect(getUTCString({ hour: 1, minute: 1, second: 61 })).toBe(
+      '2020-01-01T01:02:01.000Z',
+    );
+    expect(getUTCString({ hour: 25 })).toBe('2020-01-02T01:00:00.000Z');
   });
 });

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -104,3 +104,25 @@ export function getSelectedTimezone(timeFormat: TimeFormat): string {
 
   return timeFormat;
 }
+
+export function getUTCString({
+  date = new Date(),
+  hour = 0,
+  minute = 0,
+  second = 0,
+}: {
+  date?: Date;
+  hour?: string | number;
+  minute?: string | number;
+  second?: string | number;
+} = {}): string {
+  const utcTime = Date.UTC(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+    Number(hour),
+    Number(minute),
+    Number(second),
+  );
+  return new Date(utcTime).toISOString();
+}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Fixes incorrect UTC date on `Schedule Backfill`. We were using `Date.prototype.getDay()` which  returns the day of the week instead of `Date.prototype.getDate()` which returns the date of the month. Refactored to a utility function and added unit tests.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-2112`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
