### PR TITLE
Explicitly check for response ok false in codeServerRequest

### DIFF
--- a/src/lib/services/data-encoder.test.ts
+++ b/src/lib/services/data-encoder.test.ts
@@ -78,4 +78,16 @@ describe('Codec Server Requests for Decode and Encode', () => {
       codeServerRequest({ type: 'encode', payloads, namespace, settings }),
     ).rejects.toThrow();
   });
+
+  it('should throw an error for encode if response is not ok', async () => {
+    const response = new Response(JSON.stringify(payloads), {
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+    global.fetch = vi.fn(() => Promise.resolve(response));
+
+    await expect(
+      codeServerRequest({ type: 'encode', payloads, namespace, settings }),
+    ).rejects.toThrow();
+  });
 });

--- a/src/lib/services/data-encoder.ts
+++ b/src/lib/services/data-encoder.ts
@@ -14,7 +14,6 @@ import {
   getCodecIncludeCredentials,
   getCodecPassAccessToken,
 } from '$lib/utilities/get-codec';
-import { has } from '$lib/utilities/has';
 import { validateHttps } from '$lib/utilities/is-http';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
@@ -71,7 +70,7 @@ export async function codeServerRequest({
     requestOptions,
   )
     .then((response) => {
-      if (has(response, 'ok') && !response.ok) {
+      if (response.ok === false) {
         throw {
           statusCode: response.status,
           statusText: response.statusText,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object has non-enumerable properties and therefore `has(response, 'ok')` will always be false even if `ok` exists. This PR updates the logic to explicitly check for `response.ok === false` instead.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-2522`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
