### PR TITLE
Nexus more caller timeouts

### DIFF
--- a/src/lib/components/workflow/pending-nexus-operation/pending-nexus-operation-card.svelte
+++ b/src/lib/components/workflow/pending-nexus-operation/pending-nexus-operation-card.svelte
@@ -88,6 +88,18 @@
           operation.scheduleToCloseTimeout as string,
         )}
       {/if}
+      {#if operation.scheduleToStartTimeout}
+        {@render detail(
+          translate('workflows.schedule-to-start-timeout'),
+          operation.scheduleToCloseTimeout as string,
+        )}
+      {/if}
+      {#if operation.startToCloseTimeout}
+        {@render detail(
+          translate('workflows.start-to-close-timeout'),
+          operation.startToCloseTimeout as string,
+        )}
+      {/if}
     </div>
     <div class="flex w-full flex-col gap-4 md:flex-1 xl:w-1/2">
       {#if failed}

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -1,4 +1,5 @@
 import type { Timestamp } from '@temporalio/common';
+import type { google } from '@temporalio/proto';
 
 import type { EventGroup } from '$lib/models/event-groups/event-groups';
 import type { ActivityOptions, EventLink } from '$lib/types';
@@ -56,7 +57,11 @@ export type PendingActivityState =
   | 'CancelRequested';
 
 export type PendingChildren = import('$lib/types').PendingChildrenInfo;
-export type PendingNexusOperation = import('$lib/types').PendingNexusInfo;
+// Temporarily add fields not yet available in @temporalio/proto.
+export type PendingNexusOperation = import('$lib/types').PendingNexusInfo & {
+  scheduleToStartTimeout: google.protobuf.IDuration | null;
+  startToCloseTimeout: google.protobuf.IDuration | null;
+};
 export type Callbacks = import('$lib/types').CallbackInfo[];
 
 export type EventRequestMetadata = {


### PR DESCRIPTION
- Render new Nexus timeouts in pending nexus operation component.
- Also verified that it shows up in the event history view for the scheduled event but it was rendered not in the order I wanted and I couldn't figure out how to group all of the timeouts:

<img width="693" height="259" alt="image" src="https://github.com/user-attachments/assets/465551dc-accf-49af-a4f3-f08a0c46e9de" />
