### PR TITLE
feat(modal): update slot name to `modalTitle`

### DIFF
--- a/src/lib/components/workflow/client-actions/batch-cancel-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/batch-cancel-confirmation-modal.svelte
@@ -79,7 +79,7 @@
   confirmText={translate('common.confirm')}
   on:confirmModal={cancelWorkflows}
 >
-  <h3 slot="modal-title">
+  <h3 slot="modalTitle">
     <Translate key="workflows.batch-cancel-modal-title" />
   </h3>
   <svelte:fragment slot="content">

--- a/src/lib/components/workflow/client-actions/batch-reset-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/batch-reset-confirmation-modal.svelte
@@ -83,7 +83,7 @@
   on:confirmModal={resetWorkflows}
   confirmType="destructive"
 >
-  <h3 slot="modal-title">
+  <h3 slot="modalTitle">
     <Translate key="workflows.batch-reset-modal-title" />
   </h3>
   <svelte:fragment slot="content">

--- a/src/lib/components/workflow/client-actions/batch-terminate-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/batch-terminate-confirmation-modal.svelte
@@ -79,7 +79,7 @@
   confirmText={translate('workflows.terminate')}
   on:confirmModal={terminateWorkflows}
 >
-  <h3 slot="modal-title">
+  <h3 slot="modalTitle">
     <Translate key="workflows.batch-terminate-modal-title" />
   </h3>
   <svelte:fragment slot="content">

--- a/src/lib/components/workflow/client-actions/cancel-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/cancel-confirmation-modal.svelte
@@ -51,7 +51,7 @@
   confirmType="destructive"
   on:confirmModal={cancel}
 >
-  <h3 slot="modal-title">{translate('workflows.cancel-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('workflows.cancel-modal-title')}</h3>
   <svelte:fragment slot="content">
     <p>
       {translate('workflows.cancel-modal-confirmation')}

--- a/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
@@ -83,7 +83,7 @@
   on:cancelModal={hideResetModal}
   confirmDisabled={!$eventId}
 >
-  <h3 slot="modal-title">{translate('workflows.reset-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('workflows.reset-modal-title')}</h3>
   <svelte:fragment slot="content">
     <div class="flex w-full flex-col gap-4">
       <Select

--- a/src/lib/components/workflow/client-actions/signal-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/signal-confirmation-modal.svelte
@@ -88,7 +88,7 @@
   on:cancelModal={hideSignalModal}
   on:confirmModal={signal}
 >
-  <h3 slot="modal-title">{translate('workflows.signal-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('workflows.signal-modal-title')}</h3>
   <div slot="content" class="flex flex-col gap-4">
     {#if signalDefinitions?.length > 0 && !customSignal}
       <Select

--- a/src/lib/components/workflow/client-actions/terminate-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/terminate-confirmation-modal.svelte
@@ -61,7 +61,7 @@
   on:cancelModal={hideModal}
   on:confirmModal={terminate}
 >
-  <h3 slot="modal-title">{translate('workflows.terminate-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('workflows.terminate-modal-title')}</h3>
   <div slot="content">
     <p>
       {translate('workflows.terminate-modal-confirmation')}

--- a/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
@@ -108,7 +108,7 @@
   on:cancelModal={hideModal}
   on:confirmModal={update}
 >
-  <h3 slot="modal-title">{translate('workflows.update-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('workflows.update-modal-title')}</h3>
   <div class="flex flex-col gap-4" slot="content">
     {#if updateDefinitions?.length > 0 && !customUpdate}
       <Select

--- a/src/lib/components/workflow/download-event-history-modal.svelte
+++ b/src/lib/components/workflow/download-event-history-modal.svelte
@@ -37,7 +37,7 @@
   on:confirmModal={() => onDownloadClick()}
   on:cancelModal={() => (open = false)}
 >
-  <h3 slot="modal-title">
+  <h3 slot="modalTitle">
     {translate('common.download-event-history-json')}
   </h3>
   <div slot="content" class="flex flex-col gap-4">

--- a/src/lib/holocene/modal.stories.svelte
+++ b/src/lib/holocene/modal.stories.svelte
@@ -100,7 +100,7 @@
     on:cancelModal={action('cancel')}
     {...args}
   >
-    <h3 slot="modal-title">Modal Title</h3>
+    <h3 slot="modalTitle">Modal Title</h3>
     <p slot="content">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
       Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -106,7 +106,7 @@
     />
   {/if}
   <div id="modal-title-{id}" class="title">
-    <slot name="modal-title" />
+    <slot name="modalTitle" />
   </div>
   <form on:submit|preventDefault={confirmModal} method="dialog">
     <div id="modal-content-{id}" class="content">

--- a/src/lib/pages/nexus-edit-endpoint.svelte
+++ b/src/lib/pages/nexus-edit-endpoint.svelte
@@ -89,7 +89,7 @@
   on:cancelModal={() => (deleteConfirmationModalOpen = false)}
   confirmDisabled={confirmDeleteInput !== endpoint.spec.name}
 >
-  <h3 slot="modal-title">{translate('nexus.delete-modal-title')}</h3>
+  <h3 slot="modalTitle">{translate('nexus.delete-modal-title')}</h3>
   <div slot="content" class="flex flex-col gap-4">
     <p>
       {translate('nexus.delete-modal-confirmation-preface')}

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -414,7 +414,7 @@
       on:confirmModal={() => handlePause(schedule)}
       on:cancelModal={resetReason}
     >
-      <h3 slot="modal-title">
+      <h3 slot="modalTitle">
         {schedule?.schedule.state.paused
           ? translate('schedules.unpause-modal-title')
           : translate('schedules.pause-modal-title')}
@@ -454,7 +454,7 @@
       on:confirmModal={() => handleTriggerImmediately()}
       on:cancelModal={closeTriggerModal}
     >
-      <h3 slot="modal-title">
+      <h3 slot="modalTitle">
         {translate('schedules.trigger-modal-title')}
       </h3>
       <div slot="content">
@@ -485,7 +485,7 @@
       on:confirmModal={() => handleBackfill()}
       on:cancelModal={closeBackfillModal}
     >
-      <h3 slot="modal-title">
+      <h3 slot="modalTitle">
         {translate('schedules.schedule')}
         {translate('schedules.backfill')}
       </h3>
@@ -570,7 +570,7 @@
       on:confirmModal={handleDelete}
       on:cancelModal={resetReason}
     >
-      <h3 slot="modal-title">{translate('schedules.delete-modal-title')}</h3>
+      <h3 slot="modalTitle">{translate('schedules.delete-modal-title')}</h3>
       <div slot="content">
         <p>
           {translate('schedules.delete-modal-confirmation', {


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Svelte 5 components can't render the slot title without error since the
HTMLAttributes interface has a conflicting `title` property.

Updated all modal components to use `modalTitle` instead of `title`
for the slot name. This change ensures consistency across the codebase
and improves clarity in slot naming conventions.

Affected components include:
- Workflow client action modals (batch-cancel, batch-reset, etc.)
- Holocene modal components
- Nexus and schedule-related modals

BREAKING CHANGE: Consumers of the modal components must update their
slot names from `title` to `modalTitle` to avoid rendering issues.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

![CleanShot 2025-05-19 at 14 22 01](https://github.com/user-attachments/assets/1b5a2bac-ea8f-4c02-b8e4-6147f3bd090d)




