### PR TITLE
refactor: move fetchDeployment into Deployment component

### DIFF
--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { invalidate } from '$app/navigation';
-
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
@@ -43,6 +41,7 @@
     namespace: string;
     deploymentName: string;
     conflictToken?: string;
+    onVersionDeleted?: () => void;
   }
   let {
     routingConfig,
@@ -50,6 +49,7 @@
     namespace,
     deploymentName,
     conflictToken,
+    onVersionDeleted,
   }: Props = $props();
 
   const currentDeploymentName = $derived(
@@ -191,7 +191,7 @@
     );
     if (deleteVersionError) return;
     showDeleteVersionModal = false;
-    await invalidate('data:deployment');
+    onVersionDeleted?.();
   }
 </script>
 

--- a/src/lib/pages/deployment-page.ts
+++ b/src/lib/pages/deployment-page.ts
@@ -1,19 +1,8 @@
-import { fetchDeployment } from '$lib/services/deployments-service';
-import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
-
 export function loadDeploymentPage({
-  params,
   depends,
 }: {
   params: { namespace: string; deployment: string };
   depends: (...deps: `${string}:${string}`[]) => void;
 }) {
   depends('data:deployment');
-  const deploymentName = decodeURIForSvelte(params.deployment);
-  return {
-    deploymentPromise: fetchDeployment({
-      namespace: params.namespace,
-      deploymentName,
-    }),
-  };
 }

--- a/src/lib/pages/deployment-page.ts
+++ b/src/lib/pages/deployment-page.ts
@@ -1,8 +1,0 @@
-export function loadDeploymentPage({
-  depends,
-}: {
-  params: { namespace: string; deployment: string };
-  depends: (...deps: `${string}:${string}`[]) => void;
-}) {
-  depends('data:deployment');
-}

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -29,11 +29,15 @@
   // fetchDeployment lives here rather than in +page.ts because it requires a
   // server-relative base URL that isn't available at import time for package
   // consumers.
-  let reloadCount = $state(0);
+  let lastInvalidatedAt = $state(Date.now());
   const effectiveDeploymentPromise = $derived.by(() => {
-    reloadCount; // tracked so incrementing it re-fetches
+    lastInvalidatedAt; // tracked so updating it re-fetches
     return fetchDeployment({ namespace, deploymentName });
   });
+
+  function reload() {
+    lastInvalidatedAt = Date.now();
+  }
 
   let showDeleteModal = $state(false);
   let deleteError = $state<string | undefined>();
@@ -95,7 +99,7 @@
           {namespace}
           {deploymentName}
           conflictToken={deployment.conflictToken}
-          onVersionDeleted={() => reloadCount++}
+          onVersionDeleted={reload}
         />
       {/each}
     </PaginatedTable>

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -14,21 +14,13 @@
     deleteWorkerDeployment,
     fetchDeployment,
   } from '$lib/services/deployments-service';
-  import type { WorkerDeploymentResponse } from '$lib/types/deployments';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
-
-  interface Props {
-    deploymentPromise?: Promise<WorkerDeploymentResponse>;
-    showInstancesLink?: boolean;
-  }
-
-  let { deploymentPromise, showInstancesLink = true }: Props = $props();
 
   const { namespace } = $derived(page.params);
   const deploymentName = $derived(decodeURIForSvelte(page.params.deployment));
   const effectiveDeploymentPromise = $derived(
-    deploymentPromise ?? fetchDeployment({ namespace, deploymentName }),
+    fetchDeployment({ namespace, deploymentName }),
   );
 
   let showDeleteModal = $state(false);

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -17,11 +17,25 @@
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
 
+  interface Props {
+    showInstancesLink?: boolean;
+  }
+
+  let { showInstancesLink = true }: Props = $props();
+
   const { namespace } = $derived(page.params);
   const deploymentName = $derived(decodeURIForSvelte(page.params.deployment));
-  const effectiveDeploymentPromise = $derived(
-    fetchDeployment({ namespace, deploymentName }),
-  );
+
+  // fetchDeployment lives here rather than in +page.ts because the grpc
+  // transport requires a server-relative base URL that isn't available at
+  // the SvelteKit load layer in cloud-ui. We use a reload counter so
+  // child actions (e.g. version delete) can trigger a same-page re-fetch
+  // without navigating away.
+  let reloadCount = $state(0);
+  const effectiveDeploymentPromise = $derived.by(() => {
+    reloadCount; // tracked so incrementing it re-fetches
+    return fetchDeployment({ namespace, deploymentName });
+  });
 
   let showDeleteModal = $state(false);
   let deleteError = $state<string | undefined>();
@@ -83,6 +97,7 @@
           {namespace}
           {deploymentName}
           conflictToken={deployment.conflictToken}
+          onVersionDeleted={() => reloadCount++}
         />
       {/each}
     </PaginatedTable>

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -26,11 +26,9 @@
   const { namespace } = $derived(page.params);
   const deploymentName = $derived(decodeURIForSvelte(page.params.deployment));
 
-  // fetchDeployment lives here rather than in +page.ts because the grpc
-  // transport requires a server-relative base URL that isn't available at
-  // the SvelteKit load layer in cloud-ui. We use a reload counter so
-  // child actions (e.g. version delete) can trigger a same-page re-fetch
-  // without navigating away.
+  // fetchDeployment lives here rather than in +page.ts because it requires a
+  // server-relative base URL that isn't available at import time for package
+  // consumers.
   let reloadCount = $state(0);
   const effectiveDeploymentPromise = $derived.by(() => {
     reloadCount; // tracked so incrementing it re-fetches

--- a/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.svelte
@@ -1,17 +1,9 @@
 <script lang="ts">
   import { page } from '$app/state';
 
-  import type { PageData } from './$types';
-
   import PageTitle from '$lib/components/page-title.svelte';
   import { translate } from '$lib/i18n/translate';
   import Deployment from '$lib/pages/deployment.svelte';
-
-  interface Props {
-    data: PageData;
-  }
-
-  let { data }: Props = $props();
 
   const deployment = $derived(page.params.deployment);
 </script>
@@ -20,4 +12,4 @@
   title="{translate('deployments.deployment')} | {deployment}"
   url={page.url.href}
 />
-<Deployment deploymentPromise={data.deploymentPromise} />
+<Deployment />

--- a/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.ts
+++ b/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.ts
@@ -1,5 +1,5 @@
 import type { PageLoad } from './$types';
 
-import { loadDeploymentPage } from '$lib/pages/deployment-page';
-
-export const load: PageLoad = (event) => loadDeploymentPage(event);
+export const load: PageLoad = ({ depends }) => {
+  depends('data:deployment');
+};

--- a/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.ts
+++ b/src/routes/(app)/namespaces/[namespace]/workers/deployments/[deployment]/+page.ts
@@ -1,5 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = ({ depends }) => {
-  depends('data:deployment');
-};


### PR DESCRIPTION
## Summary

Moves deployment data fetching into the `Deployment` component rather than SvelteKit's load layer, and cleans up the related page infrastructure that was no longer doing anything useful.

## Why

`fetchDeployment` requires a server-relative base URL that isn't available at load time for package consumers. Running it inside the component ensures the transport is fully initialized before the call is made.

## Test plan

- [ ] Deployment detail page loads and displays version table
- [ ] Delete version flow refreshes the page correctly
- [ ] Delete deployment flow still works
- [ ] Existing integration tests pass