### PR TITLE
Update server/Dockerfile with new base image versions

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.12
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.15.4
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.15.13
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.15.6
 
 FROM ${BASE_BUILDER_IMAGE} AS server-builder
 


### PR DESCRIPTION
Resolves the go version mismatch between the ui-server and the base images. 

```
=> ERROR [server-builder 4/6] RUN go mod download                                                                                                        0.1s
------
 > [server-builder 4/6] RUN go mod download:
0.080 go: go.mod requires go >= 1.24.0 (running go 1.23.4; GOTOOLCHAIN=local)
------
Dockerfile:9
--------------------
   7 |
   8 |     COPY go.mod go.sum ./
   9 | >>> RUN go mod download
  10 |
  11 |     COPY . ./
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```