### PR TITLE
Fix schedule edit form infinite effect loop

### DIFF
--- a/src/lib/components/schedule/schedule-form/form.svelte
+++ b/src/lib/components/schedule/schedule-form/form.svelte
@@ -76,7 +76,7 @@
 
   const encoding: Writable<PayloadInputEncoding> = writable('json/plain');
 
-  let preset = $derived<SchedulePreset>(
+  let preset = $state<SchedulePreset>(
     page.params.schedule ? 'existing' : 'interval',
   );
 

--- a/src/lib/components/schedule/schedule-form/schedules-calendar-view.svelte
+++ b/src/lib/components/schedule/schedule-form/schedules-calendar-view.svelte
@@ -60,8 +60,12 @@
     cronString = '';
   };
 
+  let previousPreset = preset;
   $effect(() => {
-    clearSchedule();
+    if (preset !== previousPreset) {
+      clearSchedule();
+      previousPreset = preset;
+    }
   });
 </script>
 


### PR DESCRIPTION
Change preset from $derived to $state to prevent read-only conflict with bind:preset two-way binding. Guard the clearSchedule $effect to only run on preset changes, avoiding circular updates through $bindable prop bindings.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
