### PR TITLE
[DT-3582] Make Build ID and Deployment Name copyable and filterable

### DIFF
--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
 
   import Timestamp from '$lib/components/timestamp.svelte';
+  import Copyable from '$lib/holocene/copyable/index.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
@@ -47,20 +48,41 @@
 <tr>
   {#each columns as { label } (label)}
     {#if label === translate('deployments.name')}
-      <td class="py-1 text-left"
-        ><Link
-          href={routeForWorkerDeployment({
-            namespace: $page.params.namespace,
-            deployment: deployment.name,
-          })}>{deployment.name}</Link
-        ></td
-      >
+      <td class="py-1 text-left">
+        <Copyable
+          content={deployment.name}
+          copyIconTitle={translate('common.copy-icon-title')}
+          copySuccessIconTitle={translate('common.copy-success-icon-title')}
+        >
+          <Link
+            href={routeForWorkerDeployment({
+              namespace: $page.params.namespace,
+              deployment: deployment.name,
+            })}>{deployment.name}</Link
+          >
+        </Copyable>
+      </td>
     {:else if label === translate('deployments.build-id')}
       <td class="whitespace-pre-line break-words py-1 text-left">
         <div class="flex flex-col gap-1">
           {#if latestBuildId && latestNotDuplicate}
             <div class="flex items-center gap-2">
-              {latestBuildId}
+              <Copyable
+                content={latestBuildId}
+                copyIconTitle={translate('common.copy-icon-title')}
+                copySuccessIconTitle={translate(
+                  'common.copy-success-icon-title',
+                )}
+              >
+                <Link
+                  href={routeForWorkflowsWithQuery({
+                    namespace: $page.params.namespace,
+                    query: `TemporalWorkerDeploymentVersion="${deployment.name}:${latestBuildId}"`,
+                  })}
+                >
+                  {latestBuildId}
+                </Link>
+              </Copyable>
               <DeploymentStatus
                 status="Latest"
                 label={translate('deployments.latest')}
@@ -69,7 +91,22 @@
           {/if}
           {#if rampingBuildId}
             <div class="flex items-center gap-2">
-              {rampingBuildId}
+              <Copyable
+                content={rampingBuildId}
+                copyIconTitle={translate('common.copy-icon-title')}
+                copySuccessIconTitle={translate(
+                  'common.copy-success-icon-title',
+                )}
+              >
+                <Link
+                  href={routeForWorkflowsWithQuery({
+                    namespace: $page.params.namespace,
+                    query: `TemporalWorkerDeploymentVersion="${deployment.name}:${rampingBuildId}"`,
+                  })}
+                >
+                  {rampingBuildId}
+                </Link>
+              </Copyable>
               {#if deployment?.routingConfig?.rampingVersionPercentage}
                 <DeploymentStatus
                   status="Ramping"
@@ -82,7 +119,26 @@
             </div>
           {/if}
           <div class="flex items-center gap-2">
-            {currentLabel}
+            {#if versionedCurrent}
+              <Copyable
+                content={currentBuildId}
+                copyIconTitle={translate('common.copy-icon-title')}
+                copySuccessIconTitle={translate(
+                  'common.copy-success-icon-title',
+                )}
+              >
+                <Link
+                  href={routeForWorkflowsWithQuery({
+                    namespace: $page.params.namespace,
+                    query: `TemporalWorkerDeploymentVersion="${deployment.name}:${currentBuildId}"`,
+                  })}
+                >
+                  {currentLabel}
+                </Link>
+              </Copyable>
+            {:else}
+              {currentLabel}
+            {/if}
             {#if versionedCurrent}
               <DeploymentStatus
                 status="Current"

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -2,6 +2,7 @@
   import { page } from '$app/stores';
 
   import Timestamp from '$lib/components/timestamp.svelte';
+  import Copyable from '$lib/holocene/copyable/index.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
@@ -97,7 +98,20 @@
   {#each columns as { label } (label)}
     {#if label === translate('deployments.build-id')}
       <td class="text-left">
-        {versionBuildId}
+        <Copyable
+          content={versionBuildId}
+          copyIconTitle={translate('common.copy-icon-title')}
+          copySuccessIconTitle={translate('common.copy-success-icon-title')}
+        >
+          <Link
+            href={routeForWorkflowsWithQuery({
+              namespace: $page.params.namespace,
+              query: `TemporalWorkerDeploymentVersion="${getDeploymentVersionFromStruct(version)}"`,
+            })}
+          >
+            {versionBuildId}
+          </Link>
+        </Copyable>
       </td>
     {:else if label === translate('deployments.status')}
       <td class="text-left">

--- a/src/lib/components/lines-and-dots/workflow-details.svelte
+++ b/src/lib/components/lines-and-dots/workflow-details.svelte
@@ -196,6 +196,8 @@
     <DetailListColumn>
       <DetailListLabel>{translate('deployments.deployment')}</DetailListLabel>
       <DetailListLinkValue
+        copyable
+        copyableText={deployment}
         text={deployment}
         href={routeForWorkerDeployment({
           namespace,
@@ -207,14 +209,34 @@
         <DetailListLabel>
           {translate('deployments.build-id')}
         </DetailListLabel>
-        <DetailListTextValue text={versioningBuildId} />
+        <DetailListLinkValue
+          copyable
+          copyableText={versioningBuildId}
+          text={versioningBuildId}
+          href={deploymentVersion
+            ? routeForWorkflowsWithQuery({
+                namespace,
+                query: `TemporalWorkerDeploymentVersion="${deploymentVersion}"`,
+              })
+            : undefined}
+          iconName={deploymentVersion ? 'filter' : undefined}
+        />
       {/if}
 
       {#if versioningBehavior}
         <DetailListLabel>
           {translate('deployments.versioning-behavior')}
         </DetailListLabel>
-        <DetailListTextValue text={versioningBehavior} />
+        <DetailListLinkValue
+          copyable
+          copyableText={versioningBehavior}
+          text={versioningBehavior}
+          href={routeForWorkflowsWithQuery({
+            namespace,
+            query: `TemporalWorkflowVersioningBehavior="${versioningBehavior}"`,
+          })}
+          iconName="filter"
+        />
       {/if}
     </DetailListColumn>
   {/if}


### PR DESCRIPTION
## Summary
- Add Copyable wrappers to build IDs and deployment names across deployment views
- Build IDs now link to filtered workflow list showing workflows for that deployment version
- Applies to workflow details, deployment table rows, and version table rows

## Test plan
- [ ] Verify copy button appears on hover for build IDs and deployment names
- [ ] Click build ID link and verify it filters workflows by TemporalWorkerDeploymentVersion
- [ ] Test on workflow details page, deployments list, and version list