### PR TITLE
Child Workflow Timeline stuttering with scrollbars on

### DIFF
--- a/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph.svelte
@@ -59,7 +59,7 @@
 
 <div
   id="event-history-timeline-graph"
-  class="relative h-auto overflow-auto border border-t-0 border-subtle bg-primary"
+  class="relative h-auto overflow-auto border border-t-0 border-subtle bg-primary [scrollbar-gutter:stable]"
   bind:clientWidth={canvasWidth}
   style={viewportHeight ? `max-height: ${viewportHeight}px;` : ''}
   on:scroll={handleScroll}


### PR DESCRIPTION
## Summary

Implements DT-3695: Child Workflow Timeline stuttering with scrollbars on

Adds `[scrollbar-gutter:stable]` to the outer `<div>` in `timeline-graph.svelte` — the element with `bind:clientWidth={canvasWidth}` that drives SVG sizing. On OSes that always show scrollbars (Windows, macOS "Always"), the vertical scrollbar was toggling on/off due to height interaction with the 320px `max-height`, changing `clientWidth` each toggle and re-triggering SVG re-renders in a feedback loop. Reserving a stable gutter keeps `clientWidth` constant regardless of scrollbar state, breaking the loop.

No visible change on overlay-scrollbar OSes (default macOS/Linux); the existing 48px SVG gutter absorbs the reserved space.

## Test plan

- [ ] macOS with "Show scroll bars: Always": expand a parent workflow's child-workflow group that has a pending activity — timeline should render at stable width with no stutter
- [ ] Default macOS (overlay scrollbars): same workflow — no visible layout change vs. before the fix
- [ ] Inspect `#event-history-timeline-graph` in devtools — `scrollbar-gutter: stable` should be computed on it
- [ ] `pnpm check` and `pnpm lint` pass with no new errors