### PR TITLE
Do not lookup initial event for WorkflowUpdateAccepted events

### DIFF
--- a/src/lib/models/event-groups/create-event-group.test.ts
+++ b/src/lib/models/event-groups/create-event-group.test.ts
@@ -144,27 +144,4 @@ describe('createEventGroup', () => {
   it('should ignore an event that should not create an event group', () => {
     expect(createEventGroup(completedEvent)).toBeUndefined();
   });
-
-  it('should create a group from a WorkflowExecutionUpdateAccepted event and add WorkflowTaskScheduled event to group', () => {
-    const workflowTaskEvent = {
-      id: '120',
-    } as unknown as WorkflowEvent;
-
-    const updateEvent = {
-      id: '123',
-      eventId: '123',
-      workflowExecutionUpdateAcceptedEventAttributes: {
-        acceptedRequestSequencingEventId: 120,
-      },
-    } as unknown as WorkflowEvent;
-
-    expect(
-      createEventGroup(updateEvent, [workflowTaskEvent, updateEvent])
-        .initialEvent.id,
-    ).toBe(workflowTaskEvent.id);
-    expect(
-      createEventGroup(updateEvent, [workflowTaskEvent, updateEvent]).eventList
-        .length,
-    ).toBe(2);
-  });
 });

--- a/src/lib/models/event-groups/get-event-in-group.ts
+++ b/src/lib/models/event-groups/get-event-in-group.ts
@@ -9,6 +9,9 @@ import {
   isChildWorkflowExecutionTerminatedEvent,
   isChildWorkflowExecutionTimedOutEvent,
   isFailedWorkflowExecutionUpdateCompletedEvent,
+  isNexusOperationCanceledEvent,
+  isNexusOperationFailedEvent,
+  isNexusOperationTimedOutEvent,
   isSignalExternalWorkflowExecutionFailedEvent,
   isTimerCanceledEvent,
   isWorkflowExecutionCanceledEvent,
@@ -30,7 +33,9 @@ export const eventIsFailureOrTimedOut = (event: WorkflowEvent): boolean => {
     isChildWorkflowExecutionFailedEvent(event) ||
     isChildWorkflowExecutionTimedOutEvent(event) ||
     isSignalExternalWorkflowExecutionFailedEvent(event) ||
-    isFailedWorkflowExecutionUpdateCompletedEvent(event)
+    isFailedWorkflowExecutionUpdateCompletedEvent(event) ||
+    isNexusOperationFailedEvent(event) ||
+    isNexusOperationTimedOutEvent(event)
   );
 };
 
@@ -46,7 +51,8 @@ export const eventIsCanceled = (event: WorkflowEvent): boolean => {
     isActivityTaskCanceledEvent(event) ||
     isTimerCanceledEvent(event) ||
     isWorkflowExecutionCanceledEvent(event) ||
-    isChildWorkflowExecutionCanceledEvent(event)
+    isChildWorkflowExecutionCanceledEvent(event) ||
+    isNexusOperationCanceledEvent(event)
   );
 };
 

--- a/src/lib/models/event-groups/get-group-name.ts
+++ b/src/lib/models/event-groups/get-group-name.ts
@@ -12,13 +12,9 @@ import {
   isTimerStartedEvent,
   isWorkflowExecutionSignaledEvent,
   isWorkflowExecutionUpdateAcceptedEvent,
-  isWorkflowExecutionUpdateAdmittedEvent,
 } from '$lib/utilities/is-event-type';
 
-export const getEventGroupName = (
-  event: CommonHistoryEvent,
-  initialEvent?: CommonHistoryEvent,
-): string => {
+export const getEventGroupName = (event: CommonHistoryEvent): string => {
   if (!event) return '';
 
   if (isActivityTaskScheduledEvent(event)) {
@@ -54,13 +50,8 @@ export const getEventGroupName = (
   }
 
   if (isWorkflowExecutionUpdateAcceptedEvent(event)) {
-    if (isWorkflowExecutionUpdateAdmittedEvent(initialEvent)) {
-      return initialEvent.workflowExecutionUpdateAdmittedEventAttributes
-        ?.request?.input?.name;
-    } else {
-      return event.workflowExecutionUpdateAcceptedEventAttributes
-        ?.acceptedRequest?.input?.name;
-    }
+    return event.workflowExecutionUpdateAcceptedEventAttributes?.acceptedRequest
+      ?.input?.name;
   }
 
   if (isNexusOperationScheduledEvent(event)) {
@@ -111,15 +102,12 @@ export const getEventGroupLabel = (event: CommonHistoryEvent): string => {
   }
 };
 
-export const getEventGroupDisplayName = (
-  event: CommonHistoryEvent,
-  initialEvent?: CommonHistoryEvent,
-): string => {
+export const getEventGroupDisplayName = (event: CommonHistoryEvent): string => {
   if (!event) return '';
 
   if (isLocalActivityMarkerEvent(event)) {
     return getSummaryAttribute(event)?.value?.toString() ?? 'Local Activity';
   }
 
-  return getEventGroupName(event, initialEvent);
+  return getEventGroupName(event);
 };

--- a/src/lib/models/event-groups/index.ts
+++ b/src/lib/models/event-groups/index.ts
@@ -69,7 +69,7 @@ export const groupEvents = (
 
   const createGroups = (event: CommonHistoryEvent) => {
     const id = getGroupId(event);
-    const group = createEventGroup(event, events);
+    const group = createEventGroup(event);
     const pendingActivity = getPendingActivity(event, pendingActivities);
     const pendingNexusOperation = getPendingNexusOperation(
       event,
@@ -131,7 +131,7 @@ export const groupWorkflowTaskEvents = (
 
   const createGroups = (event: CommonHistoryEvent) => {
     const id = getGroupId(event);
-    const group = createWorkflowTaskGroup(event, events);
+    const group = createWorkflowTaskGroup(event);
 
     if (group) {
       groups[group.id] = group;


### PR DESCRIPTION
…add Nexus operation events to failed/timedout/canceled

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
This PR removes the custom logic for WorkflowUpdateAccepted events that finds a related initial event with AcceptedRequestSequencingEventId. This can be incorrect and is generally not all that useful. Remove all logic around this as well as add Nexus Operations to failed/timedOut/canceled checks to highlight them in the UI with the correct border

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1600" alt="Screenshot 2024-10-21 at 1 44 12 PM" src="https://github.com/user-attachments/assets/3a5b5554-d2ac-4a20-bd74-0c9fbfe8ffeb">

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
