### PR TITLE
feat(ui-server): add forward of static headers from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Once you have the prerequisites going, run the following:
 pnpm install
 ```
 
-Running `pnpm install` will attempt to download and install the most recent version of [Temporal CLI][] into `./bin/cli/temporal`. The development server will attempt to use use this version of this Temporal when starting up.
+Running `pnpm install` will attempt to download and install the most recent version of [Temporal CLI][] into `./bin/cli/temporal`. The development server will attempt to use this version of this Temporal when starting up.
 
 - If that port is already in use, the UI will fallback to trying to talk to whatever process is running on that port.
 - If you do not have a version of Temporal CLI at `./bin/cli/temporal`, the development server will look for a version of Temporal CLI in your path.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -93,11 +93,17 @@ func buildCLI() *cli.App {
 					return cli.Exit(err, 1)
 				}
 
+				middlewares := []api.Middleware{
+					headers.WithForwardHeaders(cfg.ForwardHeaders),
+				}
+
+				if len(cfg.StaticHeaders) > 0 {
+					middlewares = append(middlewares, headers.WithStaticHeaders(cfg.StaticHeaders))
+				}
+
 				opts := []server_options.ServerOption{
 					server_options.WithConfigProvider(cfgProvider),
-					server_options.WithAPIMiddleware([]api.Middleware{
-						headers.WithForwardHeaders(cfg.ForwardHeaders),
-					}),
+					server_options.WithAPIMiddleware(middlewares),
 				}
 
 				s := server.NewServer(opts...)

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -61,3 +61,5 @@ codec:
   defaultErrorLink:
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For
+staticHeaders: # can be used to always pass static headers to Temporal gRPC frontend
+  # authorization: some-tkn

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -79,4 +79,12 @@ forwardHeaders:
 {{- end }}
 {{- end }}
 
+staticHeaders:
+{{- if env "TEMPORAL_SERVER_STATIC_HEADERS" }}
+{{- range $pair := env "TEMPORAL_SERVER_STATIC_HEADERS" | split "," }}
+{{- $kv := $pair | split "=" }}
+  {{$kv._0}}: {{$kv._1}}
+{{- end }}
+{{- end }}
+
 hideLogs: {{ env "TEMPORAL_HIDE_LOGS" | default "false" }}

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -70,7 +70,9 @@ type (
 		ActivityCommandsDisabled bool `yaml:"activityCommandsDisabled"`
 		// Forward specified HTTP headers from HTTP API requests to Temporal gRPC backend
 		ForwardHeaders []string `yaml:"forwardHeaders"`
-		HideLogs       bool     `yaml:"hideLogs"`
+		// Static headers to always forward to Temporal gRPC backend
+		StaticHeaders map[string]string `yaml:"staticHeaders"`
+		HideLogs      bool              `yaml:"hideLogs"`
 		// TLS configuration options to start UI Server in TLS mode
 		UIServerTLS UIServerTLS `yaml:"uiServerTLS"`
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR introduces static headers forwarding to gRPC temporal frontend. 

Our scenario is:
- custom authorizer & claim-mapper plugin for temporal server
- TLS is provided by the infrastructure and cannot be configured
- to authenticate request, we need custom header, like `x-service-auth=some-token-here`
- it works with temporal-cli or SDK's, with grpc-meta, but UI only has forwarding headers, which is not suitable

To solve this issue, we introduce new env var: TEMPORAL_SERVER_STATIC_HEADERS. It is later converted to config field staticHeaders.

Format is: TEMPORAL_SERVER_STATIC_HEADERS="some-header=someval,another-header=someval"

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

No ui components changed.

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

No ui components changed.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

Manually tested with temporal-frontend. Added unit tests to ensure logic is correct.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

Add staticHeaders to configs, example:

```yaml
staticHeaders:
  authorization: some-tkn
```

Or use ENV var TEMPORAL_SERVER_STATIC_HEADERS="authorization=some-tkn"

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

Yes, UI startup [docs](https://github.com/temporalio/documentation/blob/992cb96f1427bd98620783aa590347846cd0e4d0/docs/references/web-ui-environment-variables.mdx).