### PR TITLE
Permanently fix formatted utc offset test

### DIFF
--- a/src/lib/stores/time-format.test.ts
+++ b/src/lib/stores/time-format.test.ts
@@ -63,6 +63,6 @@ describe('getUTCOffset', () => {
   });
 
   test('should return a formatted UTC offset for a timezone', () => {
-    expect(getUTCOffset('America/Denver' as TimeFormat)).toBe('-07:00');
+    expect(getUTCOffset('America/Phoenix' as TimeFormat)).toBe('-07:00');
   });
 });


### PR DESCRIPTION
Fix the bi-yearly utc offset issue where MDT->MST changes have breakage by using a timezone that does not adhere to DST.