### PR TITLE
Fix workflow input key for cloud-ui compatibility

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -46,7 +46,7 @@ jobs:
           INPUTS=$(jq -nc \
             --arg sha "$SHA" \
             --arg mode "release" \
-            '{"target-sha": $sha, "mode": $mode}')
+            '{"ui_commit_sha": $sha, "mode": $mode}')
 
           echo "inputs=$INPUTS" >> $GITHUB_OUTPUT
           echo "sha=$SHA" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixes the workflow input key to match what the `generate-ui-pr` workflow expects in cloud-ui.

## Problem
The workflow was using `target-sha` as the input key, but the cloud-ui workflow expects `ui_commit_sha`.

## Solution
Changed the input key from `target-sha` to `ui_commit_sha` to match the expected parameter name.

## Test plan
- [ ] Verify workflow triggers successfully after merge
- [ ] Confirm cloud-ui workflow receives the correct SHA parameter