### PR TITLE
DT-2159 - fix "Reapply Signals" checkbox on reset workflow confirmation form

### DIFF
--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -132,6 +132,7 @@
       disabled={!resetAllowed}
       variant="primary"
       on:click={() => (resetConfirmationModalOpen = true)}
+      data-testid="workflow-reset-button"
     >
       {translate('workflows.reset')}
     </Button>

--- a/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
@@ -21,23 +21,15 @@
 
   let error = '';
   let loading = false;
-  let reapplyType: ResetReapplyType;
   let eventId: Writable<string> = writable('');
   let reason: string;
+  let reapplySignals = false;
 
   const hideResetModal = () => {
     open = false;
-    reapplyType = ResetReapplyType.Signal;
+    reapplySignals = false;
     $eventId = '';
     reason = '';
-  };
-
-  const handleReapplyTypeChange = (
-    event: CustomEvent<{ checked: boolean }>,
-  ) => {
-    reapplyType = event.detail.checked
-      ? ResetReapplyType.Signal
-      : ResetReapplyType.None;
   };
 
   const reset = async () => {
@@ -49,7 +41,9 @@
         workflow,
         eventId: $eventId,
         reason,
-        reapplyType,
+        reapplyType: reapplySignals
+          ? ResetReapplyType.Signal
+          : ResetReapplyType.None,
       });
 
       if (response && response.runId) {
@@ -102,8 +96,7 @@
       </RadioGroup>
       <Checkbox
         id="reset-reapply-type-checkbox"
-        checked={reapplyType === ResetReapplyType.Signal}
-        on:change={handleReapplyTypeChange}
+        bind:checked={reapplySignals}
         label={translate('workflows.reset-reapply-type-label')}
       />
 

--- a/tests/integration/workflow-reset.spec.ts
+++ b/tests/integration/workflow-reset.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+import { ResetReapplyType } from '$src/lib/models/workflow-actions';
+import { mockWorkflowApis } from '~/test-utilities/mock-apis';
+import {
+  mockCompletedWorkflow,
+  mockWorkflowResetApi,
+  WORKFLOW_RESET_API,
+} from '~/test-utilities/mocks/workflow';
+
+const {
+  workflowExecutionInfo: {
+    execution: { workflowId, runId },
+  },
+} = mockCompletedWorkflow;
+
+const workflowUrl = `/namespaces/default/workflows/${workflowId}/${runId}/history`;
+
+test.describe('Workflow reset', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(workflowUrl);
+
+    await mockWorkflowApis(page, mockCompletedWorkflow);
+    await mockWorkflowResetApi(page);
+  });
+
+  test('allows NOT reapplying signals after the reset point', async ({
+    page,
+  }) => {
+    const requestPromise = page.waitForRequest(WORKFLOW_RESET_API);
+
+    await page.getByTestId('workflow-reset-button').click();
+    await page.locator('#reset-event-5').click();
+    await page
+      .getByTestId('reset-confirmation-modal')
+      .getByTestId('confirm-modal-button')
+      .click();
+
+    const request = await requestPromise;
+    const body = request.postDataJSON();
+
+    expect(body.resetReapplyType).toBe(ResetReapplyType.None);
+  });
+
+  test('allows reapplying signals after the reset point', async ({ page }) => {
+    const requestPromise = page.waitForRequest(WORKFLOW_RESET_API);
+
+    await page.getByTestId('workflow-reset-button').click();
+    await page.locator('#reset-event-5').click();
+    await page
+      .getByRole('checkbox', {
+        name: 'Reapply Signals that happened after the Reset point',
+      })
+      .first()
+      .click();
+
+    await page
+      .getByTestId('reset-confirmation-modal')
+      .getByTestId('confirm-modal-button')
+      .click();
+
+    const request = await requestPromise;
+    const body = request.postDataJSON();
+
+    expect(body.resetReapplyType).toBe(ResetReapplyType.Signal);
+  });
+});

--- a/tests/test-utilities/mock-apis.ts
+++ b/tests/test-utilities/mock-apis.ts
@@ -17,12 +17,14 @@ import { mockSearchAttributesApi } from './mocks/search-attributes';
 import { mockSettingsApi, SETTINGS_API } from './mocks/settings';
 import { mockSystemInfoApi } from './mocks/system-info';
 import { mockTaskQueuesApi, TASK_QUEUES_API } from './mocks/task-queues';
-import { mockWorkflowApi, WORKFLOW_API } from './mocks/workflow';
+import { mockWorkflow, mockWorkflowApi, WORKFLOW_API } from './mocks/workflow';
 import { mockWorkflowsApi, WORKFLOWS_API } from './mocks/workflows';
 import {
   mockWorkflowsCountApi,
   WORKFLOWS_COUNT_API,
 } from './mocks/workflows-count';
+
+import { WorkflowExecutionAPIResponse } from '$src/lib/types/workflows';
 
 export { mockClusterApi, CLUSTER_API } from './mocks/cluster';
 export { mockNamespaceApi, NAMESPACE_API } from './mocks/namespace';
@@ -91,10 +93,13 @@ export const mockBatchOperationApis = (page: Page) => {
   ]);
 };
 
