### PR TITLE
allow selection in code block

### DIFF
--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -164,8 +164,8 @@
     [
       getEditorTheme($useDarkMode, hasHeader),
       getActionsTheme({ hasActions: copyable || maximizable }),
-      EditorState.readOnly.of(!editable),
-      EditorView.editable.of(editable),
+      EditorState.readOnly.of(!editable), // when false, user can type in the editor
+      EditorView.editable.of(true), // always true, it means focusable, text-selectable, and scrollable by keyboard
       EditorView.contentAttributes.of({ 'aria-label': label }),
       getLineBreakExtension(editable),
       getLanguageExtension(language),
@@ -197,15 +197,6 @@
     editorView?.dispatch({
       effects: compartment.reconfigure(dynamicExtensions),
     });
-  });
-
-  // add tabindex if maximizable, so up/down arrows can scroll
-  $effect(() => {
-    if (maximizable) {
-      editorView?.scrollDOM?.setAttribute('tabindex', '0');
-    } else {
-      editorView?.scrollDOM?.removeAttribute('tabindex');
-    }
   });
 
   // when content prop changes, update the document
@@ -297,7 +288,6 @@
       class={merge('h-full', className)}
       data-testid={testId}
       {...editorProps}
-      onblur={handleEditorBlur}
     ></div>
 
     {#snippet actions()}

--- a/src/lib/holocene/maximizable/maximizable.svelte
+++ b/src/lib/holocene/maximizable/maximizable.svelte
@@ -31,11 +31,11 @@
   };
 
   const handleFocusOut = (event: FocusEvent) => {
+    const currentTarget = event.currentTarget as Element | null;
+    const relatedTarget = event.relatedTarget as Element | null;
     if (
       maximized &&
-      (!(event.currentTarget instanceof Element) ||
-        !(event.relatedTarget instanceof Element) ||
-        !event.currentTarget.contains(event.relatedTarget))
+      !(currentTarget && relatedTarget && currentTarget.contains(relatedTarget))
     ) {
       maximized = false;
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

When code block is maximized, if the user tries to select the code to copy, the component suddenly minimizes. This PR allows the user to select text without triggering minimizing.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="1508" height="472" alt="Screenshot 2025-10-28 at 6 59 12 PM" src="https://github.com/user-attachments/assets/53f32446-82b9-4446-ac73-037195f1af31" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

To get selecting working, this PR makes the CodeMirror editor always "editable" which really means focusable and selectable. Readonly still controls if the user can change the code by typing. This setup gives a pretty reasonable UX, where the user can selected text from the editor by mouse or keyboard, and scroll with up/down arrows. It's a little more "edity" than we'd probably want, but we get a lot for free. Since the editor now receives the focus, we can remove the tab index on its parent div.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
