### PR TITLE
Only query workflow metadata for running workflows

### DIFF
--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -176,6 +176,138 @@ func SetRenderRoute(e *echo.Echo, publicPath string) {
 			Content: template.HTML(renderedHTML),
 			Nonce:   nonce,
 			Theme:   theme,
+			CSS: `*,
+		body {
+			margin: 0;
+			padding: 0;
+			border: 0;
+			font-size: 100%;
+			vertical-align: baseline;
+		}
+
+		body {
+			overscroll-behavior: none;
+			position: relative;
+			padding: 1rem;
+			white-space: pre-line;
+			font-family: sans-serif;
+		}
+
+		h1 {
+			font-size: 2em;
+		}
+
+		h2 {
+			font-size: 1.5em;
+		}
+
+		h3 {
+			font-size: 1.17em;
+		}
+
+		h4 {
+			font-size: 1em;
+		}
+
+		h5 {
+			font-size: 0.83em;
+		}
+
+		h6 {
+			font-size: 0.67em;
+		}
+
+		blockquote,
+		q {
+			quotes: none;
+		}
+		blockquote:before,
+		blockquote:after,
+		q:before,
+		q:after {
+			content: '';
+			content: none;
+		}
+
+		table {
+			border-collapse: collapse;
+			border-spacing: 0;
+		}
+
+		ul,
+		ol {
+			white-space: normal;
+		}
+
+		li {
+			list-style-position: inside;
+		}
+
+		li * {
+			display: inline;
+		}
+
+		a {
+			gap: 0.5rem;
+			align-items: center;
+			border-radius: 0.25rem;
+			max-width: fit-content;
+			text-decoration: underline;
+			text-underline-offset: 2px;
+			cursor: pointer;
+		}
+
+		blockquote {
+			padding-top: 0;
+			padding-bottom: 0;
+			padding-left: 0.5rem;
+			border-left: 4px solid;
+			border-left-color: #92a4c3;
+			background: #e8efff;
+			color: #121416;
+			p {
+				font-size: 1.25rem;
+				line-height: 1.75rem;
+			}
+		}
+
+		code {
+			font-family: monospace;
+			padding-top: 0.125rem;
+			padding-bottom: 0.125rem;
+			padding-left: 0.25rem;
+			padding-right: 0.25rem;
+			border-radius: 0.25rem;
+			background: #e8efff;
+			color: #121416;
+		}
+
+		pre {
+			font-family: monospace;
+			padding: 0.25rem;
+			border-radius: 0.25rem;
+			background: #e8efff;
+			color: #121416;
+			code {
+				padding: 0;
+			}
+		}
+
+		body[data-theme='light'] {
+			background-color: #fff;
+			color: #121416;
+			a {
+				color: #444ce7;
+			}
+		}
+
+		body[data-theme='dark'] {
+  		background-color: #141414;
+			color: #f8fafc;
+			a {
+				color: #8098f9;
+			}
+		}`,
 		}
 
 		// Set headers

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+
+  import AccordionLight from '$lib/holocene/accordion/accordion-light.svelte';
+  import Icon from '$lib/holocene/icon/icon.svelte';
+  import Markdown from '$lib/holocene/monaco/markdown.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import { getWorkflowMetadata } from '$lib/services/query-service';
+  import { authUser } from '$lib/stores/auth-user';
+  import { workflowRun } from '$lib/stores/workflow-run';
+
+  $: ({ namespace } = $page.params);
+  $: ({ workflow } = $workflowRun);
+  $: currentDetails = $workflowRun?.metadata?.currentDetails || '';
+  $: openWithoutDetails = workflow.isRunning && !currentDetails;
+  $: closedWithoutDetails = !workflow.isRunning && !currentDetails;
+
+  const fetchCurrentDetails = async () => {
+    const { settings } = $page.data;
+    const metadata = await getWorkflowMetadata(
+      {
+        namespace,
+        workflow: {
+          id: workflow.id,
+          runId: workflow.runId,
+        },
+      },
+      settings,
+      $authUser?.accessToken,
+    );
+    $workflowRun.metadata = metadata;
+    if (!metadata.currentDetails) {
+      $workflowRun.metadata.currentDetails = translate(
+        'workflows.no-current-details',
+      );
+    }
+  };
+</script>
+
+{#if !openWithoutDetails}
+  <AccordionLight
+    let:open
+    onToggle={closedWithoutDetails ? fetchCurrentDetails : undefined}
+    icon={closedWithoutDetails ? 'retry' : undefined}
+  >
+    <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
+      <Icon name="flag" class="text-brand" width={32} height={32} />{translate(
+        'workflows.current-details',
+      )}
+    </div>
+    {#if open}
+      <Markdown content={currentDetails} />
+    {/if}
+  </AccordionLight>
+{/if}

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -35,11 +35,6 @@
         $authUser?.accessToken,
       );
       $workflowRun.metadata = metadata;
-      if (!metadata.currentDetails) {
-        $workflowRun.metadata.currentDetails = translate(
-          'workflows.no-current-details',
-        );
-      }
     } catch (error) {
       console.error('Error fetching current details:', error);
     } finally {

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -14,7 +14,6 @@
   $: ({ namespace } = $page.params);
   $: ({ workflow } = $workflowRun);
   $: currentDetails = $workflowRun?.metadata?.currentDetails || '';
-  $: openWithoutDetails = workflow.isRunning && !currentDetails;
   $: closedWithoutDetails = !workflow.isRunning && !currentDetails;
 
   let loading = false;
@@ -49,34 +48,32 @@
   };
 </script>
 
