### PR TITLE
Remove "Dispatch Rate Epsilon" input from compute scaling config

### DIFF
--- a/src/lib/components/deployments/version-compute-details.svelte
+++ b/src/lib/components/deployments/version-compute-details.svelte
@@ -17,7 +17,6 @@
     scalerParams.scaleUpCooloffMs !== undefined ||
       scalerParams.scaleUpBacklogThreshold !== undefined ||
       scalerParams.maxWorkerLifetimeMs !== undefined ||
-      scalerParams.scaleUpDispatchRateEpsilon !== undefined ||
       scalerParams.metricsPollIntervalMs !== undefined,
   );
 </script>
@@ -87,16 +86,6 @@
             >
             <span class="text-primary"
               >{scalerParams.maxWorkerLifetimeMs}ms</span
-            >
-          </div>
-        {/if}
-        {#if scalerParams.scaleUpDispatchRateEpsilon !== undefined}
-          <div class="flex gap-1">
-            <span class="font-medium text-secondary"
-              >{translate('deployments.dispatch-rate-epsilon')}</span
-            >
-            <span class="text-primary"
-              >{scalerParams.scaleUpDispatchRateEpsilon}</span
             >
           </div>
         {/if}

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -10,7 +10,6 @@
     scaleUpCooloffMs?: number;
     scaleUpBacklogThreshold?: number;
     maxWorkerLifetimeMs?: number;
-    scaleUpDispatchRateEpsilon?: number;
     metricsPollIntervalMs?: number;
     errors?: {
       lambdaArn?: string[];
@@ -19,7 +18,6 @@
       scaleUpCooloffMs?: string[];
       scaleUpBacklogThreshold?: string[];
       maxWorkerLifetimeMs?: string[];
-      scaleUpDispatchRateEpsilon?: string[];
       metricsPollIntervalMs?: string[];
     };
   }
@@ -31,7 +29,6 @@
     scaleUpCooloffMs = $bindable(),
     scaleUpBacklogThreshold = $bindable(),
     maxWorkerLifetimeMs = $bindable(),
-    scaleUpDispatchRateEpsilon = $bindable(),
     metricsPollIntervalMs = $bindable(),
     errors = {},
   }: Props = $props();
@@ -134,22 +131,6 @@
         translate('workers.max-worker-lifetime-ms-hint')}
       error={!!errors.maxWorkerLifetimeMs?.[0]}
       placeholder="600000"
-    />
-    <Input
-      value={scaleUpDispatchRateEpsilon !== undefined
-        ? String(scaleUpDispatchRateEpsilon)
-        : ''}
-      onchange={(e) => {
-        const val = (e.target as HTMLInputElement).value;
-        scaleUpDispatchRateEpsilon = val === '' ? undefined : Number(val);
-      }}
-      id="scaleUpDispatchRateEpsilon"
-      name="scaleUpDispatchRateEpsilon"
-      label={translate('workers.scale-up-dispatch-rate-epsilon-label')}
-      hintText={errors.scaleUpDispatchRateEpsilon?.[0] ||
-        translate('workers.scale-up-dispatch-rate-epsilon-hint')}
-      error={!!errors.scaleUpDispatchRateEpsilon?.[0]}
-      placeholder="0"
     />
     <Input
       value={metricsPollIntervalMs !== undefined

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -32,7 +32,6 @@
       scaleUpCooloffMs: undefined as number | undefined,
       scaleUpBacklogThreshold: undefined as number | undefined,
       maxWorkerLifetimeMs: undefined as number | undefined,
-      scaleUpDispatchRateEpsilon: undefined as number | undefined,
       metricsPollIntervalMs: undefined as number | undefined,
     },
     {
@@ -92,7 +91,6 @@
           bind:scaleUpCooloffMs={$form.scaleUpCooloffMs}
           bind:scaleUpBacklogThreshold={$form.scaleUpBacklogThreshold}
           bind:maxWorkerLifetimeMs={$form.maxWorkerLifetimeMs}
-          bind:scaleUpDispatchRateEpsilon={$form.scaleUpDispatchRateEpsilon}
           bind:metricsPollIntervalMs={$form.metricsPollIntervalMs}
           errors={$errors}
         />

--- a/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
@@ -20,7 +20,6 @@
       scaleUpCooloffMs?: number;
       scaleUpBacklogThreshold?: number;
       maxWorkerLifetimeMs?: number;
-      scaleUpDispatchRateEpsilon?: number;
       metricsPollIntervalMs?: number;
     };
     onSubmit: (data: EditVersionFormData) => Promise<void>;
