### PR TITLE
ci(workflows): add path filter to trigger-downstream-updates

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-    # paths:
-    # Only trigger when actual code changes are made
-    # - 'src/**'
-    # - 'package.json'
-    # - 'pnpm-lock.yaml'
+    paths:
+      # Only trigger when actual code changes are made
+      - 'src/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
   workflow_dispatch:
     inputs:
       target-sha:


### PR DESCRIPTION
## Motivation

The trigger-downstream-updates workflow currently runs on every push to main, including documentation changes and CI-only updates. This creates unnecessary workflow runs and notifications.

## Implementation

Added path filters to only trigger the workflow when changes are made to:
- `src/` directory (actual application code)
- `package.json` (dependency changes)
- `pnpm-lock.yaml` (lockfile updates)

This optimization reduces unnecessary workflow executions while still ensuring downstream updates are triggered for meaningful code changes.