### PR TITLE
Use group id for pending activity link

### DIFF
--- a/src/lib/components/event/pending-activity-summary-row.svelte
+++ b/src/lib/components/event/pending-activity-summary-row.svelte
@@ -22,7 +22,7 @@
   $: expanded = expandAll;
   $: ({ workflow, run, namespace } = $page.params);
   $: href = routeForEventHistoryEvent({
-    eventId: event.activityId,
+    eventId: group?.id,
     namespace,
     workflow,
     run,
@@ -43,9 +43,13 @@
   on:click|stopPropagation={onLinkClick}
 >
   <td class="font-mono">
-    <Link data-testid="link" {href}>
-      {event.activityId}
-    </Link>
+    {#if group?.id}
+      <Link data-testid="link" {href}>
+        {group.id}
+      </Link>
+    {:else}
+      {event.id}
+    {/if}
   </td>
   <td class="w-full overflow-hidden text-right font-normal xl:text-left">
     <div class="flex w-full items-center gap-2">


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Using activityId can lead to incorrect link, use group.id which is the id of the first event of the group which will always be correct.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
