### PR TITLE
Show the related activity events on hover/click in timeline

### DIFF
--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -65,4 +65,12 @@
   .payload {
     @apply overflow-hidden border border-subtle bg-code-block px-1 py-0.5 font-mono text-xs;
   }
+
+  .payload code {
+    @apply text-primary;
+  }
+
+  .payload pre {
+    @apply text-primary;
+  }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -427,10 +427,10 @@
 
 <style lang="postcss">
   tr[data-testid='event-summary-row'].active {
-    @apply surface-table-header;
+    @apply surface-table-related-hover;
   }
 
   tr[data-testid='event-summary-row'].active:hover {
-    @apply surface-interactive;
+    @apply surface-table-header;
   }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -424,3 +424,13 @@
     </td>
   </tr>
 {/if}
+
+<style lang="postcss">
+  tr[data-testid='event-summary-row'].active {
+    @apply bg-slate-800;
+  }
+
+  tr[data-testid='event-summary-row'].active:hover {
+    @apply border-l-4 border-slate-600 bg-slate-300;
+  }
+</style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -235,6 +235,16 @@
     event.stopPropagation();
     onRowClick();
   };
+  const handleMouseEnter = () => {
+    hoveredEventId = event.id;
+  };
+  const handleMouseLeave = () => {
+    hoveredEventId = undefined;
+  };
+
+  let hasRelatedActivities = (group, hoveredEventId) => {
+    return group?.eventIds?.has(hoveredEventId);
+  };
 
   onMount(async () => {
     if (isLocalActivityMarkerEvent(event)) {
@@ -252,6 +262,9 @@
   id={`${event.id}-${index}`}
   data-eventid={event.id}
   data-testid="event-summary-row"
+  onmouseenter={handleMouseEnter}
+  onmouseleave={handleMouseLeave}
+  class:active={hasRelatedActivities(group, hoveredEventId)}
   onclick={onLinkClick}
 >
   {#if isEventGroup(event)}

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -427,10 +427,10 @@
 
 <style lang="postcss">
   tr[data-testid='event-summary-row'].active {
-    @apply bg-slate-800;
+    @apply surface-table-header;
   }
 
   tr[data-testid='event-summary-row'].active:hover {
-    @apply border-l-4 border-slate-600 bg-slate-300;
+    @apply surface-interactive;
   }
 </style>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -63,10 +63,11 @@
     index: number;
     compact?: boolean;
     expanded?: boolean;
+    hoveredEventId?: string | undefined;
     onRowClick?: () => void;
   }
 
-  const {
+  let {
     event,
     group,
     initialItem,
@@ -74,6 +75,7 @@
     compact = false,
     expanded: expandedProp = false,
     onRowClick = () => {},
+    hoveredEventId = $bindable(),
   }: Props = $props();
 
   let expanded = $state(expandedProp);

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -36,7 +36,7 @@
   export let loading = false;
   export let compact = false;
   export let minimized = true;
-  export let hoveredEventId: string | null = null;
+  export let hoveredEventId: string | undefined = undefined;
 
   $: showGraph = !minimized && !compact;
 
@@ -100,6 +100,7 @@
     {#each visibleItems as event, index (iterableKey(event))}
       {#if isEventGroup(event)}
         <EventSummaryRow
+          bind:hoveredEventId
           event={event.initialEvent}
           {index}
           group={event}
@@ -128,6 +129,7 @@
         />
       {:else}
         <EventSummaryRow
+          bind:hoveredEventId
           {event}
           {index}
           group={groups.find((g) => isEvent(event) && g.eventIds.has(event.id))}

--- a/src/lib/components/event/event-summary-table.svelte
+++ b/src/lib/components/event/event-summary-table.svelte
@@ -36,6 +36,7 @@
   export let loading = false;
   export let compact = false;
   export let minimized = true;
+  export let hoveredEventId: string | null = null;
 
   $: showGraph = !minimized && !compact;
 

--- a/src/lib/theme/plugin.ts
+++ b/src/lib/theme/plugin.ts
@@ -150,6 +150,10 @@ const temporal = plugin(
         backgroundColor: css('--color-surface-danger'),
         color: css('--color-text-primary'),
       },
+      '.surface-table-related-hover': {
+        backgroundColor: css('--color-surface-table-related-hover'),
+        color: css('--color-text-primary'),
+      },
       '.surface-black': {
         backgroundColor: css('--color-surface-black'),
         color: css('--color-text-white'),
@@ -200,6 +204,7 @@ const temporal = plugin(
         'interactive-hover': css('--color-interactive-hover'),
         inverse: css('--color-border-inverse'),
         table: css('--color-border-table'),
+        'table-related-hover': css('--color-surface-table-related-hover'),
         information: css('--color-border-information'),
         success: css('--color-border-success'),
         warning: css('--color-border-warning'),

--- a/src/lib/theme/variables.ts
+++ b/src/lib/theme/variables.ts
@@ -166,6 +166,10 @@ export const variables = {
     dark: 'slate.950',
   },
   '--color-interactive-table-hover': {
+    light: 'indigo.200',
+    dark: 'slate.700',
+  },
+  '--color-surface-table-related-hover': {
     light: 'indigo.100',
     dark: 'slate.900',
   },


### PR DESCRIPTION
This is the first step in adding highlighting related activities in the event timeline/summary row. 

when hovering on an activity event row, a user can see a visual indicator on the related event rows 
<img width="487" alt="Screenshot 2025-06-27 at 12 27 46 PM" src="https://github.com/user-attachments/assets/1f2dca6c-1c02-4e64-b373-ed34761e52bb" />
<img width="573" alt="Screenshot 2025-06-27 at 12 27 59 PM" src="https://github.com/user-attachments/assets/d2e692c0-c6ca-42b5-844b-a7cd1c49fc6a" />


---
## Next steps:
- [ ] do the same thing for workflows
- [ ] slight dim on the other event content 