### PR TITLE
Bump Go toolchain to 1.26.2 for CVE fix

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 pnpm 10.10.0
 nodejs 22.14.0
-golang 1.24.11
+golang 1.26.2

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS server-builder
+FROM golang:1.26.2-alpine3.23 AS server-builder
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN make build-server
 
-FROM golang:1.25.7-alpine3.23 AS dockerize-builder
+FROM golang:1.26.2-alpine3.23 AS dockerize-builder
 
 ARG DOCKERIZE_VERSION=v0.10.1
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION} && \

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/ui-server/v2
 
-go 1.24.11
+go 1.26.2
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
## Summary

- `server/Dockerfile`: `golang:1.25.7-alpine3.23` → `golang:1.26.2-alpine3.23` (both builder stages)
- `server/go.mod`: `go 1.24.11` → `go 1.26.2`
- `.tool-versions`: `golang 1.24.11` → `golang 1.26.2`

Addresses known CVEs in Go 1.25.7 and 1.26.1 affecting the `ui:2.48.4` image and the bundled CLI.

## Test plan

- [ ] CI `test.yml` shows `Setup Go` resolved to 1.26.2
- [ ] CI `playwright.yml` green
- [ ] `grep -c 'golang:1.26.2-alpine3.23' server/Dockerfile` prints 2
- [ ] Post-merge: security scan no longer reports Go 1.25.7 / 1.26.1 CVEs on the `ui` image