-{#if !openWithoutDetails}
-  <AccordionLight
-    let:open
-    onToggle={closedWithoutDetails ? fetchCurrentDetails : undefined}
-    icon={closedWithoutDetails ? 'retry' : undefined}
-  >
-    <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
-      <Icon name="flag" class="text-brand" width={32} height={32} />
-      {translate('workflows.current-details')}
-      {#if loading}{translate('common.loading')}{/if}
-    </div>
-    {#if open}
-      {#key currentDetails}
-        <Markdown content={currentDetails} />
-      {/key}
+<AccordionLight
+  let:open
+  onToggle={closedWithoutDetails ? fetchCurrentDetails : undefined}
+  icon={closedWithoutDetails ? 'retry' : undefined}
+>
+  <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
+    <Icon name="flag" class="text-brand" width={32} height={32} />
+    {translate('workflows.current-details')}
+    {#if loading}{translate('common.loading')}{/if}
+  </div>
+  {#if open}
+    {#key currentDetails}
+      <Markdown content={currentDetails} />
+    {/key}
+  {/if}
+  <svelte:fragment slot="action">
+    {#if workflow.isRunning}
+      <Tooltip text={translate('workflows.update-details')} left>
+        <Button
+          variant="ghost"
+          on:click={fetchCurrentDetails}
+          disabled={loading}
+        >
+          <Icon name="retry" />
+        </Button>
+      </Tooltip>
     {/if}
-    <svelte:fragment slot="action">
-      {#if workflow.isRunning}
-        <Tooltip text={translate('workflows.update-details')} left>
-          <Button
-            variant="ghost"
-            on:click={fetchCurrentDetails}
-            disabled={loading}
-          >
-            <Icon name="retry" />
-          </Button>
-        </Tooltip>
-      {/if}
-    </svelte:fragment>
-  </AccordionLight>
-{/if}
+  </svelte:fragment>
+</AccordionLight>

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -67,7 +67,7 @@
     {/if}
     <svelte:fragment slot="action">
       {#if workflow.isRunning}
-        <Tooltip text="Update Details" left>
+        <Tooltip text={translate('workflows.update-details')} left>
           <Button
             variant="ghost"
             on:click={fetchCurrentDetails}

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -20,6 +20,7 @@
   let loading = false;
 
   const fetchCurrentDetails = async () => {
+    if (loading) return;
     loading = true;
     try {
       const { settings } = $page.data;
@@ -55,9 +56,8 @@
     icon={closedWithoutDetails ? 'retry' : undefined}
   >
     <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
-      <Icon name="flag" class="text-brand" width={32} height={32} />{translate(
-        'workflows.current-details',
-      )}
+      <Icon name="flag" class="text-brand" width={32} height={32} />
+      {translate('workflows.current-details')}
       {#if loading}{translate('common.loading')}{/if}
     </div>
     {#if open}
@@ -67,7 +67,7 @@
     {/if}
     <svelte:fragment slot="action">
       {#if workflow.isRunning}
-        <Tooltip text="Query Details" left>
+        <Tooltip text="Update Details" left>
           <Button
             variant="ghost"
             on:click={fetchCurrentDetails}

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -2,8 +2,10 @@
   import { page } from '$app/stores';
 
   import AccordionLight from '$lib/holocene/accordion/accordion-light.svelte';
+  import Button from '$lib/holocene/button.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Markdown from '$lib/holocene/monaco/markdown.svelte';
+  import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { getWorkflowMetadata } from '$lib/services/query-service';
   import { authUser } from '$lib/stores/auth-user';
@@ -15,24 +17,33 @@
   $: openWithoutDetails = workflow.isRunning && !currentDetails;
   $: closedWithoutDetails = !workflow.isRunning && !currentDetails;
 
+  let loading = false;
+
   const fetchCurrentDetails = async () => {
-    const { settings } = $page.data;
-    const metadata = await getWorkflowMetadata(
-      {
-        namespace,
-        workflow: {
-          id: workflow.id,
-          runId: workflow.runId,
+    loading = true;
+    try {
+      const { settings } = $page.data;
+      const metadata = await getWorkflowMetadata(
+        {
+          namespace,
+          workflow: {
+            id: workflow.id,
+            runId: workflow.runId,
+          },
         },
-      },
-      settings,
-      $authUser?.accessToken,
-    );
-    $workflowRun.metadata = metadata;
-    if (!metadata.currentDetails) {
-      $workflowRun.metadata.currentDetails = translate(
-        'workflows.no-current-details',
+        settings,
+        $authUser?.accessToken,
       );
+      $workflowRun.metadata = metadata;
+      if (!metadata.currentDetails) {
+        $workflowRun.metadata.currentDetails = translate(
+          'workflows.no-current-details',
+        );
+      }
+    } catch (error) {
+      console.error('Error fetching current details:', error);
+    } finally {
+      loading = false;
     }
   };
 </script>
@@ -47,9 +58,25 @@
       <Icon name="flag" class="text-brand" width={32} height={32} />{translate(
         'workflows.current-details',
       )}
+      {#if loading}{translate('common.loading')}{/if}
     </div>
     {#if open}
-      <Markdown content={currentDetails} />
+      {#key currentDetails}
+        <Markdown content={currentDetails} />
+      {/key}
     {/if}
+    <svelte:fragment slot="action">
+      {#if workflow.isRunning}
+        <Tooltip text="Query Details" left>
+          <Button
+            variant="ghost"
+            on:click={fetchCurrentDetails}
+            disabled={loading}
+          >
+            <Icon name="retry" />
+          </Button>
+        </Tooltip>
+      {/if}
+    </svelte:fragment>
   </AccordionLight>
 {/if}

--- a/src/lib/components/workflow/metadata/workflow-summary-and-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-summary-and-details.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import AccordionLight from '$lib/holocene/accordion/accordion-light.svelte';
+  import Icon from '$lib/holocene/icon/icon.svelte';
+  import Markdown from '$lib/holocene/monaco/markdown.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import { workflowRun } from '$lib/stores/workflow-run';
+
+  $: summary = $workflowRun?.userMetadata?.summary;
+  $: details = $workflowRun?.userMetadata?.details;
+  $: hasUserMetadata = summary || details;
+</script>
+
+{#if hasUserMetadata}
+  <AccordionLight let:open>
+    <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
+      <Icon name="info" class="text-brand" width={32} height={32} />{translate(
+        'workflows.summary-and-details',
+      )}
+    </div>
+    {#if open && summary}
+      <h3>{translate('workflows.summary')}</h3>
+      <Markdown content={summary} />
+    {/if}
+    {#if open && details}
+      <h3>{translate('workflows.details')}</h3>
+      <Markdown content={details} />
+    {/if}
+  </AccordionLight>
+{/if}

--- a/src/lib/holocene/accordion/accordion-light.svelte
+++ b/src/lib/holocene/accordion/accordion-light.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { HTMLAttributes } from 'svelte/elements';
-  import { noop } from 'svelte/internal';
   import { slide } from 'svelte/transition';
 
   import { v4 } from 'uuid';
@@ -14,17 +13,22 @@
     open?: boolean;
     expandable?: boolean;
     error?: string;
-    onToggle?: () => void;
+    onToggle?: () => Promise<void>;
     'data-testid'?: string;
   }
 
   export let id: string = v4();
   export let open = false;
-  export let onToggle = noop;
+  export let onToggle = undefined;
+  export let icon: IconName | undefined = undefined;
 
-  const toggleAccordion = () => {
-    open = !open;
-    onToggle();
+  const toggleAccordion = async () => {
+    if (onToggle) {
+      await onToggle();
+      open = !open;
+    } else {
+      open = !open;
+    }
   };
 </script>
 
@@ -40,14 +44,10 @@
     <div class="flex w-full flex-row items-center justify-between gap-2">
       <slot name="title" />
       <slot name="description" />
-      <div
-        class="flex flex-row items-center gap-2 pr-2"
-        on:click|stopPropagation
-        on:keyup|stopPropagation
-        role="none"
-      >
-        <slot name="action" />
-        <Icon class="m-2 shrink-0" name={open ? 'arrow-down' : 'arrow-right'} />
+      <div class="flex items-center gap-2">
+        <button class="pr-4">
+          <Icon name={icon ? icon : open ? 'arrow-down' : 'arrow-right'} />
+        </button>
       </div>
     </div>
   </button>

--- a/src/lib/holocene/accordion/accordion-light.svelte
+++ b/src/lib/holocene/accordion/accordion-light.svelte
@@ -44,7 +44,8 @@
     <div class="flex w-full flex-row items-center justify-between gap-2">
       <slot name="title" />
       <slot name="description" />
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-4">
+        <slot name="action" />
         <button class="pr-4">
           <Icon name={icon ? icon : open ? 'arrow-down' : 'arrow-right'} />
         </button>

--- a/src/lib/holocene/accordion/accordion-light.svelte
+++ b/src/lib/holocene/accordion/accordion-light.svelte
@@ -41,14 +41,12 @@
     type="button"
     on:click={toggleAccordion}
   >
-    <div class="flex w-full flex-row items-center justify-between gap-2">
+    <div class="flex w-full flex-row items-center justify-between gap-2 pr-4">
       <slot name="title" />
       <slot name="description" />
       <div class="flex items-center gap-4">
         <slot name="action" />
-        <button class="pr-4">
-          <Icon name={icon ? icon : open ? 'arrow-down' : 'arrow-right'} />
-        </button>
+        <Icon name={icon ? icon : open ? 'arrow-down' : 'arrow-right'} />
       </div>
     </div>
   </button>

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -275,4 +275,5 @@ export const Strings = {
   'update-id': 'Update ID (optional)',
   'update-name-label': 'Update name',
   'no-current-details': 'No Current Details',
+  'update-details': 'Update Details',
 } as const;

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -274,4 +274,5 @@ export const Strings = {
     'Markdown is supported in the summary and details fields. You can use {namespace}, {workflowId} or {runId} syntax in link href to create dynamic links based on the page you are on. Images are not allowed.',
   'update-id': 'Update ID (optional)',
   'update-name-label': 'Update name',
+  'no-current-details': 'No Current Details',
 } as const;

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -4,16 +4,16 @@
   import { page } from '$app/stores';
 
   import WorkflowDetails from '$lib/components/lines-and-dots/workflow-details.svelte';
+  import WorkflowCurrentDetails from '$lib/components/workflow/metadata/workflow-current-details.svelte';
+  import WorkflowSummaryAndDetails from '$lib/components/workflow/metadata/workflow-summary-and-details.svelte';
   import WorkflowActions from '$lib/components/workflow-actions.svelte';
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import WorkflowVersioningHeader from '$lib/components/workflow-versioning-header.svelte';
-  import AccordionLight from '$lib/holocene/accordion/accordion-light.svelte';
   import Alert from '$lib/holocene/alert.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
-  import Markdown from '$lib/holocene/monaco/markdown.svelte';
   import TabList from '$lib/holocene/tab/tab-list.svelte';
   import Tab from '$lib/holocene/tab/tab.svelte';
   import Tabs from '$lib/holocene/tab/tabs.svelte';
@@ -64,11 +64,6 @@
     $fullEventHistory,
     $namespaces,
   );
-
-  $: summary = $workflowRun?.userMetadata?.summary;
-  $: details = $workflowRun?.userMetadata?.details;
-  $: hasUserMetadata = summary || details;
-  $: currentDetails = $workflowRun?.metadata?.currentDetails;
 </script>
 
 <div class="flex items-center justify-between pb-4">
@@ -138,41 +133,8 @@
       <WorkflowActions {isRunning} {cancelInProgress} {workflow} {namespace} />
     </div>
   </div>
-  {#if hasUserMetadata}
-    <AccordionLight let:open>
-      <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
-        <Icon
-          name="info"
-          class="text-brand"
-          width={32}
-          height={32}
-        />{translate('workflows.summary-and-details')}
-      </div>
-      {#if open && summary}
-        <h3>{translate('workflows.summary')}</h3>
-        <Markdown content={summary} />
-      {/if}
-      {#if open && details}
-        <h3>{translate('workflows.details')}</h3>
-        <Markdown content={details} />
-      {/if}
-    </AccordionLight>
-  {/if}
-  {#if currentDetails}
-    <AccordionLight let:open>
-      <div slot="title" class="flex w-full items-center gap-2 p-2 text-xl">
-        <Icon
-          name="flag"
-          class="text-brand"
-          width={32}
-          height={32}
-        />{translate('workflows.current-details')}
-      </div>
-      {#if open}
-        <Markdown content={currentDetails} />
-      {/if}
-    </AccordionLight>
-  {/if}
+  <WorkflowSummaryAndDetails />
+  <WorkflowCurrentDetails />
   <WorkflowDetails {workflow} />
   {#if cancelInProgress}
     <div in:fly={{ duration: 200, delay: 100 }}>

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -116,11 +116,6 @@
         workflowRunController.signal,
       ).then((metadata) => {
         $workflowRun.metadata = metadata;
-        if (!metadata.currentDetails) {
-          $workflowRun.metadata.currentDetails = translate(
-            'workflows.no-current-details',
-          );
-        }
       });
     }
 

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -116,6 +116,11 @@
         workflowRunController.signal,
       ).then((metadata) => {
         $workflowRun.metadata = metadata;
+        if (!metadata.currentDetails) {
+          $workflowRun.metadata.currentDetails = translate(
+            'workflows.no-current-details',
+          );
+        }
       });
     }
 

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -101,20 +101,23 @@
     $workflowRun = { ...$workflowRun, workflow, workers };
 
     workflowRunController = new AbortController();
-    getWorkflowMetadata(
-      {
-        namespace,
-        workflow: {
-          id: workflowId,
-          runId,
+
+    if (workflow.isRunning) {
+      getWorkflowMetadata(
+        {
+          namespace,
+          workflow: {
+            id: workflowId,
+            runId,
+          },
         },
-      },
-      settings,
-      $authUser?.accessToken,
-      workflowRunController.signal,
-    ).then((metadata) => {
-      $workflowRun.metadata = metadata;
-    });
+        settings,
+        $authUser?.accessToken,
+        workflowRunController.signal,
+      ).then((metadata) => {
+        $workflowRun.metadata = metadata;
+      });
+    }
 
     $fullEventHistory = await fetchAllEvents({
       namespace,

--- a/src/lib/pages/workflow-call-stack.svelte
+++ b/src/lib/pages/workflow-call-stack.svelte
@@ -31,7 +31,6 @@
     );
 
   let stackTrace: Eventual<ParsedQuery>;
-
   $: {
     if (workflow?.isRunning) stackTrace = getStackTrace();
   }

--- a/src/lib/pages/workflow-call-stack.svelte
+++ b/src/lib/pages/workflow-call-stack.svelte
@@ -31,6 +31,7 @@
     );
 
   let stackTrace: Eventual<ParsedQuery>;
+
   $: {
     if (workflow?.isRunning) stackTrace = getStackTrace();
   }

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -52,7 +52,7 @@
   let encodePayloadResult: Promise<Payloads>;
 
   onMount(() => {
-    if (!$workflowRun?.metadata) {
+    if (!$workflowRun.metadata) {
       fetchCurrentDetails();
     }
   });
@@ -71,11 +71,6 @@
       $authUser?.accessToken,
     );
     $workflowRun.metadata = metadata;
-    if (!metadata.currentDetails) {
-      $workflowRun.metadata.currentDetails = translate(
-        'workflows.no-current-details',
-      );
-    }
   };
 
   const reset = () => {

--- a/src/lib/services/query-service.ts
+++ b/src/lib/services/query-service.ts
@@ -1,3 +1,4 @@
+import { translate } from '$lib/i18n/translate';
 import type { Payloads } from '$lib/types';
 import type { WorkflowQueryRouteParameters } from '$lib/types/api';
 import type { Eventual, Settings } from '$lib/types/global';
@@ -93,6 +94,9 @@ export async function getWorkflowMetadata(
       accessToken,
       signal,
     );
+    if (!metadata.currentDetails) {
+      metadata.currentDetails = translate('workflows.no-current-details');
+    }
     return metadata;
   } catch (e) {
     if (e.message?.includes('__temporal_workflow_metadata')) {

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -19,11 +19,7 @@ export type WorkflowRunWithWorkers = {
 export const initialWorkflowRun: WorkflowRunWithWorkers = {
   workflow: null,
   workers: { pollers: [], taskQueueStatus: null },
-  metadata: {
-    definition: {
-      queryDefinitions: [],
-    },
-  },
+  metadata: undefined,
   userMetadata: {
     summary: '',
     details: '',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Users can run into NDEs for workflows closed in the past while visiting Workflow Execution page due to Workflow Metadata query on page load. This PR changes that logic to only fetch the query on page load of running workflows. When a workflow is closed, a user can click on the Current Details accordion to run the query to get the current details.

The Workflow Metadata query will run on page load of the Query page if the workflow is closed and the query hasn't been run yet (Current Details accordion clicked).

As an additional feature, I've added an 'Update Details' button on the Current Details accordion for running workflows for a user to update the details without having to reload the whole page.

Also includes fix to add our markdown.reset css to the ui-server renderer endpoint to correctly render markdown on self-hosted.

**The one call-out I want to make is that the Current Details accordion will now always be visible, for running or closed workflows**. For running, it might not have any current details on page load, but it could later when a user wants to update the details. For closed, a user won't know if it has any current details until it's clicked and queried.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1894" alt="Screenshot 2025-02-18 at 12 27 46 PM" src="https://github.com/user-attachments/assets/f8b4a13a-6494-40ca-b1f7-44c2e5af9fec" />
<img width="1895" alt="Screenshot 2025-02-18 at 12 26 35 PM" src="https://github.com/user-attachments/assets/d0cbc6cd-73fa-452c-b860-1896524eafc3" />
<img width="1894" alt="Screenshot 2025-02-18 at 12 25 35 PM" src="https://github.com/user-attachments/assets/6047dd46-fc20-46e5-a035-1709436f1fb1" />
<img width="1894" alt="Screenshot 2025-02-18 at 12 36 53 PM" src="https://github.com/user-attachments/assets/b275b136-760d-4ca7-8300-33039e0cadc7" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
