### PR TITLE
Show correct encoding value in PayloadInput

### DIFF
--- a/src/lib/components/payload-input.svelte
+++ b/src/lib/components/payload-input.svelte
@@ -1,5 +1,9 @@
 <script context="module" lang="ts">
-  export type PayloadInputEncoding = 'json/plain' | 'json/protobuf';
+  const encoding = ['json/plain', 'json/protobuf'] as const;
+  export type PayloadInputEncoding = (typeof encoding)[number];
+  export const isPayloadInputEncodingType = (
+    x: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+  ): x is PayloadInputEncoding => encoding.includes(x);
 </script>
 
 <script lang="ts">

--- a/src/lib/components/payload-input.svelte
+++ b/src/lib/components/payload-input.svelte
@@ -21,9 +21,9 @@
   export let encoding: Writable<PayloadInputEncoding>;
   export let error = false;
   export let resetValues = false;
+  export let loading = false;
 
   let codeBlock: CodeBlock;
-  let uploaded = false;
 
   $: error = !isValidInput(input);
 
@@ -51,12 +51,12 @@
     $encoding = 'json/plain';
     input = '';
     codeBlock?.resetView(input);
-    uploaded = false;
+    loading = false;
   };
 
   const onUpload = (uploadInput: string) => {
     input = uploadInput;
-    uploaded = true;
+    loading = true;
   };
 
   onDestroy(() => {
@@ -89,7 +89,7 @@
       for="payload-input"
       label={translate('workflows.signal-payload-input-label')}
     />
-    {#key uploaded}
+    {#key loading}
       <CodeBlock
         id="payload-input"
         maxHeight={320}

--- a/src/lib/components/schedule/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-input-payload.svelte
@@ -27,8 +27,6 @@
 
 <div class="flex flex-col gap-1">
   <PayloadDecoder value={payloads} key="payloads" onDecode={setInitialInput}>
-    {#key loading}
-      <PayloadInput bind:input bind:encoding />
-    {/key}
+    <PayloadInput bind:input bind:encoding bind:loading />
   </PayloadDecoder>
 </div>

--- a/src/lib/components/schedule/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-input-payload.svelte
@@ -7,6 +7,7 @@
 
   import PayloadDecoder from '../event/payload-decoder.svelte';
   import PayloadInput, {
+    isPayloadInputEncodingType,
     type PayloadInputEncoding,
   } from '../payload-input.svelte';
 
@@ -18,9 +19,12 @@
 
   const setInitialInput = (decodedValue: string): void => {
     input = getSinglePayload(decodedValue);
-    $encoding = atob(
+    const currentEncoding = atob(
       String(payloads?.payloads[0]?.metadata?.encoding ?? 'json/plain'),
-    ) as PayloadInputEncoding;
+    );
+    if (isPayloadInputEncodingType(currentEncoding)) {
+      $encoding = currentEncoding;
+    }
     loading = false;
   };
 </script>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

# Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
This PR prevents the remount of `PayloadInput` after loading the initial values which was triggering `clearValues()` in the `PayloadInput` component and ensures the correct `Encoding` value is shown.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- Create a schedule with a `Schedule Input` and select `json/protobuf` for `Encoding` and Save 
   - [ ] Verify `json/protobuf` is set with the create and/or update schedule request 
- Select "Edit" for that schedule
   - [ ] Verify `json/protobuf` is selected
- Create a schedule with a `Schedule Input` and select `json/plain` for `Encoding` and Save 
   - [ ] Verify `json/plain` is set with the create and/or update schedule request 
- Select "Edit" for that schedule
   - [ ] Verify `json/plain` is selected

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
