### PR TITLE
Fix the wrong nano conversion in timestampToDate

### DIFF
--- a/src/lib/utilities/format-time.ts
+++ b/src/lib/utilities/format-time.ts
@@ -19,7 +19,7 @@ export function timestampToDate(ts: Timestamp): Date {
 
   const d = new Date();
 
-  d.setTime(Number(ts.seconds) * 1000 + (ts.nanos || 0) / 1000);
+  d.setTime(Number(ts.seconds) * 1000 + (ts.nanos || 0) / 1000000);
 
   return d;
 }


### PR DESCRIPTION
the date timestamp in unit of milliseconds, hence nano seconds should divide by 10^6 to provide milliseconds value instead of the previous 10^3