### PR TITLE
Fix Chip Input's focus state

### DIFF
--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -144,7 +144,7 @@
 
 <style lang="postcss">
   .input-container {
-    @apply surface-primary flex max-h-20 min-h-[2.5rem] w-full flex-row flex-wrap gap-1 overflow-y-scroll rounded border border-subtle p-2 text-sm text-primary focus-within:border-4 focus-within:border-blue-700;
+    @apply surface-primary flex max-h-20 min-h-[2.5rem] w-full flex-row flex-wrap gap-1 overflow-y-scroll rounded border border-subtle p-2 text-sm text-primary ring-inset ring-interactive focus-within:border-interactive focus-within:ring-2;
 
     .invalid {
       @apply border-red-700;


### PR DESCRIPTION
Adding a border when focused, changed the dimensions of the `Chip Input` in a slightly offputting way. This change uses a `ring` so that the dimensions of the input do not change.