### PR TITLE
Add trigger-downstream-updates workflow

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -1,0 +1,66 @@
+name: Trigger Downstream Updates
+
+on:
+  push:
+    branches:
+      - main
+    # paths:
+    # Only trigger when actual code changes are made
+    # - 'src/**'
+    # - 'package.json'
+    # - 'pnpm-lock.yaml'
+  workflow_dispatch:
+    inputs:
+      target-sha:
+        description: 'Specific SHA to use (defaults to current HEAD)'
+        required: false
+        default: ''
+
+jobs:
+  trigger-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate token for cross-repo access
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: cloud-ui,ui,pack-dependency-actions
+
+      - name: Prepare workflow inputs
+        id: prepare
+        run: |
+          # Determine SHA to use
+          if [ -n "${{ github.event.inputs.target-sha }}" ]; then
+            SHA="${{ github.event.inputs.target-sha }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+          
+          # Create workflow inputs JSON (compact format for GITHUB_OUTPUT)
+          INPUTS=$(jq -nc \
+            --arg sha "$SHA" \
+            --arg mode "release" \
+            '{"target-sha": $sha, "mode": $mode}')
+          
+          echo "inputs=$INPUTS" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "sha_short=$(echo $SHA | cut -c1-8)" >> $GITHUB_OUTPUT
+          echo "Using SHA: $(echo $SHA | cut -c1-8)"
+
+      - name: Trigger cloud-ui update
+        uses: temporalio/pack-dependency-actions/dispatch-workflow@main
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: temporalio/cloud-ui
+          workflow: generate-ui-pr.yml
+          ref: main
+          inputs: ${{ steps.prepare.outputs.inputs }}
+          add-commit-comment: true
+          commit-comment-template: '🚀 Triggered `{workflow}` in {repository} on {ref} with SHA `${{ steps.prepare.outputs.sha_short }}`'
+          log-title: Downstream Update Triggered

--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -41,13 +41,13 @@ jobs:
           else
             SHA="${{ github.sha }}"
           fi
-          
+
           # Create workflow inputs JSON (compact format for GITHUB_OUTPUT)
           INPUTS=$(jq -nc \
             --arg sha "$SHA" \
             --arg mode "release" \
             '{"target-sha": $sha, "mode": $mode}')
-          
+
           echo "inputs=$INPUTS" >> $GITHUB_OUTPUT
           echo "sha=$SHA" >> $GITHUB_OUTPUT
           echo "sha_short=$(echo $SHA | cut -c1-8)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Adds automatic workflow dispatch to temporalio/cloud-ui when changes are pushed to main
- Uses GitHub App authentication for secure cross-repo access
- Enables automatic dependency update PRs in downstream repositories

## Details
This PR adds a new GitHub Actions workflow that automatically triggers the `generate-ui-pr` workflow in the `temporalio/cloud-ui` repository whenever changes are pushed to the main branch.

### Key features:
- **GitHub App authentication**: Uses TEMPORAL_CICD_APP_ID and TEMPORAL_CICD_PRIVATE_KEY for secure cross-repo access
- **Flexible triggering**: Can be triggered automatically on push or manually via workflow_dispatch
- **SHA tracking**: Passes the exact SHA to the downstream workflow for traceability
- **Mode support**: Includes "release" mode for the downstream workflow
- **Commit comments**: Adds comments to commits for visibility (on push events)
- **Logging**: Provides clear success/failure feedback

### Configuration
The workflow requires the following secrets to be configured in the repository:
- `TEMPORAL_CICD_APP_ID`: GitHub App ID with access to both repositories
- `TEMPORAL_CICD_PRIVATE_KEY`: Private key for the GitHub App

### Testing
This same workflow configuration has been successfully tested and deployed in:
- temporalio/frontend-workflow-runner → temporalio/frontend-shared-workflows

## Test plan
- [ ] Verify the workflow file syntax is valid
- [ ] Confirm required secrets are configured
- [ ] After merge, verify workflow triggers on push to main
- [ ] Verify downstream workflow is successfully dispatched in cloud-ui