### PR TITLE
DT-2819 - support reset with pending children

### DIFF
--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -19,7 +19,7 @@
   import { refresh } from '$lib/stores/workflow-run';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { routeForWorkflowStart } from '$lib/utilities/route-for';
-  import { isVersionNewer } from '$lib/utilities/version-check';
+  import { minimumVersionRequired } from '$lib/utilities/version-check';
   import { workflowCancelEnabled } from '$lib/utilities/workflow-cancel-enabled';
   import { workflowCreateDisabled } from '$lib/utilities/workflow-create-disabled';
   import { workflowResetEnabled } from '$lib/utilities/workflow-reset-enabled';
@@ -73,7 +73,8 @@
 
   // https://github.com/temporalio/temporal/releases/tag/v1.27.1
   $: canResetWithPendingChildWorkflows =
-    isVersionNewer('1.27.1', $temporalVersion) ||
+    minimumVersionRequired('1.27.1', $temporalVersion) ||
+    $isCloud ||
     workflow.pendingChildren.length === 0;
 
   $: resetEnabled =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
As of Temporal Server [v1.27.1](https://github.com/temporalio/temporal/releases/tag/v1.27.1), resetting workflows with pending children is now supported. This PR un-gates this functionality for server versions >= 1.27.1 and cloud.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
- With the newest version of Temporal CLI, run `pnpm dev` confirm server version is >= 1.27.1
```
Checking Temporal CLI at /Users/redfort/dev/temporalio/ui/bin/cli/temporal…
Temporal CLI found at /Users/redfort/dev/temporalio/ui/bin/cli/temporal:
	 → temporal version 1.3.0 (Server 1.27.1, UI 2.36.0)
✨ temporal dev server running on port: 7233
```
- In your local clone of the samples-typescript repository, change the `childWorkflow` function in `child-workflows/src/workflows.ts` to something async, such as
```typescript
export async function childWorkflow(name: string): Promise<string> {
  return new Promise((resolve) => {
    setTimeout(() => {
      resolve(`I am a child named ${name}`);
    }, 60 * 1000)
  })
}
```
- in the `child-workflows` directory, run `npm install`
- run the sample worker with `npm start`
- in a separate shell, run the workfow with `npm run workflow`
- view the _parent_ workflow execution, it should have a workflow id of `parent-sample-0`
- Reset the workflow

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
