### PR TITLE
Add TLS support for ui-server

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -48,6 +48,9 @@ tls:
   keyData:
   enableHostVerification: false
   serverName:
+uiServerTLS:
+  certFile:
+  keyFile:
 codec:
   endpoint:
   passAccessToken: false

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -43,6 +43,9 @@ tls:
   keyData: {{ env "TEMPORAL_TLS_KEY_DATA" | default "" }}
   enableHostVerification: {{ env "TEMPORAL_TLS_ENABLE_HOST_VERIFICATION" | default "false" }}
   serverName: {{ env "TEMPORAL_TLS_SERVER_NAME" | default "" }}
+uiServerTLS:
+  certFile: {{ env "TEMPORAL_UI_SERVER_TLS_CERT" | default "" }}
+  keyFile: {{ env "TEMPORAL_UI_SERVER_TLS_KEY" | default "" }}
 auth:
   enabled: {{ env "TEMPORAL_AUTH_ENABLED" | default "false" }}
   providers:

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -69,6 +69,8 @@ type (
 		// Forward specified HTTP headers from HTTP API requests to Temporal gRPC backend
 		ForwardHeaders []string `yaml:"forwardHeaders"`
 		HideLogs       bool     `yaml:"hideLogs"`
+		// TLS configuration options to start UI Server in TLS mode
+		UIServerTLS UIServerTLS `yaml:"uiServerTLS"`
 	}
 
 	CORS struct {
@@ -88,6 +90,11 @@ type (
 		KeyData                string `yaml:"keyData"`
 		EnableHostVerification bool   `yaml:"enableHostVerification"`
 		ServerName             string `yaml:"serverName"`
+	}
+
+	UIServerTLS struct {
+		CertFile string `yaml:"certFile"`
+		KeyFile  string `yaml:"keyFile"`
 	}
 
 	Auth struct {

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -147,7 +147,14 @@ func (s *Server) Start() error {
 	}
 
 	address := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	if err := s.httpServer.Start(address); err != http.ErrServerClosed {
+	if cfg.UIServerTLS.CertFile != "" && cfg.UIServerTLS.KeyFile != "" {
+		s.httpServer.Logger.Info("Starting UI server with TLS...")
+		err = s.httpServer.StartTLS(address, cfg.UIServerTLS.CertFile, cfg.UIServerTLS.KeyFile)
+	} else {
+		err = s.httpServer.Start(address)
+	}
+
+	if err != http.ErrServerClosed {
 		s.httpServer.Logger.Fatal(err)
 	}
 	return nil


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 
Currently when start ui-server through command line or docker image, it always running over http. To make it running from more production env, it would be better to support running the server over https.

As a workaround, we could setup reverse proxy to provide https access to ui server, but still it would be great if we could support https natively.

There are an existing issues:
- https://github.com/temporalio/ui/issues/1262
- https://github.com/temporalio/ui/issues/1266

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
