### PR TITLE
VLN-521: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -6,6 +6,11 @@ on:
   pull_request_target:
     branches: [main, 'codefreeze-*']
 
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   chromatic:
     name: Run Chromatic

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,6 +11,9 @@ on:
       - 'LICENSE'
       - 'CODEOWNERS'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,6 +11,9 @@ on:
       - 'LICENSE'
       - 'CODEOWNERS'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, 'codefreeze-*']
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/trigger-downstream-updates.yml
+++ b/.github/workflows/trigger-downstream-updates.yml
@@ -16,6 +16,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   trigger-updates:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.github/workflows/chromatic.yml`: Added a workflow-level permissions block to limit the GITHUB_TOKEN to read repository contents while still allowing Chromatic to update pull requests and commit statuses.
- `.github/workflows/lint-and-test.yml`: Declared minimal workflow-level permissions so lint, type-check, and unit test jobs only receive read access to repository contents.
- `.github/workflows/playwright.yml`: Granted the workflow read-only contents permissions so the Playwright suites can check out code without unnecessary token rights.
- `.github/workflows/test.yml`: Added workflow-level permissions restricting the token to read repository contents for the server test job.
- `.github/workflows/trigger-downstream-updates.yml`: Introduced a workflow-level permissions block limiting the default token to repository read access during downstream dispatches.