### PR TITLE
Add env var to use ID Token as Bearer token

### DIFF
--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -53,6 +53,7 @@ auth:
     clientId: {{ env "TEMPORAL_AUTH_CLIENT_ID" }}
     clientSecret: {{ env "TEMPORAL_AUTH_CLIENT_SECRET" }}
     callbackUrl: {{ env "TEMPORAL_AUTH_CALLBACK_URL" }}
+    useIdTokenAsBearer: {{ env "TEMPORAL_AUTH_USE_ID_TOKEN_AS_BEARER" | default "false" }}
     scopes:
     {{- if env "TEMPORAL_AUTH_SCOPES" }}
     {{- range env "TEMPORAL_AUTH_SCOPES" | split "," }}

--- a/server/server/auth/auth.go
+++ b/server/server/auth/auth.go
@@ -104,6 +104,17 @@ func ValidateAuthHeaderExists(c echo.Context, cfgProvider *config.ConfigProvider
 		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
 	}
 
+	// Handle token swapping for OIDC providers that require ID token as Bearer
+	if len(cfg.Auth.Providers) > 0 && cfg.Auth.Providers[0].UseIDTokenAsBearer {
+		idToken := c.Request().Header.Get(AuthorizationExtrasHeader)
+		if idToken != "" {
+			// Replace the Authorization header with ID token
+			c.Request().Header.Set(echo.HeaderAuthorization, "Bearer "+idToken)
+			// Remove the Authorization-Extras header to avoid confusion
+			c.Request().Header.Del(AuthorizationExtrasHeader)
+		}
+	}
+
 	return nil
 }
 

--- a/server/server/auth/auth_test.go
+++ b/server/server/auth/auth_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/temporalio/ui-server/v2/server/auth"
+	"github.com/temporalio/ui-server/v2/server/config"
 	"golang.org/x/oauth2"
 )
 
