### PR TITLE
fix(workflow): remove extra vertical padding from history toolbar

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -130,7 +130,7 @@
 <div class="relative">
   <div
     class={merge(
-      'surface-background flex flex-wrap items-center justify-between gap-2 border-b border-subtle py-2 xl:gap-8',
+      'surface-background flex flex-wrap items-center justify-between gap-2 border-b border-subtle xl:gap-8',
       !$minimizeEventView && 'sticky top-0 z-30 md:top-12',
     )}
   >


### PR DESCRIPTION
## Summary
- Removes `py-2` from the workflow history toolbar container that was causing unnecessary vertical gaps after the tab split in #3109
- Child elements (tab buttons, view controls) already provide their own spacing, making the container-level padding redundant

## Test plan
- [ ] Verify the Timeline and Event History tabs toolbar has no extra vertical gaps
- [ ] Confirm spacing looks correct across different viewport sizes (responsive `xl:gap-8`)