### PR TITLE
Support messageType metadata on protobuf encoded Payloads

### DIFF
--- a/src/lib/components/payload-input-with-encoding.svelte
+++ b/src/lib/components/payload-input-with-encoding.svelte
@@ -39,7 +39,9 @@
   <h5 class="pb-1 text-sm font-medium">{label}</h5>
   <Card class="flex flex-col gap-2">
     <PayloadInput bind:input bind:loading {error} {id} {editing} />
-    <div class="flex items-end {editing ? 'justify-between' : 'justify-end'}">
+    <div
+      class="flex items-end gap-2 {editing ? 'justify-between' : 'justify-end'}"
+    >
       {#if editing}
         <div class="flex w-full flex-col gap-2">
           <RadioGroup

--- a/src/lib/components/payload-input-with-encoding.svelte
+++ b/src/lib/components/payload-input-with-encoding.svelte
@@ -9,7 +9,6 @@
 <script lang="ts">
   import { type Writable } from 'svelte/store';
 
-  import { onDestroy } from 'svelte';
   import { v4 as uuid } from 'uuid';
 
   import Card from '$lib/holocene/card.svelte';
@@ -23,7 +22,7 @@
   export let id = uuid();
   export let input: string;
   export let encoding: Writable<PayloadInputEncoding>;
-  export let messageType = '';
+  export let messageType: string;
   export let error = false;
   export let loading = false;
   export let label = translate('workflows.input');
@@ -34,12 +33,6 @@
       messageType = '';
     }
   }
-
-  const clearValues = () => {
-    $encoding = 'json/plain';
-  };
-
-  onDestroy(clearValues);
 </script>
 
 <div>
