### PR TITLE
Add env var to disable workflow count refresh

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -19,6 +19,7 @@ workflowResetDisabled: false
 batchActionsDisabled: false
 startWorkflowDisabled: false
 hideWorkflowQueryErrors: false
+refreshWorkflowCountsDisabled: false
 auth:
   enabled: false
   providers:

--- a/server/docker/config-template.yaml
+++ b/server/docker/config-template.yaml
@@ -18,6 +18,7 @@ workflowResetDisabled: {{ default .Env.TEMPORAL_WORKFLOW_RESET_DISABLED "false" 
 batchActionsDisabled: {{ default .Env.TEMPORAL_BATCH_ACTIONS_DISABLED "false" }}
 startWorkflowDisabled: {{ default .Env.TEMPORAL_START_WORKFLOW_DISABLED "true" }}
 hideWorkflowQueryErrors: {{ default .Env.TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS "false" }} 
+refreshWorkflowCountsDisabled: {{ default .Env.TEMPORAL_REFRESH_WORKFLOW_COUNTS_DISABLED "false" }}
 cors:
   cookieInsecure: {{ default .Env.TEMPORAL_CSRF_COOKIE_INSECURE "false" }}
   allowOrigins:

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -56,22 +56,23 @@ type CodecResponse struct {
 }
 
 type SettingsResponse struct {
-	Auth                        *Auth
-	BannerText                  string
-	DefaultNamespace            string
-	ShowTemporalSystemNamespace bool
-	FeedbackURL                 string
-	NotifyOnNewVersion          bool
-	Codec                       *CodecResponse
-	Version                     string
-	DisableWriteActions         bool
-	WorkflowTerminateDisabled   bool
-	WorkflowCancelDisabled      bool
-	WorkflowSignalDisabled      bool
-	WorkflowResetDisabled       bool
-	BatchActionsDisabled        bool
-	StartWorkflowDisabled       bool
-	HideWorkflowQueryErrors     bool
+	Auth                          *Auth
+	BannerText                    string
+	DefaultNamespace              string
+	ShowTemporalSystemNamespace   bool
+	FeedbackURL                   string
+	NotifyOnNewVersion            bool
+	Codec                         *CodecResponse
+	Version                       string
+	DisableWriteActions           bool
+	WorkflowTerminateDisabled     bool
+	WorkflowCancelDisabled        bool
+	WorkflowSignalDisabled        bool
+	WorkflowResetDisabled         bool
+	BatchActionsDisabled          bool
+	StartWorkflowDisabled         bool
+	HideWorkflowQueryErrors       bool
+	RefreshWorkflowCountsDisabled bool
 }
 
 func TemporalAPIHandler(cfgProvider *config.ConfigProviderWithRefresh, apiMiddleware []Middleware, conn *grpc.ClientConn) echo.HandlerFunc {
@@ -136,15 +137,16 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 				PassAccessToken:    cfg.Codec.PassAccessToken,
 				IncludeCredentials: cfg.Codec.IncludeCredentials,
 			},
-			Version:                   version.UIVersion,
-			DisableWriteActions:       cfg.DisableWriteActions,
-			WorkflowTerminateDisabled: cfg.WorkflowTerminateDisabled,
-			WorkflowCancelDisabled:    cfg.WorkflowCancelDisabled,
-			WorkflowSignalDisabled:    cfg.WorkflowSignalDisabled,
-			WorkflowResetDisabled:     cfg.WorkflowResetDisabled,
-			BatchActionsDisabled:      cfg.BatchActionsDisabled,
-			StartWorkflowDisabled:     cfg.StartWorkflowDisabled,
-			HideWorkflowQueryErrors:   cfg.HideWorkflowQueryErrors,
+			Version:                       version.UIVersion,
+			DisableWriteActions:           cfg.DisableWriteActions,
+			WorkflowTerminateDisabled:     cfg.WorkflowTerminateDisabled,
+			WorkflowCancelDisabled:        cfg.WorkflowCancelDisabled,
+			WorkflowSignalDisabled:        cfg.WorkflowSignalDisabled,
+			WorkflowResetDisabled:         cfg.WorkflowResetDisabled,
+			BatchActionsDisabled:          cfg.BatchActionsDisabled,
+			StartWorkflowDisabled:         cfg.StartWorkflowDisabled,
+			HideWorkflowQueryErrors:       cfg.HideWorkflowQueryErrors,
+			RefreshWorkflowCountsDisabled: cfg.RefreshWorkflowCountsDisabled,
 		}
 
 		return c.JSON(http.StatusOK, settings)

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -63,6 +63,8 @@ type (
 		StartWorkflowDisabled bool `yaml:"startWorkflowDisabled"`
 		// Whether to hide server errors for workflow queries in UI
 		HideWorkflowQueryErrors bool `yaml:"hideWorkflowQueryErrors"`
+		// Whether to disable refreshing workflow counts in UI
+		RefreshWorkflowCountsDisabled bool `yaml:"refreshWorkflowCountsDisabled"`
 		// Forward specified HTTP headers from HTTP API requests to Temporal gRPC backend
 		ForwardHeaders []string `yaml:"forwardHeaders"`
 		HideLogs       bool     `yaml:"hideLogs"`

--- a/src/lib/components/workflow/workflow-counts.svelte
+++ b/src/lib/components/workflow/workflow-counts.svelte
@@ -7,6 +7,7 @@
   import { workflowStatuses } from '$lib/models/workflow-status';
   import { fetchWorkflowCountByExecutionStatus } from '$lib/services/workflow-counts';
   import {
+    disableWorkflowCountsRefresh,
     queryWithParentWorkflowId,
     refresh,
     workflowCount,
@@ -94,13 +95,15 @@
 
   const fetchCounts = async () => {
     clearNewCounts();
-    const interval =
-      getExponentialBackoffSeconds(
-        initialIntervalSeconds,
-        attempt,
-        maxAttempts,
-      ) * 1000;
-    refreshInterval = setInterval(() => fetchNewCounts(), interval);
+    if (!$disableWorkflowCountsRefresh) {
+      const interval =
+        getExponentialBackoffSeconds(
+          initialIntervalSeconds,
+          attempt,
+          maxAttempts,
+        ) * 1000;
+      refreshInterval = setInterval(() => fetchNewCounts(), interval);
+    }
     try {
       const { count, groups } = await fetchWorkflowCountByExecutionStatus({
         namespace,

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -38,6 +38,9 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     batchActionsDisabled: !!settingsResponse?.BatchActionsDisabled,
     startWorkflowDisabled: !!settingsResponse?.StartWorkflowDisabled,
     hideWorkflowQueryErrors: !!settingsResponse?.HideWorkflowQueryErrors,
+    refreshWorkflowCountsDisabled:
+      !!settingsResponse?.RefreshWorkflowCountsDisabled,
+
     showTemporalSystemNamespace: settingsResponse?.ShowTemporalSystemNamespace,
     notifyOnNewVersion: settingsResponse?.NotifyOnNewVersion,
     feedbackURL: settingsResponse?.FeedbackURL,

--- a/src/lib/stores/workflows.ts
+++ b/src/lib/stores/workflows.ts
@@ -21,6 +21,11 @@ export const hideWorkflowQueryErrors = derived(
   ([$page]) => $page.data?.settings?.hideWorkflowQueryErrors,
 );
 
+export const disableWorkflowCountsRefresh = derived(
+  [page],
+  ([$page]) => $page.data?.settings?.refreshWorkflowCountsDisabled,
+);
+
 export const canFetchChildWorkflows = derived(
   [isCloud, temporalVersion],
   ([$isCloud, $temporalVersion]) => {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -234,6 +234,7 @@ export type SettingsResponse = {
   BatchActionsDisabled: boolean;
   StartWorkflowDisabled: boolean;
   HideWorkflowQueryErrors: boolean;
+  RefreshWorkflowCountsDisabled: boolean;
   ShowTemporalSystemNamespace: boolean;
   NotifyOnNewVersion: boolean;
   FeedbackURL: string;

--- a/tests/test-utilities/mocks/settings.ts
+++ b/tests/test-utilities/mocks/settings.ts
@@ -28,6 +28,7 @@ const defaultSettings = {
   StartWorkflowDisabled: true,
   BatchActionsDisabled: false,
   HideWorkflowQueryErrors: false,
+  RefreshWorkflowCountsDisabled: false,
 };
 
 export const mockSettingsApi = async (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Under heavy DB load, some folks would like to disable the auto-fetch of workflow count to prevent taxing DB 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
