### PR TITLE
Audit a11y issues

### DIFF
--- a/src/lib/holocene/accordion.svelte
+++ b/src/lib/holocene/accordion.svelte
@@ -83,6 +83,7 @@
   <div
     id="{id}-content"
     aria-labelledby="{id}-trigger"
+    role="textbox"
     class="mt-8 block w-full"
     class:hidden={!open}
   >

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -168,7 +168,6 @@
 
 <div class="relative min-w-[80px] grow">
   <div
-    on:keydown|stopPropagation
     bind:this={editor}
     class={className}
     data-testid={$$props.testId}

--- a/src/lib/holocene/filter-or-copy-buttons.svelte
+++ b/src/lib/holocene/filter-or-copy-buttons.svelte
@@ -23,11 +23,7 @@
 </script>
 
 {#if show}
-  <div
-    class={merge('copy-or-filter', className)}
-    on:click|preventDefault|stopPropagation={noop}
-    on:keyup|preventDefault|stopPropagation={noop}
-  >
+  <div class={merge('copy-or-filter', className)}>
     {#if filterable}
       <button
         on:click|preventDefault|stopPropagation={onFilter}


### PR DESCRIPTION
**For the `CodeBlock` component**: I could not find a single use of `CodeBlock` that had an `on:keydown` event, so it doesn't _appear_ that we're using it?

**For `filter-or-copy-buttons`**: These both appear to be `noop` functions?