### PR TITLE
[DT-3581] Show VersioningBehavior column when filtering by deployment version

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -24,8 +24,18 @@
   export let onClickConfigure: () => void;
 
   $: ({ namespace } = $page.params);
-  $: columns = $configurableTableColumns?.[namespace]?.workflows ?? [];
+  $: baseColumns = $configurableTableColumns?.[namespace]?.workflows ?? [];
   $: query = $page.url.searchParams.get('query');
+
+  $: hasVersioningFilter =
+    query?.includes('TemporalWorkerDeploymentVersion') ?? false;
+  $: hasVersioningBehaviorColumn = baseColumns.some(
+    (col) => col.label === 'Versioning Behavior',
+  );
+  $: columns =
+    hasVersioningFilter && !hasVersioningBehaviorColumn
+      ? [...baseColumns, { label: 'Versioning Behavior' }]
+      : baseColumns;
 
   let childrenIds: {
     workflowId: string;


### PR DESCRIPTION
## Summary
- Automatically add the Versioning Behavior column to the workflows table when filtering by TemporalWorkerDeploymentVersion
- Makes it easier to see workflow versioning behavior when viewing deployment-specific workflows

## Test plan
- [ ] Filter workflows by TemporalWorkerDeploymentVersion search attribute
- [ ] Verify Versioning Behavior column automatically appears
- [ ] Verify column is not shown when filter is removed