### PR TITLE
Only decode on onMount to prevent overfetching payloads

### DIFF
--- a/src/lib/components/event/payload-decoder.svelte
+++ b/src/lib/components/event/payload-decoder.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+
   import { page } from '$app/stores';
 
   import { authUser } from '$lib/stores/auth-user';
@@ -27,22 +29,22 @@
   let keyedValue = key && value?.[key] ? value[key] : value;
   let decodedValue = stringifyWithBigInt(keyedValue);
 
-  $: endpoint = getCodecEndpoint($page.data.settings);
-  $: passAccessToken = getCodecPassAccessToken($page.data.settings);
-  $: includeCredentials = getCodecIncludeCredentials($page.data.settings);
-  $: settings = {
-    ...$page.data.settings,
-    codec: {
-      ...$page.data.settings?.codec,
-      endpoint,
-      passAccessToken,
-      includeCredentials,
-    },
-  };
+  onMount(() => {
+    decodePayloads(value);
+  });
 
   const decodePayloads = async (
     _value: PotentiallyDecodable | EventAttribute | WorkflowEvent | Memo,
   ) => {
+    const settings = {
+      ...$page.data.settings,
+      codec: {
+        ...$page.data.settings?.codec,
+        endpoint: getCodecEndpoint($page.data.settings),
+        passAccessToken: getCodecPassAccessToken($page.data.settings),
+        includeCredentials: getCodecIncludeCredentials($page.data.settings),
+      },
+    };
     try {
       const convertedAttributes = await cloneAllPotentialPayloadsWithCodec(
         _value,
@@ -66,8 +68,6 @@
       console.error('Could not decode payloads');
     }
   };
-
-  $: decodePayloads(value);
 </script>
 
 <slot {decodedValue} />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Because our decoder was reactive to value, even though the value didn't change it was still triggered due to JSON.stringify. Moving to onMount will decode only on the mount of component, ensuring it doesn't over-decode. The value shouldn't change - payloads are immutable in history -  so onMount should always work. It's more apparent when the workflow is running and we refetch the workflow or get new events in the event history poll.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

**Before**

https://github.com/user-attachments/assets/313cd8b9-ef49-4fdd-9ac1-d0a250233a48

**After**

https://github.com/user-attachments/assets/8243cc2a-fe71-4f52-966e-f5f250fd814e



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
To test:

Use samples-typescript/encryption project
Add `await condition(() => false)` before the `return results` in the workflows.ts to keep the workflow running.

Turn on the codec server. Decode calls should only happen on page load or when new event is rendered. If you sit on the page, it should not re-request codec calls.


### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
