### PR TITLE
Move dispatch_commit job to run independently

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -9,6 +9,34 @@ permissions:
   contents: read
 
 jobs:
+  dispatch_commit:
+    permissions:
+      contents: write
+      pull-requests: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Prepare dispatch token
+        id: dispatch_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          permission-contents: write
+          repositories: ${{ vars.DOWNSTREAM_REPO }}
+
+      - name: Trigger ui-server workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.dispatch_token.outputs.token }}
+          repository: ${{ vars.DOWNSTREAM_ORG }}/${{ vars.DOWNSTREAM_REPO }}
+          event-type: sync-from-ui-commit
+          client-payload: |
+            {
+              "ref": "${{ github.sha }}"
+            }
+
   check_version_change:
     runs-on: ubuntu-latest
     outputs:
@@ -47,26 +75,6 @@ jobs:
           version: ${{ needs.check_version_change.outputs.current-version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare dispatch token
-        id: dispatch_token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
-          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
-          permission-contents: write
-          repositories: ${{ vars.DOWNSTREAM_REPO }}
-
-      - name: Trigger ui-server workflow
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.dispatch_token.outputs.token }}
-          repository: ${{ vars.DOWNSTREAM_ORG }}/${{ vars.DOWNSTREAM_REPO }}
-          event-type: sync-from-ui-commit
-          client-payload: |
-            {
-              "ref": "${{ github.sha }}"
-            }
 
   skip_notification:
     needs: check_version_change


### PR DESCRIPTION
## Summary
- Moved ui-server workflow dispatch to a separate job that runs on every push to main
- This job now executes independently of version change validation

## Motivation
The dispatch_commit job should notify the downstream repository of all commits to main, regardless of whether a version change has occurred. Previously, this dispatch was nested within the release_draft job which only ran when version changes were detected.

## Changes
- Created standalone `dispatch_commit` job with proper permissions
- Removed dispatch steps from `release_draft` job
- Ensured dispatch runs on every push to main branch