### PR TITLE
feat: add showInstancesLink prop to deployment header

### DIFF
--- a/src/lib/components/deployments/deployment-header.svelte
+++ b/src/lib/components/deployments/deployment-header.svelte
@@ -14,11 +14,17 @@
     namespace: string;
     deploymentName: string;
     hasVersions: boolean;
+    showInstancesLink?: boolean;
     onDeleteClick: () => void;
   }
 
-  let { namespace, deploymentName, hasVersions, onDeleteClick }: Props =
-    $props();
+  let {
+    namespace,
+    deploymentName,
+    hasVersions,
+    showInstancesLink = true,
+    onDeleteClick,
+  }: Props = $props();
 
   const workflowHref = $derived(
     routeForWorkflowsWithQuery({
@@ -40,10 +46,12 @@
     <Link href={routeForWorkerDeployments({ namespace })} icon="chevron-left">
       {translate('deployments.back-to-deployments')}
     </Link>
-    <span class="text-secondary">|</span>
-    <Link href={instancesHref}>
-      {translate('deployments.go-to-instances')}
-    </Link>
+    {#if showInstancesLink}
+      <span class="text-secondary">|</span>
+      <Link href={instancesHref}>
+        {translate('deployments.go-to-instances')}
+      </Link>
+    {/if}
   </div>
 
   <div class="flex w-full items-center justify-between">

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -20,9 +20,10 @@
 
   interface Props {
     deploymentPromise?: Promise<WorkerDeploymentResponse>;
+    showInstancesLink?: boolean;
   }
 
-  let { deploymentPromise }: Props = $props();
+  let { deploymentPromise, showInstancesLink = true }: Props = $props();
 
   const { namespace } = $derived(page.params);
   const deploymentName = $derived(decodeURIForSvelte(page.params.deployment));
@@ -56,6 +57,7 @@
     {namespace}
     {deploymentName}
     hasVersions={!!info.versionSummaries?.length}
+    {showInstancesLink}
     onDeleteClick={() => (showDeleteModal = true)}
   />
 


### PR DESCRIPTION
## Summary

- Adds optional `showInstancesLink` prop (default `true`) to `DeploymentHeader`
- Threads the prop through `deployment.svelte` so callers can hide the "Go to Instances" link
- Needed by cloud-ui to gate the link behind the `enable_worker_insights` feature flag per [this review comment](https://github.com/temporalio/cloud-ui/pull/2470#pullrequestreview-4148938694)

## Test plan

- [ ] Verify "Go to Instances" still shows by default (no prop change needed for OSS deployments)
- [ ] Verify cloud-ui can pass `showInstancesLink={false}` to hide the link when `enable_worker_insights` is disabled