### PR TITLE
Limit fetchAllRootWorkflows to 3000

### DIFF
--- a/src/lib/components/workflow/workflow-counts.svelte
+++ b/src/lib/components/workflow/workflow-counts.svelte
@@ -4,7 +4,6 @@
   import { page } from '$app/stores';
 
   import Skeleton from '$lib/holocene/skeleton/index.svelte';
-  import { workflowStatuses } from '$lib/models/workflow-status';
   import { fetchWorkflowCountByExecutionStatus } from '$lib/services/workflow-counts';
   import { workflowFilters } from '$lib/stores/filters';
   import { currentPageKey } from '$lib/stores/pagination';
@@ -18,7 +17,7 @@
     SEARCH_ATTRIBUTE_TYPE,
     type WorkflowStatus,
   } from '$lib/types/workflows';
-  import { decodePayload } from '$lib/utilities/decode-payload';
+  import { getStatusAndCountOfGroup } from '$lib/utilities/get-group-status-and-count';
   import { toListWorkflowQueryFromFilters } from '$lib/utilities/query/filter-workflow-query';
   import { combineFilters } from '$lib/utilities/query/to-list-workflow-filters';
   import { getExponentialBackoffSeconds } from '$lib/utilities/refresh-rate';
@@ -63,26 +62,6 @@
     $workflowCount.newCount = 0;
     attempt = 1;
     loading = true;
-  };
-
-  const getStatusAndCountOfGroup = (groups = []) => {
-    return groups
-      .map((group) => {
-        const status = decodePayload(
-          group?.groupValues[0],
-        ) as unknown as WorkflowStatus;
-        const count = parseInt(group.count);
-        return {
-          status,
-          count,
-        };
-      })
-      .sort((a, b) => {
-        return (
-          workflowStatuses.indexOf(a.status) -
-          workflowStatuses.indexOf(b.status)
-        );
-      });
   };
 
   const fetchNewCounts = async () => {

--- a/src/lib/components/workflow/workflow-relationships.svelte
+++ b/src/lib/components/workflow/workflow-relationships.svelte
@@ -33,6 +33,8 @@
   );
   $: ({ hasRelationships, first, next, previous, scheduleId } =
     workflowRelationships);
+
+  const MAX_UPPER_LIMIT = 3000;
 </script>
 
 <div class="flex flex-col gap-4 pb-12">
@@ -41,7 +43,7 @@
       {#await fetchAllRootWorkflowsCount(namespace, rootWorkflowId, rootRunId)}
         <Loading />
       {:then { count, groups }}
-        {#if parseInt(count) > 3000}
+        {#if parseInt(count) > MAX_UPPER_LIMIT}
           {@const statusGroups = getStatusAndCountOfGroup(groups)}
           <div class="flex flex-col gap-2 px-8 py-4">
             <h4 class="text-xl font-medium">

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -37,6 +37,7 @@ import type {
 } from '$lib/types/global';
 import type {
   ArchiveFilterParameters,
+  CountWorkflowExecutionsResponse,
   ListWorkflowExecutionsResponse,
   WorkflowExecution,
   WorkflowIdentifier,
@@ -68,6 +69,7 @@ import {
 import { formatReason } from '$lib/utilities/workflow-actions';
 
 import { fetchInitialEvent } from './events-service';
+import { fetchWorkflowCountByExecutionStatus } from './workflow-counts';
 
 export type GetWorkflowExecutionRequest = NamespaceScopedRequest & {
   workflowId: string;
@@ -789,6 +791,24 @@ const buildRoots = (
 
   return buildNode(root, []);
 };
+
+export async function fetchAllRootWorkflowsCount(
+  namespace: string,
+  rootWorkflowId: string,
+  rootRunId?: string,
+): Promise<CountWorkflowExecutionsResponse> {
+  let query = `RootWorkflowId = "${rootWorkflowId}"`;
+  if (rootRunId) {
+    query += ` AND RootRunId = "${rootRunId}"`;
+  }
+
+  const count = await fetchWorkflowCountByExecutionStatus({
+    namespace,
+    query,
+  });
+
+  return count;
+}
 
 export async function fetchAllRootWorkflows(
   namespace: string,

--- a/src/lib/utilities/get-group-status-and-count.ts
+++ b/src/lib/utilities/get-group-status-and-count.ts
@@ -1,0 +1,23 @@
+import { workflowStatuses } from '$lib/models/workflow-status';
+import type { WorkflowStatus } from '$lib/types/workflows';
+
+import { decodePayload } from './decode-payload';
+
+export const getStatusAndCountOfGroup = (groups = []) => {
+  return groups
+    .map((group) => {
+      const status = decodePayload(
+        group?.groupValues[0],
+      ) as unknown as WorkflowStatus;
+      const count = parseInt(group.count);
+      return {
+        status,
+        count,
+      };
+    })
+    .sort((a, b) => {
+      return (
+        workflowStatuses.indexOf(a.status) - workflowStatuses.indexOf(b.status)
+      );
+    });
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Limit the upper bounds of the fetchAllRootWorkflows to 3000 by querying the same RootWorkflowId query with fetchWorkflowCountByExecutionStatus. This prevents users from hitting RPS limit set by API when paginating over millions of workflows from the same RootWorkflowId.

If over 3000 workflows, show the breakdown of workflow statuses:
<img width="1814" alt="Screenshot 2025-03-26 at 3 39 09 PM" src="https://github.com/user-attachments/assets/aa078299-5685-4fd2-b918-23dda328c121" />

If under, show the current Workflow Tree 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
