### PR TITLE
Coerce Nexus Endpoint type to String

### DIFF
--- a/src/routes/(app)/nexus/[id]/edit/+page.svelte
+++ b/src/routes/(app)/nexus/[id]/edit/+page.svelte
@@ -58,7 +58,7 @@
     error = undefined;
     loading = true;
     try {
-      await deleteNexusEndpoint(endpoint.id, endpoint.version);
+      await deleteNexusEndpoint(endpoint.id, String(endpoint.version));
       goto(routeForNexus());
     } catch (e) {
       error = e as NetworkError;


### PR DESCRIPTION
Addresses type error:

```
ui/src/routes/(app)/nexus/[id]/edit/+page.svelte:61:46
Error: Argument of type 'Long' is not assignable to parameter of type 'string'. (ts)
```