### PR TITLE
Update base images

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.7
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.8
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.8
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.14.11
 
 FROM ${BASE_BUILDER_IMAGE} AS server-builder
 


### PR DESCRIPTION
The base-builder and base-server images are ~4months old at this point and the security scanner I'm using picks up a CVE-2023-45288.

This CVE is resolved in go >= 1.22.2 so is likely already resolved in base-builder 1.14.11 since that was built recently and 1.22.5 is the latest in golang:1.22-alpine3.20 if someone pulls it today.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 

[CVE-2023-45288](https://pkg.go.dev/vuln/GO-2024-2687) was detected in the latest temporal/ui:1.29.2 on dockerhub.  This is a CVE marked as High so I would like to help get it resolved.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 
Once a test image is built, I can run my image scanner against it to verify the CVE has been resolved.

### How was this tested 👻 

I was not able to build an image locally to test, but am hoping there is a CI test that publishes a test image so I can check it for function / vulnerabilities.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ 

This would require a paid account (I'm using Prisma which is a Palo Alto networks product), but likely other image scanners would pick this up as well.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
