### PR TITLE
refactor(search-attributes): poc generated schema usage

### DIFF
--- a/src/lib/services/search-attributes-service.ts
+++ b/src/lib/services/search-attributes-service.ts
@@ -1,4 +1,6 @@
-import type { SearchAttributesResponse } from '$lib/types/workflows';
+import { ListSearchAttributesResponse } from '$lib/schemas';
+import type { SearchAttributesResponseHumanized } from '$lib/types/workflows';
+import { mapEntries } from '$lib/utilities/map-entries';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 import { toSearchAttributeTypeReadable } from '$lib/utilities/screaming-enums';
@@ -6,35 +8,65 @@ import { toSearchAttributeTypeReadable } from '$lib/utilities/screaming-enums';
 export const fetchSearchAttributesForNamespace = async (
   namespace: string,
   request = fetch,
-): Promise<Omit<SearchAttributesResponse, 'storageSchema'>> => {
+): Promise<SearchAttributesResponseHumanized> => {
   try {
-    const route = routeForApi('search-attributes', { namespace });
-    const searchAttributesResponse =
-      await requestFromAPI<SearchAttributesResponse>(route, {
-        request,
-      });
+    // get the search attributes from the API
+    const parsed = await parsedResponse({ namespace, request });
 
-    const customAttributes = { ...searchAttributesResponse.customAttributes };
-    const systemAttributes = { ...searchAttributesResponse.systemAttributes };
-    Object.entries(customAttributes).forEach(([key, value]) => {
-      customAttributes[key] = toSearchAttributeTypeReadable(value);
-    });
-    Object.entries(systemAttributes).forEach(([key, value]) => {
-      systemAttributes[key] = toSearchAttributeTypeReadable(value);
-    });
-    return {
-      customAttributes,
-      systemAttributes,
-    };
-  } catch (e) {
-    console.error(
-      'Error fetching search attributes for namespace',
-      namespace,
-      e,
-    );
-    return {
-      customAttributes: {},
-      systemAttributes: {},
-    };
+    // parse the response to a human readable format
+    return humanizeSearchAttributes(parsed);
+  } catch (err) {
+    // handle the error and return a default value
+    handleError({ namespace, err });
   }
 };
