### PR TITLE
fix: display authorization error for reset workflow action

### DIFF
--- a/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/reset-confirmation-modal.svelte
@@ -72,7 +72,6 @@
     } finally {
       loading = false;
     }
-    hideResetModal();
   };
 </script>
 


### PR DESCRIPTION
Fixes #3225

## Problem

When an unauthorized user attempts a Reset action, the UI silently closes the
modal without displaying an error. Cancel and Terminate correctly show the
authorization error inside the modal.

## Root Cause

`hideResetModal()` was called unconditionally after the `try/catch/finally`
block in `reset-confirmation-modal.svelte`, closing the modal even when the
`catch` block had just set an error message. Cancel and Terminate only close
the modal inside the `try` block (on success).

## Fix

Removed the duplicate `hideResetModal()` call outside the `try/catch/finally`
block. The modal now stays open on error and displays the message via
`bind:error`, matching the pattern used by Cancel and Terminate.

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
