### PR TITLE
Revert "Revert "ChipInput Updates""

### DIFF
--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -387,9 +387,12 @@
       <Icon class="ml-2 shrink-0" name={leadingIcon} />
     {/if}
     <div
-      class="input-wrapper"
-      class:gap-1={multiselect}
-      class:p-1={multiselect && displayChips}
+      class={merge(
+        'input-wrapper',
+        multiselect && 'gap-1',
+        multiselect && 'm-1',
+        leadingIcon && multiselect && 'ml-2',
+      )}
     >
       {#if multiselect && isArrayValue(value) && value.length > 0}
         {#if displayChips}
@@ -415,7 +418,15 @@
         type="text"
         value={displayValue}
         class:disabled
-        class={merge('combobox-input', className)}
+        class={merge(
+          'combobox-input',
+          multiselect
+            ? value.length > 0 || leadingIcon
+              ? 'indent-0'
+              : 'indent-1'
+            : 'indent-2',
+          className,
+        )}
         role="combobox"
         autocomplete="off"
         autocapitalize="off"
@@ -535,10 +546,6 @@
 
   .input-wrapper {
     @apply flex w-full flex-wrap items-center;
-
-    input {
-      @apply indent-2;
-    }
   }
 
   .combobox-input {

--- a/src/lib/holocene/input/chip-input.stories.svelte
+++ b/src/lib/holocene/input/chip-input.stories.svelte
@@ -18,6 +18,7 @@
       removeChipButtonLabel: 'Remove',
       labelHidden: false,
       validator: isEmail,
+      maxLength: undefined,
       chips: ['tobias@temporal.io'],
     },
     argTypes: {
@@ -30,6 +31,7 @@
       labelHidden: { name: 'Label Hidden', control: 'boolean' },
       chips: { name: 'Chips', table: { disable: true } },
       validator: { table: { disable: true } },
+      maxLength: { name: 'Maximum Length', control: 'number' },
       removeChipButtonLabel: {
         name: 'Aria label for remove button',
         control: 'text',
@@ -80,11 +82,21 @@
 />
 
 <Story
-  name="Invalid"
+  name="Error"
   play={async ({ canvasElement, id }) => {
     const canvas = within(canvasElement);
     const input = canvas.getByTestId(id);
     await userEvent.type(input, 'bonbon');
     await userEvent.keyboard('{enter}');
+  }}
+/>
+
+<Story
+  name="With Maximum Length"
+  args={{ maxLength: 10 }}
+  play={async ({ canvasElement, id }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByTestId(id);
+    await userEvent.click(input);
   }}
 />

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -33,7 +33,7 @@
   export { className as class };
 
   afterUpdate(() => {
-    input.scrollIntoView();
+    input.scrollIntoView({ block: 'nearest', inline: 'start' });
   });
 
   const handleKeydown = (e: KeyboardEvent) => {

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -133,6 +133,7 @@
       on:keydown|stopPropagation={handleKeydown}
       on:paste={handlePaste}
       maxlength={maxLength && $values.length >= maxLength ? 0 : undefined}
+      size={placeholder.length || undefined}
     />
   </div>
 

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
 
-  import { afterUpdate, onDestroy } from 'svelte';
+  import { afterUpdate } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import Chip from '$lib/holocene/chip.svelte';
@@ -19,10 +19,10 @@
   export let validator: (value: string) => boolean = () => true;
   export let removeChipButtonLabel: string | ((chipValue: string) => string);
   export let external = false;
+  export let maxLength = 0;
 
   const values = writable<string[]>(chips);
   let displayValue = '';
-  let shouldScrollToInput = false;
   let inputContainer: HTMLDivElement;
   let input: HTMLInputElement;
 
@@ -32,25 +32,8 @@
   let className = '';
   export { className as class };
 
-  const scrollToInput = () => {
-    let rect = input.getBoundingClientRect();
-    inputContainer.scrollTo(rect.x, rect.y);
-    shouldScrollToInput = false;
-  };
-
-  const unsubscribe = values.subscribe((updatedChips) => {
-    shouldScrollToInput = updatedChips.length > chips.length;
-    chips = updatedChips;
-  });
-
   afterUpdate(() => {
-    if (shouldScrollToInput) {
-      scrollToInput();
-    }
-  });
-
-  onDestroy(() => {
-    unsubscribe();
+    input.scrollIntoView();
   });
 
   const handleKeydown = (e: KeyboardEvent) => {
@@ -74,11 +57,17 @@
 
   const handlePaste = (e: ClipboardEvent) => {
     e.preventDefault();
+    if (maxLength && $values.length >= maxLength) return;
     const clipboardContents = e.clipboardData.getData('text/plain');
-    values.update((previous) => [
-      ...previous,
-      ...clipboardContents.split(',').map((content) => content.trim()),
-    ]);
+    let newValues = clipboardContents
+      .split(',')
+      .map((content) => content.trim());
+
+    if (maxLength) {
+      newValues = newValues.slice(0, maxLength - $values.length);
+    }
+
+    values.update((previous) => [...previous, ...newValues]);
   };
 
   const handleBlur = () => {
@@ -97,15 +86,14 @@
   };
 </script>
 
-<div class={merge(disabled && 'cursor-not-allowed', className)}>
-  <Label
-    class="pb-1"
-    {required}
-    {label}
-    {disabled}
-    hidden={labelHidden}
-    for={id}
-  />
+<div
+  class={merge(
+    'group flex flex-col gap-1',
+    disabled && 'cursor-not-allowed',
+    className,
+  )}
+>
+  <Label {required} {label} {disabled} hidden={labelHidden} for={id} />
   <div
     bind:this={inputContainer}
     class={merge(
@@ -144,15 +132,37 @@
       on:blur={handleBlur}
       on:keydown|stopPropagation={handleKeydown}
       on:paste={handlePaste}
+      maxlength={maxLength && $values.length >= maxLength ? 0 : undefined}
     />
   </div>
-  {#if invalid && hintText}
-    <span class="hint">
-      {hintText}
-    </span>
+
+  {#if (invalid && hintText) || (maxLength && !disabled)}
+    <div class="flex justify-between gap-2">
+      <div
+        class="error-msg"
+        class:min-width={maxLength}
+        aria-live={invalid ? 'assertive' : 'off'}
+      >
+        {#if invalid && hintText}
+          <p>{hintText}</p>
+        {/if}
+      </div>
+      {#if maxLength && !disabled}
+        <span class="count">
+          <span
+            class="text-information"
+            class:warn={maxLength - $values?.length <= 5}
+            class:error={maxLength === $values?.length}
+          >
+            {$values?.length ?? 0}
+          </span>&nbsp;/&nbsp;{maxLength}
+        </span>
+      {/if}
+    </div>
   {/if}
+
   {#if $values.length > 0 && external}
-    <div class="mt-1 flex flex-row flex-wrap gap-1">
+    <div class="flex flex-row flex-wrap gap-1">
       {#each $values as chip, i (`${chip}-${i}`)}
         {@const valid = validator(chip)}
         <Chip
@@ -174,10 +184,26 @@
   }
 
   input {
-    @apply surface-primary inline-block w-full focus:outline-none;
+    @apply surface-primary inline-block grow focus:outline-none;
   }
 
-  .hint {
-    @apply text-xs text-danger;
+  .error-msg {
+    @apply break-words text-sm text-danger;
+  }
+
+  .error-msg.min-width {
+    @apply w-[calc(100%-6rem)];
+  }
+
+  .count {
+    @apply invisible text-right text-sm font-medium text-primary group-focus-within:visible;
+  }
+
+  .count > .warn {
+    @apply text-warning;
+  }
+
+  .count > .error {
+    @apply text-danger;
   }
 </style>

--- a/src/lib/holocene/textarea.stories.svelte
+++ b/src/lib/holocene/textarea.stories.svelte
@@ -41,17 +41,19 @@
 <script lang="ts">
   import { action } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
+  import { userEvent, within } from '@storybook/test';
 
   import { shouldNotBeTransparent } from './test-utilities';
 </script>
 
-<Template let:args>
+<Template let:args let:context>
   <Textarea
     on:input={action('input')}
     on:blur={action('blue')}
     on:change={action('change')}
     on:focus={action('focus')}
     on:keydown={action('keydown')}
+    id={context.id}
     {...args}
   />
 </Template>
@@ -69,7 +71,15 @@
 
 <Story name="Hidden Label" args={{ labelHidden: true }} />
 
-<Story name="With Maximum Length" args={{ maxLength: 10 }} />
+<Story
+  name="With Maximum Length"
+  args={{ maxLength: 10 }}
+  play={async ({ canvasElement, id }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByTestId(id);
+    await userEvent.click(input);
+  }}
+/>
 
 <Story name="With Value" args={{ value: 'Some text…' }} />
 

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -68,6 +68,7 @@
       on:blur
       on:keydown|stopPropagation
       maxlength={maxLength > 0 ? maxLength : undefined}
+      data-testid={id}
       {...$$restProps}
     />
   </div>


### PR DESCRIPTION
* Reverts temporalio/ui#2619 
* Fixes `scrollIntoView()` so screen no longer jumps
* Accounts for length of `placeholder` r.e. the size of the input

| Before | After |
|-|-|
|![Screenshot 2025-03-26 at 4 45 22 PM](https://github.com/user-attachments/assets/4600794f-5d79-47b6-8067-78c1969753ff)|![Screenshot 2025-03-26 at 4 45 35 PM](https://github.com/user-attachments/assets/be704f6b-ea4d-42a5-90c6-0fd94fbaffcd)|

