### PR TITLE
Fix schedule recent runs showing incorrect workflow

### DIFF
--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -639,11 +639,20 @@ export async function fetchWorkflowForSchedule(
     console.error(err);
   };
 
-  const route = routeForApi('workflow', parameters);
+  const route = routeForApi('workflow', {
+    namespace: parameters.namespace,
+    workflowId: parameters.workflowId,
+  });
+
   return requestFromAPI(route, {
     request,
     onError,
     handleError: onError,
+    params: parameters.runId
+      ? {
+          'execution.runId': parameters.runId,
+        }
+      : {},
   }).then(toWorkflowExecution);
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Since the workflow route is just `/namespaces/{namespace}/workflows/{workflowId}` (no `runId` in the path), and `fetchWorkflowForSchedule` was not passing `runId` as a query param, the API was returning the latest execution for that `workflowId`. 

This meant that when multiple schedule runs shared the same `workflowId`, every row fetched the same (latest) execution. 

This PR ensures the `runId` is being passed as a query param in `fetchWorkflowForSchedule` (matching `fetchWorkflow`).

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-3823`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
