### PR TITLE
Fix schedule edit double-encoding header fields

### DIFF
--- a/src/lib/stores/schedules.ts
+++ b/src/lib/stores/schedules.ts
@@ -13,10 +13,7 @@ import type {
   SchedulePresetsParameters,
   ScheduleSpecParameters,
 } from '$lib/types/schedule';
-import {
-  encodePayloads,
-  isEncodedPayload,
-} from '$lib/utilities/encode-payload';
+import { encodePayloads } from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import { routeForSchedule, routeForSchedules } from '$lib/utilities/route-for';
 import {
@@ -226,13 +223,11 @@ export const submitEditSchedule = async (
   if (fields && Object.keys(fields).length > 0) {
     try {
       for (const [key, value] of Object.entries(fields)) {
-        if (!isEncodedPayload(value)) {
-          const encodedValue = await encodePayloads({
-            input: stringifyWithBigInt(value),
-            encoding: 'json/plain',
-          });
-          fields[key] = encodedValue[0];
-        }
+        const encodedValue = await encodePayloads({
+          input: stringifyWithBigInt(value),
+          encoding: 'json/plain',
+        });
+        fields[key] = encodedValue[0];
       }
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);

--- a/src/lib/stores/schedules.ts
+++ b/src/lib/stores/schedules.ts
@@ -13,7 +13,10 @@ import type {
   SchedulePresetsParameters,
   ScheduleSpecParameters,
 } from '$lib/types/schedule';
-import { encodePayloads } from '$lib/utilities/encode-payload';
+import {
+  encodePayloads,
+  isEncodedPayload,
+} from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import { routeForSchedule, routeForSchedules } from '$lib/utilities/route-for';
 import {
@@ -26,13 +29,6 @@ type ScheduleParameterArgs = {
   spec: Partial<ScheduleSpecParameters>;
   presets: SchedulePresetsParameters;
 };
-
-// TODO: Post Beta, add support of additional fields.
-// "startTime": "2022-07-04T03:18:59.668Z",
-// "endTime": "2022-07-04T03:18:59.668Z",
-// "jitter": "string",
-// "timezoneName": "string",
-// "timezoneData": "string"
 
 const getSearchAttributes = (
   attrs: (typeof setSearchAttributes.arguments)[0],
@@ -229,13 +225,14 @@ export const submitEditSchedule = async (
   const fields = body.schedule.action.startWorkflow?.header?.fields;
   if (fields && Object.keys(fields).length > 0) {
     try {
-      const entries = Object.entries(fields);
-      for (const [key, value] of entries) {
-        const encodedValue = await encodePayloads({
-          input: stringifyWithBigInt(value),
-          encoding: 'json/plain',
-        });
-        fields[key] = encodedValue[0];
+      for (const [key, value] of Object.entries(fields)) {
+        if (!isEncodedPayload(value)) {
+          const encodedValue = await encodePayloads({
+            input: stringifyWithBigInt(value),
+            encoding: 'json/plain',
+          });
+          fields[key] = encodedValue[0];
+        }
       }
     } catch (e) {
       error.set(`${translate('data-encoder.encode-error')}: ${e?.message}`);

--- a/src/lib/utilities/encode-payload.test.ts
+++ b/src/lib/utilities/encode-payload.test.ts
@@ -8,7 +8,7 @@ import {
 import {
   encodePayloads,
   getSinglePayload,
-  isEncodedPayload,
+  isBase64EncodedPayload,
 } from './encode-payload';
 
 describe('getSinglePayload', () => {
@@ -33,10 +33,10 @@ describe('getSinglePayload', () => {
   });
 });
 
-describe('isEncodedPayload', () => {
+describe('isBase64EncodedPayload', () => {
   it('should return true for a base64-encoded payload', () => {
     expect(
-      isEncodedPayload({
+      isBase64EncodedPayload({
         metadata: { encoding: 'anNvbi9wbGFpbg==' },
         data: 'eyJmb28iOiJiYXIifQ==',
       }),
@@ -45,7 +45,7 @@ describe('isEncodedPayload', () => {
 
   it('should return true for a binary/null encoded payload', () => {
     expect(
-      isEncodedPayload({
+      isBase64EncodedPayload({
         metadata: { encoding: 'YmluYXJ5L251bGw=' },
         data: '',
       }),
@@ -54,7 +54,7 @@ describe('isEncodedPayload', () => {
 
   it('should return false for a decoded payload', () => {
     expect(
-      isEncodedPayload({
+      isBase64EncodedPayload({
         metadata: { encoding: 'json/plain' },
         data: { foo: 'bar' },
       }),
@@ -62,23 +62,35 @@ describe('isEncodedPayload', () => {
   });
 
   it('should return false for a raw string value', () => {
-    expect(isEncodedPayload('hello')).toBe(false);
+    expect(isBase64EncodedPayload('hello')).toBe(false);
   });
 
   it('should return false for a raw object value', () => {
-    expect(isEncodedPayload({ foo: 'bar' })).toBe(false);
+    expect(isBase64EncodedPayload({ foo: 'bar' })).toBe(false);
   });
 
   it('should return false for null', () => {
-    expect(isEncodedPayload(null)).toBe(false);
+    expect(isBase64EncodedPayload(null)).toBe(false);
   });
 
   it('should return false for undefined', () => {
-    expect(isEncodedPayload(undefined)).toBe(false);
+    expect(isBase64EncodedPayload(undefined)).toBe(false);
   });
 });
 
 describe('encodePayloads', () => {
+  it('should return already-encoded payload as-is', async () => {
+    const alreadyEncoded = {
+      metadata: { encoding: 'anNvbi9wbGFpbg==' },
+      data: 'eyJmb28iOiJiYXIifQ==',
+    };
+    const payload = await encodePayloads({
+      input: stringifyWithBigInt(alreadyEncoded),
+      encoding: 'json/plain',
+    });
+    expect(payload).toEqual([alreadyEncoded]);
+  });
+
   it('should encode single simple string payload', async () => {
     const payload = await encodePayloads({
       input: stringifyWithBigInt('cats'),

--- a/src/lib/utilities/encode-payload.test.ts
+++ b/src/lib/utilities/encode-payload.test.ts
@@ -5,7 +5,11 @@ import {
   stringifyWithBigInt,
 } from '$lib/utilities/parse-with-big-int';
 
-import { encodePayloads, getSinglePayload } from './encode-payload';
+import {
+  encodePayloads,
+  getSinglePayload,
+  isEncodedPayload,
+} from './encode-payload';
 
 describe('getSinglePayload', () => {
   it('should return single payload from single payload', () => {
@@ -26,6 +30,51 @@ describe('getSinglePayload', () => {
     const payload = 'cats';
     const singlePayload = getSinglePayload(stringifyWithBigInt(payload));
     expect(parseWithBigInt(singlePayload)).toEqual(payload);
+  });
+});
+
+describe('isEncodedPayload', () => {
+  it('should return true for a base64-encoded payload', () => {
+    expect(
+      isEncodedPayload({
+        metadata: { encoding: 'anNvbi9wbGFpbg==' },
+        data: 'eyJmb28iOiJiYXIifQ==',
+      }),
+    ).toBe(true);
+  });
+
+  it('should return true for a binary/null encoded payload', () => {
+    expect(
+      isEncodedPayload({
+        metadata: { encoding: 'YmluYXJ5L251bGw=' },
+        data: '',
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false for a decoded payload', () => {
+    expect(
+      isEncodedPayload({
+        metadata: { encoding: 'json/plain' },
+        data: { foo: 'bar' },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false for a raw string value', () => {
+    expect(isEncodedPayload('hello')).toBe(false);
+  });
+
+  it('should return false for a raw object value', () => {
+    expect(isEncodedPayload({ foo: 'bar' })).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isEncodedPayload(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isEncodedPayload(undefined)).toBe(false);
   });
 });
 

--- a/src/lib/utilities/encode-payload.ts
+++ b/src/lib/utilities/encode-payload.ts
@@ -11,10 +11,11 @@ import {
   stringifyWithBigInt,
 } from '$lib/utilities/parse-with-big-int';
 
-export const isEncodedPayload = (payload: Payload): boolean => {
-  const encoding = payload?.metadata?.encoding;
-  if (typeof encoding !== 'string' || typeof payload?.data !== 'string')
-    return false;
+export const isBase64EncodedPayload = (value: unknown): value is Payload => {
+  if (!value || typeof value !== 'object') return false;
+  const { metadata, data } = value as Payload;
+  const encoding = metadata?.encoding;
+  if (typeof encoding !== 'string' || typeof data !== 'string') return false;
   return atob(encoding) !== encoding;
 };
 
@@ -66,18 +67,25 @@ export const encodePayloads = async ({
   messageType = '',
   encodeWithCodec = true,
 }: EncodePayloads): Promise<Payload[]> => {
-  let payloads = null;
+  if (!input) return null;
 
-  if (input) {
-    const parsedInput = parseWithBigInt(input);
-    payloads = [setBase64Payload(parsedInput, encoding, messageType)];
-    const endpoint = get(dataEncoder).endpoint;
-    if (endpoint && encodeWithCodec) {
-      const awaitData = await encodePayloadsWithCodec({
-        payloads: { payloads },
-      });
-      payloads = awaitData?.payloads ?? null;
-    }
+  const parsedInput = parseWithBigInt(input);
+  let payloads: Payload[] = isBase64EncodedPayload(parsedInput)
+    ? [parsedInput]
+    : [
+        setBase64Payload(
+          parsedInput,
+          encoding,
+          messageType,
+        ) as unknown as Payload,
+      ];
+
+  const endpoint = get(dataEncoder).endpoint;
+  if (endpoint && encodeWithCodec) {
+    const awaitData = await encodePayloadsWithCodec({
+      payloads: { payloads },
+    });
+    payloads = (awaitData?.payloads as Payload[]) ?? null;
   }
   return payloads;
 };

--- a/src/lib/utilities/encode-payload.ts
+++ b/src/lib/utilities/encode-payload.ts
@@ -4,11 +4,19 @@ import type { PayloadInputEncoding } from '$lib/models/payload-encoding';
 import { encodePayloadsWithCodec } from '$lib/services/data-encoder';
 import { dataEncoder } from '$lib/stores/data-encoder';
 import type { Payload } from '$lib/types';
+import { atob } from '$lib/utilities/atob';
 import { btoa } from '$lib/utilities/btoa';
 import {
   parseWithBigInt,
   stringifyWithBigInt,
 } from '$lib/utilities/parse-with-big-int';
+
+export const isEncodedPayload = (payload: Payload): boolean => {
+  const encoding = payload?.metadata?.encoding;
+  if (typeof encoding !== 'string' || typeof payload?.data !== 'string')
+    return false;
+  return atob(encoding) !== encoding;
+};
 
 export const getSinglePayload = (decodedValue: string): string => {
   if (decodedValue) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Header fields from the server are already base64-encoded `Payloads`. Editing a schedule was unconditionally re-encoding them, wrapping each Payload inside a new Payload. Each subsequent edit/save compounded the encoding, which could lead to Workflow Task Failures. 

This PR adds an `isBase64EncodedPayload` check to skip encoding for already-encoded inputs in `encodePayloads`.  

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Modify this [Go sample](https://github.com/temporalio/samples-go/tree/main/schedule) to create a schedule with headers                                                                                                                                       
                                                                                                                                                                                                  
  In `schedule/starter/main.go`, register a context propagator and set the header value in the context:                                                                                                                         
     
```go                                                                                                                                                                                             
func main() {
	[...]
	ctx = context.WithValue(ctx, ctxpropagation.PropagateKey, &ctxpropagation.Values{Key: "x-custom-header", Value: "header-value"})
	c, err := client.Dial(client.Options{
		[...]
		ContextPropagators: []workflow.ContextPropagator{ctxpropagation.NewContextPropagator()},
	})
    [...]
  }    
```                                                                                                                                                                                        
                                                            
  Remove the deferred delete so the schedule sticks around for UI testing.                                              
   
2. Run the sample                                                                                                                                                                               
                                                            
  **Terminal 1: run the worker**
  `go run schedule/worker/main.go`

  **Terminal 2: create the schedule**                                                                                                                                                             
  `go run schedule/starter/main.go`
                                                                                                                                                                                                  
  3. Test in the UI                                         

     - Open the schedule in the UI
     - Open browser DevTools Network tab
     - Edit and save without changing anything and inspect the request payload
          - [ ] Verify the header fields are NOT double-wrapped in a new Payload                                                  
     -  [ ] Verify the schedule still triggers successfully after the edit                                                                          
     - Edit and save a second time
        - [ ]  Verify the request payload looks identical to step 3                     
     - [ ] Verify the triggered workflow completes without a Workflow Task Failure       

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-3821`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
