### PR TITLE
updateQueryParams to include options and preserve order of params

### DIFF
--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -105,6 +105,7 @@
       value: workflowId,
       url: $page.url,
       allowEmpty: true,
+      options: { keepFocus: true, noScroll: true, replaceState: true },
     });
   };
 
@@ -144,6 +145,7 @@
       value,
       url: $page.url,
       allowEmpty: true,
+      options: { keepFocus: true, noScroll: true, replaceState: true },
     });
   };
 

--- a/src/lib/utilities/update-query-parameters.test.ts
+++ b/src/lib/utilities/update-query-parameters.test.ts
@@ -136,7 +136,23 @@ describe('updateQueryParameters', () => {
 
     const [href, options] = goto.mock.calls[0];
 
-    expect(href).toBe('/?other=value&parameter=value');
+    expect(href).toBe('/?parameter=value&other=value');
+    expect(options).toEqual(gotoOptions);
+  });
+
+  it('should call `goto` with the correct path for the updated param and keep order if there are other params', () => {
+    const parameter = 'parameter';
+    const value = 'newValue';
+    const url = new URL(
+      `https://temporal.io/?other1=value1&${parameter}=oldValue&other2=value2`,
+    );
+    const goto = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+    updateQueryParameters({ parameter, value, url, goto });
+
+    const [href, options] = goto.mock.calls[0];
+
+    expect(href).toBe('/?other1=value1&parameter=newValue&other2=value2');
     expect(options).toEqual(gotoOptions);
   });
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When a user enters a Start Workflow field and blurs, the url will be updated with the query param, but it will not be added to browser history. The order of the query params will stay consistent as when changed.

Update goto to preserve the order of the params if the param you are changing already exists. Add unit test for it.
Update goto to pass in options to allow replaceStatus so the browser history does not get updated on goto call. 



### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
