### PR TITLE
Sort namespace picker alphabetically

### DIFF
--- a/src/lib/components/namespace-picker.svelte
+++ b/src/lib/components/namespace-picker.svelte
@@ -6,6 +6,7 @@
   import { lastUsedNamespace } from '$lib/stores/namespaces';
   import type { NamespaceListItem } from '$lib/types/global';
   import { routeForNamespace } from '$lib/utilities/route-for';
+  import { sortNamespaces } from '$lib/utilities/sort-namespaces';
 
   interface Props {
     namespaceList?: NamespaceListItem[];
@@ -35,6 +36,8 @@
     $lastUsedNamespace = namespaceListItem.namespace;
     namespaceListItem?.onClick(namespaceListItem.namespace);
   };
+
+  let sortedNamespaceList = $derived(sortNamespaces(namespaceList));
 </script>
 
 <Combobox
@@ -44,7 +47,7 @@
   {value}
   id="namespace-switcher"
   leadingIcon="namespace-switcher"
-  options={namespaceList}
+  options={sortedNamespaceList}
   optionValueKey="namespace"
   onchange={handleNamespaceSelect}
   minSize={32}

--- a/src/lib/utilities/sort-namespaces.test.ts
+++ b/src/lib/utilities/sort-namespaces.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NamespaceListItem } from '$lib/types/global';
+
+import { sortNamespaces } from './sort-namespaces';
+
+const item = (namespace: string): NamespaceListItem => ({
+  namespace,
+  onClick: () => {},
+});
+
+describe('sortNamespaces', () => {
+  it('sorts namespaces alphabetically', () => {
+    const result = sortNamespaces([
+      item('zebra'),
+      item('apple'),
+      item('mango'),
+    ]);
+    expect(result.map((n) => n.namespace)).toEqual(['apple', 'mango', 'zebra']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [item('b'), item('a')];
+    sortNamespaces(input);
+    expect(input.map((n) => n.namespace)).toEqual(['b', 'a']);
+  });
+
+  it('sorts case-insensitively via localeCompare', () => {
+    const result = sortNamespaces([item('Banana'), item('apple')]);
+    expect(result[0].namespace).toBe('apple');
+  });
+
+  it('returns an empty array when given an empty list', () => {
+    expect(sortNamespaces([])).toEqual([]);
+  });
+});

--- a/src/lib/utilities/sort-namespaces.ts
+++ b/src/lib/utilities/sort-namespaces.ts
@@ -1,0 +1,6 @@
+import type { NamespaceListItem } from '$lib/types/global';
+
+export const sortNamespaces = (
+  list: NamespaceListItem[],
+): NamespaceListItem[] =>
+  [...list].sort((a, b) => a.namespace.localeCompare(b.namespace));


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭
The namespace picker dropdown currently renders namespaces in whatever order the API returns them, which makes it hard to find a specific namespace once you have more than a handful. This sorts the list alphabetically (case-insensitive via `localeCompare`) before passing it to the Combobox.

### Screenshots (if applicable) 📸 
<img width="385" height="372" alt="image" src="https://github.com/user-attachments/assets/6373cb13-a888-4265-a355-8984bc5ba328" />

### Design Considerations 🎨
None — purely an ordering change, no visual/layout differences.

## Testing 🧪
Added simple unit test.

### How was this tested 👻

- [X] Manual testing
- [ ] E2E tests added
- [X] Unit tests added

Added `src/lib/utilities/sort-namespaces.test.ts` covering: alphabetical sort, no input mutation, case-insensitive ordering, and empty input. 

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️
1. Create several namespaces in non-alphabetical order:
   `temporal operator namespace create zebra`
   `temporal operator namespace create apple`
   `temporal operator namespace create mango`
2. Open the namespace picker in the top nav — entries should appear as apple, mango, zebra.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
