### PR TITLE
Guard getApiOrigin against undefined VITE_API

### DIFF
--- a/src/lib/utilities/get-api-origin.test.ts
+++ b/src/lib/utilities/get-api-origin.test.ts
@@ -44,4 +44,10 @@ describe('getApiOrigin', () => {
     const url = getApiOrigin(false);
     expect(url).toBe('');
   });
+
+  it('should return null when VITE_API is undefined', () => {
+    delete import.meta.env.VITE_API;
+    expect(() => getApiOrigin()).not.toThrow();
+    expect(getApiOrigin()).toBeNull();
+  });
 });

--- a/src/lib/utilities/get-api-origin.ts
+++ b/src/lib/utilities/get-api-origin.ts
@@ -2,6 +2,7 @@ import { BROWSER } from 'esm-env';
 
 export function getApiOrigin(isBrowser = BROWSER): string | null {
   const endpoint = import.meta.env.VITE_API;
+  if (endpoint === undefined) return null;
   const isRelative = !endpoint.startsWith('http');
 
   let origin = '';


### PR DESCRIPTION
## Summary

Implements - Refreshing worker deployment versioning page throws error

On page refresh, the load function calls `fetchDeployment()` → `routeForApi()` → `base()` → `getApiOrigin()`. During load, neither `page.data?.webUrl` nor `globalThis.AppConfig.apiUrl` is available, so `base()` falls through to `getApiOrigin()`. There, `import.meta.env.VITE_API` is `undefined` in cloud-ui consumer environments, causing `TypeError: Cannot read properties of undefined (reading 'startsWith')`.

**Fix:** add `if (endpoint === undefined) return null;` guard before the `startsWith` call. Uses strict equality (not `!endpoint`) to preserve the existing behaviour when `VITE_API` is an empty string.

## Test plan

- [x] New unit test: `should return null when VITE_API is undefined` — verifies no throw and null return
- [x] Existing tests all pass (`pnpm test -- --run`: 137 files, 1798 tests)
- [x] `pnpm lint` clean
- [x] `pnpm check` no new errors
- [x] `pnpm build:server` succeeds