### PR TITLE
Add initial tooltip to badge

### DIFF
--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -7,6 +7,7 @@
   import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';
   import TableRow from '$lib/holocene/table/table-row.svelte';
   import Table from '$lib/holocene/table/table.svelte';
+  import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
   import { workflowRun } from '$lib/stores/workflow-run';
@@ -68,13 +69,22 @@
               </li>
               {#if details.scheduledTime}
                 <li class="event-table-row">
-                  <h4>{translate('workflows.next-retry')}</h4>
-                  <Badge type="danger">
-                    {toTimeDifference({
-                      date: details.scheduledTime,
-                      negativeDefault: translate('workflows.no-retry'),
+                  <h4>
+                    {translate('workflows.next-retry')}
+                  </h4>
+                  <Tooltip
+                    topRight
+                    text={formatDate(details.scheduledTime, $timeFormat, {
+                      relative: $relativeTime,
                     })}
-                  </Badge>
+                  >
+                    <Badge type="danger">
+                      {toTimeDifference({
+                        date: details.scheduledTime,
+                        negativeDefault: translate('workflows.no-retry'),
+                      })}
+                    </Badge>
+                  </Tooltip>
                 </li>
               {/if}
             {/if}

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -73,7 +73,8 @@
                     {translate('workflows.next-retry')}
                   </h4>
                   <Tooltip
-                    topRight
+                    width={200}
+                    left
                     text={formatDate(details.scheduledTime, $timeFormat, {
                       relative: $relativeTime,
                     })}


### PR DESCRIPTION
Based off this request: "When there is a pending activity, we [...should be] able to hover over that duration and see the estimated time when activity will retry..."

But since we already have the amount of time until next retry, this adds a tool tip showing current duration. 

Needs design input/approval first. 

---
<img width="969" alt="Screenshot 2024-09-05 at 10 40 18 AM" src="https://github.com/user-attachments/assets/351baac4-1214-4ed5-81ab-7790d02f88e1">

