### PR TITLE
Encoded/Decoded/Readable setting for Download History

### DIFF
--- a/src/lib/components/workflow/download-event-history-modal.svelte
+++ b/src/lib/components/workflow/download-event-history-modal.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import Modal from '$lib/holocene/modal.svelte';
+  import RadioGroup from '$lib/holocene/radio-input/radio-group.svelte';
+  import RadioInput from '$lib/holocene/radio-input/radio-input.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import { downloadEventHistorySetting } from '$lib/stores/events';
+  import { page } from '$lib/svelte-mocks/app/stores';
+  import { exportHistory } from '$lib/utilities/export-history';
+
+  export let open = false;
+  export let namespace: string;
+  export let workflowId: string;
+  export let runId: string;
+
+  const onDownloadClick = () => {
+    open = false;
+    exportHistory({
+      namespace,
+      workflowId,
+      runId,
+      settings: $page.data.settings,
+      decodeSetting: $downloadEventHistorySetting,
+    });
+  };
+</script>
+
+<Modal
+  id="download-history"
+  large
+  bind:open
+  confirmType="primary"
+  confirmText={translate('common.download')}
+  cancelText={translate('common.cancel')}
+  on:confirmModal={() => onDownloadClick()}
+  on:cancelModal={() => (open = false)}
+>
+  <h3 slot="title">
+    {translate('common.download-json')}
+  </h3>
+  <div slot="content" class="flex flex-col gap-4">
+    <RadioGroup
+      group={downloadEventHistorySetting}
+      name="decode-setting"
+      class="h-auto overflow-auto"
+    >
+      <RadioInput
+        id="use-encoded-setting"
+        data-testid="use-encoded-setting-input"
+        value="encoded"
+        label={translate('events.encoded')}
+      />
+      <RadioInput
+        id="use-decoded-setting"
+        data-testid="use-decoded-setting-input"
+        value="decoded"
+        label={translate('events.decoded')}
+      />
+      <RadioInput
+        id="use-readable-setting"
+        data-testid="use-readable-setting-input"
+        value="readable"
+        label={translate('events.readable')}
+      />
+    </RadioGroup>
+  </div>
+</Modal>

--- a/src/lib/components/workflow/download-event-history-modal.svelte
+++ b/src/lib/components/workflow/download-event-history-modal.svelte
@@ -54,12 +54,14 @@
         data-testid="use-decoded-setting-input"
         value="decoded"
         label={translate('events.decoded')}
+        description={translate('events.decoded-description')}
       />
       <RadioInput
         id="use-readable-setting"
         data-testid="use-readable-setting-input"
         value="readable"
         label={translate('events.readable')}
+        description={translate('events.readable-description')}
       />
     </RadioGroup>
   </div>

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -63,6 +63,8 @@ export const Strings = {
   },
   'decode-event-history': 'Decode Event History',
   encoded: 'Encoded',
-  decoded: 'Decoded (Codec Server decoded and base64 encoded)',
-  readable: 'Human Readable (Codec Server decoded and base64 decoded)',
+  decoded: 'Decoded',
+  'decoded-description': 'Codec Server decoded and base64 encoded',
+  readable: 'Human Readable',
+  'readable-description': 'Codec Server decoded and base64 decoded',
 } as const;

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -62,4 +62,7 @@ export const Strings = {
     terminated: 'Terminated',
   },
   'decode-event-history': 'Decode Event History',
+  encoded: 'Encoded',
+  decoded: 'Decoded (Codec Server decoded and base64 encoded)',
+  readable: 'Human Readable (Codec Server decoded and base64 decoded)',
 } as const;

--- a/src/lib/layouts/workflow-history-layout-v2.svelte
+++ b/src/lib/layouts/workflow-history-layout-v2.svelte
@@ -9,11 +9,10 @@
   import TimelineGraph from '$lib/components/lines-and-dots/svg/timeline-graph.svelte';
   import WorkflowDetails from '$lib/components/lines-and-dots/workflow-details.svelte';
   import WorkflowError from '$lib/components/lines-and-dots/workflow-error.svelte';
+  import DownloadEventHistoryModal from '$lib/components/workflow/download-event-history-modal.svelte';
   import WorkflowCallStackError from '$lib/components/workflow/workflow-call-stack-error.svelte';
-  import Modal from '$lib/holocene/modal.svelte';
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
-  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
   import { translate } from '$lib/i18n/translate';
   import { groupEvents } from '$lib/models/event-groups';
   import {
@@ -22,14 +21,8 @@
     clearActives,
   } from '$lib/stores/active-events';
   import { eventViewType } from '$lib/stores/event-view';
-  import {
-    decodeEventHistory,
-    filteredEventHistory,
-    fullEventHistory,
-  } from '$lib/stores/events';
+  import { filteredEventHistory, fullEventHistory } from '$lib/stores/events';
   import { workflowRun } from '$lib/stores/workflow-run';
-  import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
-  import { exportHistory } from '$lib/utilities/export-history';
   import { getWorkflowTaskFailedEvent } from '$lib/utilities/get-workflow-task-failed-event';
 
   let showFilters = false;
@@ -57,17 +50,6 @@
 
   let canvasWidth = 0;
   let showDownloadPrompt = false;
