### PR TITLE
chore(server): optimize Docker builds with .dockerignore and improved Dockerfile

### DIFF
--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,30 @@
+# Version control
+.git
+.gitignore
+
+# Documentation
+*.md
+README*
+docs/
+
+# Tests
+*_test.go
+**/*_test.go
+
+# Development
+.env
+.env.*
+*.log
+
+# Build artifacts
+__pycache__/
+*.pyc
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# CI/CD
+.github/
+.goreleaser.yml


### PR DESCRIPTION
## Summary

This PR optimizes Docker builds for the ui-server by:
- Adding a `.dockerignore` file to exclude unnecessary files from the build context
- Improving Dockerfile structure with combined RUN commands and better layer organization
- Enhancing security by using `--chown` in COPY commands and switching to non-root user before ENTRYPOINT

These changes reduce image size, improve build performance, and enhance security posture.

## Changes

**New `.dockerignore` file:**
- Excludes version control, documentation, tests, development files, build artifacts, IDE configs, and CI/CD files from Docker build context
- Reduces build context size and improves cache efficiency

**Dockerfile improvements:**
- Combine multiple RUN commands using `&&` to reduce image layers
- Use `--chown=temporal:temporal` in COPY commands instead of separate `chown` command
- Add `USER temporal` before ENTRYPOINT for better security
- Remove unnecessary comment dividers for cleaner structure
- Move ENV before ENTRYPOINT for proper ordering

## Note

This addresses the issue raised in temporalio/ui-server#327, which was opened against the wrong repository. Changes should be made to `ui/server` which syncs to `ui-server` automatically.