### PR TITLE
Deprecate Pluralize

### DIFF
--- a/src/lib/utilities/pluralize.ts
+++ b/src/lib/utilities/pluralize.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated Prefer to use pluralization through i18ln
+ * @param word
+ * @param count
+ * @returns
+ */
 export const pluralize = (word: string, count: number): string => {
   if (count === 1) {
     return word;


### PR DESCRIPTION
Add deprecated to pluralize to help remove anything that depends on it