### PR TITLE
Allow pending lines to be clickable for Firefox and Safari

### DIFF
--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -94,6 +94,7 @@
   $: activityTaskScheduled = group.eventList.find(isActivityTaskStartedEvent);
   $: retried =
     activityTaskScheduled && activityTaskScheduled.attributes?.attempt > 1;
+  $: pendingLine = group.isPending || !!pauseTime;
 </script>
 
 <g
@@ -104,6 +105,19 @@
   class="relative cursor-pointer"
   {height}
 >
+  {#if pendingLine}
+    {@const width = pauseTime
+      ? points[1] - points[0]
+      : canvasWidth - 2 * gutter}
+    <rect
+      y={y - height / 2}
+      x={points[0]}
+      {width}
+      {height}
+      fill="transparent"
+      pointer-events="all"
+    />
+  {/if}
   {#each points as x, index}
     {@const nextPoint = points[index + 1]}
     {@const showText = textIndex === index}

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -90,7 +90,7 @@
     {/if}
   </div>
 </div>
-<div class="relative px-2 pb-24 md:px-4 lg:px-8">
+<div class="relative select-none px-2 pb-24 md:px-4 lg:px-8">
   <div
     class="flex flex-wrap items-center justify-between gap-2 bg-off-white/50 py-2 xl:gap-8 dark:bg-space-black/50"
     class:sticky-header={!$minimizeEventView}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Due to browser differences, the <g> element was not clickable for Firefox and Safari for pending activities with the animate-line class if you clicked between the pending bars in the svg. To fix this, I've added a transparent rect that provides a clickable area for pending activities. 

I've also added a select-none class to the History layout div to prevent blue highlighting in Safari when you click a timeline item.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Click on pending/paused activities in the Timeline for all browsers. They should open/close in all areas of the Timeline span for all browsers.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
