### PR TITLE
use string instead of null for dark mode system setting

### DIFF
--- a/src/lib/components/dark-mode-icon-button.svelte
+++ b/src/lib/components/dark-mode-icon-button.svelte
@@ -9,7 +9,7 @@
   } from '$lib/utilities/dark-mode';
 
   const buttonText = $derived(
-    $useDarkModePreference == null
+    $useDarkModePreference == 'system'
       ? translate('common.system-default')
       : $useDarkModePreference
         ? translate('common.night')
@@ -17,7 +17,7 @@
   );
 
   const buttonIcon: IconName = $derived(
-    $useDarkModePreference == null
+    $useDarkModePreference == 'system'
       ? 'system-window'
       : $useDarkModePreference
         ? 'moon'

--- a/src/lib/components/dark-mode-navigation-button.svelte
+++ b/src/lib/components/dark-mode-navigation-button.svelte
@@ -8,7 +8,7 @@
   } from '$lib/utilities/dark-mode';
 
   const buttonText = $derived(
-    $useDarkModePreference == null
+    $useDarkModePreference == 'system'
       ? translate('common.system-default')
       : $useDarkModePreference
         ? translate('common.night')
@@ -16,7 +16,7 @@
   );
 
   const buttonIcon: IconName = $derived(
-    $useDarkModePreference == null
+    $useDarkModePreference == 'system'
       ? 'system-window'
       : $useDarkModePreference
         ? 'moon'

--- a/src/lib/utilities/dark-mode/dark-mode.test.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.test.ts
@@ -25,16 +25,16 @@ describe('dark-mode utilities', () => {
   });
 
   describe('useDarkMode', () => {
-    it('should return true if prefers-color-scheme is dark and preference is null', () => {
+    it('should return true if prefers-color-scheme is dark and preference is system', () => {
       matchMediaMock.mockReturnValue({ matches: true }); // prefers dark
-      useDarkModePreference.set(null);
+      useDarkModePreference.set('system');
       const value = get(useDarkMode);
       expect(value).toBe(true);
     });
 
-    it('should return false if prefers-color-scheme is not dark and preference is null', () => {
+    it('should return false if prefers-color-scheme is not dark and preference is system', () => {
       matchMediaMock.mockReturnValue({ matches: false });
-      useDarkModePreference.set(null);
+      useDarkModePreference.set('system');
       const value = get(useDarkMode);
       expect(value).toBe(false);
     });
@@ -51,16 +51,16 @@ describe('dark-mode utilities', () => {
   });
 
   describe('getNextDarkModePreference', () => {
-    it('should return true if the current value is null', () => {
-      expect(getNextDarkModePreference(null)).toBe(true);
+    it('should return true if the current value is system', () => {
+      expect(getNextDarkModePreference('system')).toBe(true);
     });
 
     it('should return false if the current value is true', () => {
       expect(getNextDarkModePreference(true)).toBe(false);
     });
 
-    it('should return null if the current value is false', () => {
-      expect(getNextDarkModePreference(false)).toBe(null);
+    it('should return system if the current value is false', () => {
+      expect(getNextDarkModePreference(false)).toBe('system');
     });
   });
 

--- a/src/lib/utilities/dark-mode/dark-mode.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.ts
@@ -2,7 +2,7 @@ import { derived } from 'svelte/store';
 
 import { persistStore } from '$lib/stores/persist-store';
 
-type DarkModePreference = boolean | null;
+type DarkModePreference = boolean | 'system';
 
 export const useDarkModePreference = persistStore<DarkModePreference>(
   'dark mode',
@@ -13,7 +13,7 @@ export const useDarkModePreference = persistStore<DarkModePreference>(
 export const useDarkMode = derived(
   useDarkModePreference,
   ($useDarkModePreference) => {
-    if ($useDarkModePreference == null) {
+    if ($useDarkModePreference == 'system') {
       return (
         window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
       );
@@ -24,7 +24,7 @@ export const useDarkMode = derived(
 );
 
 export const getNextDarkModePreference = (value: DarkModePreference) =>
-  value == null ? true : value == true ? false : null;
+  value == 'system' ? true : value == true ? false : 'system';
 
 export const darkMode = (node: HTMLElement) => {
   useDarkMode.subscribe((value) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

While releasing to `cloud-ui`, manual testing revealed that the "System Default" setting for dark mode was not persisting. This is because the DarkModePreference type was `boolean | null` where null represents "system default." However, passing null to local storage removes the key (local storage is string based). 

This PR updates the DarkModePreference type to be `boolean | 'system'`, which works with local storage. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
