### PR TITLE
Add Identity to schedule edit/pause/unpause

### DIFF
--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -163,11 +163,14 @@
   };
 
   const handleTriggerImmediately = async () => {
+    const identity = get(authUser).email;
+
     scheduleUpdating = true;
     await triggerImmediately({
       namespace,
       scheduleId,
       overlapPolicy: $overlapPolicy,
+      identity,
     });
     setTimeout(() => {
       scheduleFetch = fetchSchedule(parameters);
@@ -222,6 +225,8 @@
   };
 
   const handleBackfill = async () => {
+    const identity = get(authUser).email;
+
     scheduleUpdating = true;
 
     const startTime = getUTCString({
@@ -243,6 +248,7 @@
       overlapPolicy: $overlapPolicy,
       startTime,
       endTime,
+      identity,
     });
     setTimeout(() => {
       scheduleFetch = fetchSchedule(parameters);

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
-  import { get } from 'svelte/store';
 
   import { addDays, addHours, startOfDay } from 'date-fns';
 
@@ -39,7 +38,6 @@
     triggerImmediately,
     unpauseSchedule,
   } from '$lib/services/schedule-service';
-  import { authUser } from '$lib/stores/auth-user';
   import { coreUserStore } from '$lib/stores/core-user';
   import { loading } from '$lib/stores/schedules';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
@@ -118,11 +116,10 @@
     $coreUser.namespaceWriteDisabled(namespace) || !writeActionsAreAllowed();
 
   const handleDelete = async () => {
-    const identity = get(authUser).email;
     error = '';
     try {
       $loading = true;
-      await deleteSchedule({ namespace, scheduleId, identity });
+      await deleteSchedule({ namespace, scheduleId });
       deleteConfirmationModalOpen = false;
       setTimeout(() => {
         $loading = false;
@@ -138,19 +135,16 @@
   };
 
   const handlePause = async (schedule: DescribeScheduleResponse) => {
-    const identity = get(authUser).email;
     schedule?.schedule?.state?.paused
       ? await unpauseSchedule({
           namespace,
           scheduleId,
           reason,
-          identity,
         })
       : await pauseSchedule({
           namespace,
           scheduleId,
           reason,
-          identity,
         });
     scheduleFetch = fetchSchedule(parameters);
     reason = '';
@@ -163,14 +157,11 @@
   };
 
   const handleTriggerImmediately = async () => {
-    const identity = get(authUser).email;
-
     scheduleUpdating = true;
     await triggerImmediately({
       namespace,
       scheduleId,
       overlapPolicy: $overlapPolicy,
-      identity,
     });
     setTimeout(() => {
       scheduleFetch = fetchSchedule(parameters);
@@ -225,8 +216,6 @@
   };
 
   const handleBackfill = async () => {
-    const identity = get(authUser).email;
-
     scheduleUpdating = true;
 
     const startTime = getUTCString({
@@ -248,7 +237,6 @@
       overlapPolicy: $overlapPolicy,
       startTime,
       endTime,
-      identity,
     });
     setTimeout(() => {
       scheduleFetch = fetchSchedule(parameters);

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
+  import { get } from 'svelte/store';
 
   import { addDays, addHours, startOfDay } from 'date-fns';
 
@@ -38,6 +39,7 @@
     triggerImmediately,
     unpauseSchedule,
   } from '$lib/services/schedule-service';
+  import { authUser } from '$lib/stores/auth-user';
   import { coreUserStore } from '$lib/stores/core-user';
   import { loading } from '$lib/stores/schedules';
   import { relativeTime, timeFormat } from '$lib/stores/time-format';
@@ -116,10 +118,11 @@
     $coreUser.namespaceWriteDisabled(namespace) || !writeActionsAreAllowed();
 
   const handleDelete = async () => {
+    const identity = get(authUser).email;
     error = '';
     try {
       $loading = true;
-      await deleteSchedule({ namespace, scheduleId });
+      await deleteSchedule({ namespace, scheduleId, identity });
       deleteConfirmationModalOpen = false;
       setTimeout(() => {
         $loading = false;
@@ -135,16 +138,19 @@
   };
 
   const handlePause = async (schedule: DescribeScheduleResponse) => {
+    const identity = get(authUser).email;
     schedule?.schedule?.state?.paused
       ? await unpauseSchedule({
           namespace,
           scheduleId,
           reason,
+          identity,
         })
       : await pauseSchedule({
           namespace,
           scheduleId,
           reason,
+          identity,
         });
     scheduleFetch = fetchSchedule(parameters);
     reason = '';

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -259,12 +259,14 @@ type TriggerImmediatelyOptions = {
   namespace: string;
   scheduleId: string;
   overlapPolicy: OverlapPolicy;
+  identity?: string;
 };
 
 export async function triggerImmediately({
   namespace,
   scheduleId,
   overlapPolicy,
+  identity,
 }: TriggerImmediatelyOptions): Promise<null> {
   const options = {
     patch: {
@@ -284,6 +286,7 @@ export async function triggerImmediately({
       body: stringifyWithBigInt({
         ...options,
         request_id: uuidv4(),
+        ...(identity ? { identity } : {}),
       }),
     },
   });
@@ -300,6 +303,7 @@ export async function backfillRequest({
   overlapPolicy,
   startTime,
   endTime,
+  identity,
 }: BackfillOptions): Promise<null> {
   const options = {
     patch: {
@@ -323,6 +327,7 @@ export async function backfillRequest({
       body: stringifyWithBigInt({
         ...options,
         request_id: uuidv4(),
+        ...(identity ? { identity } : {}),
       }),
     },
   });

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -92,13 +92,14 @@ export async function fetchSchedule(
 }
 
 export async function deleteSchedule(
-  parameters: ScheduleParameters,
+  parameters: ScheduleParameters & { identity?: string },
   request = fetch,
 ): Promise<void> {
   const route = routeForApi('schedule', parameters);
   return requestFromAPI(route, {
     request,
     options: { method: 'DELETE' },
+    params: parameters.identity ? { identity: parameters.identity } : {},
   });
 }
 
@@ -106,14 +107,17 @@ type CreateScheduleOptions = {
   namespace: string;
   scheduleId: string;
   body: CreateScheduleRequest;
+  identity?: string;
 };
 
 export async function createSchedule({
   namespace,
   scheduleId,
   body,
+  identity,
 }: CreateScheduleOptions): Promise<{ error: string; conflictToken: string }> {
   let error = '';
+
   const onError: ErrorCallback = (err) =>
     (error =
       err?.body?.message ??
@@ -131,6 +135,7 @@ export async function createSchedule({
         body: stringifyWithBigInt({
           request_id: uuidv4(),
           ...body,
+          ...(identity ? { identity } : {}),
         }),
       },
       onError,
@@ -145,12 +150,14 @@ type EditScheduleOptions = {
   scheduleId: string;
   request_id: string;
   body: UpdateScheduleRequest;
+  identity?: string;
 };
 
 export async function editSchedule({
   namespace,
   scheduleId,
   body,
+  identity,
 }: Partial<EditScheduleOptions>): Promise<{ error: string }> {
   let error = '';
   const onError: ErrorCallback = (err) =>
@@ -168,6 +175,7 @@ export async function editSchedule({
       body: stringifyWithBigInt({
         request_id: uuidv4(),
         ...body,
+        ...(identity ? { identity } : {}),
       }),
     },
     onError,
@@ -180,12 +188,14 @@ type PauseScheduleOptions = {
   namespace: string;
   scheduleId: string;
   reason: string;
+  identity?: string;
 };
 
 export async function pauseSchedule({
   namespace,
   scheduleId,
   reason,
+  identity,
 }: PauseScheduleOptions): Promise<null> {
   const options = {
     patch: {
@@ -203,6 +213,7 @@ export async function pauseSchedule({
       body: stringifyWithBigInt({
         ...options,
         request_id: uuidv4(),
+        ...(identity ? { identity } : {}),
       }),
     },
     onError: (error) => console.error(error),
@@ -213,12 +224,14 @@ type UnpauseScheduleOptions = {
   namespace: string;
   scheduleId: string;
   reason: string;
+  identity?: string;
 };
 
 export async function unpauseSchedule({
   namespace,
   scheduleId,
   reason,
+  identity,
 }: UnpauseScheduleOptions): Promise<null> {
   const options = {
     patch: {
@@ -236,6 +249,7 @@ export async function unpauseSchedule({
       body: stringifyWithBigInt({
         ...options,
         request_id: uuidv4(),
+        ...(identity ? { identity } : {}),
       }),
     },
   });

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -1,6 +1,9 @@
+import { get } from 'svelte/store';
+
 import { v4 as uuidv4 } from 'uuid';
 
 import { translate } from '$lib/i18n/translate';
+import { authUser } from '$lib/stores/auth-user';
 import type {
   CreateScheduleRequest,
   ListScheduleResponse,
@@ -92,14 +95,15 @@ export async function fetchSchedule(
 }
 
 export async function deleteSchedule(
-  parameters: ScheduleParameters & { identity?: string },
+  parameters: ScheduleParameters,
   request = fetch,
 ): Promise<void> {
+  const identity = get(authUser).email;
   const route = routeForApi('schedule', parameters);
   return requestFromAPI(route, {
     request,
     options: { method: 'DELETE' },
-    params: parameters.identity ? { identity: parameters.identity } : {},
+    params: identity ? { identity } : {},
   });
 }
 
@@ -107,17 +111,15 @@ type CreateScheduleOptions = {
   namespace: string;
   scheduleId: string;
   body: CreateScheduleRequest;
-  identity?: string;
 };
 
 export async function createSchedule({
   namespace,
   scheduleId,
   body,
-  identity,
 }: CreateScheduleOptions): Promise<{ error: string; conflictToken: string }> {
+  const identity = get(authUser).email;
   let error = '';
-
   const onError: ErrorCallback = (err) =>
     (error =
       err?.body?.message ??
@@ -150,15 +152,14 @@ type EditScheduleOptions = {
   scheduleId: string;
   request_id: string;
   body: UpdateScheduleRequest;
-  identity?: string;
 };
 
 export async function editSchedule({
   namespace,
   scheduleId,
   body,
-  identity,
 }: Partial<EditScheduleOptions>): Promise<{ error: string }> {
+  const identity = get(authUser).email;
   let error = '';
   const onError: ErrorCallback = (err) =>
     (error =
@@ -188,15 +189,14 @@ type PauseScheduleOptions = {
   namespace: string;
   scheduleId: string;
   reason: string;
-  identity?: string;
 };
 
 export async function pauseSchedule({
   namespace,
   scheduleId,
   reason,
-  identity,
 }: PauseScheduleOptions): Promise<null> {
+  const identity = get(authUser).email;
   const options = {
     patch: {
       pause: reason,
@@ -224,15 +224,14 @@ type UnpauseScheduleOptions = {
   namespace: string;
   scheduleId: string;
   reason: string;
-  identity?: string;
 };
 
 export async function unpauseSchedule({
   namespace,
   scheduleId,
   reason,
-  identity,
 }: UnpauseScheduleOptions): Promise<null> {
+  const identity = get(authUser).email;
   const options = {
     patch: {
       unpause: reason,
@@ -259,15 +258,14 @@ type TriggerImmediatelyOptions = {
   namespace: string;
   scheduleId: string;
   overlapPolicy: OverlapPolicy;
-  identity?: string;
 };
 
 export async function triggerImmediately({
   namespace,
   scheduleId,
   overlapPolicy,
-  identity,
 }: TriggerImmediatelyOptions): Promise<null> {
+  const identity = get(authUser).email;
   const options = {
     patch: {
       triggerImmediately: {
@@ -303,8 +301,8 @@ export async function backfillRequest({
   overlapPolicy,
   startTime,
   endTime,
-  identity,
 }: BackfillOptions): Promise<null> {
+  const identity = get(authUser).email;
   const options = {
     patch: {
       backfillRequest: [


### PR DESCRIPTION
This PR adds user identity tracking to all schedule operations (create, edit, delete, pause, unpause, trigger, and backfill) by automatically including the authenticated user's email address. For delete operations, the identity is passed as a query parameter (?identity=email), while other operations include it in the request body. This enhancement provides better audit trails and user accountability for schedule modifications.