### PR TITLE
Don't decode the full startWorkflow to allow passing startWorkflow search attributes

### DIFF
--- a/src/lib/components/schedule/schedule-form-view.svelte
+++ b/src/lib/components/schedule/schedule-form-view.svelte
@@ -65,17 +65,15 @@
 
   let errors = {};
   let name = scheduleId ?? '';
-  const decodedWorkflow = decodePayloadAttributes(
-    schedule?.action?.startWorkflow,
-  );
+
   const decodedSearchAttributes = decodePayloadAttributes({ searchAttributes });
   const indexedFields =
     decodedSearchAttributes?.searchAttributes.indexedFields ??
     ({} as { [k: string]: string });
 
-  let workflowType = decodedWorkflow?.workflowType?.name ?? '';
-  let workflowId = decodedWorkflow?.workflowId ?? '';
-  let taskQueue = decodedWorkflow?.taskQueue?.name ?? '';
+  let workflowType = schedule?.action?.startWorkflow?.workflowType?.name ?? '';
+  let workflowId = schedule?.action?.startWorkflow?.workflowId ?? '';
+  let taskQueue = schedule?.action?.startWorkflow?.taskQueue?.name ?? '';
   let input = '';
   let editInput = !schedule;
   let encoding: Writable<PayloadInputEncoding> = writable('json/plain');


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
It is possible that a schedule can be created from the SDK and includes search attributes on the action, not on the schedule itself. We were decoding the full action startWorkflow on edit, and so if there were search attributes on the startWorkflow, it would error because we weren't then re-encoding them before saving. This removes decoding the startWorkflow to keep those searchAttributes encoded and allow them to pass correctly to the server on save.

There will be a follow-up task to add UI on create/edit of a Schedule to include search attributes on the startWorkflow in addition to the Schedule itself. We will need to decode/re-encode the search attributes in that PR.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Create a schedule with startWorkflow search attributes in the SDK, then edit it in the UI. The UI should save without error:

```
  const schedule = await client.schedule.create({
    action: {
      type: 'startWorkflow',
      workflowType: reminder,
      args: ['♻️ Dear future self, please take out the recycling tonight. Sincerely, past you ❤️'],
      taskQueue: 'schedules',
      searchAttributes: {
        'CustomStringField': ['Workflow_2']
      },
    },
    scheduleId: 'sample-schedule',
    policies: {
      catchupWindow: '1 day',
      overlap: ScheduleOverlapPolicy.ALLOW_ALL,
    },
    spec: {
      intervals: [{ every: '10s' }],
    },
  });
```

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
