### PR TITLE
DT-1495 - use description instead of tooltip on reset menu item

### DIFF
--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -119,6 +119,7 @@
 {#if isRunning}
   <SplitButton
     id="workflow-actions"
+    menuClass="w-[24rem]"
     position="right"
     disabled={actionsDisabled}
     primaryActionDisabled={!cancelEnabled || cancelInProgress}
@@ -161,6 +162,7 @@
 {:else if !workflowCreateDisabled($page)}
   <SplitButton
     id="workflow-actions"
+    menuClass="w-[16rem]"
     position="right"
     primaryActionDisabled={!resetEnabled}
     on:click={() => (resetConfirmationModalOpen = true)}

--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -31,7 +31,7 @@
   let terminateConfirmationModalOpen = false;
   let resetConfirmationModalOpen = false;
   let signalConfirmationModalOpen = false;
-  let resetTooltipText: string;
+  let resetDescription: string;
   let coreUser = coreUserStore();
 
   $: cancelEnabled = workflowCancelEnabled(
@@ -71,20 +71,20 @@
     enabled: boolean;
     testId: string;
     destructive?: boolean;
-    tooltip?: string;
+    description?: string;
   }[];
 
   $: {
     if (!resetAuthorized) {
-      resetTooltipText = translate('workflows.reset-disabled-unauthorized');
+      resetDescription = translate('workflows.reset-disabled-unauthorized');
     } else if (resetAuthorized && workflow?.pendingChildren?.length > 0) {
-      resetTooltipText = translate('workflows.reset-disabled-pending-children');
+      resetDescription = translate('workflows.reset-disabled-pending-children');
     } else if (
       resetAuthorized &&
       workflow?.pendingChildren?.length === 0 &&
       $resetEvents.length === 0
     ) {
-      resetTooltipText = translate('workflows.reset-disabled-no-events');
+      resetDescription = translate('workflows.reset-disabled-no-events');
     }
   }
 
@@ -94,14 +94,14 @@
       onClick: () => (resetConfirmationModalOpen = true),
       testId: 'reset-button',
       enabled: resetEnabled,
-      tooltip: resetEnabled ? '' : resetTooltipText,
+      description: resetEnabled ? '' : resetDescription,
     },
     {
       label: translate('workflows.signal'),
       onClick: () => (signalConfirmationModalOpen = true),
       testId: 'signal-button',
       enabled: signalEnabled,
-      tooltip: signalEnabled ? '' : translate('workflows.signal-disabled'),
+      description: signalEnabled ? '' : translate('workflows.signal-disabled'),
     },
     {
       label: translate('workflows.terminate'),
@@ -109,7 +109,7 @@
       testId: 'terminate-button',
       enabled: terminateEnabled,
       destructive: true,
-      tooltip: terminateEnabled
+      description: terminateEnabled
         ? ''
         : translate('workflows.terminate-disabled'),
     },
@@ -126,20 +126,19 @@
     label={translate('workflows.request-cancellation')}
     menuLabel={translate('workflows.workflow-actions')}
   >
-    {#each workflowActions as { onClick, destructive, label, enabled, testId, tooltip }}
+    {#each workflowActions as { onClick, destructive, label, enabled, testId, description }}
       {#if destructive}
         <MenuDivider />
       {/if}
-      <Tooltip text={tooltip} hide={!tooltip} width={200} left>
-        <MenuItem
-          on:click={onClick}
-          {destructive}
-          disabled={!enabled}
-          data-testid={testId}
-        >
-          {label}
-        </MenuItem>
-      </Tooltip>
+      <MenuItem
+        on:click={onClick}
+        {destructive}
+        disabled={!enabled}
+        data-testid={testId}
+        {description}
+      >
+        {label}
+      </MenuItem>
     {/each}
     {#if !workflowCreateDisabled($page)}
       <MenuDivider />
@@ -184,7 +183,7 @@
     </MenuItem>
   </SplitButton>
 {:else}
-  <Tooltip bottomRight width={200} text={resetTooltipText} hide={resetEnabled}>
+  <Tooltip bottomRight width={200} text={resetDescription} hide={resetEnabled}>
     <Button
       aria-label={translate('workflows.reset')}
       disabled={!resetEnabled}

--- a/src/lib/holocene/split-button.svelte
+++ b/src/lib/holocene/split-button.svelte
@@ -12,6 +12,7 @@
   export let position: 'left' | 'right' = 'left';
   export let primaryActionDisabled = false;
   export let href: string | undefined = undefined;
+  export let menuClass: string | undefined = undefined;
 </script>
 
 <MenuContainer class={$$props.class}>
@@ -38,7 +39,7 @@
     />
   </div>
 
-  <Menu id="{id}-menu" {position} class="max-w-fit">
+  <Menu id="{id}-menu" {position} class={menuClass}>
     <slot />
   </Menu>
 </MenuContainer>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Instead of changing Menu and/or MenuItem to support tooltips, this PR removes the only occurrence of using a Tooltip on a MenuItem (workflow reset) and uses the MenuItem's description prop instead

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="285" alt="Screenshot 2024-10-08 at 11 26 32 AM" src="https://github.com/user-attachments/assets/be242f82-373d-48a2-94c3-cf3389b84845">
<img width="392" alt="Screenshot 2024-10-08 at 11 27 18 AM" src="https://github.com/user-attachments/assets/e3372bed-a5e5-4014-86f7-1a6cc461e158">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
