### PR TITLE
Timer value

### DIFF
--- a/src/lib/models/event-groups/get-group-name.ts
+++ b/src/lib/models/event-groups/get-group-name.ts
@@ -24,8 +24,7 @@ export const getEventGroupName = (event: CommonHistoryEvent): string => {
   if (isTimerStartedEvent(event)) {
     return `${event.timerStartedEventAttributes
       ?.timerId} (${formatDurationAbbreviated(
-      event.timerStartedEventAttributes
-        ?.startToFireTimeout as unknown as Duration,
+      event.timerStartedEventAttributes?.startToFireTimeout,
     )})`;
   }
 

--- a/src/lib/utilities/format-time.test.ts
+++ b/src/lib/utilities/format-time.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   formatDistance,
   formatDistanceAbbreviated,
+  formatDurationAbbreviated,
   fromSecondsToDaysOrHours,
   fromSecondsToMinutesAndSeconds,
   getDuration,
@@ -296,5 +297,25 @@ describe('getTimestampDifference', () => {
     const start = '2022-04-13T02:30:59.120571Z';
     const end = '2022-04-13T16:29:35.633009Z';
     expect(getTimestampDifference(start, end)).toBe(50316513);
+  });
+
+  describe('formatDurationAbbreviated', () => {
+    it('should return duration abbreviated with rounded milliseconds if under one minute', () => {
+      expect(formatDurationAbbreviated('13.439023207s')).toBe('13s, 439ms');
+    });
+    it('should return duration abbreviated with no milliseconds if over one minute', () => {
+      expect(formatDurationAbbreviated('64.2134111s')).toBe('1m, 4s');
+    });
+    it('should return duration abbreviated', () => {
+      expect(formatDurationAbbreviated('2652361s')).toBe('30d, 16h, 46m, 1s');
+    });
+    it('should return duration abbreviated', () => {
+      expect(formatDurationAbbreviated('2694361s')).toBe('1month, 4h, 26m, 1s');
+    });
+    it('should return duration abbreviated', () => {
+      expect(formatDurationAbbreviated('32694361s')).toBe(
+        '1year, 13d, 9h, 46m, 1s',
+      );
+    });
   });
 });

