### PR TITLE
Set decodedValue to prevent overfetching payload on rerenders

### DIFF
--- a/src/lib/components/event/metadata-decoder.svelte
+++ b/src/lib/components/event/metadata-decoder.svelte
@@ -13,6 +13,8 @@
   export let fallback: string = '';
   export let onDecode: (decodedValue: string) => void | undefined = undefined;
 
+  let decodedValue = '';
+
   $: endpoint = getCodecEndpoint($page.data.settings);
   $: passAccessToken = getCodecPassAccessToken($page.data.settings);
   $: includeCredentials = getCodecIncludeCredentials($page.data.settings);
@@ -27,9 +29,8 @@
   };
 
   $: decodePayload = async (_value: Payload | undefined) => {
-    if (!_value) {
-      return fallback;
-    }
+    if (!_value) return fallback;
+    if (decodedValue) return decodedValue;
 
     const metadata = await decodeSingleReadablePayloadWithCodec(
       _value,
@@ -40,6 +41,7 @@
       if (onDecode) {
         onDecode(metadata);
       }
+      decodedValue = metadata;
       return metadata;
     }
 
@@ -47,8 +49,8 @@
   };
 </script>
 
-{#await decodePayload(value) then decodedValue}
-  <slot {decodedValue} />
+{#await decodePayload(value) then metadata}
+  <slot decodedValue={metadata} />
 {:catch}
   <slot decodedValue={fallback} />
 {/await}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
To prevent overfetching a payload with rerenders, especially with the Timeline label, set a local decodedValue variable and use that if payload has already been decoded. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