@@ -63,7 +56,7 @@
           </RadioGroup>
           {#if $encoding === 'json/protobuf'}
             <Input
-              label="Message Type"
+              label={translate('workflows.message-type')}
               bind:value={messageType}
               {error}
               id="messageType"

--- a/src/lib/components/payload-input-with-encoding.svelte
+++ b/src/lib/components/payload-input-with-encoding.svelte
@@ -13,6 +13,7 @@
   import { v4 as uuid } from 'uuid';
 
   import Card from '$lib/holocene/card.svelte';
+  import Input from '$lib/holocene/input/input.svelte';
   import RadioGroup from '$lib/holocene/radio-input/radio-group.svelte';
   import RadioInput from '$lib/holocene/radio-input/radio-input.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -22,10 +23,17 @@
   export let id = uuid();
   export let input: string;
   export let encoding: Writable<PayloadInputEncoding>;
+  export let messageType = '';
   export let error = false;
   export let loading = false;
   export let label = translate('workflows.input');
   export let editing = true;
+
+  $: {
+    if ($encoding === 'json/plain' && messageType) {
+      messageType = '';
+    }
+  }
 
   const clearValues = () => {
     $encoding = 'json/plain';
@@ -40,18 +48,28 @@
     <PayloadInput bind:input bind:loading {error} {id} {editing} />
     <div class="flex items-end {editing ? 'justify-between' : 'justify-end'}">
       {#if editing}
-        <RadioGroup
-          description={translate('workflows.encoding')}
-          bind:group={encoding}
-          name="encoding"
-        >
-          <RadioInput id="json/plain" value="json/plain" label="json/plain" />
-          <RadioInput
-            id="json/protobuf"
-            value="json/protobuf"
-            label="json/protobuf"
-          />
-        </RadioGroup>
+        <div class="flex w-full flex-col gap-2">
+          <RadioGroup
+            description={translate('workflows.encoding')}
+            bind:group={encoding}
+            name="encoding"
+          >
+            <RadioInput id="json/plain" value="json/plain" label="json/plain" />
+            <RadioInput
+              id="json/protobuf"
+              value="json/protobuf"
+              label="json/protobuf"
+            />
+          </RadioGroup>
+          {#if $encoding === 'json/protobuf'}
+            <Input
+              label="Message Type"
+              bind:value={messageType}
+              {error}
+              id="messageType"
+            />
+          {/if}
+        </div>
       {/if}
       <slot name="action" />
     </div>

--- a/src/lib/components/schedule/schedule-form-view.svelte
+++ b/src/lib/components/schedule/schedule-form-view.svelte
@@ -79,6 +79,7 @@
   let input = '';
   let editInput = !schedule;
   let encoding: Writable<PayloadInputEncoding> = writable('json/plain');
+  let messageType = '';
   let daysOfWeek: string[] = [];
   let daysOfMonth: number[] = [];
   let months: string[] = [];
@@ -104,6 +105,7 @@
       taskQueue,
       ...(editInput && { input }),
       encoding: $encoding,
+      messageType,
       hour,
       minute,
       second,
@@ -218,6 +220,7 @@
           bind:input
           bind:editInput
           bind:encoding
+          bind:messageType
           payloads={schedule?.action?.startWorkflow?.input}
           showEditActions={Boolean(schedule)}
         />

--- a/src/lib/components/schedule/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-input-payload.svelte
@@ -16,11 +16,13 @@
   export let input: string;
   export let editInput: boolean;
   export let encoding: Writable<PayloadInputEncoding>;
+  export let messageType: string;
   export let payloads: Payloads;
   export let showEditActions: boolean = false;
 
   let initialInput = '';
   let initialEncoding: PayloadInputEncoding = 'json/plain';
+  let initialMessageType = '';
   let loading = true;
 
   const setInitialInput = (decodedValue: string): void => {
@@ -29,9 +31,17 @@
     const currentEncoding = atob(
       String(payloads?.payloads[0]?.metadata?.encoding ?? 'json/plain'),
     );
+    const currentMessageType = payloads?.payloads[0]?.metadata?.messageType
+      ? atob(String(payloads?.payloads[0]?.metadata?.messageType))
+      : '';
+
     if (isPayloadInputEncodingType(currentEncoding)) {
       $encoding = currentEncoding;
       initialEncoding = $encoding;
+      if (currentEncoding === 'json/protobuf' && currentMessageType) {
+        messageType = currentMessageType;
+        initialMessageType = currentMessageType;
+      }
     }
     loading = false;
   };
@@ -41,6 +51,7 @@
       editInput = false;
       input = initialInput;
       $encoding = initialEncoding;
+      messageType = initialMessageType;
     } else {
       editInput = true;
       input;
@@ -53,6 +64,7 @@
     <PayloadInputWithEncoding
       bind:input
       bind:encoding
+      bind:messageType
       bind:loading
       editing={editInput}
       id="schedule-payload-input"

--- a/src/lib/components/workflow/client-actions/signal-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/signal-confirmation-modal.svelte
@@ -30,8 +30,9 @@
   let name = '';
   let customSignal = false;
 
-  let encoding: Writable<PayloadInputEncoding> = writable(defaultEncoding);
   let input = '';
+  let encoding: Writable<PayloadInputEncoding> = writable(defaultEncoding);
+  let messageType = '';
 
   const hideSignalModal = () => {
     open = false;
@@ -39,6 +40,7 @@
     input = '';
     customSignal = false;
     $encoding = defaultEncoding;
+    messageType = '';
   };
 
   const signal = async () => {
@@ -50,6 +52,7 @@
         workflow,
         input,
         encoding: $encoding,
+        messageType,
         name,
       });
       $refresh = Date.now();
@@ -114,6 +117,6 @@
         bind:value={name}
       />
     {/if}
-    <PayloadInputWithEncoding bind:input bind:encoding />
+    <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
   </div>
 </Modal>

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -268,6 +268,7 @@ export const Strings = {
   'start-workflow-success': 'Workflow started successfully',
   'start-workflow-error': 'Error starting Workflow',
   encoding: 'Encoding',
+  'message-type': 'Message Type',
   'user-metadata': 'User Metadata',
   'markdown-supported': 'Markdown Supported',
   'markdown-description':

--- a/src/lib/pages/schedule-edit.svelte
+++ b/src/lib/pages/schedule-edit.svelte
@@ -37,6 +37,7 @@
       taskQueue,
       input,
       encoding,
+      messageType,
       hour,
       minute,
       second,
@@ -56,6 +57,7 @@
       taskQueue,
       input,
       encoding,
+      messageType,
       searchAttributes,
     };
     const spec: Partial<ScheduleSpecParameters> = {

--- a/src/lib/pages/schedules-create.svelte
+++ b/src/lib/pages/schedules-create.svelte
@@ -24,6 +24,7 @@
       taskQueue,
       input,
       encoding,
+      messageType,
       hour,
       minute,
       second,
@@ -44,6 +45,7 @@
       taskQueue,
       input,
       encoding,
+      messageType,
       searchAttributes,
     };
     const spec: Partial<ScheduleSpecParameters> = {

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -134,6 +134,8 @@
       workflowType: type,
     });
     input = initialValues.input;
+    encoding.set(initialValues.encoding);
+    messageType = initialValues.messageType;
     inputRetrieved = Date.now();
     summary = initialValues.summary;
     details = initialValues.details;

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -49,6 +49,7 @@
   let summary = '';
   let details = '';
   let encoding: Writable<PayloadInputEncoding> = writable('json/plain');
+  let messageType = '';
   let inputRetrieved = 0;
 
   let initialWorkflowId = '';
@@ -86,6 +87,7 @@
         summary,
         details,
         encoding: $encoding,
+        messageType,
         searchAttributes,
       });
       toaster.push({
@@ -262,7 +264,7 @@
       on:blur={(e) => onInputChange(e, 'workflowType')}
     />
     {#key inputRetrieved}
-      <PayloadInputWithEncoding bind:input bind:encoding />
+      <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
     {/key}
     {#if viewAdvancedOptions}
       <Card class="flex flex-col gap-2">

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -85,7 +85,11 @@
 
     try {
       encodePayloadResult = input
-        ? encodePayloads(input, 'json/plain', false)
+        ? encodePayloads({
+            input,
+            encoding: 'json/plain',
+            encodeWithCodec: false,
+          })
         : Promise.resolve(null);
       payloads = await encodePayloadResult;
     } catch (e) {

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -107,6 +107,7 @@ type StartWorkflowOptions = {
   workflowType: string;
   input: string;
   encoding: PayloadInputEncoding;
+  messageType: string;
   summary: string;
   details: string;
   searchAttributes: SearchAttributeInput[];
@@ -342,7 +343,7 @@ export async function signalWorkflow({
     workflowId,
     signalName: name,
   });
-  const payloads = await encodePayloads(input, encoding);
+  const payloads = await encodePayloads({ input, encoding });
   const settings = get(page).data.settings;
   const version = settings?.version ?? '';
   const newVersion = isVersionNewer(version, '2.22');
@@ -390,7 +391,7 @@ export async function updateWorkflow({
     workflowId,
     updateName: name,
   });
-  const payloads = await encodePayloads(input, encoding);
+  const payloads = await encodePayloads({ input, encoding });
   const body = {
     workflowExecution: {
       runId,
@@ -557,6 +558,7 @@ export async function startWorkflow({
   summary,
   details,
   encoding,
+  messageType,
   searchAttributes,
 }: StartWorkflowOptions): Promise<{ runId: string }> {
   const route = routeForApi('workflow', {
@@ -569,7 +571,7 @@ export async function startWorkflow({
 
   if (input) {
     try {
-      payloads = await encodePayloads(input, encoding);
+      payloads = await encodePayloads({ input, encoding, messageType });
     } catch (_) {
       throw new Error('Could not encode input for starting workflow');
     }
@@ -578,13 +580,19 @@ export async function startWorkflow({
   try {
     if (summary) {
       summaryPayload = (
-        await encodePayloads(stringifyWithBigInt(summary), 'json/plain')
+        await encodePayloads({
+          input: stringifyWithBigInt(summary),
+          encoding: 'json/plain',
+        })
       )[0];
     }
 
     if (details) {
       detailsPayload = (
-        await encodePayloads(stringifyWithBigInt(details), 'json/plain')
+        await encodePayloads({
+          input: stringifyWithBigInt(details),
+          encoding: 'json/plain',
+        })
       )[0];
     }
   } catch (e) {

--- a/src/lib/stores/schedules.ts
+++ b/src/lib/stores/schedules.ts
@@ -90,6 +90,7 @@ export const submitCreateSchedule = async ({
     taskQueue,
     input,
     encoding,
+    messageType,
     searchAttributes,
   } = action;
 
@@ -97,7 +98,7 @@ export const submitCreateSchedule = async ({
 
   if (input) {
     try {
-      payloads = await encodePayloads({ input, encoding });
+      payloads = await encodePayloads({ input, encoding, messageType });
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);
       return;
@@ -166,6 +167,7 @@ export const submitEditSchedule = async (
     taskQueue,
     input,
     encoding,
+    messageType,
     searchAttributes,
   } = action;
 
@@ -173,7 +175,7 @@ export const submitEditSchedule = async (
 
   if (input) {
     try {
-      payloads = await encodePayloads({ input, encoding });
+      payloads = await encodePayloads({ input, encoding, messageType });
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);
       return;

--- a/src/lib/stores/schedules.ts
+++ b/src/lib/stores/schedules.ts
@@ -97,7 +97,7 @@ export const submitCreateSchedule = async ({
 
   if (input) {
     try {
-      payloads = await encodePayloads(input, encoding);
+      payloads = await encodePayloads({ input, encoding });
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);
       return;
@@ -173,7 +173,7 @@ export const submitEditSchedule = async (
 
   if (input) {
     try {
-      payloads = await encodePayloads(input, encoding);
+      payloads = await encodePayloads({ input, encoding });
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);
       return;
@@ -210,10 +210,10 @@ export const submitEditSchedule = async (
     try {
       const entries = Object.entries(fields);
       for (const [key, value] of entries) {
-        const encodedValue = await encodePayloads(
-          stringifyWithBigInt(value),
-          'json/plain',
-        );
+        const encodedValue = await encodePayloads({
+          input: stringifyWithBigInt(value),
+          encoding: 'json/plain',
+        });
         fields[key] = encodedValue[0];
       }
     } catch (e) {

--- a/src/lib/types/schedule.ts
+++ b/src/lib/types/schedule.ts
@@ -40,6 +40,7 @@ export type ScheduleActionParameters = {
   taskQueue: string;
   input: string;
   encoding: PayloadInputEncoding;
+  messageType?: string;
   searchAttributes: SearchAttributeInput[];
 };
 

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -58,6 +58,15 @@ const ProtobufEncoded = {
   data: 'InRlc3RAdGVzdC5jb20i',
 };
 
+const ProtobufEncodedWithMessageType = {
+  metadata: {
+    encoding: 'anNvbi9wcm90b2J1Zg==',
+    messageType:
+      'dGVtcG9yYWwuYXBpLndvcmtmbG93LnYxLldvcmtmbG93RXhlY3V0aW9uU3RhcnRlZEV2ZW50QXR0cmlidXRlcw==',
+  },
+  data: 'InRlc3RAdGVzdC5jb20i',
+};
+
 const BinaryNullEncodedNoData = {
   metadata: {
     encoding: 'YmluYXJ5L251bGw=',
@@ -117,33 +126,75 @@ describe('decodePayload with returnDataOnly = false', () => {
     expect(decodePayload(WebDecodePayload, false)).toEqual(WebDecodePayload);
   });
   it('Should not decode a payload with encoding binary/null', () => {
-    const fullDecodedPayload = { ...BinaryNullEncodedNoData, data: null };
+    const fullDecodedPayload = {
+      metadata: {
+        encoding: 'binary/null',
+      },
+      data: null,
+    };
     expect(decodePayload(BinaryNullEncodedNoData, false)).toEqual(
       fullDecodedPayload,
     );
   });
   it('Should decode a payload with encoding json/plain', () => {
-    const fullDecodedPayload = { ...JsonPlainEncoded, data: Base64Decoded };
+    const fullDecodedPayload = {
+      metadata: {
+        encoding: 'json/plain',
+        type: 'Keyword',
+      },
+      data: Base64Decoded,
+    };
     expect(decodePayload(JsonPlainEncoded, false)).toEqual(fullDecodedPayload);
   });
   it('Should decode a payload with encoding json/foo', () => {
-    const fullDecodedPayload = { ...JsonFooEncoded, data: Base64Decoded };
+    const fullDecodedPayload = {
+      metadata: {
+        encoding: 'json/foo',
+        type: 'Keyword',
+      },
+      data: Base64Decoded,
+    };
     expect(decodePayload(JsonFooEncoded, false)).toEqual(fullDecodedPayload);
   });
   it('Should decode a payload with encoding json/protobuf', () => {
-    const fullDecodedPayload = { ...ProtobufEncoded, data: Base64Decoded };
+    const fullDecodedPayload = {
+      metadata: {
+        encoding: 'json/protobuf',
+        type: 'Keyword',
+      },
+      data: Base64Decoded,
+    };
     expect(decodePayload(ProtobufEncoded, false)).toEqual(fullDecodedPayload);
+  });
+  it('Should decode a payload with encoding json/protobuf with messageType', () => {
+    const fullDecodedPayload = {
+      metadata: {
+        encoding: 'json/protobuf',
+        messageType:
+          'temporal.api.workflow.v1.WorkflowExecutionStartedEventAttributes',
+      },
+      data: Base64Decoded,
+    };
+    expect(decodePayload(ProtobufEncodedWithMessageType, false)).toEqual(
+      fullDecodedPayload,
+    );
   });
   it('Should decode a json payload with encoding json/plain', () => {
     const fullDecodedPayload = {
-      ...JsonObjectEncoded,
+      metadata: {
+        encoding: 'json/plain',
+        type: 'Keyword',
+      },
       data: JsonObjectDecoded,
     };
     expect(decodePayload(JsonObjectEncoded, false)).toEqual(fullDecodedPayload);
   });
   it('Should decode a json payload with constructor keyword with encoding json/plain', () => {
     const fullDecodedPayload = {
-      ...JsonObjectEncoded,
+      metadata: {
+        encoding: 'json/plain',
+        type: 'Keyword',
+      },
       data: JsonObjectDecodedWithConstructor,
     };
     expect(decodePayload(JsonObjectEncodedWithConstructor, false)).toEqual(

--- a/src/lib/utilities/encode-payload.ts
+++ b/src/lib/utilities/encode-payload.ts
@@ -24,7 +24,17 @@ export const getSinglePayload = (decodedValue: string): string => {
 export const setBase64Payload = (
   payload: unknown,
   encoding: PayloadInputEncoding = 'json/plain',
+  messageType = '',
 ) => {
+  if (messageType) {
+    return {
+      metadata: {
+        encoding: btoa(encoding),
+        messageType: btoa(messageType),
+      },
+      data: btoa(JSON.stringify(payload)),
+    };
+  }
   return {
     metadata: {
       encoding: btoa(encoding),
@@ -33,16 +43,24 @@ export const setBase64Payload = (
   };
 };
 
-export const encodePayloads = async (
-  input: string,
-  encoding: PayloadInputEncoding,
-  encodeWithCodec: boolean = true,
-): Promise<Payloads> => {
+type EncodePayloads = {
+  input: string;
+  encoding: PayloadInputEncoding;
+  messageType?: string;
+  encodeWithCodec?: boolean;
+};
+
+export const encodePayloads = async ({
+  input,
+  encoding,
+  messageType = '',
+  encodeWithCodec = true,
+}: EncodePayloads): Promise<Payloads> => {
   let payloads = null;
 
   if (input) {
     const parsedInput = JSON.parse(input);
-    payloads = [setBase64Payload(parsedInput, encoding)];
+    payloads = [setBase64Payload(parsedInput, encoding, messageType)];
     const endpoint = get(dataEncoder).endpoint;
     if (endpoint && encodeWithCodec) {
       const awaitData = await encodePayloadsWithCodec({

--- a/src/routes/(app)/nexus/[id]/edit/+page.svelte
+++ b/src/routes/(app)/nexus/[id]/edit/+page.svelte
@@ -34,10 +34,10 @@
     body.id = endpoint.id;
     body.version = endpoint.version;
 
-    const payloads = await encodePayloads(
-      JSON.stringify(body.spec.descriptionString),
-      'json/plain',
-    );
+    const payloads = await encodePayloads({
+      input: JSON.stringify(body.spec.descriptionString),
+      encoding: 'json/plain',
+    });
     body.spec.description = payloads[0];
 
     delete body.spec.allowedCallerNamespaces;

--- a/src/routes/(app)/nexus/create/+page.svelte
+++ b/src/routes/(app)/nexus/create/+page.svelte
@@ -19,10 +19,10 @@
     loading = true;
     try {
       const body = { ...$endpointForm };
-      const payloads = await encodePayloads(
-        JSON.stringify(body.spec.descriptionString),
-        'json/plain',
-      );
+      const payloads = await encodePayloads({
+        input: JSON.stringify(body.spec.descriptionString),
+        encoding: 'json/plain',
+      });
       body.spec.description = payloads[0];
 
       delete body.spec.allowedCallerNamespaces;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
To use the `json/protobuf` encoding, you also need to pass the messageType metadata in the Payload. This PR adds support for including that field if `json/protobuf` encoding is used. If editing a schedule or starting a workflow from an existing workflow, if the encoding is `json/protobuf` and a messageType exists, set it as the initial value.

As part of this PR, I've also added base64 decoding all metadata fields instead of just the data field. This should only decode the metadata when 'Human readable' setting is set. For example, if you download the event history and select 'Decoded', the data and metadata fields should still be base64 encoded.

**To test:**

Start a new Workflow:

1. With json/plain
2. With json/protobuf + messageType and make sure initial encoding and messageType is set

Start a new Workflow from existing Workflow:

1. With json/plain
2. With json/protobuf + messageType

Create a new Schedule:

1. With json/plain
2. With json/protobuf + messageType


Edit a Schedule:

1. With json/plain
2. With json/protobuf + messageType and make sure initial encoding and messageType is set


Send a Signal:

1. With json/plain
2. With json/protobuf + messageType

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1920" alt="Screenshot 2025-02-27 at 10 09 36 AM" src="https://github.com/user-attachments/assets/b8bc5ba0-884a-44e2-a965-1925afe7181e" />
<img width="1920" alt="Screenshot 2025-02-27 at 10 08 10 AM" src="https://github.com/user-attachments/assets/ab804404-36d6-46d8-984b-f42b2952c8be" />
<img width="1920" alt="Screenshot 2025-02-27 at 10 08 26 AM" src="https://github.com/user-attachments/assets/007700a6-36c0-4cee-9900-032dbfd0cd3e" />
<img width="1920" alt="Screenshot 2025-02-27 at 10 08 51 AM" src="https://github.com/user-attachments/assets/41fa77c9-dac5-4075-a426-32b1f223a519" />
<img width="1919" alt="Screenshot 2025-02-27 at 10 12 17 AM" src="https://github.com/user-attachments/assets/240383ac-5ad9-4dc6-88e8-12926f93471e" />
<img width="1920" alt="Screenshot 2025-02-27 at 10 09 28 AM" src="https://github.com/user-attachments/assets/30339330-1ef4-4fe4-b280-702d9a1024a7" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
