### PR TITLE
Always decode last failure

### DIFF
--- a/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
+++ b/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
@@ -16,7 +16,6 @@
   import { workflowRun } from '$lib/stores/workflow-run';
   import type { PendingActivity } from '$lib/types/events';
   import { activityCommandsEnabled } from '$lib/utilities/activity-commands-enabled';
-  import { type PotentiallyDecodable } from '$lib/utilities/decode-payload';
   import { formatDate } from '$lib/utilities/format-date';
   import {
     formatAttemptsLeft,
@@ -25,7 +24,6 @@
   } from '$lib/utilities/format-event-attributes';
   import { formatDuration, getDuration } from '$lib/utilities/format-time';
   import { omit } from '$lib/utilities/omit';
-  import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
   import { toTimeDifference } from '$lib/utilities/to-time-difference';
 
   let {
@@ -189,33 +187,20 @@
         <p class="text-sm text-secondary/80">
           {translate('workflows.last-failure')}
         </p>
-        {#if activity.lastFailure?.encodedAttributes}
-          {#key activity.attempt}
-            <PayloadDecoder
-              value={activity.lastFailure as PotentiallyDecodable}
-            >
-              {#snippet children(decodedValue)}
-                <CodeBlock
-                  content={decodedValue}
-                  maxHeight={384}
-                  copyIconTitle={translate('common.copy-icon-title')}
-                  copySuccessIconTitle={translate(
-                    'common.copy-success-icon-title',
-                  )}
-                />
-              {/snippet}
-            </PayloadDecoder>
-          {/key}
-        {:else}
-          <CodeBlock
-            content={stringifyWithBigInt(
-              omit(activity.lastFailure, 'stackTrace'),
-            )}
-            maxHeight={384}
-            copyIconTitle={translate('common.copy-icon-title')}
-            copySuccessIconTitle={translate('common.copy-success-icon-title')}
-          />
-        {/if}
+        {#key activity.attempt}
+          <PayloadDecoder value={omit(activity.lastFailure, 'stackTrace')}>
+            {#snippet children(decodedValue)}
+              <CodeBlock
+                content={decodedValue}
+                maxHeight={384}
+                copyIconTitle={translate('common.copy-icon-title')}
+                copySuccessIconTitle={translate(
+                  'common.copy-success-icon-title',
+                )}
+              />
+            {/snippet}
+          </PayloadDecoder>
+        {/key}
       {/if}
     </div>
     {#if activity.lastFailure?.stackTrace}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Previously I was only decoding if failure converter was setup. However last failure details can also be a payload. So just always decode it. It should render the last failure correctly if no payloads. It should also update after every attempt.


To test, add ApplicationFailure in activity

```
      throw ApplicationFailure.create({
        message: "Error message",
        type: "ErrorType",
        details: [{ failure: `Failed at ${Date.now()}` }],
      });
```

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
