### PR TITLE
Remove max-height on chip input, fix recursive call

### DIFF
--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -22,15 +22,9 @@
 
   const values = writable<string[]>(chips);
   let displayValue = '';
-  let inputContainer: HTMLDivElement;
-  let input: HTMLInputElement;
 
   $: chips, ($values = chips);
   $: invalid = $values.some((chip) => !validator(chip));
-
-  values.subscribe((updatedChips) => {
-    chips = updatedChips;
-  });
 
   let className = '';
   export { className as class };
@@ -40,6 +34,7 @@
     if ((e.key === ',' || e.key === 'Enter') && value !== '') {
       e.preventDefault();
       values.update((previous) => [...previous, value]);
+      chips = $values;
       displayValue = '';
     }
 
@@ -51,6 +46,7 @@
       $values.length > 0
     ) {
       values.update((previous) => previous.slice(0, -1));
+      chips = $values;
     }
   };
 
@@ -67,12 +63,14 @@
     }
 
     values.update((previous) => [...previous, ...newValues]);
+    chips = $values;
   };
 
   const handleBlur = () => {
     const value = displayValue.trim();
     if (value !== '') {
       values.update((previous) => [...previous, value]);
+      chips = $values;
       displayValue = '';
     }
   };
@@ -82,6 +80,7 @@
       previous.splice(index, 1);
       return previous;
     });
+    chips = $values;
   };
 </script>
 
@@ -94,9 +93,8 @@
 >
   <Label {required} {label} {disabled} hidden={labelHidden} for={id} />
   <div
-    bind:this={inputContainer}
     class={merge(
-      'surface-primary flex max-h-20 min-h-[2.5rem] w-full flex-row flex-wrap gap-1 overflow-y-scroll border border-subtle p-2 text-sm text-primary focus-within:border-interactive focus-within:ring-2 focus-within:ring-primary/70',
+      'surface-primary flex min-h-[2.5rem] w-full flex-row flex-wrap gap-1 overflow-y-scroll border border-subtle p-2 text-sm text-primary focus-within:border-interactive focus-within:ring-2 focus-within:ring-primary/70',
       disabled && 'cursor-not-allowed opacity-65',
       invalid && 'invalid',
     )}
@@ -126,7 +124,6 @@
       {required}
       multiple
       data-testid={id}
-      bind:this={input}
       bind:value={displayValue}
       on:blur={handleBlur}
       on:keydown|stopPropagation={handleKeydown}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Remove max-height from input. When users are adding many chips, especially emails, it's very difficult to see them all with max-height and overflow-auto. Remove max-height and let the chip input expand as tall as needed.


Also, we need to update chips since that is what is getting binded (bind:chips), but 

```
  values.subscribe((updatedChips) => {
    chips = updatedChips;
  });
```

causes infinite recursive updates. So manually set chips everywhere values is updated instead.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
