### PR TITLE
Use CurrentVersion createTime

### DIFF
--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -43,13 +43,6 @@
   const currentLabel = $derived(
     versionedCurrent ? currentBuildId : translate('deployments.unversioned'),
   );
-  const latestDeploymentTimestamp = $derived(
-    latestBuildId &&
-      latestBuildId === currentBuildId &&
-      deployment.latestVersionSummary?.createTime
-      ? deployment.latestVersionSummary.createTime
-      : deployment.createTime,
-  );
 </script>
 
 <tr>
@@ -123,9 +116,14 @@
           {/if}
           <p>
             {#if versionedCurrent}
-              {formatDate(latestDeploymentTimestamp, $timeFormat, {
-                relative: $relativeTime,
-              })}
+              {formatDate(
+                deployment?.currentVersionSummary?.createTime ||
+                  deployment.createTime,
+                $timeFormat,
+                {
+                  relative: $relativeTime,
+                },
+              )}
             {:else}
               -
             {/if}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
We were using the deployment create time for current build id, use currentVersion.createTime instead to get latest current version deployed at time.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
