### PR TITLE
Fix infinite loop on root page if publicPath is set

### DIFF
--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -92,11 +92,12 @@ func buildUIIndexHandler(publicPath string, assets fs.FS) (echo.HandlerFunc, err
 		missingPublicPath := hasPublicPath && !hasPublicPathPrefix && !isExactPublicPath
 
 		if missingPublicPath {
-			target := publicPath + c.Request().URL.Path
+			cleanPath := path.Clean(c.Request().URL.Path)
+			target := publicPath + cleanPath
 			if c.Request().URL.RawQuery != "" {
 				target += "?" + c.Request().URL.RawQuery
 			}
-			return c.Redirect(http.StatusTemporaryRedirect, target)
+			return c.Redirect(http.StatusPermanentRedirect, target)
 		}
 		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTMLBytes))
 	}, nil

--- a/server/server/route/ui_test.go
+++ b/server/server/route/ui_test.go
@@ -146,7 +146,7 @@ func TestBuildUIIndexHandler_WithPublicPath_RedirectsWhenPrefixMissing(t *testin
 
 			err := handler(c)
 			assert.NoError(t, err)
-			assert.Equal(t, http.StatusTemporaryRedirect, rec.Code)
+			assert.Equal(t, http.StatusPermanentRedirect, rec.Code)
 			assert.Equal(t, tt.expectedTarget, rec.Header().Get("Location"))
 		})
 	}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Requesting the root page (e.g. `https://hostname/:port/`) when `publicPath` is set (e.g. `/custom-path`) without the `publicPath` caused an infinite loop because the server served `index.html` with base the `/custom-path` but the URL didn't match and caused SvelteKit to repeatedly fail to route.

This PR updates the catch-all index handler so it now checks `RequestURI` (which preserves the original path before the rewrite middleware). If the `publicPath` prefix is missing, it redirects to the prefixed URL (e.g. `/` → `/custom-path`). All API, health, and asset routes should be unaffected since they match their own specific handlers.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

`cd server && go test ./server/route/ -v -run TestBuildUIIndexHandler`


Run the following (with a `publicPath` set) ⬇️ 
```
cd server
pnpm build:server 
docker build -t temporal-ui-local .
docker run -p 5252:8080 -e TEMPORAL_UI_PUBLIC_PATH=/custom-path -e TEMPORAL_ADDRESS=host.docker.internal:7233 temporal-ui-local

pnpm dev:ui-server
```

Then go to http://localhost:5252
 - [ ] Verify it redirects to  `/custom-path` and does not cause an infinite loop
 - [ ] Verify `/namespaces` redirects to `/custom-path/namespaces`


Run the following (**without** a `publicPath` set)  ⬇️ 
```
docker run -p 5252:8080 -e TEMPORAL_ADDRESS=host.docker.internal:7233 temporal-ui-local
```

Then go to http://localhost:5252
 - [ ] Verify the route works as expected
 
## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

Related [Slack thread](https://temporalio.slack.com/archives/C011AAP3GFP/p1773863664893019?thread_ts=1772227388.908679&cid=C011AAP3GFP). 

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
