### PR TITLE
Decode Failures if custom FailureConverter configured

### DIFF
--- a/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
+++ b/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
@@ -16,6 +16,7 @@
   import { workflowRun } from '$lib/stores/workflow-run';
   import type { PendingActivity } from '$lib/types/events';
   import { activityCommandsEnabled } from '$lib/utilities/activity-commands-enabled';
+  import { type PotentiallyDecodable } from '$lib/utilities/decode-payload';
   import { formatDate } from '$lib/utilities/format-date';
   import {
     formatAttemptsLeft,
@@ -42,6 +43,8 @@
       page.params.namespace,
     ) && isRunning,
   );
+
+  $inspect('activity.lastFailure: ', activity.lastFailure);
 </script>
 
 <div
@@ -188,14 +191,33 @@
         <p class="text-sm text-secondary/80">
           {translate('workflows.last-failure')}
         </p>
-        <CodeBlock
-          content={stringifyWithBigInt(
-            omit(activity.lastFailure, 'stackTrace'),
-          )}
-          maxHeight={384}
-          copyIconTitle={translate('common.copy-icon-title')}
-          copySuccessIconTitle={translate('common.copy-success-icon-title')}
-        />
+        {#if activity.lastFailure?.encodedAttributes}
+          {#key activity.attempt}
+            <PayloadDecoder
+              value={activity.lastFailure as PotentiallyDecodable}
+              let:decodedValue
+              key="last-failure-attributes"
+            >
+              <CodeBlock
+                content={decodedValue}
+                maxHeight={384}
+                copyIconTitle={translate('common.copy-icon-title')}
+                copySuccessIconTitle={translate(
+                  'common.copy-success-icon-title',
+                )}
+              />
+            </PayloadDecoder>
+          {/key}
+        {:else}
+          <CodeBlock
+            content={stringifyWithBigInt(
+              omit(activity.lastFailure, 'stackTrace'),
+            )}
+            maxHeight={384}
+            copyIconTitle={translate('common.copy-icon-title')}
+            copySuccessIconTitle={translate('common.copy-success-icon-title')}
+          />
+        {/if}
       {/if}
     </div>
     {#if activity.lastFailure?.stackTrace}

--- a/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
+++ b/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
@@ -194,7 +194,6 @@
             <PayloadDecoder
               value={activity.lastFailure as PotentiallyDecodable}
               let:decodedValue
-              key="last-failure-attributes"
             >
               <CodeBlock
                 content={decodedValue}

--- a/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
+++ b/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
@@ -43,8 +43,6 @@
       page.params.namespace,
     ) && isRunning,
   );
-
-  $inspect('activity.lastFailure: ', activity.lastFailure);
 </script>
 
 <div


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If a user sets up a custom [FailureConverter](https://typescript.temporal.io/api/interfaces/common.FailureConverter), the encoded last failures were not decoded. This PR adds a check for encodedAttributes and if it exists, decode the last failure. It also adds a #key on the attempt number so the failure is re-decoded on a new failure.

Because encodedAttributes can be anything a user sets, I'm typing activity.lastFailure as PotentiallyDecodable and letting PayloadDecoder attempt the decode as best as possible.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1892" height="966" alt="Screenshot 2025-07-21 at 12 25 44 PM" src="https://github.com/user-attachments/assets/659ae34d-db08-46bf-8d83-8bb86871bd52" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
To test:

Add a custom FailureConverter to the samples-typescript/encryption project

data-converter.ts
```
async function createDataConverter(): Promise<DataConverter> {
  return {
    payloadCodecs: [await EncryptionCodec.create('test-key-id')],
    failureConverterPath: require.resolve('./failure-converter.ts'),
  };
}
```

failure-converter.ts
```
import { DefaultFailureConverter } from '@temporalio/common';

export const failureConverter = new DefaultFailureConverter({
  encodeCommonAttributes: true,
});
```

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
