### PR TITLE
fix start workflow page with null in search attribute

### DIFF
--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -20,10 +20,10 @@
   export let external = false;
   export let maxLength = 0;
 
-  const values = writable<string[]>(chips);
+  const values = writable<string[]>(Array.isArray(chips) ? [...chips] : []);
   let displayValue = '';
 
-  $: chips, ($values = chips);
+  $: chips, ($values = chips ?? []);
   $: invalid = $values.some((chip) => !validator(chip));
 
   let className = '';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
There is a bug, when pressing on the "Start workflow like this one"
<img width="462" height="150" alt="image" src="https://github.com/user-attachments/assets/da67ccec-5807-4e9f-94d7-8b1292d4dbbc" />

and the search attribute is null, it results an 500 error (which isn't really a 500 from the server, but an error in the client)
<img width="1269" height="597" alt="image" src="https://github.com/user-attachments/assets/eb4693d1-d120-4054-9aab-9743e5425fb9" />

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Just have a worfklow with search attribute that is null, and press the run like this button, it will reproduce

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
