### PR TITLE
Remove double encoding for API URL parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.28.0-decode.1",
+  "version": "2.27.15",
   "engines": {
     "pnpm": ">=8.6.0",
     "node": ">=18.15.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@temporalio/ui",
-  "version": "2.27.15",
+  "version": "2.28.0-decode.1",
   "engines": {
     "pnpm": ">=8.6.0",
     "node": ">=18.15.0"

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -39,7 +39,7 @@ const settings: Settings = {
     isLocal: true,
     envOverride: true,
   },
-  version: '2.0.0',
+  version: '2.28.0',
 };
 
 const data: App.PageData = {

--- a/src/lib/utilities/route-for-api.test.ts
+++ b/src/lib/utilities/route-for-api.test.ts
@@ -181,7 +181,7 @@ describe('API Request Encoding', () => {
       workflowId: 'workflow#with#hashes',
     });
     expect(route).toBe(
-      'http://localhost:8233/api/v1/namespaces/namespace/workflows/workflow%2523with%2523hashes',
+      'http://localhost:8233/api/v1/namespaces/namespace/workflows/workflow%23with%23hashes',
     );
   });
 
@@ -194,7 +194,7 @@ describe('API Request Encoding', () => {
         'temporal.canary.cron-workflow.sanity-2022-05-02T16:03:11-06:00/workflow.advanced-visibility.scan',
     });
     expect(route).toBe(
-      'http://localhost:8233/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%253A03%253A11-06%253A00%252Fworkflow.advanced-visibility.scan',
+      'http://localhost:8233/api/v1/namespaces/canary/workflows/temporal.canary.cron-workflow.sanity-2022-05-02T16%3A03%3A11-06%3A00%2Fworkflow.advanced-visibility.scan',
     );
   });
 });

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -81,7 +81,7 @@ const encode = (
 ): APIRouteParameters => {
   return Object.keys(parameters ?? {}).reduce(
     (acc, key) => {
-      acc[key] = encodeURIComponent(encodeURIComponent(parameters[key]));
+      acc[key] = encodeURIComponent(parameters[key]);
       return acc;
     },
     {

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -84,7 +84,6 @@ const encode = (
   return Object.keys(parameters ?? {}).reduce(
     (acc, key) => {
       if (version && minimumVersionRequired('2.23.0', version)) {
-        console.log('SINGLE ENCODING');
         acc[key] = encodeURIComponent(parameters[key]);
       } else {
         acc[key] = encodeURIComponent(encodeURIComponent(parameters[key]));

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -33,6 +33,7 @@ import type {
 } from '$lib/types/api';
 
 import { getApiOrigin } from './get-api-origin';
+import { minimumVersionRequired } from './version-check';
 
 const replaceNamespaceInApiUrl = (
   apiUrl: string,
@@ -79,9 +80,15 @@ const withBase = (path: string, namespace?: string): string => {
 const encode = (
   parameters: Partial<APIRouteParameters>,
 ): APIRouteParameters => {
+  const version = get(page)?.data?.settings?.version;
   return Object.keys(parameters ?? {}).reduce(
     (acc, key) => {
-      acc[key] = encodeURIComponent(parameters[key]);
+      if (version && minimumVersionRequired('2.23.0', version)) {
+        console.log('SINGLE ENCODING');
+        acc[key] = encodeURIComponent(parameters[key]);
+      } else {
+        acc[key] = encodeURIComponent(encodeURIComponent(parameters[key]));
+      }
       return acc;
     },
     {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
With proto/SCREAMING ENUM updates, WorkflowIds that contain certain letter combinations can't be found by api due to double encoding. This PR removes the double encoding if ui-server version is` >= 2.23.0` and keeps it if less than that.

Patterns with issues:

Quotes:
`someId'|another|test|__test__underscore|test|data'`
`id="x_'some/value'"
`

Slashes:
`Example(1/1)`

Spaces:
`Example(1 0)`

! with : 
`!foo:bar`

All of these WorkflowIds 404 with double encoding, and do not 404 with single encoding.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1727" alt="Screenshot 2024-07-08 at 9 07 06 AM" src="https://github.com/temporalio/ui/assets/7967403/74b22cf5-8804-451b-84c7-82a0e35d3ef3">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

Fixes:
#1987
#2129 
#1084 

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
