### PR TITLE
fix double decoding pending activities

### DIFF
--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -9,7 +9,6 @@
   import Loading from '$lib/holocene/loading.svelte';
   import { translate } from '$lib/i18n/translate';
   import WorkflowHeader from '$lib/layouts/workflow-header.svelte';
-  import { toDecodedPendingActivities } from '$lib/models/pending-activities';
   import {
     fetchAllEvents,
     throttleRefresh,
@@ -101,13 +100,6 @@
 
     $workflowRun = { ...$workflowRun, workflow, workers };
 
-    workflow.pendingActivities = await toDecodedPendingActivities(
-      workflow,
-      namespace,
-      settings,
-      $authUser?.accessToken,
-    );
-
     workflowRunController = new AbortController();
     getWorkflowMetadata(
       {
@@ -136,8 +128,6 @@
 
   const getOnlyWorkflowWithPendingActivities = async (refresh: number) => {
     if (refresh && $workflowRun?.workflow?.isRunning) {
-      const { settings } = $page.data;
-
       const { workflow, error } = await fetchWorkflow({
         namespace,
         workflowId,
@@ -149,12 +139,6 @@
         return;
       }
       $workflowRun.workflow = workflow;
-      workflow.pendingActivities = await toDecodedPendingActivities(
-        workflow,
-        namespace,
-        settings,
-        $authUser?.accessToken,
-      );
     }
   };
 

--- a/src/lib/models/pending-activities/index.ts
+++ b/src/lib/models/pending-activities/index.ts
@@ -1,3 +1,8 @@
+import { get } from 'svelte/store';
+
+import { page } from '$app/stores';
+
+import { authUser } from '$lib/stores/auth-user';
 import type {
   PendingActivity,
   PendingActivityWithMetadata,
@@ -47,9 +52,9 @@ const decodePendingActivity = async ({
 
 export const toDecodedPendingActivities = async (
   workflow: WorkflowExecution,
-  namespace: string,
-  settings: Settings,
-  accessToken: string,
+  namespace: string = get(page).params.namespace,
+  settings: Settings = get(page).data.settings,
+  accessToken: string = get(authUser).accessToken,
 ) => {
   const pendingActivities = workflow?.pendingActivities ?? [];
   const decodedActivities: PendingActivity[] = [];

--- a/src/lib/pages/workflow-pending-activities.svelte
+++ b/src/lib/pages/workflow-pending-activities.svelte
@@ -9,9 +9,9 @@
   import Table from '$lib/holocene/table/table.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { toDecodedPendingActivities } from '$lib/models/pending-activities';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
   import { workflowRun } from '$lib/stores/workflow-run';
-  import { decodeAllPotentialPayloadsWithCodec } from '$lib/utilities/decode-payload';
   import { formatDate } from '$lib/utilities/format-date';
   import {
     formatAttemptsLeft,
@@ -22,183 +22,183 @@
   import { omit } from '$lib/utilities/omit';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
   import { toTimeDifference } from '$lib/utilities/to-time-difference';
-
-  $: pendingActivities = $workflowRun.workflow?.pendingActivities;
 </script>
 
-{#if pendingActivities.length}
-  <Table class="mb-6 w-full min-w-[600px] table-fixed">
-    <caption class="sr-only" slot="caption"
-      >{translate('workflows.pending-activities-tab')}</caption
-    >
-    <TableHeaderRow slot="headers">
-      <th class="w-44">{translate('workflows.activity-id')}</th>
-      <th>{translate('workflows.details')}</th>
-    </TableHeaderRow>
-    {#each pendingActivities as { id, activityId, ...details } (id)}
-      {@const failed = details.attempt > 1}
-      <TableRow>
-        <td class="w-44 items-start break-all py-5 pl-5 pr-2 align-top">
-          <div class="pt-1">
-            <Link href="#{id}">{activityId}</Link>
-          </div>
-        </td>
-        <td class="px-5 py-4">
-          <ul>
-            <li class="event-table-row">
-              <h4>
-                {translate('workflows.activity-type')}
-              </h4>
-              <Badge type={failed ? 'danger' : undefined}>
-                {details.activityType}
-              </Badge>
-            </li>
-            <li class="event-table-row">
-              <h4>{translate('workflows.attempt')}</h4>
-              <Badge type={failed ? 'danger' : undefined}>
-                {#if failed}
-                  <Icon class="mr-1" name="retry" />
-                {/if}
-                {details.attempt}
-              </Badge>
-            </li>
-            {#if failed}
+{#if $workflowRun.workflow?.pendingActivities}
+  {#await toDecodedPendingActivities($workflowRun.workflow) then activities}
+    <Table class="mb-6 w-full min-w-[600px] table-fixed">
+      <caption class="sr-only" slot="caption"
+        >{translate('workflows.pending-activities-tab')}</caption
+      >
+      <TableHeaderRow slot="headers">
+        <th class="w-44">{translate('workflows.activity-id')}</th>
+        <th>{translate('workflows.details')}</th>
+      </TableHeaderRow>
+      {#each activities as { id, activityId, ...details } (id)}
+        {@const failed = details.attempt > 1}
+        <TableRow>
+          <td class="w-44 items-start break-all py-5 pl-5 pr-2 align-top">
+            <div class="pt-1">
+              <Link href="#{id}">{activityId}</Link>
+            </div>
+          </td>
+          <td class="px-5 py-4">
+            <ul>
               <li class="event-table-row">
-                <h4>{translate('workflows.attempts-left')}</h4>
-                <Badge type="danger">
-                  {formatAttemptsLeft(details.maximumAttempts, details.attempt)}
+                <h4>
+                  {translate('workflows.activity-type')}
+                </h4>
+                <Badge type={failed ? 'danger' : undefined}>
+                  {details.activityType}
                 </Badge>
               </li>
-              {#if details.scheduledTime}
+              <li class="event-table-row">
+                <h4>{translate('workflows.attempt')}</h4>
+                <Badge type={failed ? 'danger' : undefined}>
+                  {#if failed}
+                    <Icon class="mr-1" name="retry" />
+                  {/if}
+                  {details.attempt}
+                </Badge>
+              </li>
+              {#if failed}
                 <li class="event-table-row">
-                  <h4>
-                    {translate('workflows.next-retry')}
-                  </h4>
-                  <Tooltip
-                    width={200}
-                    left
-                    text={formatDate(details.scheduledTime, $timeFormat, {
-                      relative: $relativeTime,
-                    })}
-                  >
-                    <Badge type="danger">
-                      {toTimeDifference({
-                        date: details.scheduledTime,
-                        negativeDefault: translate('workflows.no-retry'),
-                      })}
-                    </Badge>
-                  </Tooltip>
-                </li>
-              {/if}
-            {/if}
-            <li class="event-table-row">
-              <h4>{translate('workflows.maximum-attempts')}</h4>
-              <Badge>{formatMaximumAttempts(details.maximumAttempts)}</Badge>
-            </li>
-            {#if failed}
-              {#if details.heartbeatDetails}
-                <li class="event-table-row">
-                  <h4>{translate('workflows.heartbeat-details')}</h4>
-                  <CodeBlock
-                    slot="value"
-                    class="pb-2"
-                    content={stringifyWithBigInt(details.heartbeatDetails)}
-                    copyIconTitle={translate('common.copy-icon-title')}
-                    copySuccessIconTitle={translate(
-                      'common.copy-success-icon-title',
+                  <h4>{translate('workflows.attempts-left')}</h4>
+                  <Badge type="danger">
+                    {formatAttemptsLeft(
+                      details.maximumAttempts,
+                      details.attempt,
                     )}
-                  />
+                  </Badge>
                 </li>
+                {#if details.scheduledTime}
+                  <li class="event-table-row">
+                    <h4>
+                      {translate('workflows.next-retry')}
+                    </h4>
+                    <Tooltip
+                      width={200}
+                      left
+                      text={formatDate(details.scheduledTime, $timeFormat, {
+                        relative: $relativeTime,
+                      })}
+                    >
+                      <Badge type="danger">
+                        {toTimeDifference({
+                          date: details.scheduledTime,
+                          negativeDefault: translate('workflows.no-retry'),
+                        })}
+                      </Badge>
+                    </Tooltip>
+                  </li>
+                {/if}
               {/if}
-              {#if details.lastFailure}
-                {@const { lastFailure } = details}
-                <li class="event-table-row">
-                  <h4>{translate('workflows.last-failure')}</h4>
-                  <div>
-                    <p>{translate('workflows.details')}</p>
-                    {#await decodeAllPotentialPayloadsWithCodec(lastFailure) then result}
+              <li class="event-table-row">
+                <h4>{translate('workflows.maximum-attempts')}</h4>
+                <Badge>{formatMaximumAttempts(details.maximumAttempts)}</Badge>
+              </li>
+              {#if failed}
+                {#if details.heartbeatDetails}
+                  <li class="event-table-row">
+                    <h4>{translate('workflows.heartbeat-details')}</h4>
+                    <CodeBlock
+                      class="pb-2"
+                      content={stringifyWithBigInt(details.heartbeatDetails)}
+                      copyIconTitle={translate('common.copy-icon-title')}
+                      copySuccessIconTitle={translate(
+                        'common.copy-success-icon-title',
+                      )}
+                    />
+                  </li>
+                {/if}
+                {#if details.lastFailure}
+                  {@const { lastFailure } = details}
+                  <li class="event-table-row">
+                    <h4>{translate('workflows.last-failure')}</h4>
+                    <div>
+                      <p>{translate('workflows.details')}</p>
                       <CodeBlock
                         class="pb-2"
                         content={stringifyWithBigInt(
-                          omit(result, 'stackTrace'),
+                          omit(lastFailure, 'stackTrace'),
                         )}
                         copyIconTitle={translate('common.copy-icon-title')}
                         copySuccessIconTitle={translate(
                           'common.copy-success-icon-title',
                         )}
                       />
-                    {/await}
-                    <p>{translate('common.stack-trace')}</p>
-                    <CodeBlock
-                      language="text"
-                      content={lastFailure.stackTrace}
-                      copyIconTitle={translate('common.copy-icon-title')}
-                      copySuccessIconTitle={translate(
-                        'common.copy-success-icon-title',
-                      )}
-                    />
-                  </div>
+                      <p>{translate('common.stack-trace')}</p>
+                      <CodeBlock
+                        language="text"
+                        content={lastFailure.stackTrace}
+                        copyIconTitle={translate('common.copy-icon-title')}
+                        copySuccessIconTitle={translate(
+                          'common.copy-success-icon-title',
+                        )}
+                      />
+                    </div>
+                  </li>
+                {/if}
+                <li class="event-table-row">
+                  <h4>{translate('workflows.retry-expiration')}</h4>
+                  <p>
+                    {formatRetryExpiration(
+                      details.maximumAttempts,
+                      formatDuration(
+                        getDuration({
+                          start: Date.now(),
+                          end: details.expirationTime,
+                        }),
+                      ),
+                    )}
+                  </p>
                 </li>
               {/if}
               <li class="event-table-row">
-                <h4>{translate('workflows.retry-expiration')}</h4>
+                <h4>{translate('workflows.last-heartbeat')}</h4>
                 <p>
-                  {formatRetryExpiration(
-                    details.maximumAttempts,
-                    formatDuration(
-                      getDuration({
-                        start: Date.now(),
-                        end: details.expirationTime,
-                      }),
-                    ),
-                  )}
-                </p>
-              </li>
-            {/if}
-            <li class="event-table-row">
-              <h4>{translate('workflows.last-heartbeat')}</h4>
-              <p>
-                {formatDate(details.lastHeartbeatTime, $timeFormat, {
-                  relative: $relativeTime,
-                  relativeStrict: true,
-                })}
-              </p>
-            </li>
-            <li class="event-table-row">
-              <h4>{translate('workflows.state')}</h4>
-              <p>{details.state}</p>
-            </li>
-            {#if details.lastStartedTime}
-              <li class="event-table-row">
-                <h4>{translate('workflows.last-started-time')}</h4>
-                <p>
-                  {formatDate(details.lastStartedTime, $timeFormat, {
+                  {formatDate(details.lastHeartbeatTime, $timeFormat, {
                     relative: $relativeTime,
+                    relativeStrict: true,
                   })}
                 </p>
               </li>
-            {/if}
-            {#if details.scheduledTime}
               <li class="event-table-row">
-                <h4>{translate('workflows.scheduled-time')}</h4>
-                <p>
-                  {formatDate(details.scheduledTime, $timeFormat, {
-                    relative: $relativeTime,
-                  })}
-                </p>
+                <h4>{translate('workflows.state')}</h4>
+                <p>{details.state}</p>
               </li>
-            {/if}
-            {#if details.lastWorkerIdentity}
-              <li class="event-table-row">
-                <h4>{translate('workflows.last-worker-identity')}</h4>
-                <p>{details.lastWorkerIdentity}</p>
-              </li>
-            {/if}
-          </ul>
-        </td>
-      </TableRow>
-    {/each}
-  </Table>
+              {#if details.lastStartedTime}
+                <li class="event-table-row">
+                  <h4>{translate('workflows.last-started-time')}</h4>
+                  <p>
+                    {formatDate(details.lastStartedTime, $timeFormat, {
+                      relative: $relativeTime,
+                    })}
+                  </p>
+                </li>
+              {/if}
+              {#if details.scheduledTime}
+                <li class="event-table-row">
+                  <h4>{translate('workflows.scheduled-time')}</h4>
+                  <p>
+                    {formatDate(details.scheduledTime, $timeFormat, {
+                      relative: $relativeTime,
+                    })}
+                  </p>
+                </li>
+              {/if}
+              {#if details.lastWorkerIdentity}
+                <li class="event-table-row">
+                  <h4>{translate('workflows.last-worker-identity')}</h4>
+                  <p>{details.lastWorkerIdentity}</p>
+                </li>
+              {/if}
+            </ul>
+          </td>
+        </TableRow>
+      {/each}
+    </Table>
+  {/await}
 {:else}
   <EmptyState title={translate('workflows.pending-activities-empty-state')} />
 {/if}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The UI was decoding pending activities twice, once in the workflow run layout, and again when expanding rows in the event history. 
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Open the UI with a running workflow that has pending a pending activity and verify only 1 call to /decode is made
Sample workflow here: https://github.com/rossedfort/temporal-sample-workflow
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
