### PR TITLE
feat: add long-term caching for immutable assets

### DIFF
--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -11,11 +11,15 @@ describe('hooks.server', () => {
       } as RequestEvent;
     };
 
-    const createMockResolve = (headers?: Record<string, string>) => {
+    const createMockResolve = (
+      headers?: Record<string, string>,
+      status = 200,
+    ) => {
       const responseHeaders = new Headers(headers);
       return vi.fn().mockResolvedValue(
         new Response('test', {
           headers: responseHeaders,
+          status,
         }),
       );
     };
@@ -85,6 +89,24 @@ describe('hooks.server', () => {
     it('should not set Cache-Control header for root path', async () => {
       const event = createMockEvent('/');
       const resolve = createMockResolve();
+
+      const response = await handle({ event, resolve });
+
+      expect(response.headers.get('Cache-Control')).toBeNull();
+    });
+
+    it('should not set Cache-Control header for error responses on immutable paths', async () => {
+      const event = createMockEvent('/_app/immutable/chunks/index.js');
+      const resolve = createMockResolve({}, 404);
+
+      const response = await handle({ event, resolve });
+
+      expect(response.headers.get('Cache-Control')).toBeNull();
+    });
+
+    it('should not set Cache-Control header for 500 responses on immutable paths', async () => {
+      const event = createMockEvent('/_app/immutable/chunks/index.js');
+      const resolve = createMockResolve({}, 500);
 
       const response = await handle({ event, resolve });
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,12 +1,14 @@
 import type { Handle } from '@sveltejs/kit';
 
+const ONE_YEAR = 31536000; // 365 days in seconds
+
 export const handle: Handle = async ({ event, resolve }) => {
   const response = await resolve(event, {});
 
-  if (event.url.pathname.startsWith('/_app/immutable/')) {
+  if (response.ok && event.url.pathname.startsWith('/_app/immutable/')) {
     response.headers.set(
       'Cache-Control',
-      'public, max-age=31536000, immutable',
+      `public, max-age=${ONE_YEAR}, immutable`,
     );
   }
 


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add Cache-Control headers for /_app/immutable/* paths to enable aggressive browser caching of static content-addressable filenames. This has a strong performance impact when the UI is behind a proxy that is preventing multiplexing connections. Without it, I observe slow serial downloading of these static assets.

- Set Cache-Control: public, max-age=31536000, immutable (one year)
- Applied in hooks.server.ts

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ X ] Manual testing
- [ ] E2E tests added
- [ X ] Unit tests added

Add comprehensive test coverage for Cache-Control header middleware in hooks.server.ts:
- Verify headers are set correctly for /_app/immutable/* paths
- Verify headers are not set for other paths
- Test preservation of existing headers
- Cover various immutable asset subdirectories

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
Observe header application and local caching using developer tools in browser.