### PR TITLE
Update table row hover color to match Figma design

### DIFF
--- a/src/lib/theme/variables.ts
+++ b/src/lib/theme/variables.ts
@@ -166,7 +166,7 @@ export const variables = {
     dark: 'slate.950',
   },
   '--color-interactive-table-hover': {
-    light: 'indigo.200',
+    light: 'indigo.100',
     dark: 'slate.700',
   },
   '--color-surface-table-related-hover': {


### PR DESCRIPTION
## Summary
- Updated `--color-interactive-table-hover` light mode color from `indigo.200` to `indigo.100`
- This change aligns the table row hover state with the design specifications from Figma (#E0EAFF)

## Test plan
- [x] Verify table row hover color matches Figma design
- [x] Test in both light and dark modes
- [x] Ensure no visual regressions in table interactions