### PR TITLE
Fix dark mode image swap on table empty state

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
@@ -24,7 +24,8 @@
 </script>
 
 <svelte:head>
-  <link rel="preload" as="image" href={noResultsImages} />
+  <link rel="preload" as="image" href={emptyImageDark} />
+  <link rel="preload" as="image" href={emptyImageLight} />
 </svelte:head>
 <div
   class="h-auto w-full overflow-hidden xl:flex xl:min-h-[480px] xl:flex-row"

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
@@ -26,9 +26,12 @@
 <svelte:head>
   <link rel="preload" as="image" href={noResultsImages} />
 </svelte:head>
-<div class="h-auto w-full overflow-hidden xl:flex-row" aria-live="polite">
+<div
+  class="h-auto w-full overflow-hidden xl:flex xl:min-h-[480px] xl:flex-row"
+  aria-live="polite"
+>
   <div
-    class="surface-primary flex w-auto min-w-[280px] flex-col gap-4 p-8 xl:min-w-[520px]"
+    class="surface-primary flex w-auto min-w-[280px] flex-col gap-4 p-8 xl:min-w-[520px] xl:flex-1"
   >
     <h2>
       {#if query}
@@ -74,11 +77,14 @@
       </ul>
     {/if}
   </div>
-  <div class="bg-[#DDD6FE]">
+  <div
+    class="bg-[#DDD6FE] bg-contain bg-no-repeat xl:flex xl:min-h-full xl:flex-1 xl:items-stretch xl:justify-center"
+    style="background-image: url({noResultsImages});"
+  >
     <img
       src={noResultsImages}
       alt=""
-      class="max-h-full max-w-full object-contain"
+      class="max-h-full max-w-full object-contain xl:hidden"
     />
   </div>
 </div>

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
@@ -5,10 +5,13 @@
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import { workflowError } from '$lib/stores/workflows';
-  import emptyImage from '$lib/vendor/empty-state-dark_2x.png';
-  import noResultsImages from '$lib/vendor/empty-state-light_2x.png';
+  import { useDarkMode } from '$lib/utilities/dark-mode';
+  import emptyImageDark from '$lib/vendor/empty-state-dark_2x.png';
+  import emptyImageLight from '$lib/vendor/empty-state-light_2x.png';
 
   $: query = $page.url.searchParams.get('query');
+
+  $: noResultsImages = $useDarkMode ? emptyImageDark : emptyImageLight;
 
   const samples = [
     'samples-go',
@@ -21,14 +24,11 @@
 </script>
 
 <svelte:head>
-  <link rel="preload" as="image" href={emptyImage} />
+  <link rel="preload" as="image" href={noResultsImages} />
 </svelte:head>
-<div
-  class="flex h-auto w-full flex-col overflow-hidden xl:flex-row"
-  aria-live="polite"
->
+<div class="h-auto w-full overflow-hidden xl:flex-row" aria-live="polite">
   <div
-    class="surface-primary flex w-auto min-w-[280px] flex-col gap-4 border-b border-subtle p-8 xl:min-w-[520px] xl:border-b-0 xl:border-r"
+    class="surface-primary flex w-auto min-w-[280px] flex-col gap-4 p-8 xl:min-w-[520px]"
   >
     <h2>
       {#if query}
@@ -76,9 +76,9 @@
   </div>
   <div class="bg-[#DDD6FE]">
     <img
-      src={query ? noResultsImages : emptyImage}
+      src={noResultsImages}
       alt=""
-      class="aspect-auto"
+      class="max-h-full max-w-full object-contain"
     />
   </div>
 </div>


### PR DESCRIPTION
DT-2917
Bug in dark mode: When no filter results in Workflow list table , the image is in light mode

Cloud
<img width="1186" height="615" alt="Screenshot 2025-07-15 at 4 06 25 PM" src="https://github.com/user-attachments/assets/701d2971-3235-4750-899c-21b25a0d92fe" />
<img width="1187" height="619" alt="Screenshot 2025-07-15 at 4 06 33 PM" src="https://github.com/user-attachments/assets/16666673-dc71-46f7-be16-83ab8204ffd9" />

UI
<img width="1190" height="507" alt="Screenshot 2025-07-15 at 4 10 02 PM" src="https://github.com/user-attachments/assets/c1d3730e-8371-4d6b-a5a0-970bd6765e48" />
<img width="1195" height="452" alt="Screenshot 2025-07-15 at 4 10 10 PM" src="https://github.com/user-attachments/assets/2f9ae28c-c145-4b36-bb07-d449ac78487e" />
