### PR TITLE
Add relative path prefix support to routeFor utilities

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -24,6 +24,7 @@ consumeAuthCookies();
 initCoreProvider({
   getAccessToken: async () => getAuthUser().accessToken ?? '',
   getIdToken: async () => getAuthUser().idToken,
+  getRoutePrefix: () => '',
   api: {
     preRequest: ossPreRequest,
     postResponse: ossPostResponse,

--- a/src/lib/stores/route-prefix.ts
+++ b/src/lib/stores/route-prefix.ts
@@ -1,0 +1,5 @@
+import { get, writable } from 'svelte/store';
+
+export const routePrefix = writable<string>('');
+
+export const getRoutePrefix = (): string => get(routePrefix);

--- a/src/lib/stores/route-prefix.ts
+++ b/src/lib/stores/route-prefix.ts
@@ -1,5 +1,0 @@
-import { get, writable } from 'svelte/store';
-
-export const routePrefix = writable<string>('');
-
-export const getRoutePrefix = (): string => get(routePrefix);

--- a/src/lib/utilities/core-provider.ts
+++ b/src/lib/utilities/core-provider.ts
@@ -17,6 +17,7 @@ export type PostResponseHook = (
 export type CoreProvider = {
   getAccessToken: () => Promise<string>;
   getIdToken: () => Promise<string | undefined>;
+  getRoutePrefix: () => string;
   api: {
     preRequest: PreRequestHook;
     postResponse: PostResponseHook;
@@ -28,6 +29,7 @@ export type CoreProvider = {
 export type InitOptions = {
   getAccessToken: () => Promise<string>;
   getIdToken?: () => Promise<string | undefined>;
+  getRoutePrefix?: () => string;
   api?: {
     preRequest?: PreRequestHook;
     postResponse?: PostResponseHook;
@@ -45,6 +47,7 @@ export function initCoreProvider(options: InitOptions): void {
   provider = {
     getAccessToken: options.getAccessToken,
     getIdToken: options.getIdToken ?? (async () => undefined),
+    getRoutePrefix: options.getRoutePrefix ?? (() => ''),
     api: {
       preRequest: options.api?.preRequest ?? passthrough,
       postResponse: options.api?.postResponse ?? passthroughResponse,
@@ -62,6 +65,11 @@ export async function getAccessToken(): Promise<string> {
 export async function getIdToken(): Promise<string | undefined> {
   if (!BROWSER || !provider) return undefined;
   return provider.getIdToken();
+}
+
+export function getRoutePrefix(): string {
+  if (!BROWSER || !provider) return '';
+  return provider.getRoutePrefix();
 }
 
 export async function getDataEncoderEndpoint(

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -2,8 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { base } from '$app/paths';
 
-import { routePrefix } from '$lib/stores/route-prefix';
-
+import { initCoreProvider } from './core-provider';
 import * as routeForModule from './route-for';
 import {
   routeForArchivalEventHistory,
@@ -277,7 +276,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   };
 
   afterEach(() => {
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
   });
 
   const prefixedCases: [string, () => string | undefined][] = [
@@ -409,7 +411,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   it.each(prefixedCases)(
     '%s should include base + prefix when prefix is set',
     (_name, fn) => {
-      routePrefix.set(prefix);
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => prefix,
+      });
       const result = fn();
       expect(typeof result).toBe('string');
       expect(result).toMatch(new RegExp(`^${base}${prefix}`));
@@ -422,7 +427,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   it.each(authCases)(
     '%s should NOT include prefix (auth routes excluded)',
     (_name, fn) => {
-      routePrefix.set(prefix);
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => prefix,
+      });
       const result = fn();
       expect(typeof result).toBe('string');
       expect(result).not.toContain(prefix);

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -2,8 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { base } from '$app/paths';
 
-import { routePrefix } from '$lib/stores/route-prefix';
-
+import { initCoreProvider } from './core-provider';
 import * as routeForModule from './route-for';
 import {
   routeForArchivalEventHistory,
@@ -237,7 +236,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   };
 
   afterEach(() => {
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
   });
 
   const prefixedCases: [string, () => string | undefined][] = [
@@ -369,7 +371,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   it.each(prefixedCases)(
     '%s should include base + prefix when prefix is set',
     (_name, fn) => {
-      routePrefix.set(prefix);
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => prefix,
+      });
       const result = fn();
       expect(typeof result).toBe('string');
       expect(result).toMatch(new RegExp(`^${base}${prefix}`));
@@ -382,7 +387,10 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
   it.each(authCases)(
     '%s should NOT include prefix (auth routes excluded)',
     (_name, fn) => {
-      routePrefix.set(prefix);
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => prefix,
+      });
       const result = fn();
       expect(typeof result).toBe('string');
       expect(result).not.toContain(prefix);

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { base } from '$app/paths';
+
+import { routePrefix } from '$lib/stores/route-prefix';
 
 import * as routeForModule from './route-for';
 import {
@@ -256,4 +258,174 @@ describe('routeFor functions should resolve the base path exactly once', () => {
       );
     }
   });
+});
+
+describe('routeFor functions with prefix should resolve base + prefix correctly', () => {
+  const prefix = '/projects/my-project';
+
+  const namespaceParams = { namespace: 'default' };
+  const workflowParams = {
+    namespace: 'default',
+    workflow: 'wf-id',
+    run: 'run-id',
+  };
+  const scheduleParams = { namespace: 'default', scheduleId: 'sched-1' };
+  const activityParams = {
+    namespace: 'default',
+    activityId: 'act-1',
+    runId: 'run-1',
+  };
+
+  afterEach(() => {
+    routePrefix.set('');
+  });
+
+  const prefixedCases: [string, () => string | undefined][] = [
+    ['routeForNamespaces', () => routeForNamespaces()],
+    ['routeForNexus', () => routeForNexus()],
+    ['routeForNexusEndpoint', () => routeForNexusEndpoint('ep-1')],
+    ['routeForNexusEndpointEdit', () => routeForNexusEndpointEdit('ep-1')],
+    ['routeForNexusEndpointCreate', () => routeForNexusEndpointCreate()],
+    ['routeForNamespace', () => routeForNamespace(namespaceParams)],
+    ['routeForNamespaceSelector', () => routeForNamespaceSelector()],
+    ['routeForWorkflows', () => routeForWorkflows(namespaceParams)],
+    [
+      'routeForArchivalWorkflows',
+      () => routeForArchivalWorkflows(namespaceParams),
+    ],
+    ['routeForWorkflow', () => routeForWorkflow(workflowParams)],
+    ['routeForSchedules', () => routeForSchedules(namespaceParams)],
+    ['routeForScheduleCreate', () => routeForScheduleCreate(namespaceParams)],
+    ['routeForSchedule', () => routeForSchedule(scheduleParams)],
+    ['routeForScheduleEdit', () => routeForScheduleEdit(scheduleParams)],
+    [
+      'routeForArchivalEventHistory',
+      () => routeForArchivalEventHistory(workflowParams),
+    ],
+    [
+      'routeForEventHistoryEvent',
+      () => routeForEventHistoryEvent({ ...workflowParams, eventId: '1' }),
+    ],
+    ['routeForEventHistory', () => routeForEventHistory(workflowParams)],
+    ['routeForTimeline', () => routeForTimeline(workflowParams)],
+    ['routeForWorkers', () => routeForWorkers(workflowParams)],
+    [
+      'routeForWorkerDeployments',
+      () => routeForWorkerDeployments(namespaceParams),
+    ],
+    [
+      'routeForWorkerDeployment',
+      () =>
+        routeForWorkerDeployment({
+          namespace: 'default',
+          deployment: 'dep-1',
+        }),
+    ],
+    [
+      'routeForWorkerDeploymentVersion',
+      () =>
+        routeForWorkerDeploymentVersion({
+          namespace: 'default',
+          deployment: 'dep-1',
+          version: 'v1',
+        }),
+    ],
+    ['routeForRelationships', () => routeForRelationships(workflowParams)],
+    [
+      'routeForTaskQueue',
+      () => routeForTaskQueue({ namespace: 'default', queue: 'q-1' }),
+    ],
+    ['routeForCallStack', () => routeForCallStack(workflowParams)],
+    ['routeForWorkflowQuery', () => routeForWorkflowQuery(workflowParams)],
+    ['routeForUserMetadata', () => routeForUserMetadata(workflowParams)],
+    [
+      'routeForWorkflowSearchAttributes',
+      () => routeForWorkflowSearchAttributes(workflowParams),
+    ],
+    ['routeForWorkflowMemo', () => routeForWorkflowMemo(workflowParams)],
+    ['routeForWorkflowUpdate', () => routeForWorkflowUpdate(workflowParams)],
+    [
+      'routeForPendingActivities',
+      () => routeForPendingActivities(workflowParams),
+    ],
+    ['routeForNexusLinks', () => routeForNexusLinks(workflowParams)],
+    ['routeForEventHistoryImport', () => routeForEventHistoryImport()],
+    ['routeForBatchOperations', () => routeForBatchOperations(namespaceParams)],
+    [
+      'routeForBatchOperation',
+      () => routeForBatchOperation({ namespace: 'default', jobId: 'job-1' }),
+    ],
+    [
+      'routeForStandaloneActivities',
+      () => routeForStandaloneActivities(namespaceParams),
+    ],
+    [
+      'routeForStandaloneActivitiesWithQuery',
+      () =>
+        routeForStandaloneActivitiesWithQuery(namespaceParams, 'test-query'),
+    ],
+    [
+      'routeForStartStandaloneActivity',
+      () => routeForStartStandaloneActivity(namespaceParams),
+    ],
+    [
+      'routeForStandaloneActivityDetails',
+      () => routeForStandaloneActivityDetails(activityParams),
+    ],
+    [
+      'routeForStandaloneActivityWorkers',
+      () => routeForStandaloneActivityWorkers(activityParams),
+    ],
+    [
+      'routeForStandaloneActivitySearchAttributes',
+      () => routeForStandaloneActivitySearchAttributes(activityParams),
+    ],
+    [
+      'routeForStandaloneActivityMetadata',
+      () => routeForStandaloneActivityMetadata(activityParams),
+    ],
+    [
+      'routeForWorkflowStart',
+      () => routeForWorkflowStart({ namespace: 'default' }),
+    ],
+    [
+      'routeForWorkflowsWithQuery',
+      () => routeForWorkflowsWithQuery({ namespace: 'default', query: 'test' }),
+    ],
+  ];
+
+  const authCases: [string, () => string | undefined][] = [
+    [
+      'routeForAuthentication',
+      () =>
+        routeForAuthentication({
+          settings: { auth: {}, baseUrl: 'https://example.com' },
+          searchParams: new URLSearchParams(),
+        }),
+    ],
+    ['routeForLoginPage', () => routeForLoginPage('', false)],
+  ];
+
+  it.each(prefixedCases)(
+    '%s should include base + prefix when prefix is set',
+    (_name, fn) => {
+      routePrefix.set(prefix);
+      const result = fn();
+      expect(typeof result).toBe('string');
+      expect(result).toMatch(new RegExp(`^${base}${prefix}`));
+      expect(result).not.toMatch(
+        new RegExp(`${base}${prefix}${base}${prefix}`),
+      );
+    },
+  );
+
+  it.each(authCases)(
+    '%s should NOT include prefix (auth routes excluded)',
+    (_name, fn) => {
+      routePrefix.set(prefix);
+      const result = fn();
+      expect(typeof result).toBe('string');
+      expect(result).not.toContain(prefix);
+    },
+  );
 });

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { base } from '$app/paths';
+
+import { routePrefix } from '$lib/stores/route-prefix';
 
 import * as routeForModule from './route-for';
 import {
@@ -216,4 +218,174 @@ describe('routeFor functions should resolve the base path exactly once', () => {
       );
     }
   });
+});
+
+describe('routeFor functions with prefix should resolve base + prefix correctly', () => {
+  const prefix = '/projects/my-project';
+
+  const namespaceParams = { namespace: 'default' };
+  const workflowParams = {
+    namespace: 'default',
+    workflow: 'wf-id',
+    run: 'run-id',
+  };
+  const scheduleParams = { namespace: 'default', scheduleId: 'sched-1' };
+  const activityParams = {
+    namespace: 'default',
+    activityId: 'act-1',
+    runId: 'run-1',
+  };
+
+  afterEach(() => {
+    routePrefix.set('');
+  });
+
+  const prefixedCases: [string, () => string | undefined][] = [
+    ['routeForNamespaces', () => routeForNamespaces()],
+    ['routeForNexus', () => routeForNexus()],
+    ['routeForNexusEndpoint', () => routeForNexusEndpoint('ep-1')],
+    ['routeForNexusEndpointEdit', () => routeForNexusEndpointEdit('ep-1')],
+    ['routeForNexusEndpointCreate', () => routeForNexusEndpointCreate()],
+    ['routeForNamespace', () => routeForNamespace(namespaceParams)],
+    ['routeForNamespaceSelector', () => routeForNamespaceSelector()],
+    ['routeForWorkflows', () => routeForWorkflows(namespaceParams)],
+    [
+      'routeForArchivalWorkflows',
+      () => routeForArchivalWorkflows(namespaceParams),
+    ],
+    ['routeForWorkflow', () => routeForWorkflow(workflowParams)],
+    ['routeForSchedules', () => routeForSchedules(namespaceParams)],
+    ['routeForScheduleCreate', () => routeForScheduleCreate(namespaceParams)],
+    ['routeForSchedule', () => routeForSchedule(scheduleParams)],
+    ['routeForScheduleEdit', () => routeForScheduleEdit(scheduleParams)],
+    [
+      'routeForArchivalEventHistory',
+      () => routeForArchivalEventHistory(workflowParams),
+    ],
+    [
+      'routeForEventHistoryEvent',
+      () => routeForEventHistoryEvent({ ...workflowParams, eventId: '1' }),
+    ],
+    ['routeForEventHistory', () => routeForEventHistory(workflowParams)],
+    ['routeForTimeline', () => routeForTimeline(workflowParams)],
+    ['routeForWorkers', () => routeForWorkers(workflowParams)],
+    [
+      'routeForWorkerDeployments',
+      () => routeForWorkerDeployments(namespaceParams),
+    ],
+    [
+      'routeForWorkerDeployment',
+      () =>
+        routeForWorkerDeployment({
+          namespace: 'default',
+          deployment: 'dep-1',
+        }),
+    ],
+    [
+      'routeForWorkerDeploymentVersion',
+      () =>
+        routeForWorkerDeploymentVersion({
+          namespace: 'default',
+          deployment: 'dep-1',
+          version: 'v1',
+        }),
+    ],
+    ['routeForRelationships', () => routeForRelationships(workflowParams)],
+    [
+      'routeForTaskQueue',
+      () => routeForTaskQueue({ namespace: 'default', queue: 'q-1' }),
+    ],
+    ['routeForCallStack', () => routeForCallStack(workflowParams)],
+    ['routeForWorkflowQuery', () => routeForWorkflowQuery(workflowParams)],
+    ['routeForUserMetadata', () => routeForUserMetadata(workflowParams)],
+    [
+      'routeForWorkflowSearchAttributes',
+      () => routeForWorkflowSearchAttributes(workflowParams),
+    ],
+    ['routeForWorkflowMemo', () => routeForWorkflowMemo(workflowParams)],
+    ['routeForWorkflowUpdate', () => routeForWorkflowUpdate(workflowParams)],
+    [
+      'routeForPendingActivities',
+      () => routeForPendingActivities(workflowParams),
+    ],
+    ['routeForNexusLinks', () => routeForNexusLinks(workflowParams)],
+    ['routeForEventHistoryImport', () => routeForEventHistoryImport()],
+    ['routeForBatchOperations', () => routeForBatchOperations(namespaceParams)],
+    [
+      'routeForBatchOperation',
+      () => routeForBatchOperation({ namespace: 'default', jobId: 'job-1' }),
+    ],
+    [
+      'routeForStandaloneActivities',
+      () => routeForStandaloneActivities(namespaceParams),
+    ],
+    [
+      'routeForStandaloneActivitiesWithQuery',
+      () =>
+        routeForStandaloneActivitiesWithQuery(namespaceParams, 'test-query'),
+    ],
+    [
+      'routeForStartStandaloneActivity',
+      () => routeForStartStandaloneActivity(namespaceParams),
+    ],
+    [
+      'routeForStandaloneActivityDetails',
+      () => routeForStandaloneActivityDetails(activityParams),
+    ],
+    [
+      'routeForStandaloneActivityWorkers',
+      () => routeForStandaloneActivityWorkers(activityParams),
+    ],
+    [
+      'routeForStandaloneActivitySearchAttributes',
+      () => routeForStandaloneActivitySearchAttributes(activityParams),
+    ],
+    [
+      'routeForStandaloneActivityMetadata',
+      () => routeForStandaloneActivityMetadata(activityParams),
+    ],
+    [
+      'routeForWorkflowStart',
+      () => routeForWorkflowStart({ namespace: 'default' }),
+    ],
+    [
+      'routeForWorkflowsWithQuery',
+      () => routeForWorkflowsWithQuery({ namespace: 'default', query: 'test' }),
+    ],
+  ];
+
+  const authCases: [string, () => string | undefined][] = [
+    [
+      'routeForAuthentication',
+      () =>
+        routeForAuthentication({
+          settings: { auth: {}, baseUrl: 'https://example.com' },
+          searchParams: new URLSearchParams(),
+        }),
+    ],
+    ['routeForLoginPage', () => routeForLoginPage('', false)],
+  ];
+
+  it.each(prefixedCases)(
+    '%s should include base + prefix when prefix is set',
+    (_name, fn) => {
+      routePrefix.set(prefix);
+      const result = fn();
+      expect(typeof result).toBe('string');
+      expect(result).toMatch(new RegExp(`^${base}${prefix}`));
+      expect(result).not.toMatch(
+        new RegExp(`${base}${prefix}${base}${prefix}`),
+      );
+    },
+  );
+
+  it.each(authCases)(
+    '%s should NOT include prefix (auth routes excluded)',
+    (_name, fn) => {
+      routePrefix.set(prefix);
+      const result = fn();
+      expect(typeof result).toBe('string');
+      expect(result).not.toContain(prefix);
+    },
+  );
 });

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { base } from '$app/paths';
 
@@ -8,8 +8,8 @@ import type {
   EventSortOrder,
   WorkflowViewPreference,
 } from '$lib/stores/event-view';
-import { routePrefix } from '$lib/stores/route-prefix';
 
+import { initCoreProvider } from './core-provider';
 import {
   baseRouteForWorkflow,
   hasParameters,
@@ -567,31 +567,30 @@ describe('routeFor worker deployment version and serverless routes', () => {
 describe('routeFor with prefix', () => {
   const prefix = '/projects/my-project';
 
-  afterEach(() => {
-    routePrefix.set('');
+  beforeEach(() => {
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => prefix,
+    });
   });
 
   it('should prepend prefix to root route', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
   });
 
   it('should prepend prefix to namespace route', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespace({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default`,
     );
   });
 
   it('should propagate prefix through leaf functions', () => {
-    routePrefix.set(prefix);
     expect(routeForWorkflows({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default/workflows`,
     );
   });
 
   it('should propagate prefix through deep leaf functions', () => {
-    routePrefix.set(prefix);
     expect(
       routeForCallStack({
         namespace: 'default',
@@ -602,24 +601,24 @@ describe('routeFor with prefix', () => {
   });
 
   it('should propagate prefix to nexus routes', () => {
-    routePrefix.set(prefix);
     expect(routeForNexus()).toBe(`${base}${prefix}/nexus`);
   });
 
   it('should propagate prefix to schedule routes', () => {
-    routePrefix.set(prefix);
     expect(routeForSchedules({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default/schedules`,
     );
   });
 
   it('should not apply prefix when store is empty', () => {
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
     expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 
   it('should not apply prefix to auth routes', () => {
-    routePrefix.set(prefix);
     const settings = { auth: {}, baseUrl: 'https://localhost' };
     const searchParams = new URLSearchParams();
     const sso = routeForAuthentication({ settings, searchParams });
@@ -627,15 +626,16 @@ describe('routeFor with prefix', () => {
   });
 
   it('should not apply prefix to login page', () => {
-    routePrefix.set(prefix);
     const login = routeForLoginPage('', false);
     expect(login).not.toContain(prefix);
   });
 
   it('should revert to default behavior when prefix is cleared', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
     expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 });

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -8,6 +8,7 @@ import type {
   EventSortOrder,
   WorkflowViewPreference,
 } from '$lib/stores/event-view';
+import { routePrefix } from '$lib/stores/route-prefix';
 
 import {
   baseRouteForWorkflow,
@@ -24,6 +25,7 @@ import {
   routeForLoginPage,
   routeForNamespace,
   routeForNamespaces,
+  routeForNexus,
   routeForPendingActivities,
   routeForSchedule,
   routeForScheduleCreate,
@@ -528,5 +530,81 @@ describe('routeForWorkflow', () => {
     });
     expect(path).toContain('sort=ascending');
     expect(path).not.toContain('sort=descending');
+  });
+});
+
+describe('routeFor with prefix', () => {
+  const prefix = '/projects/my-project';
+
+  afterEach(() => {
+    routePrefix.set('');
+  });
+
+  it('should prepend prefix to root route', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
+  });
+
+  it('should prepend prefix to namespace route', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespace({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default`,
+    );
+  });
+
+  it('should propagate prefix through leaf functions', () => {
+    routePrefix.set(prefix);
+    expect(routeForWorkflows({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default/workflows`,
+    );
+  });
+
+  it('should propagate prefix through deep leaf functions', () => {
+    routePrefix.set(prefix);
+    expect(
+      routeForCallStack({
+        namespace: 'default',
+        workflow: 'abc',
+        run: 'def',
+      }),
+    ).toBe(`${base}${prefix}/namespaces/default/workflows/abc/def/call-stack`);
+  });
+
+  it('should propagate prefix to nexus routes', () => {
+    routePrefix.set(prefix);
+    expect(routeForNexus()).toBe(`${base}${prefix}/nexus`);
+  });
+
+  it('should propagate prefix to schedule routes', () => {
+    routePrefix.set(prefix);
+    expect(routeForSchedules({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default/schedules`,
+    );
+  });
+
+  it('should not apply prefix when store is empty', () => {
+    routePrefix.set('');
+    expect(routeForNamespaces()).toBe(`${base}/namespaces`);
+  });
+
+  it('should not apply prefix to auth routes', () => {
+    routePrefix.set(prefix);
+    const settings = { auth: {}, baseUrl: 'https://localhost' };
+    const searchParams = new URLSearchParams();
+    const sso = routeForAuthentication({ settings, searchParams });
+    expect(sso).not.toContain(prefix);
+  });
+
+  it('should not apply prefix to login page', () => {
+    routePrefix.set(prefix);
+    const login = routeForLoginPage('', false);
+    expect(login).not.toContain(prefix);
+  });
+
+  it('should revert to default behavior when prefix is cleared', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
+    routePrefix.set('');
+    expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 });

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -8,6 +8,7 @@ import type {
   EventSortOrder,
   WorkflowViewPreference,
 } from '$lib/stores/event-view';
+import { routePrefix } from '$lib/stores/route-prefix';
 
 import {
   baseRouteForWorkflow,
@@ -24,6 +25,7 @@ import {
   routeForLoginPage,
   routeForNamespace,
   routeForNamespaces,
+  routeForNexus,
   routeForPendingActivities,
   routeForSchedule,
   routeForScheduleCreate,
@@ -559,5 +561,81 @@ describe('routeFor worker deployment version and serverless routes', () => {
   it('should route to worker deployment create', () => {
     const path = routeForWorkerDeploymentCreate({ namespace: 'default' });
     expect(path).toBe(`${base}/namespaces/default/workers/deployments/create`);
+  });
+});
+
+describe('routeFor with prefix', () => {
+  const prefix = '/projects/my-project';
+
+  afterEach(() => {
+    routePrefix.set('');
+  });
+
+  it('should prepend prefix to root route', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
+  });
+
+  it('should prepend prefix to namespace route', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespace({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default`,
+    );
+  });
+
+  it('should propagate prefix through leaf functions', () => {
+    routePrefix.set(prefix);
+    expect(routeForWorkflows({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default/workflows`,
+    );
+  });
+
+  it('should propagate prefix through deep leaf functions', () => {
+    routePrefix.set(prefix);
+    expect(
+      routeForCallStack({
+        namespace: 'default',
+        workflow: 'abc',
+        run: 'def',
+      }),
+    ).toBe(`${base}${prefix}/namespaces/default/workflows/abc/def/call-stack`);
+  });
+
+  it('should propagate prefix to nexus routes', () => {
+    routePrefix.set(prefix);
+    expect(routeForNexus()).toBe(`${base}${prefix}/nexus`);
+  });
+
+  it('should propagate prefix to schedule routes', () => {
+    routePrefix.set(prefix);
+    expect(routeForSchedules({ namespace: 'default' })).toBe(
+      `${base}${prefix}/namespaces/default/schedules`,
+    );
+  });
+
+  it('should not apply prefix when store is empty', () => {
+    routePrefix.set('');
+    expect(routeForNamespaces()).toBe(`${base}/namespaces`);
+  });
+
+  it('should not apply prefix to auth routes', () => {
+    routePrefix.set(prefix);
+    const settings = { auth: {}, baseUrl: 'https://localhost' };
+    const searchParams = new URLSearchParams();
+    const sso = routeForAuthentication({ settings, searchParams });
+    expect(sso).not.toContain(prefix);
+  });
+
+  it('should not apply prefix to login page', () => {
+    routePrefix.set(prefix);
+    const login = routeForLoginPage('', false);
+    expect(login).not.toContain(prefix);
+  });
+
+  it('should revert to default behavior when prefix is cleared', () => {
+    routePrefix.set(prefix);
+    expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
+    routePrefix.set('');
+    expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 });

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { base } from '$app/paths';
 
@@ -8,8 +8,8 @@ import type {
   EventSortOrder,
   WorkflowViewPreference,
 } from '$lib/stores/event-view';
-import { routePrefix } from '$lib/stores/route-prefix';
 
+import { initCoreProvider } from './core-provider';
 import {
   baseRouteForWorkflow,
   hasParameters,
@@ -536,31 +536,30 @@ describe('routeForWorkflow', () => {
 describe('routeFor with prefix', () => {
   const prefix = '/projects/my-project';
 
-  afterEach(() => {
-    routePrefix.set('');
+  beforeEach(() => {
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => prefix,
+    });
   });
 
   it('should prepend prefix to root route', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
   });
 
   it('should prepend prefix to namespace route', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespace({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default`,
     );
   });
 
   it('should propagate prefix through leaf functions', () => {
-    routePrefix.set(prefix);
     expect(routeForWorkflows({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default/workflows`,
     );
   });
 
   it('should propagate prefix through deep leaf functions', () => {
-    routePrefix.set(prefix);
     expect(
       routeForCallStack({
         namespace: 'default',
@@ -571,24 +570,24 @@ describe('routeFor with prefix', () => {
   });
 
   it('should propagate prefix to nexus routes', () => {
-    routePrefix.set(prefix);
     expect(routeForNexus()).toBe(`${base}${prefix}/nexus`);
   });
 
   it('should propagate prefix to schedule routes', () => {
-    routePrefix.set(prefix);
     expect(routeForSchedules({ namespace: 'default' })).toBe(
       `${base}${prefix}/namespaces/default/schedules`,
     );
   });
 
   it('should not apply prefix when store is empty', () => {
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
     expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 
   it('should not apply prefix to auth routes', () => {
-    routePrefix.set(prefix);
     const settings = { auth: {}, baseUrl: 'https://localhost' };
     const searchParams = new URLSearchParams();
     const sso = routeForAuthentication({ settings, searchParams });
@@ -596,15 +595,16 @@ describe('routeFor with prefix', () => {
   });
 
   it('should not apply prefix to login page', () => {
-    routePrefix.set(prefix);
     const login = routeForLoginPage('', false);
     expect(login).not.toContain(prefix);
   });
 
   it('should revert to default behavior when prefix is cleared', () => {
-    routePrefix.set(prefix);
     expect(routeForNamespaces()).toBe(`${base}${prefix}/namespaces`);
-    routePrefix.set('');
+    initCoreProvider({
+      getAccessToken: async () => '',
+      getRoutePrefix: () => '',
+    });
     expect(routeForNamespaces()).toBe(`${base}/namespaces`);
   });
 });

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -2,17 +2,24 @@ import { get } from 'svelte/store';
 
 import { BROWSER } from 'esm-env';
 
-import { resolve } from '$app/paths';
+import { base, resolve } from '$app/paths';
 import type { ResolvedPathname } from '$app/types';
 
 import {
   eventFilterSort,
   workflowViewPreference,
 } from '$lib/stores/event-view';
+import { getRoutePrefix } from '$lib/stores/route-prefix';
 import type { EventView } from '$lib/types/events';
 import type { Settings } from '$lib/types/global';
 import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { toURL } from '$lib/utilities/to-url';
+
+const withPrefix = (path: ResolvedPathname): ResolvedPathname => {
+  const prefix = getRoutePrefix();
+  if (!prefix) return path;
+  return `${base}${prefix}${path.slice(base.length)}` as ResolvedPathname;
+};
 
 interface RouteParameters {
   namespace: string;
@@ -76,33 +83,33 @@ export interface StartActivityExecutionQueryParams {
 }
 
 export const routeForNamespaces = (): ResolvedPathname => {
-  return resolve('/namespaces', {});
+  return withPrefix(resolve('/namespaces', {}));
 };
 
 export const routeForNexus = (): ResolvedPathname => {
-  return resolve('/nexus', {});
+  return withPrefix(resolve('/nexus', {}));
 };
 
 export const routeForNexusEndpoint = (id: string): ResolvedPathname => {
-  return resolve('/nexus/[id]', { id });
+  return withPrefix(resolve('/nexus/[id]', { id }));
 };
 
 export const routeForNexusEndpointEdit = (id: string): ResolvedPathname => {
-  return resolve('/nexus/[id]/edit', { id });
+  return withPrefix(resolve('/nexus/[id]/edit', { id }));
 };
 
 export const routeForNexusEndpointCreate = (): ResolvedPathname => {
-  return resolve('/nexus/create', {});
+  return withPrefix(resolve('/nexus/create', {}));
 };
 
 export const routeForNamespace = ({
   namespace,
 }: NamespaceParameter): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]', { namespace });
+  return withPrefix(resolve('/namespaces/[namespace]', { namespace }));
 };
 
 export const routeForNamespaceSelector = (): ResolvedPathname => {
-  return resolve('/select-namespace', {});
+  return withPrefix(resolve('/select-namespace', {}));
 };
 
 export const routeForWorkflows = (
@@ -354,9 +361,11 @@ export const routeForWorkerDeployments = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]/workers/deployments', {
-    namespace,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/workers/deployments', {
+      namespace,
+    }),
+  );
 };
 
 export const routeForWorkerInstance = ({
@@ -381,10 +390,12 @@ export const routeForWorkerDeployment = ({
   deployment: string;
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
-  return resolve('/namespaces/[namespace]/workers/deployments/[deployment]', {
-    namespace,
-    deployment: deploymentName,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/workers/deployments/[deployment]', {
+      namespace,
+      deployment: deploymentName,
+    }),
+  );
 };
 
 export const routeForWorkerDeploymentVersion = ({
@@ -560,12 +571,14 @@ export const routeForEventHistoryImport = (
   view?: EventView,
 ): ResolvedPathname => {
   if (namespace && view) {
-    return resolve('/import/events/[namespace]/workflow/run/history/[view]', {
-      namespace,
-      view,
-    });
+    return withPrefix(
+      resolve('/import/events/[namespace]/workflow/run/history/[view]', {
+        namespace,
+        view,
+      }),
+    );
   }
-  return resolve('/import/events', {});
+  return withPrefix(resolve('/import/events', {}));
 };
 
 export const routeForBatchOperations = ({
@@ -573,9 +586,11 @@ export const routeForBatchOperations = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]/batch-operations', {
-    namespace,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/batch-operations', {
+      namespace,
+    }),
+  );
 };
 
 export const routeForBatchOperation = ({
@@ -587,10 +602,12 @@ export const routeForBatchOperation = ({
 }): ResolvedPathname => {
   const jId = encodeURIForSvelte(jobId);
 
-  return resolve('/namespaces/[namespace]/batch-operations/[jobId]', {
-    namespace,
-    jobId: jId,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/batch-operations/[jobId]', {
+      namespace,
+      jobId: jId,
+    }),
+  );
 };
 
 export const hasParameters =

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -377,10 +377,12 @@ export const routeForWorkerInstance = ({
   workerInstanceKey: string;
 }): ResolvedPathname => {
   const workerInstanceKeyEncoded = encodeURIForSvelte(workerInstanceKey);
-  return resolve('/namespaces/[namespace]/workers/[workerInstanceKey]', {
-    namespace,
-    workerInstanceKey: workerInstanceKeyEncoded,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/workers/[workerInstanceKey]', {
+      namespace,
+      workerInstanceKey: workerInstanceKeyEncoded,
+    }),
+  );
 };
 
 export const routeForWorkerDeployment = ({
@@ -422,12 +424,14 @@ export const routeForWorkerDeploymentVersionCreate = ({
   deployment: string;
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
-  return resolve(
-    '/namespaces/[namespace]/workers/deployments/[deployment]/versions/create',
-    {
-      namespace,
-      deployment: deploymentName,
-    },
+  return withPrefix(
+    resolve(
+      '/namespaces/[namespace]/workers/deployments/[deployment]/versions/create',
+      {
+        namespace,
+        deployment: deploymentName,
+      },
+    ),
   );
 };
 
@@ -442,13 +446,15 @@ export const routeForWorkerDeploymentVersionEdit = ({
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
   const buildIdEncoded = encodeURIForSvelte(buildId);
-  return resolve(
-    '/namespaces/[namespace]/workers/deployments/[deployment]/versions/[buildId]/edit',
-    {
-      namespace,
-      deployment: deploymentName,
-      buildId: buildIdEncoded,
-    },
+  return withPrefix(
+    resolve(
+      '/namespaces/[namespace]/workers/deployments/[deployment]/versions/[buildId]/edit',
+      {
+        namespace,
+        deployment: deploymentName,
+        buildId: buildIdEncoded,
+      },
+    ),
   );
 };
 
@@ -457,9 +463,11 @@ export const routeForWorkerDeploymentCreate = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]/workers/deployments/create', {
-    namespace,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/workers/deployments/create', {
+      namespace,
+    }),
+  );
 };
 
 export const routeForRelationships = (

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -2,17 +2,24 @@ import { get } from 'svelte/store';
 
 import { BROWSER } from 'esm-env';
 
-import { resolve } from '$app/paths';
+import { base, resolve } from '$app/paths';
 import type { ResolvedPathname } from '$app/types';
 
 import {
   eventFilterSort,
   workflowViewPreference,
 } from '$lib/stores/event-view';
+import { getRoutePrefix } from '$lib/stores/route-prefix';
 import type { EventView } from '$lib/types/events';
 import type { Settings } from '$lib/types/global';
 import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { toURL } from '$lib/utilities/to-url';
+
+const withPrefix = (path: ResolvedPathname): ResolvedPathname => {
+  const prefix = getRoutePrefix();
+  if (!prefix) return path;
+  return `${base}${prefix}${path.slice(base.length)}` as ResolvedPathname;
+};
 
 type RouteParameters = {
   namespace: string;
@@ -76,33 +83,33 @@ export interface StartActivityExecutionQueryParams {
 }
 
 export const routeForNamespaces = (): ResolvedPathname => {
-  return resolve('/namespaces', {});
+  return withPrefix(resolve('/namespaces', {}));
 };
 
 export const routeForNexus = (): ResolvedPathname => {
-  return resolve('/nexus', {});
+  return withPrefix(resolve('/nexus', {}));
 };
 
 export const routeForNexusEndpoint = (id: string): ResolvedPathname => {
-  return resolve('/nexus/[id]', { id });
+  return withPrefix(resolve('/nexus/[id]', { id }));
 };
 
 export const routeForNexusEndpointEdit = (id: string): ResolvedPathname => {
-  return resolve('/nexus/[id]/edit', { id });
+  return withPrefix(resolve('/nexus/[id]/edit', { id }));
 };
 
 export const routeForNexusEndpointCreate = (): ResolvedPathname => {
-  return resolve('/nexus/create', {});
+  return withPrefix(resolve('/nexus/create', {}));
 };
 
 export const routeForNamespace = ({
   namespace,
 }: NamespaceParameter): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]', { namespace });
+  return withPrefix(resolve('/namespaces/[namespace]', { namespace }));
 };
 
 export const routeForNamespaceSelector = (): ResolvedPathname => {
-  return resolve('/select-namespace', {});
+  return withPrefix(resolve('/select-namespace', {}));
 };
 
 export const routeForWorkflows = (
@@ -333,9 +340,11 @@ export const routeForWorkerDeployments = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]/worker-deployments', {
-    namespace,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/worker-deployments', {
+      namespace,
+    }),
+  );
 };
 
 export const routeForWorkerDeployment = ({
@@ -346,10 +355,12 @@ export const routeForWorkerDeployment = ({
   deployment: string;
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
-  return resolve('/namespaces/[namespace]/worker-deployments/[deployment]', {
-    namespace,
-    deployment: deploymentName,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/worker-deployments/[deployment]', {
+      namespace,
+      deployment: deploymentName,
+    }),
+  );
 };
 
 export const routeForWorkerDeploymentVersion = ({
@@ -477,12 +488,14 @@ export const routeForEventHistoryImport = (
   view?: EventView,
 ): ResolvedPathname => {
   if (namespace && view) {
-    return resolve('/import/events/[namespace]/workflow/run/history/[view]', {
-      namespace,
-      view,
-    });
+    return withPrefix(
+      resolve('/import/events/[namespace]/workflow/run/history/[view]', {
+        namespace,
+        view,
+      }),
+    );
   }
-  return resolve('/import/events', {});
+  return withPrefix(resolve('/import/events', {}));
 };
 
 export const routeForBatchOperations = ({
@@ -490,9 +503,11 @@ export const routeForBatchOperations = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return resolve('/namespaces/[namespace]/batch-operations', {
-    namespace,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/batch-operations', {
+      namespace,
+    }),
+  );
 };
 
 export const routeForBatchOperation = ({
@@ -504,10 +519,12 @@ export const routeForBatchOperation = ({
 }): ResolvedPathname => {
   const jId = encodeURIForSvelte(jobId);
 
-  return resolve('/namespaces/[namespace]/batch-operations/[jobId]', {
-    namespace,
-    jobId: jId,
-  });
+  return withPrefix(
+    resolve('/namespaces/[namespace]/batch-operations/[jobId]', {
+      namespace,
+      jobId: jId,
+    }),
+  );
 };
 
 export const hasParameters =

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -9,11 +9,12 @@ import {
   eventFilterSort,
   workflowViewPreference,
 } from '$lib/stores/event-view';
-import { getRoutePrefix } from '$lib/stores/route-prefix';
 import type { EventView } from '$lib/types/events';
 import type { Settings } from '$lib/types/global';
 import { encodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { toURL } from '$lib/utilities/to-url';
+
+import { getRoutePrefix } from './core-provider';
 
 const withPrefix = (path: ResolvedPathname): ResolvedPathname => {
   const prefix = getRoutePrefix();


### PR DESCRIPTION
## Summary

- Adds a `routePrefix` mechanism via `CoreProvider` that allows consuming projects (e.g., Temporal Cloud) to inject a path prefix into all UI route functions
- Introduces a `withPrefix` helper that inserts the prefix between the SvelteKit `base` path and the route path across the 12 root `resolve()` calls — leaf functions inherit the prefix automatically through existing string concatenation
- Auth routes (`routeForAuthentication`, `routeForLoginPage`) are explicitly excluded to avoid breaking SSO flows
- Moves `getRoutePrefix` to `CoreProvider` so the prefix is available globally and configured at initialization

## Changes

- **`core-provider.ts`**: Added `getRoutePrefix` to the `CoreProvider` type and `InitOptions`, with a default no-op returning `''`
- **`route-for.ts`**: Added `withPrefix()` helper wrapping all root route functions; auth routes left unwrapped
- **`hooks.client.ts`**: OSS init passes `getRoutePrefix: () => ''` to maintain current behavior
- **`route-for.test.ts`**: Added test suite verifying prefix propagation through root, namespace, workflow, nexus, and schedule routes, plus exclusion from auth routes
- **`route-for-base-path.test.ts`**: Added comprehensive parameterized tests covering all `routeFor` functions with prefix enabled, ensuring `base + prefix` appears exactly once and auth routes remain prefix-free

## Test plan

- [ ] `pnpm test -- --run` passes all new and existing route-for tests
- [ ] Verify OSS app behavior is unchanged (prefix defaults to empty string)
- [ ] Verify consuming project can set a prefix and all navigation routes include it
- [ ] Verify auth/login routes do not include the prefix