### PR TITLE
 Fix ExecutionStatus filters not showing up on page refresh

### DIFF
--- a/src/lib/utilities/query/to-list-workflow-filters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.test.ts
@@ -8,29 +8,29 @@ import {
   toListWorkflowFilters,
 } from './to-list-workflow-filters';
 
-const executionStatusQuery = 'ExecutionStatus="Completed"';
+const executionStatusQuery = '`ExecutionStatus`="Completed"';
 const multipleExecutionStatusQuery =
-  '(ExecutionStatus="Canceled" OR ExecutionStatus="Failed" OR ExecutionStatus="Completed")';
+  '(`ExecutionStatus`="Canceled" OR `ExecutionStatus`="Failed" OR `ExecutionStatus`="Completed")';
 
-const workflowIdQuery = 'WorkflowId="Hello world"';
-const workflowTypeQuery = 'WorkflowType="World"';
-const workflowQuery1 = 'WorkflowId="Hello world" AND WorkflowType="World"';
-const startTimeQuery = 'StartTime > "2022-04-18T17:45:18-06:00"';
-const closeTimeQuery = 'CloseTime > "2022-04-18T17:45:18-06:00"';
-const booleanQuery = 'CustomBoolField=true';
+const workflowIdQuery = '`WorkflowId`="Hello world"';
+const workflowTypeQuery = '`WorkflowType`="World"';
+const workflowQuery1 = '`WorkflowId`="Hello world" AND `WorkflowType`="World"';
+const startTimeQuery = '`StartTime` > "2022-04-18T17:45:18-06:00"';
+const closeTimeQuery = '`CloseTime` > "2022-04-18T17:45:18-06:00"';
+const booleanQuery = '`CustomBoolField`=true';
 const betweenTimeQuery =
-  'StartTime BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"';
+  '`StartTime` BETWEEN "2023-07-28T00:00:00-00:00" AND "2023-07-28T06:00:00-00:00"';
 const workflowQuery2 =
-  'WorkflowType="World" AND StartTime > "2022-04-18T17:45:18-06:00"';
+  '`WorkflowType`="World" AND `StartTime` > "2022-04-18T17:45:18-06:00"';
 const workflowQuery3 =
-  'WorkflowType="World" AND StartTime > "2022-04-18T17:45:18-06:00" AND ExecutionStatus="Canceled"';
+  '`WorkflowType`="World" AND `StartTime` > "2022-04-18T17:45:18-06:00" AND `ExecutionStatus`="Canceled"';
 const workflowQuery4 =
-  '(ExecutionStatus="Canceled" OR ExecutionStatus="Failed" OR ExecutionStatus="Completed") AND WorkflowType="World" AND StartTime > "2022-04-18T17:45:18-06:00"';
+  '(`ExecutionStatus`="Canceled" OR `ExecutionStatus`="Failed" OR `ExecutionStatus`="Completed") AND WorkflowType="World" AND StartTime > "2022-04-18T17:45:18-06:00"';
 const customAttributesWithSpacesQuery =
   '`Custom Bool Field`=true AND `Custom Keyword Field`="Hello world"';
 const workflowQueryWithSpaces =
-  'WorkflowId="One and Two" AND `Custom Keyword Field`="Hello = world"';
-const prefixQuery = 'WorkflowType STARTS_WITH "hello"';
+  '`WorkflowId`="One and Two" AND `Custom Keyword Field`="Hello = world"';
+const prefixQuery = '`WorkflowType` STARTS_WITH "hello"';
 
 const attributes = {
   CloseTime: 'Datetime',

--- a/src/lib/utilities/query/tokenize.test.ts
+++ b/src/lib/utilities/query/tokenize.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { tokenize } from './tokenize';
 
-const executionStatusQuery = 'ExecutionStatus="Completed"';
-const startTimeQuery = 'StartTime > "2022-04-18T17:45:18-06:00"';
-const workflowQuery = 'WorkflowId="Hello" and WorkflowType="World"';
+const executionStatusQuery = '`ExecutionStatus`="Completed"';
+const startTimeQuery = '`StartTime` > "2022-04-18T17:45:18-06:00"';
+const workflowQuery = '`WorkflowId`="Hello" and `WorkflowType`="World"';
 const customAttributesWithSpacesQuery =
-  '(ExecutionStatus="Running" OR ExecutionStatus="TimedOut") AND `Custom Key Word`="Hello there" AND WorkflowId="some workflow" AND `Custom Boolean`=true';
+  '(`ExecutionStatus`="Running" OR `ExecutionStatus`="TimedOut") AND `Custom Key Word`="Hello there" AND `WorkflowId`="some workflow" AND `Custom Boolean`=true';
 const combinedQuery =
-  'WorkflowId="Hello" and WorkflowType="World" and StartTime BETWEEN "2022-04-18T18:09:49-06:00" AND "2022-04-20T18:09:49-06:00"';
+  '`WorkflowId`="Hello" and `WorkflowType`="World" and `StartTime` BETWEEN "2022-04-18T18:09:49-06:00" AND "2022-04-20T18:09:49-06:00"';
 const valuesWithSpacesQuery =
-  '`Custom Key Word`="Hello there world" AND WorkflowId="one and two = three" OR WorkflowType="example=\'one\'"';
+  '`Custom Key Word`="Hello there world" AND `WorkflowId`="one and two = three" OR `WorkflowType`="example=\'one\'"';
 
 describe('tokenize', () => {
   it('should eliminate spaces', () => {

--- a/src/lib/utilities/query/tokenize.ts
+++ b/src/lib/utilities/query/tokenize.ts
@@ -41,7 +41,9 @@ export const tokenize = (string: string): Tokens => {
     if (isBacktick(character)) {
       const isPotentialStartofAttribute =
         cursor === 0 ||
-        (isSpace(string[cursor - 1]) && isOperator(tokens[tokens.length - 1]));
+        (isSpace(string[cursor - 1]) &&
+          isOperator(tokens[tokens.length - 1])) ||
+        isParenthesis(string[cursor - 1]);
       const hasClosingBacktick = string.slice(cursor + 1).includes(character);
 
       if (isPotentialStartofAttribute && hasClosingBacktick) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If multiple statues are selected, when the page was refreshed not all statues were showing up as a filter "chip" below the search input/filter button. 

This PR fixes this by accounting for the possibility of a parenthesis as being the beginning of a search attribute in the `tokenize` util (as in the case with "(`ExecutionStatus`="Running" OR `ExecutionStatus`="TimedOut")"). It also updates several tests to have backticks for a more accurate representation of what queries look like.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
* Select multiple `ExecutionStatus` options from the `Filter` in the Workflows list view
   - [ ] Verify all `ExecutionStatus` filters show up as expected
* Refresh the page
   - [ ] Verify all `ExecutionStatus` filters show up as expected
### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-2295`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