-
-  const onDownloadClick = () => {
-    showDownloadPrompt = false;
-    exportHistory({
-      namespace: decodeURIForSvelte(namespace),
-      workflowId: decodeURIForSvelte(workflow?.id),
-      runId: decodeURIForSvelte(workflow?.runId),
-      settings: $page.data.settings,
-      decodeEventHistory: $decodeEventHistory,
-    });
-  };
 
   const zoomOut = () => {
     if (zoomLevel < 10) zoomLevel += 0.5;
@@ -179,25 +161,9 @@
     {/if}
   </div>
 </div>
-<Modal
-  id="download-history"
-  large
+<DownloadEventHistoryModal
   bind:open={showDownloadPrompt}
-  confirmType="primary"
-  confirmText={translate('common.download')}
-  cancelText={translate('common.cancel')}
-  on:confirmModal={() => onDownloadClick()}
-  on:cancelModal={() => (showDownloadPrompt = false)}
->
-  <h3 slot="title">
-    {translate('common.download-json')}
-  </h3>
-  <div slot="content" class="flex flex-col gap-4">
-    <ToggleSwitch
-      label={translate('events.decode-event-history')}
-      id="decode-event-history"
-      bind:checked={$decodeEventHistory}
-      data-testid="decode-event-history-toggle"
-    />
-  </div>
-</Modal>
+  {namespace}
+  workflowId={workflow.id}
+  runId={workflow.runId}
+/>

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -2,31 +2,29 @@
   import { page } from '$app/stores';
 
   import EventHistoryTimeline from '$lib/components/event/event-history-timeline.svelte';
+  import DownloadEventHistoryModal from '$lib/components/workflow/download-event-history-modal.svelte';
   import InputAndResults from '$lib/components/workflow/input-and-results.svelte';
   import PendingActivities from '$lib/components/workflow/pending-activities.svelte';
   import WorkflowCallStackError from '$lib/components/workflow/workflow-call-stack-error.svelte';
   import WorkflowSummary from '$lib/components/workflow/workflow-summary.svelte';
   import WorkflowTypedError from '$lib/components/workflow/workflow-typed-error.svelte';
   import Accordion from '$lib/holocene/accordion.svelte';
-  import Modal from '$lib/holocene/modal.svelte';
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
-  import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
   import { translate } from '$lib/i18n/translate';
   import { eventFilterSort, eventViewType } from '$lib/stores/event-view';
-  import { decodeEventHistory, fullEventHistory } from '$lib/stores/events';
+  import { fullEventHistory } from '$lib/stores/events';
   import {
     workflowRun,
     workflowTimelineViewOpen,
   } from '$lib/stores/workflow-run';
   import type { EventView } from '$lib/types/events';
-  import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
-  import { exportHistory } from '$lib/utilities/export-history';
   import { getWorkflowStartedCompletedAndTaskFailedEvents } from '$lib/utilities/get-started-completed-and-task-failed-events';
   import { getWorkflowTaskFailedEvent } from '$lib/utilities/get-workflow-task-failed-event';
 
   let showDownloadPrompt = false;
 
+  $: ({ namespace } = $page.params);
   $: ({ workflow } = $workflowRun);
   $: workflowEvents =
     getWorkflowStartedCompletedAndTaskFailedEvents($fullEventHistory);
@@ -40,17 +38,6 @@
       $page.url.searchParams.delete('page');
     }
     $eventViewType = view;
-  };
-
-  const onDownloadClick = () => {
-    showDownloadPrompt = false;
-    exportHistory({
-      namespace: decodeURIForSvelte($page.params.namespace),
-      workflowId: decodeURIForSvelte(workflow?.id),
-      runId: decodeURIForSvelte(workflow?.runId),
-      settings: $page.data.settings,
-      decodeEventHistory: $decodeEventHistory,
-    });
   };
 </script>
 
@@ -141,26 +128,9 @@
     <slot />
   </section>
 </div>
-
-<Modal
-  id="download-history"
-  large
+<DownloadEventHistoryModal
   bind:open={showDownloadPrompt}
-  confirmType="primary"
-  confirmText={translate('common.download')}
-  cancelText={translate('common.cancel')}
-  on:confirmModal={() => onDownloadClick()}
-  on:cancelModal={() => (showDownloadPrompt = false)}
->
-  <h3 slot="title">
-    {translate('common.download-json')}
-  </h3>
-  <div slot="content" class="flex flex-col gap-4">
-    <ToggleSwitch
-      label={translate('events.decode-event-history')}
-      id="decode-event-history"
-      bind:checked={$decodeEventHistory}
-      data-testid="decode-event-history-toggle"
-    />
-  </div>
-</Modal>
+  {namespace}
+  workflowId={workflow.id}
+  runId={workflow.runId}
+/>

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -97,3 +97,12 @@ export const decodeEventHistory = persistStore<boolean>(
   true,
   true,
 );
+
+export type DownloadEventHistorySetting = 'encoded' | 'decoded' | 'readable';
+
+export const downloadEventHistorySetting =
+  persistStore<DownloadEventHistorySetting>(
+    'downloadEventHistorySetting',
+    'encoded',
+    true,
+  );


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add new option to allow downloading Event History as codec server decoded but still in base64 encoding.

Note: All three options will still show even if Codec Server is not configured. This is because the history could be encoded but the the Codec Server is not configured (i.e. cannot say to just base64 decode if no Codec Server - payloads could be non json payloads).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" alt="Screenshot 2024-06-24 at 11 44 46 AM" src="https://github.com/temporalio/ui/assets/7967403/633ba146-f33d-494c-979a-91835e67db80">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
To test:

- Use samples-go/codec-server
- Pick each of the three options
- "Encoded" should be binary/snappy encoded
- "Decoded" should be json/plain encoded
- "Readable" should be human readable

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
