### PR TITLE
Update Github Action Dependencies

### DIFF
--- a/.github/actions/checkout-and-setup/action.yml
+++ b/.github/actions/checkout-and-setup/action.yml
@@ -10,7 +10,7 @@ runs:
         run_install: false
         version: 8.6.0
     - name: Install Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/bump-package-version.yml
+++ b/.github/workflows/bump-package-version.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Node setup
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -23,7 +23,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and Setup Node
         uses: ./.github/actions/checkout-and-setup
       - name: Lint
@@ -31,7 +31,7 @@ jobs:
   check-types:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and Setup Node
         uses: ./.github/actions/checkout-and-setup
       - name: Check Types
@@ -39,7 +39,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and Setup Node
         uses: ./.github/actions/checkout-and-setup
       - name: Run Unit Tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and Setup Node
         uses: ./.github/actions/checkout-and-setup
       - name: Install Playwright Browsers
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Checkout and Setup Node

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -9,7 +9,7 @@ jobs:
     if: startsWith(github.head_ref, 'releases/') && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Checkout and Setup Node
         uses: ./.github/actions/checkout-and-setup
       - name: Build package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Checkout and setup Node

--- a/.github/workflows/update-ui-server.yml
+++ b/.github/workflows/update-ui-server.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Checkout and Setup Node
@@ -28,7 +28,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout UI Server
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: temporalio/ui-server
           path: ui-server


### PR DESCRIPTION
Bumps `actions/setup-node` and `actions/checkout` to `v4`.