### PR TITLE
Add prefix for Metadata to show Activity Type in Timeline

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -200,6 +200,9 @@
         {/if}
       </div>
     {/if}
+    {#if primaryAttribute?.key}
+      <EventDetailsRow {...primaryAttribute} {attributes} />
+    {/if}
     {#if currentEvent?.userMetadata?.summary}
       <MetadataDecoder
         value={currentEvent.userMetadata.summary}
@@ -214,12 +217,8 @@
               {decodedValue}
             </Badge>
           </div>
-        {:else}
-          <EventDetailsRow {...primaryAttribute} {attributes} />
         {/if}
       </MetadataDecoder>
-    {:else if primaryAttribute?.key}
-      <EventDetailsRow {...primaryAttribute} {attributes} />
     {/if}
     {#if currentEvent?.links?.length}
       <EventLink
@@ -235,7 +234,7 @@
         {attributes}
       />
     {/if}
-    {#if compact && secondaryAttribute?.key}
+    {#if compact && secondaryAttribute?.key && !currentEvent?.userMetadata?.summary}
       <EventDetailsRow {...secondaryAttribute} {attributes} />
     {/if}
   </td>

--- a/src/lib/components/event/metadata-decoder.svelte
+++ b/src/lib/components/event/metadata-decoder.svelte
@@ -32,9 +32,8 @@
   };
 
   const setPrefix = (metadata: string) => {
-    let value = metadata;
     if (prefix) {
-      metadata = `${prefix} • ${value}`;
+      metadata = `${prefix} • ${metadata}`;
     }
     if (metadata.length < maxLength) return metadata;
     return metadata.slice(0, maxLength) + '...';

--- a/src/lib/components/event/metadata-decoder.svelte
+++ b/src/lib/components/event/metadata-decoder.svelte
@@ -11,7 +11,10 @@
 
   export let value: Payload | undefined = undefined;
   export let fallback: string = '';
+  export let prefix: string = '';
   export let onDecode: (decodedValue: string) => void | undefined = undefined;
+
+  const maxLength = 100;
 
   let decodedValue = '';
 
@@ -28,6 +31,15 @@
     },
   };
 
+  const setPrefix = (metadata: string) => {
+    let value = metadata;
+    if (prefix) {
+      metadata = `${prefix} • ${value}`;
+    }
+    if (metadata.length < maxLength) return metadata;
+    return metadata.slice(0, maxLength) + '...';
+  };
+
   $: decodePayload = async (_value: Payload | undefined) => {
     if (!_value) return fallback;
     if (decodedValue) return decodedValue;
@@ -38,11 +50,11 @@
     );
 
     if (typeof metadata === 'string') {
+      decodedValue = setPrefix(metadata);
       if (onDecode) {
-        onDecode(metadata);
+        onDecode(decodedValue);
       }
-      decodedValue = metadata;
-      return metadata;
+      return decodedValue;
     }
 
     decodedValue = fallback;

--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -6,6 +6,7 @@
   import type { EventGroup } from '$lib/models/event-groups/event-groups';
   import { setActiveGroup } from '$lib/stores/active-events';
   import { getMillisecondDuration } from '$lib/utilities/format-time';
+  import { isActivityTaskScheduledEvent } from '$lib/utilities/is-event-type';
 
   import {
     CategoryIcon,
@@ -129,6 +130,9 @@
       {:else}
         <MetadataDecoder
           value={group?.userMetadata?.summary}
+          prefix={isActivityTaskScheduledEvent(group.initialEvent)
+            ? group?.displayName
+            : ''}
           fallback={group?.displayName}
           let:decodedValue
         >


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
After internal feedback, users want to still see the Activity Type in the Timeline/Event Summary Row. In the Timeline, combine the prefix and the decoded value and truncate it if it's over 100 characters.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1878" alt="Screenshot 2025-02-06 at 1 32 13 PM" src="https://github.com/user-attachments/assets/cac03bc9-8b27-4983-b40b-2bf8084b7f4f" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
