### PR TITLE
Fix NaN in Batch Operations results

### DIFF
--- a/src/lib/components/batch-operations/results.svelte
+++ b/src/lib/components/batch-operations/results.svelte
@@ -8,19 +8,27 @@
 
   let { operation }: Props = $props();
 
-  let { completeOperationCount, failureOperationCount, totalOperationCount } =
-    $derived(operation);
+  let {
+    completeOperationCount = 0,
+    failureOperationCount = 0,
+    totalOperationCount = 0,
+  } = $derived(operation);
+
+  const getPercentage = (count: number, total: number) => {
+    const percentage = Math.round((count / total) * 100);
+    return isNaN(percentage) ? 0 : percentage;
+  };
 
   let completePercent = $derived(
-    Math.round((completeOperationCount / totalOperationCount) * 100),
+    getPercentage(completeOperationCount, totalOperationCount),
   );
   let failurePercent = $derived(
-    Math.round((failureOperationCount / totalOperationCount) * 100),
+    getPercentage(failureOperationCount, totalOperationCount),
   );
   let progressPercent = $derived(
-    Math.round(
-      ((completeOperationCount + failureOperationCount) / totalOperationCount) *
-        100,
+    getPercentage(
+      completeOperationCount + failureOperationCount,
+      totalOperationCount,
     ),
   );
 </script>
@@ -35,9 +43,9 @@
         })}
       </span>
       <span class="text-xs font-semibold">
-        {Intl.NumberFormat('en-US').format(operation.completeOperationCount)} / {Intl.NumberFormat(
+        {Intl.NumberFormat('en-US').format(completeOperationCount)} / {Intl.NumberFormat(
           'en-US',
-        ).format(operation.totalOperationCount)}
+        ).format(totalOperationCount)}
       </span>
     </div>
     <div class="relative h-2 w-full overflow-hidden rounded bg-indigo-100">
@@ -52,14 +60,14 @@
     <div class="flex justify-between">
       <span class="text-xs font-semibold text-success"
         >{translate('batch.operations-succeeded', {
-          count: operation.completeOperationCount,
+          count: completeOperationCount,
         })}</span
       >
       <span
         class="text-xs font-semibold"
         class:text-red-700={failurePercent > 0}
         >{translate('batch.operations-failed', {
-          count: operation.failureOperationCount,
+          count: failureOperationCount,
         })}</span
       >
     </div>

--- a/src/lib/types/batch.ts
+++ b/src/lib/types/batch.ts
@@ -55,9 +55,9 @@ export type BatchOperation = {
   state: BatchOperationState;
   startTime: string;
   closeTime: string;
-  totalOperationCount: number;
-  completeOperationCount: number;
-  failureOperationCount: number;
+  totalOperationCount?: number;
+  completeOperationCount?: number;
+  failureOperationCount?: number;
   identity: string;
   reason: string;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
On the `/namespaces/[namespace/batch-operations/[batch-operation]` page, if percentages based on `totalOperationCount`, `completeOperationCount`, and `failureOperationCount` are `NaN` show `0%` instead.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-3363`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