-export const mockWorkflowApis = (page: Page) => {
+export const mockWorkflowApis = (
+  page: Page,
+  workflow: WorkflowExecutionAPIResponse = mockWorkflow,
+) => {
   return Promise.all([
     mockNamespaceApis(page),
-    mockWorkflowApi(page),
+    mockWorkflowApi(page, workflow),
     mockEventHistoryApi(page),
     mockTaskQueuesApi(page),
   ]);

--- a/tests/test-utilities/mocks/workflow.ts
+++ b/tests/test-utilities/mocks/workflow.ts
@@ -1,6 +1,9 @@
 import type { Page } from '@playwright/test';
 
+import type { WorkflowExecutionAPIResponse } from '$src/lib/types/workflows';
+
 export const WORKFLOW_API = '**/api/v1/namespaces/*/workflows/*?';
+export const WORKFLOW_RESET_API = '**/api/v1/namespaces/*/workflows/*/reset*';
 
 export const mockWorkflow = {
   executionConfig: {
@@ -26,6 +29,7 @@ export const mockWorkflow = {
     historyLength: '6',
     parentNamespaceId: '',
     parentExecution: null,
+    historySizeBytes: '',
     executionTime: '2022-04-28T05:50:48.264756929Z',
     memo: {
       fields: {},
@@ -117,13 +121,79 @@ export const mockWorkflow = {
     },
   ],
   pendingChildren: [],
-  pendingWorkflowTask: null,
-};
+} satisfies WorkflowExecutionAPIResponse;
 
-export const mockWorkflowApi = (page: Page) => {
+export const mockCompletedWorkflow = {
+  executionConfig: {
+    taskQueue: {
+      name: 'await_signals',
+      kind: 'TASK_QUEUE_KIND_NORMAL',
+    },
+    workflowExecutionTimeout: '0s',
+    workflowRunTimeout: '0s',
+    defaultWorkflowTaskTimeout: '10s',
+  },
+  workflowExecutionInfo: {
+    execution: {
+      workflowId: 'await_signals_f1483b17-152e-442d-a8c0-145682f76d4f',
+      runId: '5776fab0-f316-4880-9fa5-6ebb2293a1c5',
+    },
+    type: {
+      name: 'AwaitSignalsWorkflow',
+    },
+    startTime: '2024-05-17T15:25:26.888913Z',
+    closeTime: '2024-05-17T15:25:30.921605Z',
+    status: 'WORKFLOW_EXECUTION_STATUS_COMPLETED',
+    historyLength: '16',
+    executionTime: '2024-05-17T15:25:26.888913Z',
+    memo: {},
+    searchAttributes: {
+      indexedFields: {
+        BuildIds: {
+          metadata: {
+            encoding: 'anNvbi9wbGFpbg==',
+            type: 'S2V5d29yZExpc3Q=',
+          },
+          data: 'WyJ1bnZlcnNpb25lZCIsInVudmVyc2lvbmVkOjYzNTliM2IxYWQwYTZhYWY3N2M3NTdlODU0NzA3YTA1Il0=',
+        },
+      },
+    },
+    autoResetPoints: {
+      points: [
+        {
+          buildId: '6359b3b1ad0a6aaf77c757e854707a05',
+          runId: '5776fab0-f316-4880-9fa5-6ebb2293a1c5',
+          firstWorkflowTaskCompletedId: '5',
+          createTime: '2024-05-17T15:25:26.894727Z',
+          resettable: true,
+        },
+      ],
+    },
+    taskQueue: 'await_signals',
+    stateTransitionCount: '10',
+    historySizeBytes: '1668',
+    mostRecentWorkerVersionStamp: {
+      buildId: '6359b3b1ad0a6aaf77c757e854707a05',
+    },
+  },
+} satisfies WorkflowExecutionAPIResponse;
+
+export const mockWorkflowApi = (
+  page: Page,
+  workflow: WorkflowExecutionAPIResponse = mockWorkflow,
+) => {
   return page.route(WORKFLOW_API, (route) => {
     return route.fulfill({
-      json: mockWorkflow,
+      json: workflow,
     });
   });
+};
+
+export const mockWorkflowResetApi = (page: Page) => {
+  return page.route(WORKFLOW_RESET_API, (route) => {
+    return route.fulfill({
+      json: {},
+    });
+  });
+  return;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
- Previously we were using the `on:change` handler in the reset workflow form to toggle the `resetType` local state between `ResetReapplyType.None` and `ResetReapplyType.Signal`. The `resetType` variable was not initialized with a value, so if the user did not check and uncheck the checkbox, it would never accurately reflect the `ResetReapplyType.None` state. In this case, `undefined` was sent to the reset workflow API, and the default of `ResetReapplyType.Signal` was used. 
- Now I've updated this component to use a `reapplySignals` var initialized as `false` and `bind` the value so that it stays in sync without the need for a change handler. Keeping the previous approach of using a change handler would have worked if I just added `ResetReapplyType.None` as the initial value for the `resetType` local state, but I think this approach is cleaner.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

Ran the `await-signals` sample in samples-go, and waited for the workflow to finish.

- reset the workflow leaving the checkbox unchecked, and verified signals were _not_ applied after the reset point
- reset the workflow with the checkbox checked, and verified signals _were_ applied after the reset point
- reset the workflow after checking/unchecking the checkbox, and verified signals were _not_ applied after the reset point

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
