### PR TITLE
Add hidden edit btn and default route prop

### DIFF
--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -17,12 +17,11 @@
   let {
     endpoint,
     editDisabled = false,
-    editHidden = false,
-    backHref = routeForNexus,
+    backHref = routeForNexus(),
     taskQueueStatus,
   }: {
     endpoint: Endpoint;
-    backHref?: () => string;
+    backHref: string;
     editDisabled?: boolean;
     editHidden?: boolean;
     taskQueueStatus?: Snippet;
@@ -31,7 +30,7 @@
 
 <div class="flex flex-col gap-8">
   <div class="relative flex flex-col gap-4 text-sm">
-    <Link href={backHref()} icon="chevron-left">
+    <Link href={backHref} icon="chevron-left">
       {translate('nexus.back-to-endpoints')}
     </Link>
   </div>
@@ -42,7 +41,6 @@
       </h1>
       <Button
         href={routeForNexusEndpointEdit(endpoint.id)}
-        hidden={editHidden}
         disabled={editDisabled}>{translate('common.edit')}</Button
       >
     </div>

--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -17,17 +17,21 @@
   let {
     endpoint,
     editDisabled = false,
+    editHidden = false,
+    route = routeForNexus,
     taskQueueStatus,
   }: {
     endpoint: Endpoint;
+    route?: () => string;
     editDisabled?: boolean;
+    editHidden?: boolean;
     taskQueueStatus?: Snippet;
   } = $props();
 </script>
 
 <div class="flex flex-col gap-8">
   <div class="relative flex flex-col gap-4 text-sm">
-    <Link href={routeForNexus()} icon="chevron-left">
+    <Link href={route()} icon="chevron-left">
       {translate('nexus.back-to-endpoints')}
     </Link>
   </div>
@@ -38,6 +42,7 @@
       </h1>
       <Button
         href={routeForNexusEndpointEdit(endpoint.id)}
+        hidden={editHidden}
         disabled={editDisabled}>{translate('common.edit')}</Button
       >
     </div>

--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -18,11 +18,11 @@
     endpoint,
     editDisabled = false,
     editHidden = false,
-    route = routeForNexus,
+    backHref = routeForNexus,
     taskQueueStatus,
   }: {
     endpoint: Endpoint;
-    route?: () => string;
+    backHref?: () => string;
     editDisabled?: boolean;
     editHidden?: boolean;
     taskQueueStatus?: Snippet;
@@ -31,7 +31,7 @@
 
 <div class="flex flex-col gap-8">
   <div class="relative flex flex-col gap-4 text-sm">
-    <Link href={route()} icon="chevron-left">
+    <Link href={backHref()} icon="chevron-left">
       {translate('nexus.back-to-endpoints')}
     </Link>
   </div>

--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -23,7 +23,6 @@
     endpoint: Endpoint;
     backHref?: string;
     editDisabled?: boolean;
-    editHidden?: boolean;
     taskQueueStatus?: Snippet;
   } = $props();
 </script>

--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -21,7 +21,7 @@
     taskQueueStatus,
   }: {
     endpoint: Endpoint;
-    backHref: string;
+    backHref?: string;
     editDisabled?: boolean;
     editHidden?: boolean;
     taskQueueStatus?: Snippet;


### PR DESCRIPTION
This adds the ability to change the route on the `back` breadcrumb on the nexus details page while still keeping the original functionality. 