### PR TITLE
fix(security): remediate command injection vulnerabilities in GitHub Actions

### DIFF
--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -34,12 +34,15 @@ jobs:
 
       - name: Prepare workflow inputs
         id: prepare
+        env:
+          INPUT_TARGET_SHA: ${{ github.event.inputs.target-sha }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           # Determine SHA to use
-          if [ -n "${{ github.event.inputs.target-sha }}" ]; then
-            SHA="${{ github.event.inputs.target-sha }}"
+          if [ -n "$INPUT_TARGET_SHA" ]; then
+            SHA="$INPUT_TARGET_SHA"
           else
-            SHA="${{ github.sha }}"
+            SHA="$GITHUB_SHA"
           fi
 
           # Create workflow inputs JSON (compact format for GITHUB_OUTPUT)

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -98,23 +98,35 @@ jobs:
 
       - name: Dry run summary
         if: inputs.mode == 'dry-run'
+        env:
+          CURRENT_VERSION: ${{ steps.validate-sync.outputs.current-version }}
+          NEW_VERSION: ${{ steps.calculate-version.outputs.new-version }}
+          SPECIFIC_VERSION: ${{ inputs.specific_version }}
+          INPUT_MODE: ${{ inputs.mode }}
+          BUMP_TYPE: ${{ steps.analyze-prs.outputs.bump-type }}
+          VERSION_CHANGED: ${{ steps.calculate-version.outputs.version-changed }}
+          CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
         run: |
           echo "## 🔍 Dry Run Results"
           echo ""
-          echo "**Current Version:** ${{ steps.validate-sync.outputs.current-version }}"
-          echo "**New Version:** ${{ steps.calculate-version.outputs.new-version }}"
-          if [[ -n "${{ inputs.specific_version }}" ]]; then
+          echo "**Current Version:** $CURRENT_VERSION"
+          echo "**New Version:** $NEW_VERSION"
+          if [[ -n "$SPECIFIC_VERSION" ]]; then
             echo "**Version Source:** Specific version (manual override)"
-            echo "**Specified Version:** ${{ inputs.specific_version }}"
+            echo "**Specified Version:** $SPECIFIC_VERSION"
           else
-            echo "**Version Source:** ${{ inputs.mode == 'manual' && 'Manual bump type' || 'Auto-detected from commits' }}"
-            echo "**Bump Type:** ${{ steps.analyze-prs.outputs.bump-type }}"
+            VERSION_SOURCE="Auto-detected from commits"
+            if [ "$INPUT_MODE" = "manual" ]; then
+              VERSION_SOURCE="Manual bump type"
+            fi
+            echo "**Version Source:** $VERSION_SOURCE"
+            echo "**Bump Type:** $BUMP_TYPE"
           fi
-          echo "**Version Changed:** ${{ steps.calculate-version.outputs.version-changed }}"
+          echo "**Version Changed:** $VERSION_CHANGED"
           echo ""
-          if [[ -n "${{ steps.generate-changelog.outputs.changelog }}" ]]; then
+          if [[ -n "$CHANGELOG" ]]; then
             echo "### 📝 Changes Since Last Version"
-            echo "${{ steps.generate-changelog.outputs.changelog }}"
+            echo "$CHANGELOG"
             echo ""
           fi
           echo "**Note:** This was a dry run. No files were modified."


### PR DESCRIPTION
## Summary

Fixes command injection vulnerabilities (VLN-418) by moving GitHub context variables to environment variables to prevent shell injection attacks.

## Security Impact

- **Severity**: High
- **Type**: Command Injection
- **Ticket**: [VLN-418](https://temporalio.atlassian.net/browse/VLN-418)

## Changes

- **version-bump.yml**: Move all `github.event.inputs.*`, `steps.*.outputs.*` to environment variables
- **trigger-downstream-updates.yml**: Move `github.event.inputs.target-sha` to `INPUT_TARGET_SHA` environment variable

## Modified Files

- `.github/workflows/version-bump.yml`
- `.github/workflows/trigger-downstream-updates.yml`

## References

- Similar fix: temporalio/frontend-workflow-runner#9
- [GitHub Security: Script Injections](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections)
- [GitHub Security Lab: Untrusted Input](https://securitylab.github.com/research/github-actions-untrusted-input/)

This prevents untrusted user input from being interpreted as shell commands.

[VLN-418]: https://temporalio.atlassian.net/browse/VLN-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