@@ -41,7 +40,6 @@
       scaleUpCooloffMs: initialData.scaleUpCooloffMs,
       scaleUpBacklogThreshold: initialData.scaleUpBacklogThreshold,
       maxWorkerLifetimeMs: initialData.maxWorkerLifetimeMs,
-      scaleUpDispatchRateEpsilon: initialData.scaleUpDispatchRateEpsilon,
       metricsPollIntervalMs: initialData.metricsPollIntervalMs,
     },
     {
@@ -81,7 +79,6 @@
           bind:scaleUpCooloffMs={$form.scaleUpCooloffMs}
           bind:scaleUpBacklogThreshold={$form.scaleUpBacklogThreshold}
           bind:maxWorkerLifetimeMs={$form.maxWorkerLifetimeMs}
-          bind:scaleUpDispatchRateEpsilon={$form.scaleUpDispatchRateEpsilon}
           bind:metricsPollIntervalMs={$form.metricsPollIntervalMs}
           errors={$errors}
         />

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
@@ -51,7 +51,6 @@
     scaleUpCooloffMs: undefined as number | undefined,
     scaleUpBacklogThreshold: undefined as number | undefined,
     maxWorkerLifetimeMs: undefined as number | undefined,
-    scaleUpDispatchRateEpsilon: undefined as number | undefined,
     metricsPollIntervalMs: undefined as number | undefined,
   };
 
@@ -134,7 +133,6 @@
             bind:scaleUpCooloffMs={$form.scaleUpCooloffMs}
             bind:scaleUpBacklogThreshold={$form.scaleUpBacklogThreshold}
             bind:maxWorkerLifetimeMs={$form.maxWorkerLifetimeMs}
-            bind:scaleUpDispatchRateEpsilon={$form.scaleUpDispatchRateEpsilon}
             bind:metricsPollIntervalMs={$form.metricsPollIntervalMs}
             errors={$errors}
           />

--- a/src/lib/components/workers/serverless-worker-form/shared.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.ts
@@ -19,7 +19,6 @@ const scalingFields = {
   scaleUpCooloffMs: z.number().int().min(0).optional(),
   scaleUpBacklogThreshold: z.number().int().min(0).optional(),
   maxWorkerLifetimeMs: z.number().int().min(0).optional(),
-  scaleUpDispatchRateEpsilon: z.number().min(0).optional(),
   metricsPollIntervalMs: z.number().int().min(10000).optional(),
 };
 

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -71,7 +71,6 @@ export const Strings = {
   'scale-up-cooloff': 'Scale-up Cooloff',
   'backlog-threshold': 'Backlog Threshold',
   'max-worker-lifetime': 'Max Worker Lifetime',
-  'dispatch-rate-epsilon': 'Dispatch Rate Epsilon',
   'metrics-poll-interval': 'Metrics Poll Interval',
   'filter-deployments': 'Filter deployments',
   'drainage-status': 'Drainage Status',

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -281,9 +281,6 @@ export const Strings = {
   'max-worker-lifetime-ms-label': 'Max Worker Lifetime (ms)',
   'max-worker-lifetime-ms-hint':
     'Refresh a worker after this many ms when there is backlog. 0 = disabled. Default: 600000.',
-  'scale-up-dispatch-rate-epsilon-label': 'Dispatch Rate Epsilon',
-  'scale-up-dispatch-rate-epsilon-hint':
-    'Suppress scale-up when processing rate change is within this value. 0 = disabled.',
   'metrics-poll-interval-ms-label': 'Metrics Poll Interval (ms)',
   'metrics-poll-interval-ms-hint':
     'Interval between metrics polls. Min: 10000. Default: 60000.',

--- a/src/lib/pages/serverless-worker-create.svelte
+++ b/src/lib/pages/serverless-worker-create.svelte
@@ -80,7 +80,6 @@
         scaleUpCooloffMs: data.scaleUpCooloffMs,
         scaleUpBacklogThreshold: data.scaleUpBacklogThreshold,
         maxWorkerLifetimeMs: data.maxWorkerLifetimeMs,
-        scaleUpDispatchRateEpsilon: data.scaleUpDispatchRateEpsilon,
         metricsPollIntervalMs: data.metricsPollIntervalMs,
       },
     );

