### PR TITLE
fix(api): add URL decoding for workflow ID in handler

### DIFF
--- a/server/server/api/rawhistory_test.go
+++ b/server/server/api/rawhistory_test.go
@@ -60,6 +60,62 @@ func TestWorkflowRawHistoryHandler_HappyPath(t *testing.T) {
 	mockService.AssertExpectations(t)
 }
 
+func TestWorkflowRawHistoryHandler_URLDecoding(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// URL encoded workflow ID (this is "test/workflow+id")
+	c.SetParamNames("namespace", "workflow", "runid")
+	c.SetParamValues("test-namespace", "test%2Fworkflow%2Bid", "test-runid")
+
+	mockService := new(MockWorkflowService)
+	// Check that the decoded workflow ID is passed to the service
+	mockService.On("GetWorkflowExecutionHistory", mock.Anything, mock.MatchedBy(func(req *workflowservice.GetWorkflowExecutionHistoryRequest) bool {
+		return req.Execution.WorkflowId == "test/workflow+id"
+	})).Return(&workflowservice.GetWorkflowExecutionHistoryResponse{
+		History: &history.History{
+			Events: []*history.HistoryEvent{
+				{EventId: 1, EventType: 1},
+			},
+		},
+	}, nil)
+
+	handler := api.WorkflowRawHistoryHandler(mockService)
+
+	err := handler(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestWorkflowRawHistoryHandler_InvalidURLEncoding(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	// Invalid URL encoding with incomplete percent encoding
+	c.SetParamNames("namespace", "workflow", "runid")
+	c.SetParamValues("test-namespace", "invalid%2", "test-runid")
+
+	mockService := new(MockWorkflowService)
+	// The service should not be called because decoding fails
+	handler := api.WorkflowRawHistoryHandler(mockService)
+
+	err := handler(c)
+
+	// Error should be returned
+	httpErr, ok := err.(*echo.HTTPError)
+	assert.True(t, ok)
+	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
+	assert.Contains(t, httpErr.Message, "Invalid workflow ID")
+	// No calls to the service should be made
+	mockService.AssertNotCalled(t, "GetWorkflowExecutionHistory")
+}
+
 func TestRawHistory_StreamEvents_ErrorHandling(t *testing.T) {
 	mockService := new(MockWorkflowService)
 	mockService.On("GetWorkflowExecutionHistory", mock.Anything, mock.Anything).

--- a/src/lib/components/workflow-raw-history-link.svelte
+++ b/src/lib/components/workflow-raw-history-link.svelte
@@ -3,15 +3,17 @@
   import { translate } from '$lib/i18n/translate';
   import { isCloud } from '$lib/stores/advanced-visibility';
   import { parameters } from '$lib/stores/events';
-  import { routeForWorkflowHistoryJson } from '$lib/utilities/route-for';
+  import { routeForEventHistory } from '$lib/utilities/route-for';
 
   const { namespace, workflowId, runId } = $parameters;
 
-  $: href = routeForWorkflowHistoryJson({
+  $: href = routeForEventHistory({
     namespace,
     workflow: workflowId,
     run: runId,
   });
+
+  $: jsonHref = href + '.json';
 </script>
 
 {#if !$isCloud}
@@ -19,7 +21,7 @@
     <Link
       icon="external-link"
       class="whitespace-nowrap"
-      {href}
+      href={jsonHref}
       newTab={true}
       data-testid="view-raw-event-history"
     >

--- a/src/lib/services/events-service.ts
+++ b/src/lib/services/events-service.ts
@@ -51,7 +51,7 @@ export const getEndpointForRawHistory = ({
       workflowId,
       runId,
     },
-    false,
+    true,
   );
 };
 

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -132,14 +132,6 @@ export const routeForWorkflow = ({
   return `${routeForWorkflows(parameters)}/${wid}/${run}`;
 };
 
-export const routeForWorkflowHistoryJson = ({
-  workflow,
-  run,
-  ...parameters
-}: WorkflowParameters): string => {
-  return `${routeForWorkflows(parameters)}/${workflow}/${run}/history.json`;
-};
-
 export const routeForSchedules = (parameters: NamespaceParameter): string => {
   return `${routeForNamespace(parameters)}/schedules`;
 };


### PR DESCRIPTION
## Description & Motivation 💭

This PR introduces several updates and fixes to improve the handling of workflow history and related functionalities:

- **URL Decoding for Workflow Parameter**: Added decoding for the `workflow` parameter in `WorkflowRawHistoryHandler` to properly handle encoded workflow IDs. Invalid URL-encoded workflow IDs now return an HTTP 400 error.
- **UI Update**: Updated the workflow history link in the Svelte component to append a `.json` suffix, ensuring consistency with the raw history format. The route utility function was also updated to reflect this change.
- **Raw History Endpoint Enhancement**: Adjusted the `getEndpointForRawHistory` function to support query strings, enabling more flexible usage of the raw history endpoint.
- **Test Coverage**: Added tests to cover URL decoding, invalid encoding scenarios, and the updated behavior of the raw history link.

https://github.com/user-attachments/assets/c816d880-c868-4af8-a0a1-dededfff1b71

## Testing 🧪

### How was this tested? 👻
- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test:
1. Verify that encoded workflow IDs are correctly decoded and invalid encodings return HTTP 400.
2. Check that the workflow history link in the UI appends `.json` as expected.
3. Confirm that query strings are properly handled in the raw history endpoint.

## Checklists

### Merge Checklist
- [x] Ensure all tests pass.
- [x] Verify that the `.json` suffix is consistently applied in the UI.
- [x] Confirm that query strings work as intended in the raw history endpoint.

### Issue(s) Closed
- N/A

## Docs

### Any docs updates needed?
- N/A
