### PR TITLE
Add links to workflow counts on list workflows page

### DIFF
--- a/src/lib/components/workflow/workflow-counts.svelte
+++ b/src/lib/components/workflow/workflow-counts.svelte
@@ -3,6 +3,7 @@
 
   import { page } from '$app/stores';
 
+  import Link from '$lib/holocene/link.svelte';
   import Skeleton from '$lib/holocene/skeleton/index.svelte';
   import { workflowStatuses } from '$lib/models/workflow-status';
   import { fetchWorkflowCountByExecutionStatus } from '$lib/services/workflow-counts';
@@ -121,13 +122,15 @@
 <div class="flex min-h-[24px] flex-wrap items-center gap-2">
   {#each statusGroups as { count, status } (status)}
     {#if !loading}
-      <WorkflowCountStatus
-        {status}
-        {count}
-        newCount={newStatusGroups.find((g) => g.status === status)
-          ? newStatusGroups.find((g) => g.status === status).count - count
-          : 0}
-      />
+      <Link href={`/workflows/${namespace}/?status=${status}`} role="button">
+        <WorkflowCountStatus
+          {status}
+          {count}
+          newCount={newStatusGroups.find((g) => g.status === status)
+            ? newStatusGroups.find((g) => g.status === status).count - count
+            : 0}
+        />
+      </Link>
     {:else}
       <Skeleton class="h-6 w-24 rounded" />
     {/if}

--- a/src/lib/components/workflow/workflow-counts.svelte
+++ b/src/lib/components/workflow/workflow-counts.svelte
@@ -122,7 +122,10 @@
 <div class="flex min-h-[24px] flex-wrap items-center gap-2">
   {#each statusGroups as { count, status } (status)}
     {#if !loading}
-      <Link href={`/workflows/${namespace}/?status=${status}`} role="button">
+      <Link
+        href={`/namespaces/${namespace}/workflows?query=%60ExecutionStatus%60%3D"${status}"`}
+        role="button"
+      >
         <WorkflowCountStatus
           {status}
           {count}


### PR DESCRIPTION
When clicking on the Workflow Counts on the List Workflows page—they should update the current execution status filter on the workflows list.

For example, if were to click on “7,940 Failed”, they should take the user to /namespaces/${namespace}/workflows?query=%60ExecutionStatus%60%3D"Failed".





---
<img width="1245" alt="Screenshot 2024-09-10 at 1 45 34 PM" src="https://github.com/user-attachments/assets/8d582c88-b673-46e5-9531-e03ccc5e6c6a">
