### PR TITLE
Create Version Bump PR as Draft

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -33,7 +33,9 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   version-bump:
@@ -145,6 +147,7 @@ jobs:
           delete-branch: true
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          draft: always-true
 
       - name: Summary
         if: inputs.mode != 'dry-run'

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -116,7 +116,6 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |
             chore: bump version to ${{ steps.calculate-version.outputs.new-version }}
 
@@ -145,8 +144,9 @@ jobs:
             🤖 This PR was automatically created by the Version Bump workflow.
           branch: version-bump-${{ steps.calculate-version.outputs.new-version }}
           delete-branch: true
-          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          reviewers: ${{ github.actor }}
+          committer: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           draft: always-true
 
       - name: Summary


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Some of the required checks dont run when its generated by github actions. The
always draft trick worked in cloud so lets try that in ui as well. This also
sets the author and committer to the user who created the PR.

