### PR TITLE
DT-2686 - show last failure stack trace separately in pending activities

### DIFF
--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -11,6 +11,7 @@
   import { translate } from '$lib/i18n/translate';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
   import { workflowRun } from '$lib/stores/workflow-run';
+  import { decodeAllPotentialPayloadsWithCodec } from '$lib/utilities/decode-payload';
   import { formatDate } from '$lib/utilities/format-date';
   import {
     formatAttemptsLeft,
@@ -18,6 +19,7 @@
     formatRetryExpiration,
   } from '$lib/utilities/format-event-attributes';
   import { formatDuration, getDuration } from '$lib/utilities/format-time';
+  import { omit } from '$lib/utilities/omit';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
   import { toTimeDifference } from '$lib/utilities/to-time-difference';
 
@@ -109,17 +111,33 @@
                 </li>
               {/if}
               {#if details.lastFailure}
+                {@const { lastFailure } = details}
                 <li class="event-table-row">
                   <h4>{translate('workflows.last-failure')}</h4>
-                  <CodeBlock
-                    slot="value"
-                    class="pb-2"
-                    content={stringifyWithBigInt(details.lastFailure)}
-                    copyIconTitle={translate('common.copy-icon-title')}
-                    copySuccessIconTitle={translate(
-                      'common.copy-success-icon-title',
-                    )}
-                  />
+                  <div>
+                    <p>{translate('workflows.details')}</p>
+                    {#await decodeAllPotentialPayloadsWithCodec(lastFailure) then result}
+                      <CodeBlock
+                        class="pb-2"
+                        content={stringifyWithBigInt(
+                          omit(result, 'stackTrace'),
+                        )}
+                        copyIconTitle={translate('common.copy-icon-title')}
+                        copySuccessIconTitle={translate(
+                          'common.copy-success-icon-title',
+                        )}
+                      />
+                    {/await}
+                    <p>{translate('common.stack-trace')}</p>
+                    <CodeBlock
+                      language="text"
+                      content={lastFailure.stackTrace}
+                      copyIconTitle={translate('common.copy-icon-title')}
+                      copySuccessIconTitle={translate(
+                        'common.copy-success-icon-title',
+                      )}
+                    />
+                  </div>
                 </li>
               {/if}
               <li class="event-table-row">

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -242,7 +242,6 @@ export const cloneAllPotentialPayloadsWithCodec = async (
     | EventAttribute
     | WorkflowEvent
     | Memo
-    | Failure
     | null,
   namespace: string,
   settings: Settings,
@@ -250,7 +249,7 @@ export const cloneAllPotentialPayloadsWithCodec = async (
   decodeSetting: DownloadEventHistorySetting = 'readable',
   returnDataOnly: boolean = true,
 ): Promise<
-  PotentiallyDecodable | EventAttribute | WorkflowEvent | Memo | Failure | null
+  PotentiallyDecodable | EventAttribute | WorkflowEvent | Memo | null
 > => {
   if (!anyAttributes) return anyAttributes;
 
@@ -297,8 +296,10 @@ export const convertPayloadToJsonWithCodec = async ({
   settings,
   accessToken,
 }: {
-  attributes: EventAttribute | PotentiallyDecodable;
-} & EventRequestMetadata): Promise<EventAttribute | PotentiallyDecodable> => {
+  attributes: EventAttribute | PotentiallyDecodable | Failure;
+} & EventRequestMetadata): Promise<
+  EventAttribute | PotentiallyDecodable | Failure
+> => {
   const decodedAttributes = await decodeAllPotentialPayloadsWithCodec(
     attributes,
     namespace,

--- a/src/lib/utilities/decode-payload.ts
+++ b/src/lib/utilities/decode-payload.ts
@@ -10,7 +10,12 @@ import type {
   passAccessToken,
 } from '$lib/stores/data-encoder-config';
 import type { DownloadEventHistorySetting } from '$lib/stores/events';
-import type { Memo, Payloads, Payload as RawPayload } from '$lib/types';
+import type {
+  Failure,
+  Memo,
+  Payloads,
+  Payload as RawPayload,
+} from '$lib/types';
 import type {
   EventAttribute,
   EventRequestMetadata,
@@ -191,11 +196,11 @@ export const decodeSingleReadablePayloadWithCodec = async (
 };
 
 export const decodeAllPotentialPayloadsWithCodec = async (
-  anyAttributes: EventAttribute | PotentiallyDecodable,
+  anyAttributes: EventAttribute | PotentiallyDecodable | Failure,
   namespace: string = get(page).params.namespace,
   settings: Settings = get(page).data.settings,
   accessToken: string = get(authUser).accessToken,
-): Promise<EventAttribute | PotentiallyDecodable> => {
+): Promise<EventAttribute | PotentiallyDecodable | Failure> => {
   const decode = decodeReadablePayloads(settings);
 
   if (anyAttributes) {
@@ -237,6 +242,7 @@ export const cloneAllPotentialPayloadsWithCodec = async (
     | EventAttribute
     | WorkflowEvent
     | Memo
+    | Failure
     | null,
   namespace: string,
   settings: Settings,
@@ -244,7 +250,7 @@ export const cloneAllPotentialPayloadsWithCodec = async (
   decodeSetting: DownloadEventHistorySetting = 'readable',
   returnDataOnly: boolean = true,
 ): Promise<
-  PotentiallyDecodable | EventAttribute | WorkflowEvent | Memo | null
+  PotentiallyDecodable | EventAttribute | WorkflowEvent | Memo | Failure | null
 > => {
   if (!anyAttributes) return anyAttributes;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We got feedback that the stack trace on pending activity failures was difficult to interpret because it was being shown in a JSON codeblock. This PR moves the stack trace to a separate code block which is formatted correctly.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
| before | after |
| --- | --- |
|<img width="1372" alt="Screenshot 2025-01-28 at 2 14 04 PM" src="https://github.com/user-attachments/assets/ba6132da-97ae-42f4-94f6-473a85a1c3f0" />|<img width="1372" alt="Screenshot 2025-01-28 at 2 13 46 PM" src="https://github.com/user-attachments/assets/fa63f20a-c14e-4e0e-a360-841c6941b1be" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
1. Create an activity that will fail
```typescript
import { ApplicationFailure } from "@temporalio/common";

const failAfter = (seconds: number) => {
  return new Promise((_, reject) => {
    setTimeout(() => {
      reject();
    }, seconds * 1000);
  })
}

export const pendingFailure = async (): Promise<void> => {
  try {
    await failAfter(5);
  } catch {
    throw new ApplicationFailure('Error', 'unknown', false, ['Foo', 'Bar', 42]);
  }
}
```
2. Define a workflow that executes this activity - note, do not specify `maximumAttempts` so the activity can fail endlessly. Also specify a high enough `startToCloseTimeout` to be able to test
```typescript
const {
  pendingFailure,
} = proxyActivities<typeof activities>({
  retry: {
    initialInterval: '50 milliseconds',
  },
  startToCloseTimeout: '1 day',
});
```
3. Run the  workflow, view the Pending Activities tab for the resulting workflow execution, and verify changes.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
