### PR TITLE
Add UI_SERVER_HOT_RELOAD environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Set these environment variables if you want to change their defaults
 | VITE_API  | Temporal HTTP API address. Set to empty `` to use relative paths | http://localhost:8322 | Build |
 | VITE_MODE | Build target                                                     | development           | Build |
 | UI_SERVER_VERBOSE | Enable verbose output to see Air build logs and server output for debugging | false | Development |
-
+| UI_SERVER_HOT_RELOAD | Enable hot reload using Air                           | false | Development |
 
 ## Releases
 

--- a/utilities/ui-server.ts
+++ b/utilities/ui-server.ts
@@ -29,10 +29,11 @@ export const createUIServer = async (
 
   // Check for verbose mode via env var or options
   const verbose = options?.verbose ?? process.env.UI_SERVER_VERBOSE === 'true';
+  const hotReload = process.env.UI_SERVER_HOT_RELOAD === 'true';
 
   let uiServerProcess: ReturnType<typeof $>;
 
-  if (env === 'development') {
+  if (hotReload) {
     // Install Air if not already available
     try {
       await $`which air`.quiet();


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

- Replace hardcoded development mode check with configurable hot reload option
- Allows explicit control over Air hot reloading independent of env

Seems some devs experienced a failure when the script trys to install air. So
until the root cause is mitigated, air will be opt-in. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

![CleanShot 2025-06-18 at 19 15 25@2x](https://github.com/user-attachments/assets/3837ca55-920b-4b76-9694-e6ad60e81f40)

