### PR TITLE
Fix issue with quotes after conditional in query value 

### DIFF
--- a/src/lib/utilities/query/tokenize.test.ts
+++ b/src/lib/utilities/query/tokenize.test.ts
@@ -63,6 +63,22 @@ describe('tokenize', () => {
     ]);
   });
 
+  it('should tokenize the not equal to conditional', () => {
+    const result = [
+      'WorkflowId',
+      '=',
+      'Hello',
+      'and',
+      'WorkflowType',
+      '!=',
+      'World',
+    ];
+    let query = '`WorkflowId`="Hello" and `WorkflowType`!="World"';
+    expect(tokenize(query)).toEqual(result);
+    query = '`WorkflowId` = "Hello" and `WorkflowType` != "World"';
+    expect(tokenize(query)).toEqual(result);
+  });
+
   it('should tokenize the customAttributesWithSpacesQuery', () => {
     const query = customAttributesWithSpacesQuery;
 
@@ -149,6 +165,12 @@ describe('tokenize', () => {
 
   it('should tokenize the startsWithQuery', () => {
     const query = startsWithQuery;
+
+    expect(tokenize(query)).toEqual(['WorkflowType', 'STARTS_WITH', 'Hello']);
+  });
+
+  it('should tokenize the startsWithQuery without spaces', () => {
+    const query = '`WorkflowType`STARTS_WITH"Hello"';
 
     expect(tokenize(query)).toEqual(['WorkflowType', 'STARTS_WITH', 'Hello']);
   });

--- a/src/lib/utilities/query/tokenize.ts
+++ b/src/lib/utilities/query/tokenize.ts
@@ -84,9 +84,11 @@ export const tokenize = (string: string): Tokens => {
       continue;
     } else if (
       isConditional(midConditional) &&
-      (isSpace(string[cursor + 2]) || isParenthesis(string[cursor + 2]))
+      (isSpace(string[cursor + 2]) ||
+        isQuote(string[cursor + 2]) ||
+        isParenthesis(string[cursor + 2]))
     ) {
-      // To prevent false positives like "inspect" being a "in" conditional, check for space or parenthesis after the midConditional
+      // To prevent false positives like "inspect" being a "in" conditional, check for space, quote, or parenthesis after the midConditional
       buffer += midConditional;
       addBufferToTokens();
       cursor += 2;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Adds check for quotes after `midConditional` in `tokenize` in addition to space and parenthesis checks added in https://github.com/temporalio/ui/pull/2781.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
* From the `Filter` dropdown select `WorkflowType` > `Not equal to` > enter and value and submit
* View the Raw Query
    - [ ] Verify there are no spaces before/after the conditional (`WorkflowType!="..."`)
* Refresh the page
    - [ ] Verify the filter "chip" shows up as expected (`WorkflowType != "..."`)

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-3107`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
