### PR TITLE
Use globalThis.accessToken() for codec server calls

### DIFF
--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -24,12 +24,10 @@ export async function decodePayloadsWithCodec({
   payloads,
   namespace = get(page).params.namespace,
   settings = get(page).data.settings,
-  accessToken = get(authUser).accessToken,
 }: {
   payloads: PotentialPayloads;
   namespace?: string;
   settings?: Settings;
-  accessToken?: string;
 }): Promise<PotentialPayloads> {
   const endpoint = getCodecEndpoint(settings);
   const passAccessToken = getCodecPassAccessToken(settings);
@@ -42,6 +40,10 @@ export async function decodePayloadsWithCodec({
 
   if (passAccessToken) {
     if (validateHttps(endpoint)) {
+      let accessToken = get(authUser).accessToken;
+      if (globalThis?.AccessToken) {
+        accessToken = await globalThis?.AccessToken();
+      }
       headers['Authorization'] = `Bearer ${accessToken}`;
     } else {
       setLastDataEncoderFailure();


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Now with 15 minute token refreshes, we want to grab the access token for every request to codec (similar to request-from-api) instead of using the token from authUser after login since it can expire.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
