### PR TITLE
Update pre-release badge to secondary in Workers

### DIFF
--- a/src/lib/layouts/workers-layout.svelte
+++ b/src/lib/layouts/workers-layout.svelte
@@ -30,7 +30,7 @@
         href={workersHref}
         active={page.url.pathname.endsWith('/workers')}
       >
-        <Badge type="secondary" class="shrink-0">Pre-Release</Badge>
+        <Badge type="secondary" class="shrink-0">Pre-release</Badge>
       </Tab>
       <Tab
         label={translate('deployments.deployments')}

--- a/src/lib/layouts/workers-layout.svelte
+++ b/src/lib/layouts/workers-layout.svelte
@@ -30,7 +30,7 @@
         href={workersHref}
         active={page.url.pathname.endsWith('/workers')}
       >
-        <Badge class="shrink-0">Pre-Release</Badge>
+        <Badge type="secondary" class="shrink-0">Pre-Release</Badge>
       </Tab>
       <Tab
         label={translate('deployments.deployments')}


### PR DESCRIPTION
Nit: This PR updates "Pre-release" badge in Workers page to align with what's used in Standalone Activities. #forconsistency