### PR TITLE
Add render route in ui-server

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -4,6 +4,7 @@ go 1.23
 
 require (
 	github.com/coreos/go-oidc/v3 v3.11.0
+	github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81
 	github.com/gorilla/securecookie v1.1.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	github.com/labstack/echo/v4 v4.9.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -11,6 +11,8 @@ github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0
 github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81 h1:5lyLWsV+qCkoYqsKUDuycESh9DEIPVKN6iCFeL7ag50=
+github.com/gomarkdown/markdown v0.0.0-20241105142532-d03b89096d81/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=

--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -24,7 +24,10 @@ package route
 
 import (
 	"bytes"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
+	"html/template"
 	"io/fs"
 	"log"
 	"net/http"
@@ -32,17 +35,12 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
+
 	"github.com/labstack/echo/v4"
 )
-
-// Set render route
-func SetRenderRoute(e *echo.Echo, publicPath string) {
-	renderPath := path.Join(publicPath, "render")
-	e.GET(renderPath, func(c echo.Context) error {
-		// Forward the request to the SvelteKit handler
-		return c.File(path.Join(publicPath, "render"))
-	})
-}
 
 // SetUIRoutes sets UI routes
 func SetUIRoutes(e *echo.Echo, publicPath string, assets fs.FS) error {
@@ -95,4 +93,100 @@ func buildUIIndexHandler(publicPath string, assets fs.FS) (echo.HandlerFunc, err
 func buildUIAssetsHandler(assets fs.FS) echo.HandlerFunc {
 	handler := http.FileServer(http.FS(assets))
 	return echo.WrapHandler(handler)
+}
+
+func generateNonce() string {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(bytes)
+}
+
+// Generate CSP header
+func generateCSP(nonce string) string {
+	return fmt.Sprintf(
+		"base-uri 'self'; default-src 'none'; style-src 'nonce-%s'; script-src 'nonce-%s'; frame-ancestors 'self'; form-action 'none'; sandbox allow-same-origin allow-popups allow-popups-to-escape-sandbox;",
+		nonce,
+		nonce,
+	)
+}
+
+// Process markdown content
+func processMarkdown(content string) string {
+	// Create markdown parser with extensions
+	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
+	p := parser.NewWithExtensions(extensions)
+
+	// Parse markdown to AST
+	ast := p.Parse([]byte(content))
+
+	// Setup HTML renderer
+	opts := html.RendererOptions{
+		Flags: html.CommonFlags | html.HrefTargetBlank,
+	}
+	renderer := html.NewRenderer(opts)
+
+	// Render to HTML
+	return string(markdown.Render(ast, renderer))
+}
+
+// Template for the HTML page
+const pageTemplate = `
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Rendered Markdown</title>
+	<base target="_blank">
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<style nonce="{{.Nonce}}">
+			{{.CSS}}
+	</style>
+</head>
+<body class="prose" {{if .Theme}}data-theme="{{.Theme}}"{{end}}>
+	<main>
+			{{.Content}}
+	</main>
+</body>
+</html>
+`
+
+func SetRenderRoute(e *echo.Echo, publicPath string) {
+	renderPath := path.Join(publicPath, "render")
+
+	// Parse template once at startup
+	tmpl := template.Must(template.New("page").Parse(pageTemplate))
+
+	e.GET(renderPath, func(c echo.Context) error {
+		content := c.QueryParam("content")
+		theme := c.QueryParam("theme")
+
+		// Process markdown to HTML
+		renderedHTML := processMarkdown(content)
+
+		nonce := generateNonce()
+
+		data := struct {
+			Content template.HTML
+			Nonce   string
+			Theme   string
+			CSS     string
+		}{
+			Content: template.HTML(renderedHTML),
+			Nonce:   nonce,
+			Theme:   theme,
+		}
+
+		// Set headers
+		c.Response().Header().Set("Content-Type", "text/html")
+		c.Response().Header().Set("Content-Security-Policy", generateCSP(nonce))
+
+		err := tmpl.Execute(c.Response().Writer, data)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
 }

--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -28,11 +28,21 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"path"
 	"regexp"
 	"strings"
 
 	"github.com/labstack/echo/v4"
 )
+
+// Set render route
+func SetRenderRoute(e *echo.Echo, publicPath string) {
+	renderPath := path.Join(publicPath, "render")
+	e.GET(renderPath, func(c echo.Context) error {
+		// Forward the request to the SvelteKit handler
+		return c.File(path.Join(publicPath, "render"))
+	})
+}
 
 // SetUIRoutes sets UI routes
 func SetUIRoutes(e *echo.Echo, publicPath string, assets fs.FS) error {

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -127,6 +127,7 @@ func NewServer(opts ...server_options.ServerOption) *Server {
 			}
 		}
 		route.SetUIRoutes(e, cfg.PublicPath, assets)
+		route.SetRenderRoute(e, cfg.PublicPath)
 	}
 
 	s := &Server{


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Because we use the static adapter and serve static assets in ui-server... it's not possible to route a ui-server request for /render route to Sveltekit's /render route. So the easiest path forward is to recreate the markdown logic in ui-server until we replace ui-server. 

So for development/CI/Cloud, we will still use vercel adapter and the render/+server.ts route.

For self-hosted/CLI, we will use this ui-server route.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1719" alt="Screenshot 2024-11-18 at 3 05 32 PM" src="https://github.com/user-attachments/assets/10cd1629-731d-40a2-b825-a380929ae119">


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
