### PR TITLE
Add new responsive styles to input on api pagination

### DIFF
--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -226,7 +226,7 @@
       <Input
         icon="search"
         id="api-pagination-search-input"
-        class="w-full grow sm:w-1/2"
+        class="grow"
         bind:value={query}
         label={filterInputPlaceholder}
         labelHidden

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -215,7 +215,7 @@
 <slot name="header" visibleItems={$store.visibleItems} />
 <div class="relative mb-8 flex flex-col gap-4">
   <div
-    class="flex flex-row items-center gap-4 flex-wrap {$$slots[
+    class="flex flex-row flex-wrap items-center gap-4 {$$slots[
       'action-top-left'
     ]
       ? 'justify-between'
@@ -226,7 +226,7 @@
       <Input
         icon="search"
         id="api-pagination-search-input"
-        class="w-full sm:w-1/2"
+        class="w-full grow sm:w-1/2"
         bind:value={query}
         label={filterInputPlaceholder}
         labelHidden
@@ -237,7 +237,7 @@
       />
     {/if}
     <nav
-      class="flex gap-4 flex-row flex-wrap justify-center"
+      class="flex flex-row flex-wrap justify-center gap-4"
       aria-label="{$$restProps['aria-label']} 1"
     >
       <slot name="action-top-center" />

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -237,7 +237,7 @@
       />
     {/if}
     <nav
-      class="flex shrink-0 flex-col gap-4 sm:flex-row"
+      class="flex gap-4 flex-row flex-wrap justify-center"
       aria-label="{$$restProps['aria-label']} 1"
     >
       <slot name="action-top-center" />

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -215,7 +215,7 @@
 <slot name="header" visibleItems={$store.visibleItems} />
 <div class="relative mb-8 flex flex-col gap-4">
   <div
-    class="flex flex-col items-center gap-4 max-xl:flex max-xl:flex-col sm:flex-row {$$slots[
+    class="flex flex-row items-center gap-4 flex-wrap {$$slots[
       'action-top-left'
     ]
       ? 'justify-between'

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -226,7 +226,7 @@
       <Input
         icon="search"
         id="api-pagination-search-input"
-        class="w-1/2 grow"
+        class="w-full grow sm:w-1/2"
         bind:value={query}
         label={filterInputPlaceholder}
         labelHidden

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -215,7 +215,7 @@
 <slot name="header" visibleItems={$store.visibleItems} />
 <div class="relative mb-8 flex flex-col gap-4">
   <div
-    class="flex flex-col items-center gap-4 lg:flex-row {$$slots[
+    class="flex flex-col items-center gap-4 sm:flex-row md:flex-row lg:flex-col {$$slots[
       'action-top-left'
     ]
       ? 'justify-between'
@@ -226,7 +226,7 @@
       <Input
         icon="search"
         id="api-pagination-search-input"
-        class="grow"
+        class="w-1/2 grow"
         bind:value={query}
         label={filterInputPlaceholder}
         labelHidden
@@ -237,7 +237,7 @@
       />
     {/if}
     <nav
-      class="flex shrink-0 flex-col gap-4 md:flex-row"
+      class="flex shrink-0 flex-col gap-4 sm:flex-row lg:flex-col"
       aria-label="{$$restProps['aria-label']} 1"
     >
       <slot name="action-top-center" />

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -215,7 +215,7 @@
 <slot name="header" visibleItems={$store.visibleItems} />
 <div class="relative mb-8 flex flex-col gap-4">
   <div
-    class="flex flex-col items-center gap-4 sm:flex-row md:flex-row lg:flex-col {$$slots[
+    class="flex flex-col items-center gap-4 max-xl:flex max-xl:flex-col sm:flex-row xl:flex-col {$$slots[
       'action-top-left'
     ]
       ? 'justify-between'
@@ -237,7 +237,7 @@
       />
     {/if}
     <nav
-      class="flex shrink-0 flex-col gap-4 sm:flex-row lg:flex-col"
+      class="flex shrink-0 flex-col gap-4 sm:flex-row"
       aria-label="{$$restProps['aria-label']} 1"
     >
       <slot name="action-top-center" />

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -215,7 +215,7 @@
 <slot name="header" visibleItems={$store.visibleItems} />
 <div class="relative mb-8 flex flex-col gap-4">
   <div
-    class="flex flex-col items-center gap-4 max-xl:flex max-xl:flex-col sm:flex-row xl:flex-col {$$slots[
+    class="flex flex-col items-center gap-4 max-xl:flex max-xl:flex-col sm:flex-row {$$slots[
       'action-top-left'
     ]
       ? 'justify-between'
@@ -226,7 +226,7 @@
       <Input
         icon="search"
         id="api-pagination-search-input"
-        class="w-full grow sm:w-1/2"
+        class="w-full sm:w-1/2"
         bind:value={query}
         label={filterInputPlaceholder}
         labelHidden


### PR DESCRIPTION

Adjust responsive breakpoints for namespace filtering

This adds a change to the input and nav styles on the API pagination component in holocene to fix breakpoints for namespace filtering. 


MD
---
<img width="859" alt="Screenshot 2024-09-17 at 6 39 07 PM" src="https://github.com/user-attachments/assets/d176d009-956c-4402-acf2-b6556e910d3c">

XS
---
<img width="437" alt="Screenshot 2024-09-17 at 6 39 29 PM" src="https://github.com/user-attachments/assets/5a6dd4ba-37c5-4de3-a45e-ab833089bfef">

LG
---
<img width="916" alt="Screenshot 2024-09-17 at 6 39 46 PM" src="https://github.com/user-attachments/assets/89b36f8d-e535-4c26-a1a8-c2f4236e612b">

XL
---
<img width="1142" alt="Screenshot 2024-09-17 at 6 40 00 PM" src="https://github.com/user-attachments/assets/06676c2b-48bb-473a-a7e8-3e4ec3a89e09">
