### PR TITLE
feat: add onItemsChange callback to PaginatedTable

### DIFF
--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -32,6 +32,7 @@
     maxHeight?: string;
     onError?: ((error: Error | unknown) => void) | undefined;
     onFetch: () => Promise<PaginatedRequest<T>>;
+    onItemsChange?: (items: T[]) => void;
     onShiftUp?: KeyboardHandler;
     onShiftDown?: KeyboardHandler;
     onSpace?: KeyboardHandler;
@@ -51,6 +52,7 @@
   export let maxHeight = '';
   export let onError: ((error: Error) => void) | undefined = undefined;
   export let onFetch: () => Promise<PaginatedRequest<T>>;
+  export let onItemsChange: ((items: T[]) => void) | undefined = undefined;
   export let onShiftUp: KeyboardHandler = undefined;
   export let onShiftDown: KeyboardHandler = undefined;
   export let onSpace: KeyboardHandler = undefined;
@@ -180,6 +182,10 @@
         }
         break;
     }
+  }
+
+  $: if (onItemsChange && $store.visibleItems) {
+    onItemsChange($store.visibleItems);
   }
 
   $: adjustedTotal =

--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -184,7 +184,9 @@
     }
   }
 
-  $: if (onItemsChange && $store.visibleItems) {
+  let previousItems: T[] | undefined;
+  $: if (onItemsChange && $store.visibleItems !== previousItems) {
+    previousItems = $store.visibleItems;
     onItemsChange($store.visibleItems);
   }
 


### PR DESCRIPTION
## Summary

- Adds an optional `onItemsChange` callback prop to the `api-paginated` `PaginatedTable` component
- Fires whenever `$store.visibleItems` changes (initial fetch, page navigation, cached page, page size change)
- Follows the existing callback pattern used by `onError`, `onShiftUp`, `onShiftDown`, `onSpace`
- Enables consumers to react to visible table data changes without slot prop workarounds

**Motivation:** Cloud UI's billing invoices page ([DT-3724](https://temporalio.atlassian.net/browse/DT-3724)) needs to sync a chart component with the table's visible data. The current approach uses a comma expression in the slot to extract `visibleItems`, which is fragile. This callback provides a clean, first-class way to observe item changes.

This table needs the prop, for this chart.

<img width="1491" height="624" alt="Screenshot 2026-04-13 at 3 28 30 PM" src="https://github.com/user-attachments/assets/381954a6-faf9-4102-89bb-fb5cb1055985" />


## Test plan

I built ui and tested the new prop in cloud-ui locally. Works well.

- [x] Verify existing PaginatedTable behavior is unchanged when `onItemsChange` is not provided
- [x] Pass `onItemsChange` callback and verify it fires on initial load
- [x] Verify callback fires on forward/backward page navigation
- [x] Verify callback fires on cached page navigation (no new fetch)
- [x] Verify callback fires on page size change

[DT-3724]: https://temporalio.atlassian.net/browse/DT-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