### PR TITLE
Make DateTime Workflow filters persist for ease of use

### DIFF
--- a/src/lib/components/search-attribute-filter/datetime-filter.svelte
+++ b/src/lib/components/search-attribute-filter/datetime-filter.svelte
@@ -18,10 +18,17 @@
   import { supportsAdvancedVisibility } from '$lib/stores/advanced-visibility';
   import {
     endDate,
+    endHour,
+    endMinute,
+    endSecond,
     getTimezone,
     relativeTimeDuration,
     relativeTimeUnit,
     startDate,
+    startHour,
+    startMinute,
+    startSecond,
+    TIME_UNIT_OPTIONS,
     timeFormat,
     timeFormatType,
   } from '$lib/stores/time-format';
@@ -36,31 +43,24 @@
   $: isTimeRange = $filter.conditional === 'BETWEEN';
   $: selectedTime = getSelectedTimezone($timeFormat);
 
-  let startHour = '';
-  let startMinute = '';
-  let startSecond = '';
-
-  let endHour = '';
-  let endMinute = '';
-  let endSecond = '';
-
-  const TIME_UNIT_OPTIONS = ['minutes', 'hours', 'days'];
-
-  let timeUnit = $relativeTimeUnit || TIME_UNIT_OPTIONS[0];
-  let relativeTime = $relativeTimeDuration || '';
-
   $: useBetweenDateTimeQuery = isTimeRange || !$supportsAdvancedVisibility;
   $: disabled =
     $timeFormatType === 'relative' &&
     !useBetweenDateTimeQuery &&
