### PR TITLE
Fix subtitle size and padding on proj nav

### DIFF
--- a/src/lib/holocene/navigation/cloud-nav-bar.svelte
+++ b/src/lib/holocene/navigation/cloud-nav-bar.svelte
@@ -38,7 +38,7 @@
         class={merge(
           'font-secondary mb-0 hidden whitespace-nowrap font-medium text-white group-data-[nav=open]:block',
           subtitle === 'Cloud' ? 'text-2xl' : 'text-base',
-          subtitle === 'Cloud' ? '' : 'px-2',
+          subtitle !== 'Cloud' && 'px-2',
         )}
       >
         {subtitle}


### PR DESCRIPTION
Slight fix that does two things 
- makes subtitle size smaller on project nav 
- adds padding to new subtitles to align subtitle when small with nav items (while leaving original style intact)