### PR TITLE
Input bug in Firefox: Difficult to Set Focus in Input Textarea for "Start a Workflow"

### DIFF
--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -187,7 +187,7 @@
   <div
     bind:this={editor}
     role="textbox"
-    class={`inline min-w-[80px] cursor-text rounded-xl ${className} ${
+    class={`inline min-w-[80px] cursor-text rounded-xl outline-none ${className} ${
       editable ? 'editable' : 'readOnly'
     }`}
     class:inline

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -69,7 +69,7 @@
     copy(e, content);
   };
 
-  let editor: HTMLElement;
+  let editor: HTMLDivElement | null = null;
   let view: EditorView;
 
   const formatJSON = (jsonData: string): string => {
@@ -174,19 +174,31 @@
     }
   };
 
+  $: disabled = disabled || copyable;
+  function handleFocus() {
+    if (editor) {
+      editor.focus();
+    }
+  }
   $: content, language, setView();
 </script>
 
-<div class="relative min-w-[80px] grow">
+<div role="button" class="relative" tabindex={0} on:focus={handleFocus}>
   <div
     bind:this={editor}
-    class={className}
+    role="textbox"
+    class={`inline min-w-[80px] cursor-text rounded-xl ${className} ${
+      editable ? 'editable' : 'readOnly'
+    }`}
     class:inline
+    contenteditable={editable}
     data-testid={$$props.testId}
     class:editable
+    tabindex={-1}
     class:readOnly={!editable}
     {...$$restProps}
   />
+
   {#if copyable}
     <CopyButton
       {copyIconTitle}

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -183,10 +183,9 @@
   $: content, language, setView();
 </script>
 
-<div role="button" class="relative" tabindex={0} on:focus={handleFocus}>
+<div class="relative" tabindex={0} on:focus={handleFocus}>
   <div
     bind:this={editor}
-    role="textbox"
     class={`rounded-x inline min-w-[80px] cursor-text ${className} ${
       editable ? 'editable' : 'readOnly'
     }`}

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -187,7 +187,7 @@
   <div
     bind:this={editor}
     role="textbox"
-    class={`inline min-w-[80px] cursor-text rounded-xl outline-none ${className} ${
+    class={`rounded-x inline min-w-[80px] cursor-text ${className} ${
       editable ? 'editable' : 'readOnly'
     }`}
     class:inline

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -90,7 +90,6 @@
   export let label: string;
   export let multiselect = false;
   export let value: string | string[] = multiselect ? [] : undefined;
-  export let toggleLabel: string;
   export let noResultsText: string;
   export let disabled = false;
   export let labelHidden = false;

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -97,7 +97,6 @@
   <div class="input-group flex rounded-lg">
     <slot name="before-input" {disabled} />
     <div
-      role="button"
       class="input-container"
       class:disabled
       class:error

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -100,8 +100,8 @@
       class:disabled
       class:error
       class:noBorder
-      class:unroundLeft
-      class:unroundRight
+      class:unroundLeft={unroundLeft || $$slots['before-input']}
+      class:unroundRight={unroundRight || $$slots['after-input']}
       class:invalid={!valid}
       tabindex={disabled ? undefined : 0}
       on:focus={handleFocus}
@@ -124,7 +124,15 @@
         {spellcheck}
         {required}
         {autocomplete}
+        data-lpignore="true"
+        data-1p-ignore="true"
         bind:value
+        on:click|stopPropagation
+        on:input
+        on:keydown|stopPropagation
+        on:change
+        on:focus
+        on:blur
         data-testid={testId}
         {...$$restProps}
       />

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -77,7 +77,9 @@
   let inputRef: HTMLInputElement | null = null;
 
   function handleFocus() {
-    inputRef?.focus();
+    if (autoFocus && !disabled) {
+      inputRef?.focus();
+    }
   }
 
   const dispatch = createEventDispatcher();

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -74,8 +74,10 @@
 
   let testId = $$props['data-testid'] || id;
 
-  function callFocus(input: HTMLInputElement) {
-    if (autoFocus && input) input.focus();
+  let inputRef: HTMLInputElement | null = null;
+
+  function handleFocus() {
+    inputRef?.focus();
   }
 
   const dispatch = createEventDispatcher();
@@ -93,25 +95,28 @@
   <div class="input-group flex rounded-lg">
     <slot name="before-input" {disabled} />
     <div
+      role="button"
       class="input-container"
       class:disabled
       class:error
       class:noBorder
-      class:unroundLeft={unroundLeft || $$slots['before-input']}
-      class:unroundRight={unroundRight || $$slots['after-input']}
+      class:unroundLeft
+      class:unroundRight
       class:invalid={!valid}
+      tabindex={disabled ? undefined : 0}
+      on:focus={handleFocus}
     >
       {#if icon}
         <span class="icon-container">
           <Icon name={icon} />
         </span>
       {/if}
+
       <input
+        bind:this={inputRef}
         class="input"
         class:disabled
         {disabled}
-        data-lpignore="true"
-        data-1p-ignore="true"
         maxlength={maxLength > 0 ? maxLength : undefined}
         {placeholder}
         {id}
@@ -120,16 +125,10 @@
         {required}
         {autocomplete}
         bind:value
-        on:click|stopPropagation
-        on:input
-        on:keydown|stopPropagation
-        on:change
-        on:focus
-        on:blur
-        use:callFocus
         data-testid={testId}
         {...$$restProps}
       />
+
       {#if copyable}
         <div class="copy-icon-container">
           <button aria-label={copyButtonLabel} on:click={(e) => copy(e, value)}>
@@ -185,7 +184,7 @@
 <style lang="postcss">
   /* Base styles */
   .input-container {
-    @apply surface-primary relative box-border inline-flex h-10 w-full items-center rounded-lg border-2 border-subtle text-sm focus-within:outline-none focus-within:ring-4 focus-within:ring-primary/70;
+    @apply surface-primary relative box-border inline-flex h-10 w-full cursor-text items-center rounded-lg border-2 border-subtle text-sm focus-within:outline-none focus-within:ring-4 focus-within:ring-primary/70;
 
     &.error,
     &.invalid {


### PR DESCRIPTION

This change makes the whole visible input field selectable and reactive.

<img width="1067" alt="Screenshot 2024-10-15 at 5 04 21 PM" src="https://github.com/user-attachments/assets/947d77e0-4998-4c9e-91ae-bbde21b07be6">
