### PR TITLE
Change default group for consistency and openshift compatability

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,9 +20,8 @@ ARG TEMPORAL_CLOUD_UI="false"
 
 WORKDIR /home/ui-server
 
-RUN addgroup -g 5000 temporal
-RUN adduser -u 5000 -G temporal -D temporal
-
+RUN addgroup -g 1000 temporal
+RUN adduser -u 1000 -G temporal -D temporal
 RUN mkdir ./config
 
 COPY --from=server-builder /home/server-builder/ui-server ./


### PR DESCRIPTION
## Description & motivation 💭
This PR updates the Dockerfile used to build the Temporal UI server image to make it compatible with OpenShift's default security constraints. Specifically:

* Changed the user and group ID from 5000 to 1000, a more common non-root default

These changes:

* Enable the image to run in OpenShift environments without requiring privileged SCCs or custom UID assignments

* Make the Dockerfile consistent with other Temporal repositories that follow a similar non-root UID convention for container compatibility

### Issue(s) closed 
- Resolves [temporalio/ui#1757](https://github.com/temporalio/ui/issues/1757)
