### PR TITLE
Keep Pending Activities/Operations at the top of Timeline and Compact view

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -280,9 +280,10 @@
       <Icon
         name={CategoryIcon[event.category].name}
         title={CategoryIcon[event.category].title}
-        class="mr-1 inline {isEventGroup(event) && event.isPending
-          ? ' animate-pulse'
-          : ''}"
+        class={merge(
+          'mr-1 inline',
+          isEventGroup(event) && event.isPending && 'animate-pulse',
+        )}
       />
       {displayName}
     </p>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -280,8 +280,7 @@
       <Icon
         name={CategoryIcon[event.category].name}
         title={CategoryIcon[event.category].title}
-        class="mr-1 inline{isEventGroup(event) &&
-        (event.pendingActivity || event.pendingNexusOperation)
+        class="mr-1 inline {isEventGroup(event) && event.isPending
           ? ' animate-pulse'
           : ''}"
       />

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -111,7 +111,11 @@
 
   const displayName = $derived(
     isEventGroup(event)
-      ? event.label
+      ? event.pendingActivity
+        ? translate('workflows.pending-activity')
+        : event.pendingNexusOperation
+          ? translate('workflows.pending-nexus-operation')
+          : event.label
       : isLocalActivityMarkerEvent(event)
         ? translate('events.category.local-activity')
         : spaceBetweenCapitalLetters(event.name),
@@ -276,7 +280,10 @@
       <Icon
         name={CategoryIcon[event.category].name}
         title={CategoryIcon[event.category].title}
-        class="mr-1 inline"
+        class="mr-1 inline{isEventGroup(event) &&
+        (event.pendingActivity || event.pendingNexusOperation)
+          ? ' animate-pulse'
+          : ''}"
       />
       {displayName}
     </p>

--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -14,6 +14,7 @@
     EventTypeCategory,
     IterableEventWithPending,
   } from '$lib/types/events';
+  import { orderGroupsByPending } from '$lib/utilities/order-groups-by-pending';
 
   export let history: IterableEventWithPending[];
   export let groups: EventGroups;
@@ -34,7 +35,7 @@
   $: pendingNexusOperations = workflow.pendingNexusOperations;
 
   $: items = compact
-    ? groups
+    ? orderGroupsByPending(groups, reverseSort)
     : reverseSort
       ? [...pendingNexusOperations, ...pendingActivities, ...history]
       : [...history, ...pendingActivities, ...pendingNexusOperations];

--- a/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
@@ -1,9 +1,6 @@
 <script lang="ts">
   import { timestamp } from '$lib/components/timestamp.svelte';
-  import type {
-    EventGroup,
-    EventGroups,
-  } from '$lib/models/event-groups/event-groups';
+  import type { EventGroups } from '$lib/models/event-groups/event-groups';
   import { activeGroupHeight, activeGroups } from '$lib/stores/active-events';
   import { fullEventHistory } from '$lib/stores/events';
   import { eventStatusFilter } from '$lib/stores/filters';
@@ -49,15 +46,14 @@
     scrollY = e?.target?.scrollTop;
   };
 
