### PR TITLE
Allow slots to override text content

### DIFF
--- a/src/lib/holocene/tooltip.stories.svelte
+++ b/src/lib/holocene/tooltip.stories.svelte
@@ -120,3 +120,14 @@
 <Story name="Right" args={{ right: true }} />
 
 <Story name="Right with Icon" args={{ right: true, icon: 'trash' }} />
+
+<Story name="With Content instead of text">
+  <Tooltip bottomRight show>
+    <div slot="content">
+      <div>whadup</div>
+      <div>whadup</div>
+      <div>whadup</div>
+    </div>
+    <Button>Tooltip</Button>
+  </Tooltip>
+</Story>

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -93,8 +93,10 @@
     >
       <div class="inline-block rounded-lg bg-slate-800 px-2 py-2">
         <div class="flex gap-2 text-slate-100">
-          {#if icon}<Icon name={icon} class="inline h-4 text-white" />{/if}
-          <span>{text}</span>
+          <slot name="content">
+            {#if icon}<Icon name={icon} class="inline h-4 text-white" />{/if}
+            <span>{text}</span>
+          </slot>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Make it so you can allow the call site to render whatever they want instead of just text to support multiline content and more.
![Screenshot 2024-09-12 at 11 37 09 AM](https://github.com/user-attachments/assets/9b0e3e2c-ea97-42bf-8995-9ee519c535bb)