@@ -105,6 +106,113 @@ func TestSetUser(t *testing.T) {
 				assert.NoError(t, err)
 				setCookie := tt.ctx.Response().Header().Get(echo.HeaderSetCookie)
 				assert.Contains(t, setCookie, "user0")
+			}
+		})
+	}
+}
+
+func TestValidateAuthHeaderExists(t *testing.T) {
+	tests := []struct {
+		name                 string
+		authEnabled          bool
+		useIDTokenAsBearer   bool
+		authHeader           string
+		authExtrasHeader     string
+		expectedAuthHeader   string
+		expectedError        bool
+	}{
+		{
+			name:          "auth disabled - no validation",
+			authEnabled:   false,
+			authHeader:    "",
+			expectedError: false,
+		},
+		{
+			name:          "auth enabled - no auth header",
+			authEnabled:   true,
+			authHeader:    "",
+			expectedError: true,
+		},
+		{
+			name:          "auth enabled - with auth header",
+			authEnabled:   true,
+			authHeader:    "Bearer access-token",
+			expectedError: false,
+		},
+		{
+			name:               "useIDTokenAsBearer disabled - headers unchanged",
+			authEnabled:        true,
+			useIDTokenAsBearer: false,
+			authHeader:         "Bearer access-token",
+			authExtrasHeader:   "id-token",
+			expectedAuthHeader: "Bearer access-token",
+			expectedError:      false,
+		},
+		{
+			name:               "useIDTokenAsBearer enabled - swap tokens",
+			authEnabled:        true,
+			useIDTokenAsBearer: true,
+			authHeader:         "Bearer access-token",
+			authExtrasHeader:   "id-token",
+			expectedAuthHeader: "Bearer id-token",
+			expectedError:      false,
+		},
+		{
+			name:               "useIDTokenAsBearer enabled - no extras header",
+			authEnabled:        true,
+			useIDTokenAsBearer: true,
+			authHeader:         "Bearer access-token",
+			authExtrasHeader:   "",
+			expectedAuthHeader: "Bearer access-token",
+			expectedError:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			if tt.authHeader != "" {
+				req.Header.Set(echo.HeaderAuthorization, tt.authHeader)
+			}
+			if tt.authExtrasHeader != "" {
+				req.Header.Set("authorization-extras", tt.authExtrasHeader)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			// Create config provider
+			cfg := &config.Config{
+				Auth: config.Auth{
+					Enabled: tt.authEnabled,
+				},
+			}
+			if tt.useIDTokenAsBearer {
+				cfg.Auth.Providers = []config.AuthProvider{
+					{
+						UseIDTokenAsBearer: true,
+					},
+				}
+			}
+			cfgProvider, err := config.NewConfigProviderWithRefresh(cfg)
+			assert.NoError(t, err)
+
+			// Execute
+			err = auth.ValidateAuthHeaderExists(c, cfgProvider)
+
+			// Assert
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				if tt.expectedAuthHeader != "" {
+					assert.Equal(t, tt.expectedAuthHeader, c.Request().Header.Get(echo.HeaderAuthorization))
+				}
+				// When useIDTokenAsBearer is enabled and extras header exists, it should be removed
+				if tt.useIDTokenAsBearer && tt.authExtrasHeader != "" {
+					assert.Empty(t, c.Request().Header.Get("authorization-extras"))
+				}
 			}
 		})
 	}

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -114,6 +114,8 @@ type (
 		CallbackURL string `yaml:"callbackUrl"`
 		// Options added as URL query params when redirecting to auth provider. Can be used to configure custom auth flows such as Auth0 invitation flow.
 		Options map[string]interface{} `yaml:"options"`
+		// UseIDTokenAsBearer - Use ID token instead of access token as Bearer in Authorization header
+		UseIDTokenAsBearer bool `yaml:"useIdTokenAsBearer"`
 	}
 
 	Codec struct {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR adds support for using ID tokens as Bearer tokens in the Authorization header for OIDC providers that require this authentication pattern.

### Changes:
- Added `useIdTokenAsBearer` configuration option to the `AuthProvider` struct
- Implemented server-side token swapping in the auth middleware
- When enabled, the server will use the ID token from the `authorization-extras` header as the Bearer token instead of the access token

### Motivation:
Some OIDC providers (like certain Auth0 configurations) return opaque access tokens that cannot be used for API authorization. Instead, they require the ID token (which is a JWT) to be used as the Bearer token. This change allows the Temporal UI to work with such providers without requiring client-side configuration changes.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
N/A - Backend configuration change

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
- The configuration is kept at the provider level since it's OIDC-specific
- The client remains agnostic to this configuration - it always sends access token as Bearer and ID token in extras
- Token swapping happens transparently on the server side before forwarding to Temporal

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing with local OIDC provider
- [ ] E2E tests added
- [x] Unit tests added for `ValidateAuthHeaderExists` function with token swapping scenarios

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Configure an OIDC provider in your `development.yaml`:
   ```yaml
     auth:
       enabled: true
       providers:
         - type: oidc
           providerUrl: <your-provider-url>
           clientId: <your-client-id>
           clientSecret: <your-client-secret>
           callbackUrl: http://localhost:8080/auth/sso/callback
           useIdTokenAsBearer: true  # Enable the feature
   ```
2. Start the UI server and authenticate via OIDC (Tested with https://github.com/panva/node-oidc-provider/ but many other OIDC providers will work)
3. Verify that API requests to Temporal use the ID token as the Bearer token
4. Check server logs to confirm token swapping is occurring
5. Log in successfully

Checklists

Draft Checklist

- Code implementation complete
- Unit tests added
- Manual testing completed

Merge Checklist

- Code review feedback addressed
- Documentation updated if needed

Issue(s) closed
https://github.com/temporalio/ui/issues/2365

Docs

Any docs updates needed?

Yes, the following documentation should be updated:
- Add useIdTokenAsBearer to the auth provider configuration documentation
- Include an example configuration for OIDC providers that require ID tokens as Bearer tokens
- Document when and why this option should be used (opaque access tokens scenario)