### PR TITLE
Add support for CA certificate for auth provider

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -34,6 +34,8 @@ auth:
       issuerUrl: "" # needed if the Issuer Url and the Provider Url are different
       clientId: xxxxxxxxxxxxxxxxxxxx
       clientSecret: xxxxxxxxxxxxxxxxxxxx
+      caFile:
+      caData:
       scopes:
         - openid
         - profile

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -61,6 +61,8 @@ auth:
     clientSecret: {{ env "TEMPORAL_AUTH_CLIENT_SECRET" }}
     callbackUrl: {{ env "TEMPORAL_AUTH_CALLBACK_URL" }}
     useIdTokenAsBearer: {{ env "TEMPORAL_AUTH_USE_ID_TOKEN_AS_BEARER" | default "false" }}
+    caFile: {{ env "TEMPORAL_AUTH_CA" | default "" }}
+    caData: {{ env "TEMPORAL_AUTH_CA_DATA" | default "" }}
     scopes:
     {{- if env "TEMPORAL_AUTH_SCOPES" }}
     {{- range env "TEMPORAL_AUTH_SCOPES" | split "," }}

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -134,6 +134,10 @@ type (
 		Options map[string]interface{} `yaml:"options"`
 		// UseIDTokenAsBearer - Use ID token instead of access token as Bearer in Authorization header
 		UseIDTokenAsBearer bool `yaml:"useIdTokenAsBearer"`
+		// CaFile - optional custom CA bundle for contacting the auth provider
+		CaFile string `yaml:"caFile"`
+		// CaData - optional base64-encoded CA bundle for contacting the auth provider
+		CaData string `yaml:"caData"`
 	}
 
 	Codec struct {

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -23,6 +23,7 @@
 package route
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -38,6 +39,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/temporalio/ui-server/v2/server/auth"
 	"github.com/temporalio/ui-server/v2/server/config"
+	"github.com/temporalio/ui-server/v2/server/rpc"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
@@ -75,15 +77,17 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 	ctx := context.Background()
 	serverCfg, err := cfgProvider.GetConfig()
 	if err != nil {
-		fmt.Printf("unable to get auth config: %s\n", err)
+		log.Printf("unable to get auth config: %s\n", err)
+		return
 	}
 
 	if !serverCfg.Auth.Enabled {
 		return
 	}
 
-	if len(serverCfg.Auth.Providers) == 0 {
-		log.Fatal(`auth providers configuration is empty. Configure an auth provider or disable auth`)
+	err = validateAuthConfig(&serverCfg.Auth)
+	if err != nil {
+		log.Fatalf("invalid auth config: %s\n", err)
 	}
 
 	providerCfg := serverCfg.Auth.Providers[0] // only single provider is currently supported
@@ -91,6 +95,22 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 	if len(providerCfg.IssuerUrl) > 0 {
 		ctx = oidc.InsecureIssuerURLContext(ctx, providerCfg.IssuerUrl)
 	}
+
+	// Configure HTTP client (with timeout) and optional custom CA if provided via caFile or caData
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	if providerCfg.CaFile != "" || providerCfg.CaData != "" {
+		caCertPool, err := rpc.LoadCACert(providerCfg.CaFile, providerCfg.CaData)
+		if err != nil {
+			log.Fatalf("Unable to load auth CA certificate: %s\n", err)
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+		httpClient.Transport = transport
+	}
+	ctx = oidc.ClientContext(ctx, httpClient)
+
 	provider, err := oidc.NewProvider(ctx, providerCfg.ProviderURL)
 	if err != nil {
 		log.Fatal(err)
@@ -367,4 +387,17 @@ func nonceFromString(nonce string) (*Nonce, error) {
 type Nonce struct {
 	Nonce     string `json:"nonce"`
 	ReturnURL string `json:"return_url"`
+}
+
+func validateAuthConfig(cfg *config.Auth) error {
+	if len(cfg.Providers) == 0 {
+		return fmt.Errorf(`auth providers configuration is empty. Configure an auth provider or disable auth`)
+	}
+	for _, providerCfg := range cfg.Providers {
+		if providerCfg.CaFile != "" && providerCfg.CaData != "" {
+			return fmt.Errorf("cannot specify Auth CA file and CA data at the same time")
+		}
+	}
+
+	return nil
 }

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -23,6 +23,7 @@
 package route
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -38,6 +39,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/temporalio/ui-server/v2/server/auth"
 	"github.com/temporalio/ui-server/v2/server/config"
+	"github.com/temporalio/ui-server/v2/server/rpc"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
@@ -75,15 +77,17 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 	ctx := context.Background()
 	serverCfg, err := cfgProvider.GetConfig()
 	if err != nil {
-		fmt.Printf("unable to get auth config: %s\n", err)
+		log.Printf("unable to get auth config: %s\n", err)
+		return
 	}
 
 	if !serverCfg.Auth.Enabled {
 		return
 	}
 
-	if len(serverCfg.Auth.Providers) == 0 {
-		log.Fatal(`auth providers configuration is empty. Configure an auth provider or disable auth`)
+	err = validateAuthConfig(&serverCfg.Auth)
+	if err != nil {
+		log.Fatalf("invalid auth config: %s\n", err)
 	}
 
 	providerCfg := serverCfg.Auth.Providers[0] // only single provider is currently supported
@@ -91,6 +95,22 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 	if len(providerCfg.IssuerUrl) > 0 {
 		ctx = oidc.InsecureIssuerURLContext(ctx, providerCfg.IssuerUrl)
 	}
+
+	// Configure HTTP client (with timeout) and optional custom CA if provided via caFile or caData
+	httpClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	if providerCfg.CaFile != "" || providerCfg.CaData != "" {
+		caCertPool, err := rpc.LoadCACert(providerCfg.CaFile, providerCfg.CaData)
+		if err != nil {
+			log.Fatalf("Unable to load auth CA certificate: %s\n", err)
+		}
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.TLSClientConfig = &tls.Config{RootCAs: caCertPool}
+		httpClient.Transport = transport
+	}
+	ctx = oidc.ClientContext(ctx, httpClient)
+
 	provider, err := oidc.NewProvider(ctx, providerCfg.ProviderURL)
 	if err != nil {
 		log.Fatal(err)
@@ -395,4 +415,17 @@ func nonceFromString(nonce string) (*Nonce, error) {
 type Nonce struct {
 	Nonce     string `json:"nonce"`
 	ReturnURL string `json:"return_url"`
+}
+
+func validateAuthConfig(cfg *config.Auth) error {
+	if len(cfg.Providers) == 0 {
+		return fmt.Errorf(`auth providers configuration is empty. Configure an auth provider or disable auth`)
+	}
+	for _, providerCfg := range cfg.Providers {
+		if providerCfg.CaFile != "" && providerCfg.CaData != "" {
+			return fmt.Errorf("cannot specify Auth CA file and CA data at the same time")
+		}
+	}
+
+	return nil
 }

--- a/server/server/route/auth_test.go
+++ b/server/server/route/auth_test.go
@@ -1,0 +1,47 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/temporalio/ui-server/v2/server/config"
+)
+
+func TestValidateAuthConfig_NoProviders(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled:   true,
+		Providers: []config.AuthProvider{},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestValidateAuthConfig_CaFileAndCaDataMutuallyExclusive(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled: true,
+		Providers: []config.AuthProvider{
+			{
+				CaFile: "file",
+				CaData: "data",
+			},
+		},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestValidateAuthConfig_ValidConfig(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled: true,
+		Providers: []config.AuthProvider{
+			{
+				ProviderURL: "https://example.com",
+				ClientID:    "id",
+				CallbackURL: "https://example.com/callback",
+				CaFile:      "file",
+			},
+		},
+	})
+
+	assert.NoError(t, err)
+}

--- a/server/server/route/auth_test.go
+++ b/server/server/route/auth_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/temporalio/ui-server/v2/server/config"
 )
 
 func TestCookieSecureForCallbackURL(t *testing.T) {
@@ -62,4 +64,43 @@ func TestCookieSecureForCallbackURL(t *testing.T) {
 			a.Equal(tt.want, got)
 		})
 	}
+}
+
+func TestValidateAuthConfig_NoProviders(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled:   true,
+		Providers: []config.AuthProvider{},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestValidateAuthConfig_CaFileAndCaDataMutuallyExclusive(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled: true,
+		Providers: []config.AuthProvider{
+			{
+				CaFile: "file",
+				CaData: "data",
+			},
+		},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestValidateAuthConfig_ValidConfig(t *testing.T) {
+	err := validateAuthConfig(&config.Auth{
+		Enabled: true,
+		Providers: []config.AuthProvider{
+			{
+				ProviderURL: "https://example.com",
+				ClientID:    "id",
+				CallbackURL: "https://example.com/callback",
+				CaFile:      "file",
+			},
+		},
+	})
+
+	assert.NoError(t, err)
 }

--- a/server/server/rpc/tls.go
+++ b/server/server/rpc/tls.go
@@ -139,7 +139,7 @@ func CreateTLSConfig(address string, cfg *config.TLS) (*tls.Config, error) {
 	}
 
 	if configureCertPool {
-		caCertPool, err := loadCACert(cfg)
+		caCertPool, err := LoadCACert(cfg.CaFile, cfg.CaData)
 		if err != nil {
 			log.Fatalf("Unable to load server CA certificate")
 			return nil, err
@@ -171,9 +171,12 @@ func CreateTLSConfig(address string, cfg *config.TLS) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-func loadCACert(cfg *config.TLS) (caPool *x509.CertPool, err error) {
-	pathOrUrl := cfg.CaFile
-	caData := cfg.CaData
+// LoadCACert loads a CA certificate bundle from a file path or HTTPS URL, or from base64-encoded data,
+// and returns a certificate pool containing the parsed certificates.
+func LoadCACert(pathOrUrl string, caData string) (caPool *x509.CertPool, err error) {
+	if pathOrUrl == "" && caData == "" {
+		return nil, errors.New("no CA certificate source provided")
+	}
 
 	caPool = x509.NewCertPool()
 	var caBytes []byte

--- a/server/server/rpc/tls_cert_loader_test.go
+++ b/server/server/rpc/tls_cert_loader_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 	"os"
@@ -79,6 +80,22 @@ func TestCertLoader_ReloadsNewKeyPair(t *testing.T) {
 			assert.NotEqual(t, expect1.Certificate, loaded2.Certificate)
 		})
 	}
+}
+
+func TestLoadCACert_FromBase64Data(t *testing.T) {
+	certPEM, _ := generateCertKeyPair(t, "ca")
+
+	caData := base64.StdEncoding.EncodeToString(certPEM)
+
+	pool, err := LoadCACert("", caData)
+	assert.NoError(t, err)
+	assert.NotNil(t, pool)
+}
+
+func TestLoadCACert_EmptyInputsError(t *testing.T) {
+	pool, err := LoadCACert("", "")
+	assert.EqualError(t, err, "no CA certificate source provided")
+	assert.Nil(t, pool)
 }
 
 func generateCertKeyPair(t *testing.T, commonName string) (certPEM, keyPEM []byte) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
When using an SSO provider with a certificate signed by our own internal CA, the ui server is currently unable to verify the certificate. This change adds support for providing a CA certificate to enable verification of the used certificate.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
N/A

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
minimal impact, only used IF a CA cert is provided.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Added tests and I already use this to connect to a self-hosted keycloak.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Deploy this new version & provide a caFile or caData (base64 encoded) to trust a custom certificate for SSO.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
[#2957](https://github.com/temporalio/ui/issues/2957)
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
Changes required are mimimal, but the [env vars for web UI ](https://docs.temporal.io/references/web-ui-environment-variables#temporal_auth_scopes) should be updated with:
```
TEMPORAL_AUTH_CA
The path for the Transport Layer Security (TLS) Certificate Authority file for the auth provider endpoint.

In order to use TLS with a self-hosted Auth provider, you'll need a CA certificate issued by a trusted Certificate Authority. Set this variable to properly locate and use the file.

TEMPORAL_AUTH_CA_DATA
Stores the data for a TLS CA file.

This variable can be used instead of providing a path for `TEMPORAL_AUTH_CA`.
```