### PR TITLE
fix(select): make Option children optional to prevent runtime error

### DIFF
--- a/src/lib/holocene/select/option.svelte
+++ b/src/lib/holocene/select/option.svelte
@@ -15,6 +15,7 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { getContext, onDestroy, onMount } from 'svelte';
 
   import MenuItem, {
@@ -30,6 +31,7 @@
 
   interface Props extends Omit<MenuItemWithoutHrefProps, 'value' | 'onclick'> {
     value: T;
+    children: Snippet;
     onclick?: (value: T) => void;
   }
 


### PR DESCRIPTION
## Summary
- Add explicit `children: Snippet` type to Option Props interface to enforce that Option components must have content
- This provides clear compile-time feedback when children are missing, rather than a cryptic runtime error

## Test plan
- [ ] Verify Option components with children still render correctly
- [ ] Verify Option components without children show a type error at compile time