### PR TITLE
Fix reason input on Pause Schedule modal in night mode

### DIFF
--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -17,6 +17,7 @@
   import Button from '$lib/holocene/button.svelte';
   import DatePicker from '$lib/holocene/date-picker.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
+  import Input from '$lib/holocene/input/input.svelte';
   import Link from '$lib/holocene/link.svelte';
   import Loading from '$lib/holocene/loading.svelte';
   import MenuItem from '$lib/holocene/menu/menu-item.svelte';
@@ -437,11 +438,12 @@
             ? translate('schedules.unpause-reason')
             : translate('schedules.pause-reason')}
         </p>
-        <input
-          class="mt-4 block w-full rounded-md border border-slate-200 p-2"
-          placeholder={translate('common.reason')}
+        <Input
+          id="pause-reason"
           bind:value={reason}
-          on:keydown|stopPropagation
+          placeholder={translate('common.reason')}
+          label={translate('common.reason')}
+          labelHidden
         />
       </div>
     </Modal>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Updates the `Pause Schedule` modal to use the Holocene `Input` component with night mode compatible styling.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
| Before | After |
|--|--|
|<img width="552" alt="Screenshot 2024-07-09 at 9 39 03 PM" src="https://github.com/temporalio/ui/assets/15069288/a340d541-d3a1-4bec-b3a3-21e7fbd582ec">|<img width="551" alt="Screenshot 2024-07-09 at 9 42 59 PM" src="https://github.com/temporalio/ui/assets/15069288/a145f04c-a578-4af1-8782-a7d8f59c7036">|
|<img width="549" alt="Screenshot 2024-07-09 at 9 38 53 PM" src="https://github.com/temporalio/ui/assets/15069288/86386676-c901-4d39-a925-69400e452d06">|<img width="545" alt="Screenshot 2024-07-09 at 9 43 10 PM" src="https://github.com/temporalio/ui/assets/15069288/4e6e9fe4-e646-459e-97f0-5b63478a4ed4">|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
