### PR TITLE
Fix issue with conditional in query value

### DIFF
--- a/src/lib/utilities/query/tokenize.test.ts
+++ b/src/lib/utilities/query/tokenize.test.ts
@@ -155,16 +155,19 @@ describe('tokenize', () => {
 
   it('should tokenize the startsWithInQuery for values with IN conditional in them', () => {
     const query = '`WorkflowType` STARTS_WITH "Inspect"';
+
     expect(tokenize(query)).toEqual(['WorkflowType', 'STARTS_WITH', 'Inspect']);
   });
 
   it('should tokenize the startsWithInQuery for values with IS conditional in them', () => {
     const query = '`WorkflowType` STARTS_WITH "issue"';
+
     expect(tokenize(query)).toEqual(['WorkflowType', 'STARTS_WITH', 'issue']);
   });
 
   it('should tokenize the startsWithInQuery for values with JOIN conditional in them', () => {
     const query = '`WorkflowType` STARTS_WITH "Joiner"';
+
     expect(tokenize(query)).toEqual(['WorkflowType', 'STARTS_WITH', 'Joiner']);
   });
 });

--- a/src/lib/utilities/query/tokenize.ts
+++ b/src/lib/utilities/query/tokenize.ts
@@ -73,7 +73,6 @@ export const tokenize = (string: string): Tokens => {
     }
 
     // Conditional can be up to three characters long (!==)
-    // TODO: Fix for starts_with
     const midConditional = `${string[cursor]}${string[cursor + 1]}`;
     const maxConditional = `${string[cursor]}${string[cursor + 1]}${
       string[cursor + 2]
@@ -87,6 +86,7 @@ export const tokenize = (string: string): Tokens => {
       isConditional(midConditional) &&
       (isSpace(string[cursor + 2]) || isParenthesis(string[cursor + 2]))
     ) {
+      // To prevent false positives like "inspect" being a "in" conditional, check for space or parenthesis after the midConditional
       buffer += midConditional;
       addBufferToTokens();
       cursor += 2;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Fix chip filter issue where STARTS_WITH queries that had values with conditionals such as "inspect" (in) or "issue" (is) or "joiner" (join) would show only the conditionals (in) instead of the full value. The fix is checking for a space or a parenthesis after the midconditional (two letter conditionals where this is an issue).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
**Before**
<img width="1726" alt="Screenshot 2025-06-24 at 8 36 19 AM" src="https://github.com/user-attachments/assets/d88dd887-363e-42b2-82f9-8a99ca269bc1" />


**After**
<img width="1727" alt="Screenshot 2025-06-24 at 8 34 36 AM" src="https://github.com/user-attachments/assets/18fcb35f-fc49-4731-a6f8-5526a57da3af" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