-  $: activeGroupsHeightAboveGroup = (group: EventGroup) => {
-    const groupIndex = filteredGroups.findIndex((g) => g.id === group.id);
-    const activeGroupIsAbove = $activeGroups?.filter((id) => {
-      const activeIndex = filteredGroups.findIndex((g) => g.id === id);
-      return activeIndex !== -1 && activeIndex < groupIndex;
-    });
+  $: groupIndexMap = new Map(filteredGroups.map((g, i) => [g.id, i]));
 
-    if (!activeGroupIsAbove?.length) return 0;
-    return expandedGroupHeight;
+  $: activeGroupsHeightAboveGroup = (groupIndex: number) => {
+    const hasActiveAbove = $activeGroups?.some((id) => {
+      const activeIndex = groupIndexMap.get(id);
+      return activeIndex !== undefined && activeIndex < groupIndex;
+    });
+    return hasActiveAbove ? expandedGroupHeight : 0;
   };
 </script>
 
@@ -110,7 +106,7 @@
       />
       <WorkflowRow {workflow} y={height} length={canvasWidth} />
       {#each filteredGroups as group, index (group.id)}
-        {@const y = (index + 2) * height + activeGroupsHeightAboveGroup(group)}
+        {@const y = (index + 2) * height + activeGroupsHeightAboveGroup(index)}
         {#if !viewportHeight || (y > scrollY - 2 * height && y < scrollY + viewportHeight * height)}
           {#key group.eventList.length}
             <TimelineGraphRow

--- a/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
@@ -5,7 +5,6 @@
     EventGroups,
   } from '$lib/models/event-groups/event-groups';
   import { activeGroupHeight, activeGroups } from '$lib/stores/active-events';
-  import { eventFilterSort } from '$lib/stores/event-view';
   import { fullEventHistory } from '$lib/stores/events';
   import { eventStatusFilter } from '$lib/stores/filters';
   import type { WorkflowExecution } from '$lib/types/workflows';
@@ -51,10 +50,10 @@
   };
 
   $: activeGroupsHeightAboveGroup = (group: EventGroup) => {
+    const groupIndex = filteredGroups.findIndex((g) => g.id === group.id);
     const activeGroupIsAbove = $activeGroups?.filter((id) => {
-      if ($eventFilterSort === 'ascending')
-        return parseInt(id) < parseInt(group.id);
-      return parseInt(id) > parseInt(group.id);
+      const activeIndex = filteredGroups.findIndex((g) => g.id === id);
+      return activeIndex !== -1 && activeIndex < groupIndex;
     });
 
     if (!activeGroupIsAbove?.length) return 0;

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -33,6 +33,7 @@
     updateEventFilterParams,
   } from '$lib/utilities/event-filter-params';
   import { getWorkflowTaskFailedEvent } from '$lib/utilities/get-workflow-task-failed-event';
+  import { orderGroupsByPending } from '$lib/utilities/order-groups-by-pending';
 
   const { namespace } = $derived(page.params);
   const { workflow } = $derived($workflowRun);
@@ -84,7 +85,7 @@
 
   let items = $derived(
     (compact
-      ? groups
+      ? orderGroupsByPending(groups, reverseSort)
       : reverseSort
         ? [...pendingNexusOperations, ...pendingActivities, ...history]
         : [...history, ...pendingActivities, ...pendingNexusOperations]) as

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -26,6 +26,7 @@
     updateEventFilterParams,
   } from '$lib/utilities/event-filter-params';
   import { getWorkflowTaskFailedEvent } from '$lib/utilities/get-workflow-task-failed-event';
+  import { orderGroupsByPending } from '$lib/utilities/order-groups-by-pending';
 
   $: ({ namespace } = $page.params);
   $: ({ workflow } = $workflowRun);
@@ -47,7 +48,10 @@
     pendingNexusOperations,
   );
 
-  $: groups = reverseSort ? [...ascendingGroups].reverse() : ascendingGroups;
+  $: groups = orderGroupsByPending(
+    reverseSort ? [...ascendingGroups].reverse() : ascendingGroups,
+    reverseSort,
+  );
 
   $: workflowTaskFailedError = getWorkflowTaskFailedEvent(
     $currentEventHistory,

--- a/src/lib/utilities/order-groups-by-pending.test.ts
+++ b/src/lib/utilities/order-groups-by-pending.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EventGroup } from '$lib/models/event-groups/event-groups';
+
+import { orderGroupsByPending } from './order-groups-by-pending';
+
+const pendingGroup = (id: string) =>
+  ({ id, isPending: true }) as unknown as EventGroup;
+const completedGroup = (id: string) =>
+  ({ id, isPending: false }) as unknown as EventGroup;
+
+describe('orderGroupsByPending', () => {
+  it('should put pending groups first when descending', () => {
+    const groups = [
+      completedGroup('1'),
+      pendingGroup('2'),
+      completedGroup('3'),
+    ];
+    const result = orderGroupsByPending(groups, true);
+    expect(result.map((g) => g.id)).toEqual(['2', '1', '3']);
+  });
+
+  it('should put pending groups last when ascending', () => {
+    const groups = [
+      completedGroup('1'),
+      pendingGroup('2'),
+      completedGroup('3'),
+    ];
+    const result = orderGroupsByPending(groups, false);
+    expect(result.map((g) => g.id)).toEqual(['1', '3', '2']);
+  });
+
+  it('should preserve relative order within pending and non-pending subsets', () => {
+    const groups = [
+      pendingGroup('10'),
+      completedGroup('3'),
+      pendingGroup('5'),
+      completedGroup('7'),
+    ];
+    const result = orderGroupsByPending(groups, true);
+    expect(result.map((g) => g.id)).toEqual(['10', '5', '3', '7']);
+  });
+
+  it('should return groups in original order when no groups are pending', () => {
+    const groups = [
+      completedGroup('1'),
+      completedGroup('2'),
+      completedGroup('3'),
+    ];
+    const descResult = orderGroupsByPending(groups, true);
+    const ascResult = orderGroupsByPending(groups, false);
+    expect(descResult.map((g) => g.id)).toEqual(['1', '2', '3']);
+    expect(ascResult.map((g) => g.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('should return groups in original order when all groups are pending', () => {
+    const groups = [pendingGroup('1'), pendingGroup('2'), pendingGroup('3')];
+    const descResult = orderGroupsByPending(groups, true);
+    const ascResult = orderGroupsByPending(groups, false);
+    expect(descResult.map((g) => g.id)).toEqual(['1', '2', '3']);
+    expect(ascResult.map((g) => g.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('should return empty array for empty input', () => {
+    expect(orderGroupsByPending([], true)).toEqual([]);
+    expect(orderGroupsByPending([], false)).toEqual([]);
+  });
+
+  it('should not mutate the input array', () => {
+    const groups = [
+      completedGroup('1'),
+      pendingGroup('2'),
+      completedGroup('3'),
+    ];
+    const original = [...groups];
+    orderGroupsByPending(groups, true);
+    expect(groups).toEqual(original);
+  });
+});

--- a/src/lib/utilities/order-groups-by-pending.ts
+++ b/src/lib/utilities/order-groups-by-pending.ts
@@ -4,10 +4,9 @@ export const orderGroupsByPending = (
   groups: EventGroups,
   reverseSort: boolean,
 ): EventGroups => {
-  const pendingGroups = groups.filter((g) => g.isPending);
-  const nonPendingGroups = groups.filter((g) => !g.isPending);
-
-  return reverseSort
-    ? [...pendingGroups, ...nonPendingGroups]
-    : [...nonPendingGroups, ...pendingGroups];
+  return groups.toSorted((a, b) => {
+    if (a.isPending === b.isPending) return 0;
+    if (a.isPending) return reverseSort ? -1 : 1;
+    return reverseSort ? 1 : -1;
+  });
 };

--- a/src/lib/utilities/order-groups-by-pending.ts
+++ b/src/lib/utilities/order-groups-by-pending.ts
@@ -1,0 +1,13 @@
+import type { EventGroups } from '$lib/models/event-groups/event-groups';
+
+export const orderGroupsByPending = (
+  groups: EventGroups,
+  reverseSort: boolean,
+): EventGroups => {
+  const pendingGroups = groups.filter((g) => g.isPending);
+  const nonPendingGroups = groups.filter((g) => !g.isPending);
+
+  return reverseSort
+    ? [...pendingGroups, ...nonPendingGroups]
+    : [...nonPendingGroups, ...pendingGroups];
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->
Make it easier for our users to find pending activities and operations without needing to scroll to find them.

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Summary

  - Pending activities and nexus operations now consistently appear at the top of Compact and Timeline views (descending) or bottom (ascending), matching the existing All view behavior
  - Compact view pending groups display "Pending Activity" / "Pending Nexus Operation" as the event type with a pulsing icon, matching the All view presentation
  - Fixed a bug in the timeline's activeGroupsHeightAboveGroup that used numeric ID comparison to determine row ordering — replaced with index-based comparison that works correctly regardless of group reordering

### Test plan

  - Open a workflow with pending activities in descending order
  - Verify All view shows pending activities at the top (existing behavior, unchanged)
  - Switch to Compact view — pending groups should appear at the top with "Pending Activity" label and pulsing icon
  - Switch to Timeline view — pending groups should appear as the topmost rows
  - Toggle to ascending sort — pending groups should move to the bottom in all three views
  - Verify expanding a group row in Timeline view does not overlap adjacent rows
  - Test with the failed/pending status filter enabled in Timeline view
  - Verify workflows with no pending activities render normally in all views
  - Unit tests pass: pnpm test -- --run src/lib/utilities/order-groups-by-pending.test.ts
 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1728" height="907" alt="Screenshot 2026-04-14 at 2 08 30 PM" src="https://github.com/user-attachments/assets/1973d856-0501-460e-9ee4-d9bc5d511afc" />
<img width="1658" height="782" alt="Screenshot 2026-04-14 at 2 12 30 PM" src="https://github.com/user-attachments/assets/e8ad793e-3060-4fdf-87a4-639a591e9932" />
<img width="1657" height="574" alt="Screenshot 2026-04-14 at 3 07 38 PM" src="https://github.com/user-attachments/assets/0303eddd-5291-4e71-af1e-9d0e31d55bf8" />



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
