### PR TITLE
feat: add ability to search workflows by Activity ID

### DIFF
--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -24,6 +24,7 @@ export const searchAttributes: Readable<SearchAttributes> = derived(
   ([$allSearchAttributes]) => ({
     ...$allSearchAttributes.customAttributes,
     ...$allSearchAttributes.systemAttributes,
+    ActivityId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   }),
 );
 
@@ -172,6 +173,7 @@ export const sortedSearchAttributeOptions: Readable<SearchAttributeOption[]> =
       'WorkflowId',
       'WorkflowType',
       'RunId',
+      'ActivityId',
       'StartTime',
       'CloseTime',
     ];

--- a/src/lib/types/workflows.ts
+++ b/src/lib/types/workflows.ts
@@ -118,6 +118,7 @@ export type FilterParameters = {
   executionStatus?: WorkflowStatus;
   timeRange?: Duration | string;
   query?: string;
+  activityId?: string;
 };
 
 export type ArchiveFilterParameters = Omit<FilterParameters, 'timeRange'> & {

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -18,7 +18,8 @@ export type QueryKey =
   | 'CloseTime'
   | 'ExecutionTime'
   | 'ExecutionStatus'
-  | 'RunId';
+  | 'RunId'
+  | 'ActivityId';
 
 type FilterValue = string | Duration;
 
@@ -29,6 +30,7 @@ const filterKeys: Readonly<Record<string, QueryKey>> = {
   executionStatus: 'ExecutionStatus',
   closeTime: 'CloseTime',
   runId: 'RunId',
+  activityId: 'ActivityId',
 } as const;
 
 const isValid = (value: unknown, conditional: string): boolean => {

--- a/src/lib/utilities/query/list-workflow-query.ts
+++ b/src/lib/utilities/query/list-workflow-query.ts
@@ -14,14 +14,16 @@ export type QueryKey =
   | 'StartTime'
   | 'CloseTime'
   | 'ExecutionTime'
-  | 'ExecutionStatus';
+  | 'ExecutionStatus'
+  | 'ActivityId';
 
 export type FilterKey =
   | 'workflowId'
   | 'workflowType'
   | 'timeRange'
   | 'executionStatus'
-  | 'closeTime';
+  | 'closeTime'
+  | 'activityId';
 
 type FilterValue = string | Duration;
 
@@ -31,6 +33,7 @@ const queryKeys: Readonly<Record<string, QueryKey>> = {
   timeRange: 'StartTime',
   executionStatus: 'ExecutionStatus',
   closeTime: 'CloseTime',
+  activityId: 'ActivityId',
 } as const;
 
 const filterKeys: readonly FilterKey[] = [
@@ -39,6 +42,7 @@ const filterKeys: readonly FilterKey[] = [
   'timeRange',
   'executionStatus',
   'closeTime',
+  'activityId',
 ] as const;
 
 const isValid = (value: unknown): boolean => {

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -79,6 +79,7 @@ const DefaultAttributes: SearchAttributes = {
   WorkflowId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   WorkflowType: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   RunId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
+  ActivityId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
 };
 
 export const toListWorkflowFilters = (

--- a/src/lib/utilities/query/to-list-workflow-parameters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-parameters.test.ts
@@ -17,7 +17,8 @@ const defaultParameters = {
   workflowId: '',
   workflowType: '',
   executionStatus: null,
-  timeRange: null,
+  timeRange: undefined,
+  activityId: '',
 };
 
 describe('toListWorkflowParameters', () => {

--- a/src/lib/utilities/query/to-list-workflow-parameters.ts
+++ b/src/lib/utilities/query/to-list-workflow-parameters.ts
@@ -32,6 +32,7 @@ const isWorkflowTypeStatement = is('WorkflowType');
 const isWorkflowIdStatement = is('WorkflowId');
 const isStartTimeStatement = is('StartTime');
 const isExecutionStatusStatement = is('ExecutionStatus');
+const isActivityIdStatement = is('ActivityId');
 
 export const toListWorkflowParameters = (query: string): ParsedParameters => {
   const tokens = tokenize(query);
@@ -39,7 +40,8 @@ export const toListWorkflowParameters = (query: string): ParsedParameters => {
     workflowId: '',
     workflowType: '',
     executionStatus: null,
-    timeRange: null,
+    timeRange: undefined,
+    activityId: '',
   };
 
   tokens.forEach((token, index) => {
@@ -66,6 +68,9 @@ export const toListWorkflowParameters = (query: string): ParsedParameters => {
         console.error('Error parsing StartTime from query', error);
       }
     }
+
+    if (isActivityIdStatement(token))
+      parameters.activityId = getTwoAhead(tokens, index);
   });
 
   return parameters;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 

Closes #3249

Users who encounter activity failures see ActivityId in their application logs but have no way to search for the parent workflow in the UI. This PR adds ActivityId as a searchable attribute in the workflow filter bar, allowing users to find workflows containing a specific activity by its ID.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [X] Manual testing
- [X] E2E tests added
- [X] Unit tests added

Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️
1. Navigate to any namespace's workflow list page
2. Click the "Add Filter" button in the filter bar
3. Verify ActivityId appears in the dropdown (near the top, after RunId
4. Select ActivityId, enter an activity ID value, and confirm the query filters correctly
5. Toggle "View raw query" and verify the query contains ActivityId="<value>"

