### PR TITLE
fix(workflows): add GitHub App token to version bump PR creation

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -111,11 +111,27 @@ jobs:
         with:
           new-version: ${{ steps.calculate-version.outputs.new-version }}
 
+      - name: Generate token for cross-repo access
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: ui
+
       - name: Create Pull Request
         if: inputs.mode != 'dry-run' && steps.calculate-version.outputs.version-changed == 'true'
         id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ steps.generate_token.outputs.token }}
+          branch: version-bump-${{ steps.calculate-version.outputs.new-version }}
+          delete-branch: true
+          reviewers: ${{ github.actor }}
+          committer: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          draft: always-true
           commit-message: |
             chore: bump version to ${{ steps.calculate-version.outputs.new-version }}
 
@@ -142,12 +158,6 @@ jobs:
 
             ---
             🤖 This PR was automatically created by the Version Bump workflow.
-          branch: version-bump-${{ steps.calculate-version.outputs.new-version }}
-          delete-branch: true
-          reviewers: ${{ github.actor }}
-          committer: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          draft: always-true
 
       - name: Summary
         if: inputs.mode != 'dry-run'


### PR DESCRIPTION
## Summary
- Add GitHub App token generation to the version bump workflow
- Use the token for the create-pull-request action to ensure proper permissions

## Motivation
The version bump workflow needs appropriate permissions to create pull requests with the correct access rights. This change generates a GitHub App token and uses it for the PR creation step.

## Changes
- Added token generation step using `actions/create-github-app-token@v2`
- Modified create-pull-request action to use the generated token
- Ensures the workflow can create PRs with proper cross-repo access

## Test Plan
- [ ] Test version bump workflow in dry-run mode
- [ ] Verify token generation works correctly
- [ ] Confirm PR creation succeeds with new token