### PR TITLE
Corrected location of output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm dev:temporal-cli
 
 ### Building the UI
 
-The Temporal UI can be built for local preview. You must set the `VITE_TEMPORAL_UI_BUILD_TARGET` environment variable in order to build the assets. This will be set for you if you use either of the following `pnpm` scripts. The resulting assets will be placed in `./build`.
+The Temporal UI can be built for local preview. You must set the `VITE_TEMPORAL_UI_BUILD_TARGET` environment variable in order to build the assets. This will be set for you if you use either of the following `pnpm` scripts. The resulting assets will be placed in `./build` by default or the directory defined by the `BUILD_PATH` environment variable.
 
 > You can preview the built app with `pnpm run preview`, regardless of whether you installed an adapter. This should _not_ be used to serve your app in production.
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The README stated that the `pnpm build:local` command builds output in the `./dist` directory, but I ran it and found that this was not the case. I observed that output is actually created in the `./build` directory and the message that appears at the end of the build (shown in the screenshot below) confirms this.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="944" height="189" alt="image" src="https://github.com/user-attachments/assets/cf97c8d6-08c3-4666-9648-ee11576e83bf" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

No

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

Using the source code for v2.45.0, I ran the `pnpm build:local` command. When the build completed, there was no `./dist` directory, but there was now a `./build` directory.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [X] Manual testing

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->
N/A

### Merge Checklist <!-- Add todos if not ready to merge -->
N/A

### Issue(s) closed <!-- add issue number here -->
N/A

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
AFAIK, this README is the only source of information about how to build the project. No further updates are needed.
