### PR TITLE
Timeline colors fix

### DIFF
--- a/src/lib/components/lines-and-dots/constants.ts
+++ b/src/lib/components/lines-and-dots/constants.ts
@@ -214,6 +214,8 @@ export const getNextDistanceAndOffset = (
   return { nextDistance, offset };
 };
 
+export const DEFAULT_STROKE_COLOR = 'currentColor';
+
 export const getStatusStrokeColor = (
   status: WorkflowStatus | EventClassification | 'Delayed',
 ): string => {
@@ -236,7 +238,7 @@ export const getStatusStrokeColor = (
     case 'Delayed':
       return '#fbbf24';
     default:
-      return 'currentColor';
+      return DEFAULT_STROKE_COLOR;
   }
 };
 
@@ -263,7 +265,7 @@ export const getCategoryStrokeColor = (
     case 'retry':
       return '#FF9B70';
     default:
-      return 'currentColor';
+      return DEFAULT_STROKE_COLOR;
   }
 };
 

--- a/src/lib/components/lines-and-dots/svg/line.svelte
+++ b/src/lib/components/lines-and-dots/svg/line.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import {
+    DEFAULT_STROKE_COLOR,
     getCategoryStrokeColor,
     getStatusStrokeColor,
   } from '$lib/components/lines-and-dots/constants';
@@ -46,15 +47,17 @@
   );
 
   const strokeColor = $derived.by(() => {
-    let color = 'currentColor';
+    let color = DEFAULT_STROKE_COLOR;
     if (status) {
       color = status === 'none' ? '#141414' : getStatusStrokeColor(status);
     }
     if (category) {
-      color = getCategoryStrokeColor(category);
+      const categoryColor = getCategoryStrokeColor(category);
+      if (categoryColor !== DEFAULT_STROKE_COLOR) color = categoryColor;
     }
     if (classification) {
-      color = getStatusStrokeColor(classification);
+      const statusColor = getStatusStrokeColor(classification);
+      if (statusColor !== DEFAULT_STROKE_COLOR) color = statusColor;
     }
     if (delayed && [classification, status].includes('Running')) {
       color = getStatusStrokeColor('Delayed');


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

In instances where both a `category` and `classification` are passed to the `<Line />` component we only want to set the stroke color for whichever has a defined color (e.g. category could be `timer` and classification could be `Started`, but `Started` does not have a defined color in `getStatusStrokeColor()` and we don't want to set the stroke color to the default `currentColor`). 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="1137" height="347" alt="Screenshot 2026-02-25 at 3 59 52 PM" src="https://github.com/user-attachments/assets/770647f7-43a0-471d-a324-b4c5adbee673" />|<img width="1129" height="391" alt="Screenshot 2026-02-25 at 3 59 34 PM" src="https://github.com/user-attachments/assets/a99dedda-7028-4f45-bdae-84d96421e1a4" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
