### PR TITLE
fix combobox option props mismatch and textarea prop spreading

### DIFF
--- a/src/lib/holocene/combobox/combobox-option.svelte
+++ b/src/lib/holocene/combobox/combobox-option.svelte
@@ -4,7 +4,6 @@
   interface Props {
     selected?: boolean;
     disabled?: boolean;
-    multiselect?: boolean;
     label: string;
   }
 

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -494,7 +494,6 @@
 
     {#each list as option}
       <ComboboxOption
-        {multiselect}
         on:click={() => handleSelectOption(option)}
         selected={isSelected(option, value)}
         label={getDisplayValue(option)}

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -54,7 +54,7 @@
     <textarea
       bind:value
       class={merge(
-        'surface-primary min-h-fit w-full px-3 py-2 text-sm focus-visible:outline-none',
+        'surface-primary min-h-fit w-full px-3 py-2 text-sm placeholder:text-secondary focus-visible:outline-none',
         disabled && 'cursor-not-allowed opacity-50',
       )}
       {id}
@@ -68,6 +68,7 @@
       on:blur
       on:keydown|stopPropagation
       maxlength={maxLength > 0 ? maxLength : undefined}
+      {...$$restProps}
     />
   </div>
   <div class="flex justify-between gap-2">


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
- When I fixed the a11y issue with Combobox options where `multiselect` was true, I left the `multiselect` prop in the type definition. This PR removes that and fixes where we were passing the prop in Combobox
- Also add a placeholder text style to Textarea and pass restProps to the `<textarea />` element so it can be used in a form for startup program application.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
