### PR TITLE
Check heartbeat time for pending activities for Timeline color

### DIFF
--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -58,6 +58,11 @@
   const pauseTime = $derived(
     pendingActivity && pendingActivity.pauseInfo?.pauseTime,
   );
+  const noHeartbeatAfterRetryAttempt = $derived(
+    pendingActivity &&
+      pendingActivity.attempt > 1 &&
+      pendingActivity?.lastStartedTime > pendingActivity?.lastHeartbeatTime,
+  );
 
   let decodedLocalActivity: SummaryAttribute | undefined = $state(undefined);
 
@@ -242,7 +247,7 @@
         startPoint={[x, y]}
         endPoint={[canvasWidth - gutter, y]}
         category={pendingActivity
-          ? pendingActivity.attempt > 1
+          ? noHeartbeatAfterRetryAttempt
             ? 'retry'
             : 'pending'
           : group.category}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Currently if any pending activity has greater than 1 attempt, we show it as red in the Timeline. However that doesn't accurately show the health of the current attempt. If the the last heartbeat time is after the last started time (attempt), then turn Timeline item back to purple to indicate it's not in a failed state.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" height="906" alt="Screenshot 2026-01-09 at 2 38 48 PM" src="https://github.com/user-attachments/assets/a5e658d9-de2b-4123-8055-148883629e56" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
