### PR TITLE
Send release tag ref in CI dispatch

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -56,7 +56,7 @@ jobs:
           event-type: sync-from-ui-release
           client-payload: |
             {
-              "ref": "${{ github.sha }}",
+              "ref": "refs/tags/${{ github.event.release.tag_name }}",
               "release_tag": "${{ github.event.release.tag_name }}",
               "release_url": "${{ github.event.release.html_url }}"
             }


### PR DESCRIPTION
## Description & motivation 💭

The release published workflow currently dispatches the main branch SHA instead of the actual release tag reference to the UI server. This change fixes the workflow to send `refs/tags/{tag_name}` so the UI server builds from the specific release tag rather than main branch.

### Design Considerations 🎨

N/A - workflow configuration change only.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing - verified the workflow change is syntactically correct
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Merge this PR
2. Create a test release
3. Verify the UI server receives the correct tag reference in the dispatch payload

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

## Docs

### Any docs updates needed?

No documentation updates needed - internal workflow change.