### PR TITLE
Add empty state for upcoming runs

### DIFF
--- a/src/lib/components/schedule/schedule-upcoming-runs.svelte
+++ b/src/lib/components/schedule/schedule-upcoming-runs.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Panel from '$lib/components/panel.svelte';
+  import EmptyState from '$lib/holocene/empty-state.svelte';
   import { translate } from '$lib/i18n/translate';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
   import { formatDate } from '$lib/utilities/format-date';
@@ -9,7 +10,7 @@
   export let futureRuns: Timestamp[] = [];
 </script>
 
-<Panel>
+<Panel class="w-full">
   <h2 class="mb-4">{translate('schedules.upcoming-runs')}</h2>
   {#each futureRuns.slice(0, 5) as run}
     <div class="row">
@@ -20,6 +21,10 @@
         })}
       </p>
     </div>
+  {:else}
+    <EmptyState
+      title={translate('schedules.upcoming-runs-empty-state-title')}
+    />
   {/each}
 </Panel>
 

--- a/src/lib/i18n/locales/en/schedules.ts
+++ b/src/lib/i18n/locales/en/schedules.ts
@@ -19,6 +19,7 @@ export const Strings = {
   'recent-runs': 'Recent Runs',
   'recent-runs-empty-state-title': 'No Recent Runs',
   'upcoming-runs': 'Upcoming Runs',
+  'upcoming-runs-empty-state-title': 'No Upcoming Runs',
   loading: 'Loading Schedule...',
   deleting: 'Deleting Schedule...',
   'delete-schedule-error': 'Cannot delete schedule. {{error}}',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Adds empty state for `Upcoming Runs` on schedule detail page.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
| Before | After |
|-|-|
|![Screenshot 2024-09-26 at 3 11 46 PM](https://github.com/user-attachments/assets/f9742424-cbbf-40d5-87a5-414d5ce75cd0)|![Screenshot 2024-09-26 at 3 12 43 PM](https://github.com/user-attachments/assets/aefbd0f3-d3ac-4c32-bb4a-f9b9d53efcdb)|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-2469`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
