### PR TITLE
fix: Fixed UI redirects if `TEMPORAL_UI_PUBLIC_PATH` is provided for home button and `/render`. (#2846)

### DIFF
--- a/src/lib/holocene/markdown-editor/preview.svelte
+++ b/src/lib/holocene/markdown-editor/preview.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { type ClassNameValue, twMerge } from 'tailwind-merge';
 
+  import { base } from '$app/paths';
   import { page } from '$app/state';
 
   import { useDarkMode } from '$lib/utilities/dark-mode';
@@ -50,7 +51,7 @@
   const templatedContent = $derived(replaceTemplate(content));
   const previewTheme = $derived($useDarkMode ? 'dark' : 'light');
   const previewPath = $derived(
-    `/render?content=${encodeURIComponent(templatedContent)}&theme=${previewTheme}&overrideTheme=${overrideTheme}`,
+    `${base}/render?content=${encodeURIComponent(templatedContent)}&theme=${previewTheme}&overrideTheme=${overrideTheme}`,
   );
 </script>
 

--- a/src/lib/holocene/navigation/navigation-container.svelte
+++ b/src/lib/holocene/navigation/navigation-container.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { twMerge as merge } from 'tailwind-merge';
 
+  import { base } from '$app/paths';
   import { page } from '$app/stores';
 
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -13,6 +14,7 @@
   const toggle = () => ($navOpen = !$navOpen);
 
   $: version = $page.data?.settings?.version ?? '';
+  $: baseUrl = base === '' ? '/' : base;
 </script>
 
 <nav
@@ -30,7 +32,7 @@
   <div
     class="flex items-center justify-between pb-4 group-data-[nav=closed]:flex-col group-data-[nav=closed]:gap-2"
   >
-    <a href="/" class="flex w-fit items-center gap-1 text-nowrap">
+    <a href={baseUrl} class="flex w-fit items-center gap-1 text-nowrap">
       <Logo height={24} width={24} class="m-1" />
       <p class="text-base font-medium group-data-[nav=closed]:hidden">
         {isCloud ? 'Cloud' : 'Self-Hosted'}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
This PR will fix the UI redirects while using subpaths for Temporal home button and render endpoint mentioned in #2846.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Add `TEMPORAL_UI_PUBLIC_PATH` environment variable.
2. Click the upper left Temporal home button.
3. It should redirect to the subpath rather than the origin.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
