### PR TITLE
fix(workflow): restore input/result height and breadcrumb link

### DIFF
--- a/src/lib/components/workflow/input-and-results-payload.svelte
+++ b/src/lib/components/workflow/input-and-results-payload.svelte
@@ -63,8 +63,7 @@
                   copySuccessIconTitle={translate(
                     'common.copy-success-icon-title',
                   )}
-                  minHeight={120}
-                  maxHeight={120}
+                  maxHeight={300}
                 />
               {/each}
             {:else}
@@ -74,8 +73,7 @@
                 copySuccessIconTitle={translate(
                   'common.copy-success-icon-title',
                 )}
-                minHeight={120}
-                maxHeight={120}
+                maxHeight={300}
               />
             {/if}
           {/snippet}
@@ -87,8 +85,7 @@
               content={decodedValue}
               copyIconTitle={translate('common.copy-icon-title')}
               copySuccessIconTitle={translate('common.copy-success-icon-title')}
-              minHeight={120}
-              maxHeight={120}
+              maxHeight={300}
             />
           {/snippet}
         </PayloadDecoder>
@@ -99,8 +96,7 @@
       content={isRunning ? 'Results will appear upon completion.' : 'null'}
       language="text"
       copyable={false}
-      minHeight={120}
-      maxHeight={120}
+      maxHeight={300}
     />
   {/if}
 </div>

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -112,7 +112,7 @@
     </Link>
     {#if eventId}
       <Link
-        href={routeForEventHistory({
+        href={routeForTimeline({
           ...routeParameters,
         })}
         data-testid="back-to-workflow-execution"


### PR DESCRIPTION
## Summary
- Restores CodeBlock `maxHeight` from `120px` back to `300px` (the pre-split value) in `input-and-results-payload.svelte`. The height was reduced during the timeline/history split (#3109), making input and result sections too small to read without scrolling.
- Fixes the "back to workflow execution" breadcrumb in `workflow-header.svelte` to use `routeForTimeline` instead of `routeForEventHistory`, so clicking back from an event detail lands on the Timeline tab (the new default).

### Link audit
All other `routeForEventHistory` usages are correct — they're either the History tab link itself, links to specific events within history, or import/utility code.

## Test plan
- [ ] Workflow detail page input and result sections show full content without excessive scrolling (up to 300px)
- [ ] Viewing an event detail and clicking the breadcrumb back link lands on Timeline tab, not History
- [ ] History tab link in tab bar still works correctly