--- a/src/lib/pages/worker-deployment-version-create.svelte
+++ b/src/lib/pages/worker-deployment-version-create.svelte
@@ -45,7 +45,6 @@
           scaleUpCooloffMs: data.scaleUpCooloffMs,
           scaleUpBacklogThreshold: data.scaleUpBacklogThreshold,
           maxWorkerLifetimeMs: data.maxWorkerLifetimeMs,
-          scaleUpDispatchRateEpsilon: data.scaleUpDispatchRateEpsilon,
           metricsPollIntervalMs: data.metricsPollIntervalMs,
         },
       );

--- a/src/lib/pages/worker-deployment-version-edit.svelte
+++ b/src/lib/pages/worker-deployment-version-edit.svelte
@@ -59,7 +59,6 @@
         scaleUpCooloffMs: scalerDetails.scaleUpCooloffMs,
         scaleUpBacklogThreshold: scalerDetails.scaleUpBacklogThreshold,
         maxWorkerLifetimeMs: scalerDetails.maxWorkerLifetimeMs,
-        scaleUpDispatchRateEpsilon: scalerDetails.scaleUpDispatchRateEpsilon,
         metricsPollIntervalMs: scalerDetails.metricsPollIntervalMs,
       }}
       cancelHref={backHref}
@@ -73,7 +72,6 @@
             scaleUpCooloffMs: data.scaleUpCooloffMs,
             scaleUpBacklogThreshold: data.scaleUpBacklogThreshold,
             maxWorkerLifetimeMs: data.maxWorkerLifetimeMs,
-            scaleUpDispatchRateEpsilon: data.scaleUpDispatchRateEpsilon,
             metricsPollIntervalMs: data.metricsPollIntervalMs,
           },
         );


### PR DESCRIPTION
## Summary

Implements: removes the `scaleUpDispatchRateEpsilon` ("Dispatch Rate Epsilon") input from the serverless worker compute scaling configuration UI per feedback from Muneeb Ahmad.

This is a UI-only removal. The service layer API mapping remains intact so the backend contract is unchanged and existing deployments are unaffected.

**Files changed:**
- `compute-fields.svelte` — remove Input block, Props entry, and destructure
- `shared.ts` — remove field from Zod `scalingFields` schema
- `serverless-worker-create-form.svelte` — remove initial data + bind prop
- `create-version-form.svelte` — remove initial data + bind prop
- `edit-version-form.svelte` — remove Props interface entry, initial data, and bind prop
- `serverless-worker-create.svelte` — remove from `buildLambdaComputeConfig` call
- `worker-deployment-version-create.svelte` — same
- `worker-deployment-version-edit.svelte` — same (2 references)
- `version-compute-details.svelte` — remove read-only display row
- `en/workers.ts` — remove label and hint i18n keys
- `en/deployments.ts` — remove `dispatch-rate-epsilon` i18n key

## Test plan

- [ ] `pnpm check` passes (0 errors)
- [ ] `pnpm lint` passes (0 errors)
- [ ] `pnpm test -- --run` passes (1797 tests)
- [ ] Serverless worker create form — no Dispatch Rate Epsilon field visible
- [ ] Create version form — no Dispatch Rate Epsilon field visible
- [ ] Edit version form — no Dispatch Rate Epsilon field visible
- [ ] Version compute details — no Dispatch Rate Epsilon row visible