### PR TITLE
fix(codec-server): add spacing between action buttons

### DIFF
--- a/src/lib/components/codec-server-form/codec-server-form-content.svelte
+++ b/src/lib/components/codec-server-form/codec-server-form-content.svelte
@@ -86,11 +86,14 @@
           onSuccess(dataToSave);
           return { type: 'success' };
         } catch (error) {
+          const errorMessage =
+            error instanceof Error
+              ? error.message
+              : 'Failed to save codec server configuration';
           return {
             type: 'error',
             error: {
-              message:
-                error.message || 'Failed to save codec server configuration',
+              message: errorMessage,
             },
           };
         }


### PR DESCRIPTION
## Summary
- Added `mt-4` margin to the Save/Cancel button container in the codec server form
- Creates visual separation between the "Add Custom Message and Link" button and the form action buttons

## Test plan
- [ ] Verify spacing appears correctly in codec server form