--- a/src/lib/utilities/format-time.test.ts
+++ b/src/lib/utilities/format-time.test.ts
@@ -300,6 +300,9 @@ describe('getTimestampDifference', () => {
   });
 
   describe('formatDurationAbbreviated', () => {
+    it('should return duration abbreviated with full milliseconds if under one second', () => {
+      expect(formatDurationAbbreviated('0.86920383s')).toBe('869.20383ms');
+    });
     it('should return duration abbreviated with rounded milliseconds if under one minute', () => {
       expect(formatDurationAbbreviated('13.439023207s')).toBe('13s, 439ms');
     });

--- a/src/lib/utilities/to-duration.test.ts
+++ b/src/lib/utilities/to-duration.test.ts
@@ -349,6 +349,7 @@ describe('fromSeconds', () => {
   it('should correctly format milliseconds', () => {
     expect(fromSeconds('0.001s')).toEqual('1 millisecond');
     expect(fromSeconds('0.006s')).toEqual('6 milliseconds');
+    expect(fromSeconds('0.6s')).toEqual('600 milliseconds');
     expect(fromSeconds('0.06s')).toEqual('60 milliseconds');
     expect(fromSeconds('0.0006s')).toEqual('0.6 milliseconds');
     expect(fromSeconds('0.00006s')).toEqual('0.06 milliseconds');
@@ -358,14 +359,17 @@ describe('fromSeconds', () => {
 
   it('should correctly format seconds', () => {
     expect(fromSeconds('0s')).toEqual('');
+    expect(fromSeconds('0.00s')).toEqual('');
     expect(fromSeconds('1s')).toEqual('1 second');
     expect(fromSeconds('6s')).toEqual('6 seconds');
     expect(fromSeconds('6.00s')).toEqual('6 seconds');
-    expect(fromSeconds('0.00s')).toEqual('');
+    expect(fromSeconds('6.412382134s')).toEqual('6 seconds, 412 milliseconds');
+    expect(fromSeconds('59.32322s')).toEqual('59 seconds, 323 milliseconds');
   });
 
   it('should correctly format minutes', () => {
     expect(fromSeconds('60s')).toEqual('1 minute');
+    expect(fromSeconds('61.1234123412s')).toEqual('1 minute, 1 second');
   });
 
   it('should correctly format hours', () => {
@@ -383,11 +387,10 @@ describe('fromSeconds', () => {
 
   it('should correctly format hours, minutes, seconds and milliseconds', () => {
     expect(fromSeconds('3661s')).toEqual('1 hour, 1 minute, 1 second');
-    expect(fromSeconds('3661.06s')).toEqual(
-      '1 hour, 1 minute, 1 second, 60 milliseconds',
-    );
-    expect(fromSeconds('3661.006s')).toEqual(
-      '1 hour, 1 minute, 1 second, 6 milliseconds',
+    expect(fromSeconds('3661.06s')).toEqual('1 hour, 1 minute, 1 second');
+    expect(fromSeconds('3661.006s')).toEqual('1 hour, 1 minute, 1 second');
+    expect(fromSeconds('2148128.1234123412s')).toEqual(
+      '24 days, 20 hours, 42 minutes, 8 seconds',
     );
   });
 

--- a/src/lib/utilities/to-duration.ts
+++ b/src/lib/utilities/to-duration.ts
@@ -131,7 +131,6 @@ export const fromSeconds = (
   seconds: string,
   { delimiter = ', ' } = {},
 ): string => {
-  console.log('SECONDS: ', seconds);
   const parsedSeconds = parseInt(seconds);
   const parsedDecimal = parseFloat(`.${seconds.split('.')[1] ?? 0}`);
 

--- a/src/lib/utilities/to-duration.ts
+++ b/src/lib/utilities/to-duration.ts
@@ -131,6 +131,7 @@ export const fromSeconds = (
   seconds: string,
   { delimiter = ', ' } = {},
 ): string => {
+  console.log('SECONDS: ', seconds);
   const parsedSeconds = parseInt(seconds);
   const parsedDecimal = parseFloat(`.${seconds.split('.')[1] ?? 0}`);
 
@@ -143,10 +144,16 @@ export const fromSeconds = (
     Math.round(parsedDecimal * 1000 * 1000000000) / 1000000000; // round to nanoseconds
 
   if (!milliseconds) return durationString;
-  const msString = `${milliseconds} ${pluralize('millisecond', milliseconds)}`;
+  if (!durationString)
+    return `${milliseconds} ${pluralize('millisecond', milliseconds)}`;
+  if (parsedSeconds < 60) {
+    return `${durationString}, ${milliseconds.toFixed(0)} ${pluralize(
+      'millisecond',
+      milliseconds,
+    )}`;
+  }
 
-  if (!durationString) return msString;
-  return `${durationString}, ${msString}`;
+  return `${durationString}`;
 };
 
 export const isValidDurationQuery = (value: string): boolean => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Timer values get super long when including milliseconds. We show values like 1 month, 3 days, 18 hours, 28 minutes, 3 seconds, 829.3312342 milliseconds. That is too much accuracy for a large duration.

This PR changes the behavior to the following:

- full milliseconds including decimals if duration is under one second (871.123138 milliseconds)
- Whole milliseconds if duration is under one minute (18 seconds, 392 milliseconds)
- No milliseconds if duration is over one minute (8 minutes, 38 seconds)

Unit tests are updated and added to

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" alt="Screenshot 2024-09-06 at 10 10 45 AM" src="https://github.com/user-attachments/assets/a619a129-738f-4f9d-b15e-5e3f211e7ac4">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
