### PR TITLE
feat: integrate Temporal HTTP client for search attributes

### DIFF
--- a/.env.http-api
+++ b/.env.http-api
@@ -1,0 +1,4 @@
+VITE_TEMPORAL_PORT="7134"
+VITE_API="http://localhost:8233"
+VITE_MODE="development"
+VITE_TEMPORAL_UI_BUILD_TARGET="local"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint:fix": "eslint --ignore-path .gitignore --fix .",
     "dev": "pnpm dev:ui-server -- --open",
     "dev:ui-server": ". ./.env.ui-server && vite dev --mode ui-server",
+    "dev:http-api": ". ./.env.http-api && vite dev --mode ui-server",
     "dev:local-temporal": ". ./.env.local-temporal && vite dev --mode local-temporal",
     "dev:temporal-cli": "vite dev --mode temporal-server",
     "dev:docker": ". ./.env && VITE_API=http://localhost:8080 vite dev --mode docker",

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -1,13 +1,14 @@
 import type { SearchAttributesResponseHumanized } from '$lib/types/workflows';
 import { toSearchAttributeTypeReadable } from '$lib/utilities/screaming-enums';
-import { temporalDefaultClient } from '$lib/utilities/temporal-client';
+import { temporalClient } from '$lib/utilities/temporal-client';
 
 export const fetchSearchAttributesForNamespace = async (
   namespace: string,
 ): Promise<SearchAttributesResponseHumanized> => {
   try {
-    const searchAttributesResponse =
-      await temporalDefaultClient.listSearchAttributes({ namespace });
+    const searchAttributesResponse = await temporalClient.listSearchAttributes({
+      namespace,
+    });
 
     // DEPRECATED
     //

--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -1,30 +1,42 @@
-import type { SearchAttributesResponse } from '$lib/types/workflows';
-import { requestFromAPI } from '$lib/utilities/request-from-api';
-import { routeForApi } from '$lib/utilities/route-for-api';
+import type { SearchAttributesResponseHumanized } from '$lib/types/workflows';
 import { toSearchAttributeTypeReadable } from '$lib/utilities/screaming-enums';
+import { temporalDefaultClient } from '$lib/utilities/temporal-client';
 
 export const fetchSearchAttributesForNamespace = async (
   namespace: string,
-  request = fetch,
-): Promise<Omit<SearchAttributesResponse, 'storageSchema'>> => {
+): Promise<SearchAttributesResponseHumanized> => {
   try {
-    const route = routeForApi('search-attributes', { namespace });
     const searchAttributesResponse =
-      await requestFromAPI<SearchAttributesResponse>(route, {
-        request,
-      });
+      await temporalDefaultClient.listSearchAttributes({ namespace });
 
-    const customAttributes = { ...searchAttributesResponse.customAttributes };
-    const systemAttributes = { ...searchAttributesResponse.systemAttributes };
-    Object.entries(customAttributes).forEach(([key, value]) => {
-      customAttributes[key] = toSearchAttributeTypeReadable(value);
-    });
-    Object.entries(systemAttributes).forEach(([key, value]) => {
-      systemAttributes[key] = toSearchAttributeTypeReadable(value);
-    });
+    // DEPRECATED
+    //
+    // const route = routeForApi('search-attributes', { namespace });
+    // await requestFromAPI<SearchAttributesResponse>(route, {
+    //   request,
+    // });
+    //
+    // const customAttributes = { ...searchAttributesResponse.customAttributes };
+    // const systemAttributes = { ...searchAttributesResponse.systemAttributes };
+    // Object.entries(customAttributes).forEach(([key, value]) => {
+    //   customAttributes[key] = toSearchAttributeTypeReadable(value);
+    // });
+    // Object.entries(systemAttributes).forEach(([key, value]) => {
+    //   systemAttributes[key] = toSearchAttributeTypeReadable(value);
+    // });
+    //
+    // END DEPRECATED
+
     return {
-      customAttributes,
-      systemAttributes,
+      customAttributes: mapEntries(
+        searchAttributesResponse.customAttributes || {},
+        toSearchAttributeTypeReadable,
+      ),
+
+      systemAttributes: mapEntries(
+        searchAttributesResponse.systemAttributes || {},
+        toSearchAttributeTypeReadable,
+      ),
     };
   } catch (e) {
     console.error(
@@ -38,3 +50,38 @@ export const fetchSearchAttributesForNamespace = async (
     };
   }
 };
+
+/*
+ * This function is probably a bit obtuse, so lets break it down:
+ *
+1. **Generic Function**: 
+   - The function `mapEntries` is a generic function, which means it can work with any data types specified at the time of calling. It uses four generic type parameters: `T`, `U`, `V`, and `W`.
+
+2. **Type Parameters**:
+   - `T`: Represents the type of the values in the input object `obj`.
+   - `U`: Represents the type of the values in the output object.
+   - `V`: A record type where keys are strings and values are of type `T`.
+   - `W`: A record type where keys are strings and values are of type `U`.
+
+3. **Function Parameters**:
+   - `obj: V`: The input object, which is a record with string keys and values of type `T`.
+   - `fn: (value: T) => U`: A function that takes a value of type `T` and returns a value of type `U`.
+
+4. **Function Logic**:
+   - `Object.entries(obj)`: Converts the input object `obj` into an array of key-value pairs.
+   - `.map(([key, value]) => [key, fn(value)])`: Iterates over each key-value pair, applying the function `fn` to each value. It returns a new array of key-value pairs where the values have been transformed by `fn`.
+   - `Object.fromEntries(...)`: Converts the array of transformed key-value pairs back into an object.
+
+5. **Return Type**:
+   - The function returns an object of type `W`, which is a record with the same keys as the input object but with values transformed to type `U`.
+*/
+function mapEntries<
+  T,
+  U,
+  V extends Record<string, T>,
+  W extends Record<string, U>,
+>(obj: V, fn: (value: T) => U): W {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, fn(value)]),
+  ) as W;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -218,10 +218,6 @@ export type ScheduleActionResult =
 // api.query
 export type QueryResult = temporal.api.query.v1.IWorkflowQueryResult;
 
-// api.operatorservice
-export type ListSearchAttributesResponse =
-  temporal.api.operatorservice.v1.IListSearchAttributesResponse;
-
 // api.batch
 export type BatchCancelOperation =
   temporal.api.batch.v1.IBatchOperationCancellation;

--- a/src/lib/types/workflows.ts
+++ b/src/lib/types/workflows.ts
@@ -136,10 +136,9 @@ export type SearchAttributes = {
   [k: string]: SearchAttributeType;
 };
 
-export type SearchAttributesResponse = {
+export type SearchAttributesResponseHumanized = {
   customAttributes: Record<string, SearchAttributeType>;
   systemAttributes: Record<string, SearchAttributeType>;
-  storageSchema: import('$lib/types').ListSearchAttributesResponse['storageSchema'];
 };
 
 export type WorkflowSearchAttributes = {

--- a/src/lib/utilities/screaming-enums.ts
+++ b/src/lib/utilities/screaming-enums.ts
@@ -1,3 +1,5 @@
+import type { ListSearchAttributesResponse } from 'temporal-http-client/schemas/list-search-attributes-response';
+
 import type {
   ArchivalState,
   CallbackState,
@@ -14,11 +16,10 @@ import type {
 
 import type { EventType } from './is-event-type';
 
-export const fromScreamingEnum = <T>(
-  potentialScreamingEnum: T,
+export const fromScreamingEnum = <T, V>(
+  potentialScreamingEnum: V,
   prefix: string,
-): T => {
-  if (!potentialScreamingEnum) return potentialScreamingEnum;
+): T | V => {
   const stringEnum = String(potentialScreamingEnum);
   const split = stringEnum.split('_');
   if (!split || split.length <= 1) return potentialScreamingEnum;
@@ -31,8 +32,11 @@ export const fromScreamingEnum = <T>(
 };
 
 export const toSearchAttributeTypeReadable = (
-  status: SearchAttributeType,
-): SearchAttributeType => {
+  status:
+    | ListSearchAttributesResponse['customAttributes'][string]
+    | ListSearchAttributesResponse['systemAttributes'][string]
+    | SearchAttributeType,
+): typeof status => {
   return fromScreamingEnum(status, 'IndexedValueType');
 };
 

--- a/src/lib/utilities/temporal-client.ts
+++ b/src/lib/utilities/temporal-client.ts
@@ -1,0 +1,13 @@
+import Client from 'temporal-http-client';
+
+import { getApiOrigin } from './get-api-origin';
+
+export const newClient = (apiUrl?: string) => {
+  if (!apiUrl) {
+    apiUrl = getApiOrigin();
+  }
+
+  return new Client(apiUrl);
+};
+
+export const temporalDefaultClient = newClient();

--- a/src/lib/utilities/temporal-client.ts
+++ b/src/lib/utilities/temporal-client.ts
@@ -10,4 +10,4 @@ export const newClient = (apiUrl?: string) => {
   return new Client(apiUrl);
 };
 
-export const temporalDefaultClient = newClient();
+export const temporalClient = newClient();

--- a/src/routes/(app)/namespaces/[namespace]/+layout.ts
+++ b/src/routes/(app)/namespaces/[namespace]/+layout.ts
@@ -6,13 +6,12 @@ import { allSearchAttributes } from '$lib/stores/search-attributes';
 export const load: LayoutLoad = async ({
   params,
   parent,
-  fetch,
 }): Promise<LayoutData> => {
   await parent();
-  const attributes = await fetchSearchAttributesForNamespace(
-    params.namespace,
-    fetch,
-  );
+
+  // there is a console warn about using the fetch provided rather than
+  // window.fetch. The client would need to be updated to facilitate this
+  const attributes = await fetchSearchAttributesForNamespace(params.namespace);
 
   allSearchAttributes.set(attributes);
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR refactors the search attributes service by implmenting the API requests
using the new `temporal-http-client` package.

The client provides a more strucuted approach to interacting with the temporal API.
By abstracting the request client, we are not only able to iterate on the client
functionality in isolation but also, the types used within the client can be
generated from the temporal OpenAPI specification.

This means that we can easily update the client to match the latest API changes
without having to worry about the types in the codebase.

For more insight into how this is type generation is accomplished, peep the
source here: https://github.com/stevekinney/temporal-http-client

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

Navigate to any page that loads namespace details. 

```
http://localhost:3000/namespaces/{namespace}
```

This will call the `getSearchAttributes` API and load the search attributes. It
also maps the response to a more human readable format.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

- [ ] Fix up unit tests
- [ ] Resolve fetch warning

Fetch Warning
```
client.ts:1559 Loading http://localhost:8081/api/v1/namespaces/default/search-attributes using `window.fetch`. For best results, use the `fetch` that is passed to your `load` function: https://kit.svelte.dev/docs/load#making-fetch-requests
```

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
