### PR TITLE
chore: add setup-worktree skill

### DIFF
--- a/.claude/skills/setup-worktree/SKILL.md
+++ b/.claude/skills/setup-worktree/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: setup-worktree
+description: Set up a new git worktree for this repo by copying gitignored files (bin/) and building server assets so pnpm dev works without errors
+---
+
+## Purpose
+
+When a new git worktree is created, gitignored files (like the Temporal CLI binary in `bin/`) are missing and server assets haven't been built. Run this skill to get a new worktree ready for development.
+
+## Steps
+
+### 1. Find the main worktree
+
+```bash
+git worktree list
+```
+
+The first entry is the main worktree path. Use it as the source for copying gitignored files.
+
+### 2. Copy gitignored files
+
+```bash
+MAIN=$(git worktree list | head -1 | awk '{print $1}')
+
+# Copy the Temporal CLI binary
+cp -r $MAIN/bin ./bin
+
+# Copy any .env files if present
+for f in $MAIN/.env $MAIN/.env.*; do
+  [ -f "$f" ] && cp "$f" . && echo "Copied $(basename $f)"
+done
+```
+
+### 3. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 4. Build server assets
+
+Builds the frontend into `server/ui/assets/` which the Go server embeds. Required for `pnpm dev` to start.
+
+```bash
+pnpm build:server
+```
+
+### 5. Verify
+
+```bash
+ls bin/cli/temporal      # Temporal CLI binary exists
+ls server/ui/assets/     # Server assets were built
+```
+
+`pnpm dev` should now start without errors.
+
+## Why each step is needed
+
+| Step                | Why                                                                                                                                           |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copy `bin/`         | Contains the Temporal CLI — gitignored, not re-downloaded without a full `pnpm install` prepare script run                                    |
+| Copy `.env*`        | Local environment config — gitignored, needed for dev modes                                                                                   |
+| `pnpm install`      | Installs `node_modules` in the new worktree                                                                                                   |
+| `pnpm build:server` | Runs `VITE_API= BUILD_PATH=server/ui/assets/local vite build` — without this, `pnpm dev` fails because the embedded server assets are missing |

--- a/.claude/skills/setup-worktree/SKILL.md
+++ b/.claude/skills/setup-worktree/SKILL.md
@@ -9,47 +9,27 @@ When a new git worktree is created, gitignored files (like the Temporal CLI bina
 
 ## Steps
 
-### 1. Find the main worktree
+### 1. Find the main worktree path
 
 ```bash
 git worktree list
 ```
 
-The first entry is the main worktree path. Use it as the source for copying gitignored files.
+The first entry is the main worktree (e.g. `/Users/ross/code/ui`). Use it as `$MAIN`.
 
-### 2. Copy gitignored files
+### 2. Copy .env from the main worktree
 
 ```bash
 MAIN=$(git worktree list | head -1 | awk '{print $1}')
-
-# Copy the Temporal CLI binary
-cp -r $MAIN/bin ./bin
-
-# Copy any .env files if present
-for f in $MAIN/.env $MAIN/.env.*; do
-  [ -f "$f" ] && cp "$f" . && echo "Copied $(basename $f)"
-done
+cp $MAIN/.env ./.env
 ```
 
-### 3. Install dependencies
-
-```bash
-pnpm install
-```
-
-### 4. Build server assets
+### 3. Build server assets
 
 Builds the frontend into `server/ui/assets/` which the Go server embeds. Required for `pnpm dev` to start.
 
 ```bash
 pnpm build:server
-```
-
-### 5. Verify
-
-```bash
-ls bin/cli/temporal      # Temporal CLI binary exists
-ls server/ui/assets/     # Server assets were built
 ```
 
 `pnpm dev` should now start without errors.
@@ -58,7 +38,5 @@ ls server/ui/assets/     # Server assets were built
 
 | Step                | Why                                                                                                                                           |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Copy `bin/`         | Contains the Temporal CLI — gitignored, not re-downloaded without a full `pnpm install` prepare script run                                    |
-| Copy `.env*`        | Local environment config — gitignored, needed for dev modes                                                                                   |
-| `pnpm install`      | Installs `node_modules` in the new worktree                                                                                                   |
+| Copy `.env`         | Gitignored — not present in a fresh worktree, needed for dev modes                                                                            |
 | `pnpm build:server` | Runs `VITE_API= BUILD_PATH=server/ui/assets/local vite build` — without this, `pnpm dev` fails because the embedded server assets are missing |

--- a/.claude/skills/setup-worktree/SKILL.md
+++ b/.claude/skills/setup-worktree/SKILL.md
@@ -15,7 +15,7 @@ When a new git worktree is created, gitignored files (like the Temporal CLI bina
 git worktree list
 ```
 
-The first entry is the main worktree (e.g. `/Users/ross/code/ui`). Use it as `$MAIN`.
+The first entry is the main worktree. Use it as `$MAIN`.
 
 ### 2. Copy .env from the main worktree
 


### PR DESCRIPTION
## Summary

Adds a Claude Code skill that documents the steps needed to initialize a new git worktree for development.

When a worktree is created, gitignored files don't exist in the new directory. This skill tells Claude how to:
1. Copy `bin/` (Temporal CLI binary) from the main worktree
2. Copy any `.env*` files
3. Run `pnpm install`
4. Run `pnpm build:server` (builds frontend assets into `server/ui/assets/` so `pnpm dev` works)

Invoke with `/setup-worktree` after creating a new worktree.