### PR TITLE
fix: prevent 'No Workers Running' flash during workflow load

### DIFF
--- a/src/lib/components/workflow/workflow-call-stack-error.svelte
+++ b/src/lib/components/workflow/workflow-call-stack-error.svelte
@@ -18,7 +18,7 @@
       title={translate('workflows.workflow-error-no-workers-title')}
     >
       {translate('workflows.workflow-error-no-workers-description', {
-        taskQueue: workflow?.taskQueue,
+        taskQueue: workflow?.taskQueue ?? '',
       })}
     </Alert>
   </div>

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -39,9 +39,9 @@
   $: showJson = $page.url.searchParams.has('json');
   $: fullJson = { ...$workflowRun, eventHistory: $fullEventHistory };
 
-  let workflowError: NetworkError;
+  let workflowError: NetworkError | null = null;
   let workflowRunController: AbortController;
-  let refreshInterval;
+  let refreshInterval: ReturnType<typeof setInterval> | null = null;
 
   const { copy, copied } = copyToClipboard();
 
@@ -89,6 +89,10 @@
 
     if (error) {
       workflowError = error;
+      return;
+    }
+
+    if (!workflow) {
       return;
     }
 

--- a/src/lib/stores/workflow-run.ts
+++ b/src/lib/stores/workflow-run.ts
@@ -10,7 +10,7 @@ export type WorkflowRunWithWorkers = {
   workflow: WorkflowExecution | null;
   workers: TaskQueueResponse;
   workersLoaded: boolean;
-  metadata: WorkflowMetadata;
+  metadata: WorkflowMetadata | null;
   userMetadata: {
     summary: string;
     details: string;
@@ -21,7 +21,7 @@ export const initialWorkflowRun: WorkflowRunWithWorkers = {
   workflow: null,
   workers: { pollers: [], taskQueueStatus: null },
   workersLoaded: false,
-  metadata: undefined,
+  metadata: null,
   userMetadata: {
     summary: '',
     details: '',


### PR DESCRIPTION
## Summary

Fixes a race condition where the "No Workers Running" warning would briefly flash when opening a workflow, even when workers were actively running.

**Root cause:** The `workflow-call-stack-error` component checked `!workers?.pollers?.length` to show the warning, but the initial store state has `pollers: []`. When a workflow loaded, the warning would briefly appear before worker data finished loading.

**Fix:** Added a `workersLoaded` flag to the store to distinguish between:
- "Workers are loading" (`workersLoaded: false`, `pollers: []`)
- "Workers loaded with none found" (`workersLoaded: true`, `pollers: []`)

The warning now only shows in the second case.

## Changes

- `src/lib/stores/workflow-run.ts` - Added `workersLoaded: boolean` to store type
- `src/lib/layouts/workflow-run-layout.svelte` - Sets `workersLoaded: true` after fetching
- `src/lib/components/workflow/workflow-call-stack-error.svelte` - Checks `workersLoaded` before showing warning

## Test plan

- [ ] Open a workflow that has workers running - should NOT see the "No Workers Running" flash
- [ ] Open a workflow with no workers polling its task queue - should still see the warning (after load completes)
- [ ] Navigate between workflows - warning should not flash during transitions