### PR TITLE
Tone down border-primary in dark mode

### DIFF
--- a/src/lib/theme/plugin.ts
+++ b/src/lib/theme/plugin.ts
@@ -96,8 +96,8 @@ const dark: Partial<Variables<keyof typeof variables>> = {
   '--color-surface-error': rgb(getColor('red', 950)),
   '--color-surface-success': rgb(getColor('green', 950)),
 
-  '--color-border-primary': rgb(getColor('slate', 400)),
-  '--color-border-secondary': rgb(getColor('slate', 600)),
+  '--color-border-primary': rgb(getColor('slate', 600)),
+  '--color-border-secondary': rgb(getColor('slate', 700)),
   '--color-border-subtle': rgb(getColor('slate', 800)),
   '--color-border-table': rgb(getColor('slate', 900)),
   '--color-border-inverse': rgb(colors.black),

--- a/src/lib/theme/plugin.ts
+++ b/src/lib/theme/plugin.ts
@@ -96,7 +96,7 @@ const dark: Partial<Variables<keyof typeof variables>> = {
   '--color-surface-error': rgb(getColor('red', 950)),
   '--color-surface-success': rgb(getColor('green', 950)),
 
-  '--color-border-primary': rgb(colors.offWhite),
+  '--color-border-primary': rgb(getColor('slate', 400)),
   '--color-border-secondary': rgb(getColor('slate', 600)),
   '--color-border-subtle': rgb(getColor('slate', 800)),
   '--color-border-table': rgb(getColor('slate', 900)),


### PR DESCRIPTION
## Before

![before-namespace@2x](https://github.com/temporalio/ui/assets/251000/7cac4e54-d814-4b7e-9419-40f2deda7fc1)
![before-combox@2x](https://github.com/temporalio/ui/assets/251000/cc0e78fb-123c-4688-a647-cd8df1f1b0f3)

## After

![after-namespace@2x](https://github.com/temporalio/ui/assets/251000/bf6ce093-7494-49c9-9e8a-5a92688b9097)
![after-combobox@2x](https://github.com/temporalio/ui/assets/251000/c05b2b1b-3d6f-4868-b3fa-d9b1cb52d45d)
