### PR TITLE
Adjust breadcrumb spacing and min-height

### DIFF
--- a/src/lib/holocene/navigation/cloud-nav-bar.svelte
+++ b/src/lib/holocene/navigation/cloud-nav-bar.svelte
@@ -30,9 +30,11 @@
 </script>
 
 <div
-  class="flex items-center justify-between pb-4 group-data-[nav=closed]:flex-col group-data-[nav=closed]:gap-2"
+  class="flex items-center justify-between pb-2 group-data-[nav=closed]:flex-col group-data-[nav=closed]:gap-2"
 >
-  <div class="flex flex-row items-center justify-start">
+  <div
+    class="flex flex-row items-center justify-start group-data-[nav=open]:min-h-7"
+  >
     <a href={resolve('', {})} class="text-inherit flex items-center">
       <Logo
         height={24}


### PR DESCRIPTION
This PR reduces bottom padding and adds a minimum height to the breadcrumb in the left nav to improve layout alignment and visual consistency in the navigation bar. Essentially, it addresses issue [no. 2 highlighted in this comment](https://github.com/temporalio/cloud-ui/pull/2276#issuecomment-4113508361).

| Before    | After |
| -------- | ------- |
| <img alt="Screenshot 2026-03-27 at 9 48 38 AM" src="https://private-user-images.githubusercontent.com/4129613/567961741-3376bada-8426-4748-b47e-a432384d37dd.gif?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzYxNzU3NTMsIm5iZiI6MTc3NjE3NTQ1MywicGF0aCI6Ii80MTI5NjEzLzU2Nzk2MTc0MS0zMzc2YmFkYS04NDI2LTQ3NDgtYjQ3ZS1hNDMyMzg0ZDM3ZGQuZ2lmP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI2MDQxNCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNjA0MTRUMTQwNDEzWiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NTNmNTQ2NjQxM2NmMzI4NWVkNjA0Y2YzMzAxMzhhNDBjOWIzNGI4MzAyZDE5MzE1ZmMyZTU5NjkzZjU3MzAxMCZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmcmVzcG9uc2UtY29udGVudC10eXBlPWltYWdlJTJGZ2lmIn0.8ldVO14H85yVNF0Fbnsmp314RbKgdTswsC2JSKGlHmE" />  |  <img alt="Screenshot 2026-03-27 at 9 47 59 AM" src="https://github.com/user-attachments/assets/b87188f9-f04d-4dc4-b1de-9bebd932dd47" />  |
