### PR TITLE
Add min-h-screen to fix scroll gap on nav

### DIFF
--- a/src/lib/holocene/navigation/navigation-container.svelte
+++ b/src/lib/holocene/navigation/navigation-container.svelte
@@ -17,7 +17,7 @@
 
 <nav
   class={merge(
-    'group grid h-screen min-h-[600px] w-16 grid-cols-[2rem] grid-rows-[fit-content(1.5rem)_minmax(3rem,4rem)_1fr_8rem] gap-2 border-r border-subtle px-4 py-5 transition-width data-[nav=open]:w-[180px] data-[nav=open]:grid-cols-[100%]',
+    'group grid min-h-screen w-16 grid-cols-[2rem] grid-rows-[fit-content(1.5rem)_minmax(3rem,4rem)_1fr_8rem] gap-2 border-r border-subtle px-4 py-5 transition-width data-[nav=open]:w-[180px] data-[nav=open]:grid-cols-[100%]',
     'focus-visible:[&_[role=button]]:outline-none focus-visible:[&_[role=button]]:ring-2 focus-visible:[&_[role=button]]:ring-primary/70 focus-visible:[&_a]:outline-none focus-visible:[&_a]:ring-2 focus-visible:[&_a]:ring-primary/70',
     isCloud
       ? 'bg-gradient-to-b from-indigo-600 to-indigo-950 text-off-white focus-visible:[&_[role=button]]:ring-success focus-visible:[&_a]:ring-success'


### PR DESCRIPTION
Added `min-h-screen` to nav container component to try and fix weird gap on nav if browser window is smaller than the height of the nav. 

This is happening on core and cloud so some adjustments may need to happen in cloud as well, if this truly fixes the issue.  



<img width="405" alt="Screenshot 2025-04-02 at 1 14 38 PM" src="https://github.com/user-attachments/assets/85ea83ab-86ef-43f8-9498-aa54f25e4db6" />
