### PR TITLE
Add taskQueueView store to persist Worker tab on Task Queue page

### DIFF
--- a/src/lib/pages/task-queue.svelte
+++ b/src/lib/pages/task-queue.svelte
@@ -7,12 +7,15 @@
   import Tabs from '$lib/holocene/tab/tabs.svelte';
   import { translate } from '$lib/i18n/translate';
   import { getPollers } from '$lib/services/pollers-service';
+  import { taskQueueView } from '$lib/stores/task-queue-view';
 
   import TaskQueueVersioning from './task-queue-versioning.svelte';
 
   $: ({ queue: taskQueue, namespace } = $page.params);
 
-  let view: 'workers' | 'versioning' = 'workers';
+  const onTab = (view: 'workers' | 'versioning') => {
+    $taskQueueView = view;
+  };
 </script>
 
 {#await getPollers({ queue: taskQueue, namespace }) then workers}
@@ -25,16 +28,18 @@
         <Tab
           label={translate('workers.workers')}
           id="worker-tab"
-          onClick={() => (view = 'workers')}
+          onClick={() => onTab('workers')}
+          active={$taskQueueView === 'workers'}
         />
         <Tab
           label={translate('workers.versioning')}
           id="versioning-tab"
-          onClick={() => (view = 'versioning')}
+          onClick={() => onTab('versioning')}
+          active={$taskQueueView === 'versioning'}
         />
       </TabList>
     </Tabs>
-    {#if view === 'versioning'}
+    {#if $taskQueueView === 'versioning'}
       <TaskQueueVersioning {taskQueue} {workers} />
     {:else}
       <WorkerTable {workers} />

--- a/src/lib/stores/task-queue-view.ts
+++ b/src/lib/stores/task-queue-view.ts
@@ -1,0 +1,8 @@
+import { persistStore } from '$lib/stores/persist-store';
+import type { TaskQueueView } from '$lib/types/events';
+
+export const taskQueueView = persistStore<TaskQueueView>(
+  'taskQueueView',
+  'workers',
+  true,
+);

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -151,6 +151,7 @@ export type ChildEvent = StartChildWorkflowExecutionInitiatedEvent &
   ChildWorkflowExecutionTerminatedEvent;
 
 export type EventView = 'compact' | 'feed' | 'json';
+export type TaskQueueView = 'workers' | 'versioning';
 
 export type IterableEvent = WorkflowEvent | EventGroup;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Quality of life improvement to refresh task queue page and keep on the same tab

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
