### PR TITLE
Check if call stack is string before rendering in code-block

### DIFF
--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -194,6 +194,8 @@ export const Strings = {
     'Please make sure you have at least one worker running.',
   'call-stack-alert':
     'This is a call stack showing each location where Workflow code is waiting.',
+  'call-stack-error':
+    'Call stack could not be retrieved. Check if Codec Server is required.',
   'call-stack-at': 'Call Stack at',
   'call-stack-link-preface': 'To enable ',
   'call-stack-link': 'call stacks',

--- a/src/lib/pages/workflow-call-stack.svelte
+++ b/src/lib/pages/workflow-call-stack.svelte
@@ -52,25 +52,32 @@
         <Skeleton class="h-48 w-full rounded-sm" />
       </div>
     {:then result}
-      <Alert
-        intent="info"
-        icon="info"
-        title={translate('workflows.call-stack-alert')}
-        class="mb-4 w-fit"
-      />
-      <p>
-        {translate('workflows.call-stack-at')}
-        {refreshDate}
-      </p>
-      <div class="my-2 flex h-full items-start">
-        <CodeBlock
-          content={result}
-          language="text"
-          testId="query-call-stack"
-          copyIconTitle={translate('common.copy-icon-title')}
-          copySuccessIconTitle={translate('common.copy-success-icon-title')}
+      {#if typeof result === 'string'}
+        <Alert
+          intent="info"
+          title={translate('workflows.call-stack-alert')}
+          class="mb-4 w-fit"
         />
-      </div>
+        <p>
+          {translate('workflows.call-stack-at')}
+          {refreshDate}
+        </p>
+        <div class="my-2 flex h-full items-start">
+          <CodeBlock
+            content={result}
+            language="text"
+            testId="query-call-stack"
+            copyIconTitle={translate('common.copy-icon-title')}
+            copySuccessIconTitle={translate('common.copy-success-icon-title')}
+          />
+        </div>
+      {:else}
+        <Alert
+          intent="warning"
+          title={translate('workflows.call-stack-error')}
+          class="mb-4 w-fit"
+        />
+      {/if}
     {:catch _error}
       <EmptyState
         title={translate('common.error-occurred')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
If a codec server is used but not configured in the UI, don't attempt to render the encoded payload in CodeBlock which will lead to an error in CodeMirror. Only render CodeBlock if call stack is string.

If not a string, show an alert and a hint to check Codec Server.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
Using Codec Server in workflow code but not configured in UI to use:

**Before**
<img width="1920" height="884" alt="Screenshot 2025-08-20 at 8 20 25 AM" src="https://github.com/user-attachments/assets/e50066e3-4127-4843-9ee6-f0d9c4957bdf" />

**After**
<img width="1920" height="884" alt="Screenshot 2025-08-20 at 8 09 28 AM" src="https://github.com/user-attachments/assets/af9185cd-d93d-4bc2-b1cf-ba72565545aa" />

**When configured**
<img width="1920" height="884" alt="Screenshot 2025-08-20 at 8 09 12 AM" src="https://github.com/user-attachments/assets/d1f9665d-3906-48b1-8325-ba6691173013" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