+
+async function parsedResponse({
+  namespace,
+  request = fetch,
+}: {
+  namespace: string;
+  request?: typeof fetch;
+}) {
+  const route = routeForApi('search-attributes', { namespace });
+  const searchAttributesResponse =
+    await requestFromAPI<ListSearchAttributesResponse>(route, {
+      request,
+    });
+
+  // The parse call is integral to the service implementation as it passes the
+  // response through the zod schema and validates the content
+  return ListSearchAttributesResponse.parse(searchAttributesResponse);
+}
+
+function humanizeSearchAttributes(
+  parsed: ListSearchAttributesResponse,
+): SearchAttributesResponseHumanized {
+  return {
+    customAttributes: mapEntries(
+      parsed.customAttributes || {},
+      toSearchAttributeTypeReadable,
+    ),
+
+    systemAttributes: mapEntries(
+      parsed.systemAttributes || {},
+      toSearchAttributeTypeReadable,
+    ),
+  };
+}
+
+function handleError({
+  namespace,
+  err,
+}: {
+  namespace: string;
+  err: unknown;
+}): SearchAttributesResponseHumanized {
+  const message = 'Error fetching search attributes for namespace:';
+  console.error(message, namespace, err);
+
+  return {
+    customAttributes: {},
+    systemAttributes: {},
+  };
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -218,10 +218,6 @@ export type ScheduleActionResult =
 // api.query
 export type QueryResult = temporal.api.query.v1.IWorkflowQueryResult;
 
-// api.operatorservice
-export type ListSearchAttributesResponse =
-  temporal.api.operatorservice.v1.IListSearchAttributesResponse;
-
 // api.batch
 export type BatchCancelOperation =
   temporal.api.batch.v1.IBatchOperationCancellation;

--- a/src/lib/types/workflows.ts
+++ b/src/lib/types/workflows.ts
@@ -136,10 +136,9 @@ export type SearchAttributes = {
   [k: string]: SearchAttributeType;
 };
 
-export type SearchAttributesResponse = {
+export type SearchAttributesResponseHumanized = {
   customAttributes: Record<string, SearchAttributeType>;
   systemAttributes: Record<string, SearchAttributeType>;
-  storageSchema: import('$lib/types').ListSearchAttributesResponse['storageSchema'];
 };
 
 export type WorkflowSearchAttributes = {

--- a/src/lib/utilities/map-entries.ts
+++ b/src/lib/utilities/map-entries.ts
@@ -1,0 +1,98 @@
+/*
+ * This function is probably a bit obtuse, so lets break it down:
+ *
+1. **Generic Function**: 
+   - The function `mapEntries` is a generic function, which means it can work
+   with any data types specified at the time of calling. It uses four generic
+   type parameters: `T`, `U`, `V`, and `W`.
+
+2. **Type Parameters**:
+   - `T`: Represents the type of the values in the input object `obj`.
+   - `U`: Represents the type of the values in the output object.
+   - `V`: A record type where keys are strings and values are of type `T`.
+   - `W`: A record type where keys are strings and values are of type `U`.
+
+3. **Function Parameters**:
+   - `obj: V`: The input object, which is a record with string keys and values
+   of type `T`.
+   - `fn: (value: T) => U`: A function that takes a value of type `T` and
+   returns a value of type `U`.
+
+4. **Function Logic**:
+   - `Object.entries(obj)`: Converts the input object `obj` into an array of 
+   key-value pairs.
+   - `.map(([key, value]) => [key, fn(value)])`: Iterates over each key-value
+   pair, applying the function `fn` to each value. It returns a new array of
+   key-value pairs where the values have been transformed by `fn`.
+   - `Object.fromEntries(...)`: Converts the array of transformed key-value
+   pairs back into an object.
+
+5. **Return Type**:
+   - The function returns an object of type `W`, which is a record with the 
+     same keys as the input object but with values transformed to type `U`.
+
+### Example
+
+Suppose you have an object representing search attributes in a workflow, and
+you want to convert the property values from screaming enums to humanized names. 
+Here's how you might use `mapEntries` to achieve this:
+
+#### Input
+
+Suppose you have an object representing search attributes with screaming enum
+values:
+
+```typescript
+const searchAttributes = {
+  attribute1: 'INDEXED_VALUE_TYPE_STRING',
+  attribute2: 'INDEXED_VALUE_TYPE_INT',
+  attribute3: 'INDEXED_VALUE_TYPE_BOOL',
+};
+```
+
+#### Transformation Function
+
+We'll use the `toSearchAttributeTypeReadable` function to convert these
+screaming enum values into a more readable format:
+
+```typescript
+import { toSearchAttributeTypeReadable } from '$lib/utilities/screaming-enums';
+
+const humanizedAttributes = mapEntries(searchAttributes, toSearchAttributeTypeReadable);
+```
+
+#### Output
+
+The `humanizedAttributes` object will be:
+
+```typescript
+{
+  attribute1: 'String',
+  attribute2: 'Int',
+  attribute3: 'Bool',
+}
+```
+
+### Explanation
+
+- **Input Object**: `searchAttributes` is an object where each key is an
+attribute name and each value is a screaming enum representing the attribute
+type.
+- **Transformation Function**: `toSearchAttributeTypeReadable` converts each
+screaming enum value into a human-readable string by removing the prefix and
+capitalizing the first letter of each word.
+- **Output Object**: `humanizedAttributes` is the result of applying
+`mapEntries` to `searchAttributes` with `toSearchAttributeTypeReadable`. It has
+the same keys as `searchAttributes`, but the values are transformed to a more
+readable format.
+*/
+export function mapEntries<
+  T,
+  U,
+  V extends Record<string, T>,
+  W extends Record<string, U>,
+>(obj: V, fn: (value: T) => U): W {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, fn(value)]),
+  ) as W;
+}

--- a/src/lib/utilities/screaming-enums.ts
+++ b/src/lib/utilities/screaming-enums.ts
@@ -1,3 +1,4 @@
+import type { ListSearchAttributesResponse } from '$lib/schemas';
 import type {
   ArchivalState,
   CallbackState,
@@ -14,10 +15,10 @@ import type {
 
 import type { EventType } from './is-event-type';
 
-export const fromScreamingEnum = <T>(
-  potentialScreamingEnum: T,
+export const fromScreamingEnum = <T, V>(
+  potentialScreamingEnum: V,
   prefix: string,
-): T => {
+): T | V => {
   if (!potentialScreamingEnum) return potentialScreamingEnum;
   const stringEnum = String(potentialScreamingEnum);
   const split = stringEnum.split('_');
@@ -31,8 +32,11 @@ export const fromScreamingEnum = <T>(
 };
 
 export const toSearchAttributeTypeReadable = (
-  status: SearchAttributeType,
-): SearchAttributeType => {
+  status:
+    | ListSearchAttributesResponse['customAttributes'][string]
+    | ListSearchAttributesResponse['systemAttributes'][string]
+    | SearchAttributeType,
+): typeof status => {
   return fromScreamingEnum(status, 'IndexedValueType');
 };
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Also: Refactored the `fetchSearchAttributesForNamespace` function to enhance readability and maintainability. Introduced helper functions for parsing responses, mutating attributes, and handling errors.

Changes include:
- Replaced inline logic with `parsedResponse` and `mutateSearchAttributes`.
- Added `mapEntries` utility for transforming object entries.
- Updated types to align with the new schema-based approach.
- Removed redundant `ListSearchAttributesResponse` type.

This improves code clarity and aligns with schema validation practices.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
