### PR TITLE
feat: add support for persistent database in Temporal server

### DIFF
--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -22,6 +22,22 @@ const shouldSkip = (server: ViteDevServer): boolean => {
   return false;
 };
 
+const persistentDB = (server: ViteDevServer): string | undefined => {
+  const filename = server.config.env.VITE_TEMPORAL_DB;
+  if (!filename) {
+    console.warn(
+      magenta(
+        'No VITE_TEMPORAL_DB environment variable set. Using in-memory database.',
+      ),
+    );
+    return;
+  }
+
+  console.log(magenta(`Using persistent database at ${filename}.`));
+
+  return filename;
+};
+
 const getPortFromApiEndpoint = (endpoint: string, fallback = 8233): number => {
   return validatePort(
     endpoint.slice(endpoint.lastIndexOf(':') + 1, endpoint.length),
@@ -68,6 +84,7 @@ export function temporalServer(): Plugin {
       temporal = await createTemporalServer({
         port,
         uiPort,
+        dbFilename: persistentDB(server),
       });
 
       await temporal.ready();

--- a/scripts/start-temporal-server.ts
+++ b/scripts/start-temporal-server.ts
@@ -14,6 +14,7 @@ const options: TemporalServerOptions = {
   path: args['path'],
   logLevel: args['logLevel'] ?? args['log-level'],
   codecEndpoint: args['codecEndpoint'] ?? args['codec-endpoint'],
+  dbFilename: args['dbFilename'] ?? args['db-filename'],
 };
 
 const server: TemporalServer = await createTemporalServer(options);

--- a/utilities/temporal-server.ts
+++ b/utilities/temporal-server.ts
@@ -17,6 +17,7 @@ export type TemporalServerOptions = {
   logLevel?: string;
   codecEndpoint?: string;
   headless?: boolean;
+  dbFilename?: string;
 };
 
 const warn = (message: Parameters<typeof console.warn>[0]) => {
@@ -61,6 +62,7 @@ export const createTemporalServer = async ({
   logLevel = 'error',
   codecEndpoint,
   headless = false,
+  dbFilename,
 }: TemporalServerOptions = {}) => {
   const cliPath = await getCLIPath(path);
 
@@ -77,6 +79,10 @@ export const createTemporalServer = async ({
 
   if (headless) {
     flags.push('--headless');
+  }
+
+  if (dbFilename) {
+    flags.push(`--db-filename=${dbFilename}`);
   }
 
   const temporal =


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

- Introduced the `dbFilename` parameter to Temporal server options.
- Added logic to read the `VITE_TEMPORAL_DB` environment variable.
- Updated CLI flags to include `--db-filename` when provided.
- Enhanced scripts and plugins to handle persistent database paths.

I noticed that when certain config changes occur, the current Temporal server is
restarted, and workflows used for troubleshooting are lost. This optional
setting maintains the existing functionality while adding the ability to
persist data across restarts. 


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

Try it out:

```
VITE_TEMPORAL_DB="../temporal.db" pnpm dev
```

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