-    (!relativeTime || error(relativeTime));
+    (!$relativeTimeDuration || error($relativeTimeDuration));
 
   const onStartDateChange = (d: CustomEvent) => {
     $startDate = startOfDay(d.detail);
+    $startHour = '';
+    $startMinute = '';
+    $startSecond = '';
   };
 
   const onEndDateChange = (d: CustomEvent) => {
     $endDate = startOfDay(d.detail);
+    $endHour = '';
+    $endMinute = '';
+    $endSecond = '';
   };
 
   const applyTimeChanges = (
@@ -77,21 +77,19 @@
 
   const onApply = () => {
     if ($timeFormatType === 'relative' && !useBetweenDateTimeQuery) {
-      if (!relativeTime) return;
-      $filter.value = toDate(`${relativeTime} ${timeUnit}`);
+      if (!$relativeTimeDuration) return;
+      $filter.value = toDate(`${$relativeTimeDuration} ${$relativeTimeUnit}`);
       $filter.customDate = false;
-      $relativeTimeDuration = relativeTime;
-      $relativeTimeUnit = timeUnit;
     } else {
       let startDateWithTime = applyTimeChanges($startDate, {
-        hour: startHour,
-        minute: startMinute,
-        second: startSecond,
+        hour: $startHour,
+        minute: $startMinute,
+        second: $startSecond,
       });
       let endDateWithTime = applyTimeChanges($endDate, {
-        hour: endHour,
-        minute: endMinute,
-        second: endSecond,
+        hour: $endHour,
+        minute: $endMinute,
+        second: $endSecond,
       });
 
       const timezone = getTimezone($timeFormat);
@@ -163,9 +161,9 @@
               clearLabel={translate('common.clear-input-button-label')}
             />
             <TimePicker
-              bind:hour={startHour}
-              bind:minute={startMinute}
-              bind:second={startSecond}
+              bind:hour={$startHour}
+              bind:minute={$startMinute}
+              bind:second={$startSecond}
               twelveHourClock={false}
             />
           </div>
@@ -182,9 +180,9 @@
               clearLabel={translate('common.clear-input-button-label')}
             />
             <TimePicker
-              bind:hour={endHour}
-              bind:minute={endMinute}
-              bind:second={endSecond}
+              bind:hour={$endHour}
+              bind:minute={$endMinute}
+              bind:second={$endSecond}
               twelveHourClock={false}
             />
           </div>
@@ -204,14 +202,14 @@
                 label={translate('common.relative')}
                 labelHidden
                 id="relative-datetime-input"
-                bind:value={relativeTime}
+                bind:value={$relativeTimeDuration}
                 placeholder="00"
-                error={error(relativeTime)}
+                error={error($relativeTimeDuration)}
                 class="h-10"
                 disabled={$timeFormatType !== 'relative'}
               />
               <Select
-                bind:value={timeUnit}
+                bind:value={$relativeTimeUnit}
                 id="relative-datetime-unit-input"
                 label={translate('common.time-unit')}
                 labelHidden
@@ -246,9 +244,9 @@
                 disabled={$timeFormatType !== 'absolute'}
               />
               <TimePicker
-                bind:hour={startHour}
-                bind:minute={startMinute}
-                bind:second={startSecond}
+                bind:hour={$startHour}
+                bind:minute={$startMinute}
+                bind:second={$startSecond}
                 twelveHourClock={false}
                 disabled={$timeFormatType !== 'absolute'}
               />

--- a/src/lib/stores/time-format.ts
+++ b/src/lib/stores/time-format.ts
@@ -5,6 +5,9 @@ import { persistStore } from '$lib/stores/persist-store';
 import { getLocalTimezone } from '$lib/utilities/format-date';
 
 type TimeFormatTypes = 'relative' | 'absolute';
+
+export const TIME_UNIT_OPTIONS = ['minutes', 'hours', 'days'];
+
 export const timeFormat = persistStore('timeFormat', 'UTC' as TimeFormat);
 export const timeFormatType = persistStore(
   'timeFormatType',
@@ -13,10 +16,20 @@ export const timeFormatType = persistStore(
 
 export const relativeTime = persistStore('relativeTime', false);
 export const relativeTimeDuration = persistStore('relativeTimeDuration', '');
-export const relativeTimeUnit = persistStore('relativeTimeUnit', '');
+export const relativeTimeUnit = persistStore(
+  'relativeTimeUnit',
+  TIME_UNIT_OPTIONS[0],
+);
 
 export const startDate = persistStore('startDate', startOfDay(new Date()));
+export const startHour = persistStore('startHour', '');
+export const startMinute = persistStore('startMinute', '');
+export const startSecond = persistStore('startSecond', '');
+
 export const endDate = persistStore('endDate', startOfDay(new Date()));
+export const endHour = persistStore('endHour', '');
+export const endMinute = persistStore('endMinute', '');
+export const endSecond = persistStore('endSecond', '');
 
 export type TimeFormat = keyof typeof Timezones | 'UTC' | 'local';
 

--- a/src/lib/stores/time-format.ts
+++ b/src/lib/stores/time-format.ts
@@ -1,10 +1,22 @@
+import { startOfDay } from 'date-fns';
 import * as dateTz from 'date-fns-tz';
 
 import { persistStore } from '$lib/stores/persist-store';
 import { getLocalTimezone } from '$lib/utilities/format-date';
 
+type TimeFormatTypes = 'relative' | 'absolute';
 export const timeFormat = persistStore('timeFormat', 'UTC' as TimeFormat);
+export const timeFormatType = persistStore(
+  'timeFormatType',
+  'relative' as TimeFormatTypes,
+);
+
 export const relativeTime = persistStore('relativeTime', false);
+export const relativeTimeDuration = persistStore('relativeTimeDuration', '');
+export const relativeTimeUnit = persistStore('relativeTimeUnit', '');
+
+export const startDate = persistStore('startDate', startOfDay(new Date()));
+export const endDate = persistStore('endDate', startOfDay(new Date()));
 
 export type TimeFormat = keyof typeof Timezones | 'UTC' | 'local';
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Currently, when a user sets either a relative time or an absolute date in the Workflow filters, it does not persist as a value when they click on the filter to change it. A user must re-enter a value. This PR persists the last type (relative vs. absolute) and the value (a duration and unit or a date). 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
https://github.com/user-attachments/assets/b1490ec1-b12c-4d62-8853-78f064ff4b78



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
#2531 

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
