### PR TITLE
DT-3334 - add change event to dark mode in top nav

### DIFF
--- a/src/lib/components/dark-mode-menu.svelte
+++ b/src/lib/components/dark-mode-menu.svelte
@@ -9,18 +9,23 @@
   } from '$lib/holocene/menu';
   import { translate } from '$lib/i18n/translate';
   import { useDarkModePreference } from '$lib/utilities/dark-mode';
-  import type { DarkModePreference } from '$lib/utilities/dark-mode/dark-mode';
+  import {
+    type DarkModePreference,
+    prefersDarkMode,
+  } from '$lib/utilities/dark-mode/dark-mode';
 
   interface Props {
     position: 'left' | 'right';
     hideLabel?: boolean;
     size?: ButtonStyles['size'];
+    onchange?: (prefersDarkMode: boolean) => void;
   }
 
   const {
     position = 'right',
     hideLabel = false,
     size = undefined,
+    onchange,
   }: Props = $props();
 
   const menuButtonText = $derived(
@@ -41,6 +46,7 @@
 
   const setDarkModePreference = (preference: DarkModePreference) => {
     $useDarkModePreference = preference;
+    onchange?.(prefersDarkMode(preference));
   };
 </script>
 

--- a/src/lib/components/top-nav.svelte
+++ b/src/lib/components/top-nav.svelte
@@ -10,6 +10,7 @@
 
   let className: ClassNameValue = '';
   export { className as class };
+  export let onThemeChange: (prefersDarkMode: boolean) => void = () => {};
 </script>
 
 <svelte:window bind:innerWidth={screenWidth} />
@@ -34,7 +35,11 @@
   <div class="flex items-center gap-2">
     <TimezoneSelect position={screenWidth < 768 ? 'left' : 'right'} />
     <DataEncoderStatus />
-    <DarkModeMenu hideLabel position={screenWidth < 768 ? 'left' : 'right'} />
+    <DarkModeMenu
+      onchange={onThemeChange}
+      hideLabel
+      position={screenWidth < 768 ? 'left' : 'right'}
+    />
     <slot />
   </div>
 </nav>

--- a/src/lib/utilities/dark-mode/dark-mode.ts
+++ b/src/lib/utilities/dark-mode/dark-mode.ts
@@ -10,18 +10,17 @@ export const useDarkModePreference = persistStore<DarkModePreference>(
   true,
 );
 
-export const useDarkMode = derived(
-  useDarkModePreference,
-  ($useDarkModePreference) => {
-    if ($useDarkModePreference == 'system') {
-      return (
-        window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
-      );
-    } else {
-      return $useDarkModePreference;
-    }
-  },
-);
+export const prefersDarkMode = (useDarkModePreference: DarkModePreference) => {
+  if (useDarkModePreference == 'system') {
+    return (
+      window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
+    );
+  } else {
+    return useDarkModePreference;
+  }
+};
+
+export const useDarkMode = derived(useDarkModePreference, prefersDarkMode);
 
 export const getNextDarkModePreference = (value: DarkModePreference) =>
   value == 'system' ? true : value == true ? false : 'system';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Mike F wants the Cloud UI to identify users with the `dark_mode` trait when they change their theme preference. This exposes a new prop on the top nav and dark mode menu components to allow cloud UI to react to changes and make the necessary identify call.
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
