### PR TITLE
Remove double encoding for api route

### DIFF
--- a/src/lib/utilities/route-for-api.test.ts
+++ b/src/lib/utilities/route-for-api.test.ts
@@ -181,7 +181,7 @@ describe('API Request Encoding', () => {
       workflowId: 'workflow#with#hashes',
     });
     expect(route).toBe(
-      'http://localhost:8233/api/v1/namespaces/namespace/workflows/workflow%2523with%2523hashes',
+      'http://localhost:8233/api/v1/namespaces/namespace/workflows/workflow%23with%23hashes',
     );
   });
 
@@ -193,8 +193,57 @@ describe('API Request Encoding', () => {
       workflowId:
         'temporal.canary.cron-workflow.sanity-2022-05-02T16:03:11-06:00/workflow.advanced-visibility.scan',
     });
+
     expect(route).toBe(
-      'http://localhost:8233/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%253A03%253A11-06%253A00%252Fworkflow.advanced-visibility.scan',
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%3A03%3A11-06%3A00%2Fworkflow.advanced-visibility.scan',
+    );
+  });
+
+  it('should handle spaces', () => {
+    const route = routeForApi('workflow', {
+      ...parameters,
+      namespace: 'canary',
+      runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
+      workflowId: 'workflowId with spaces',
+    });
+    expect(route).toBe(
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/workflowId%20with%20spaces',
+    );
+  });
+
+  it('should handle parenthesis', () => {
+    const route = routeForApi('workflow', {
+      ...parameters,
+      namespace: 'canary',
+      runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
+      workflowId: 'workflowId()',
+    });
+    expect(route).toBe(
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/workflowId()',
+    );
+  });
+
+  it('should handle space and parenthesis', () => {
+    const route = routeForApi('workflow', {
+      ...parameters,
+      namespace: 'canary',
+      runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
+      workflowId: 'workflowId ()',
+    });
+    expect(route).toBe(
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/workflowId%20()',
+    );
+  });
+
+  it('should handle special characters', () => {
+    const route = routeForApi('workflow', {
+      ...parameters,
+      namespace: 'canary',
+      runId: '47e33895-aff5-475a-9b53-73abdee8bebe',
+      workflowId: 'workflowId?@:;=+$,',
+    });
+    expect(route).toBe(
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/workflowId%3F%40%3A%3B%3D%2B%24%2C',
     );
   });
 });

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -81,7 +81,7 @@ const encode = (
 ): APIRouteParameters => {
   return Object.keys(parameters ?? {}).reduce(
     (acc, key) => {
-      acc[key] = encodeURIComponent(encodeURIComponent(parameters[key]));
+      acc[key] = encodeURIComponent(parameters[key]);
       return acc;
     },
     {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
I'm guessing this is an ancient relic of pre-v1.0 Sveltekit where we needed to double encode the URI. This can cause issues with WorkflowIds like `workflow ()` and I'm sure other combinations. It also adds extra %25 characters which I'm shocked haven't been an issue on the server. I've removed the double encoding and added more unit tests for special characters.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
