### PR TITLE
Use initiatedEvent for startChildFailed event grouping

### DIFF
--- a/src/lib/models/event-groups/get-event-in-group.ts
+++ b/src/lib/models/event-groups/get-event-in-group.ts
@@ -13,6 +13,7 @@ import {
   isNexusOperationFailedEvent,
   isNexusOperationTimedOutEvent,
   isSignalExternalWorkflowExecutionFailedEvent,
+  isStartChildWorkflowExecutionFailedEvent,
   isTimerCanceledEvent,
   isWorkflowExecutionCanceledEvent,
   isWorkflowExecutionFailedEvent,
@@ -32,6 +33,7 @@ export const eventIsFailureOrTimedOut = (event: WorkflowEvent): boolean => {
     isWorkflowTaskFailedEvent(event) ||
     isChildWorkflowExecutionFailedEvent(event) ||
     isChildWorkflowExecutionTimedOutEvent(event) ||
+    isStartChildWorkflowExecutionFailedEvent(event) ||
     isSignalExternalWorkflowExecutionFailedEvent(event) ||
     isFailedWorkflowExecutionUpdateCompletedEvent(event) ||
     isNexusOperationFailedEvent(event) ||

--- a/src/lib/models/event-groups/get-group-id.ts
+++ b/src/lib/models/event-groups/get-group-id.ts
@@ -22,6 +22,7 @@ import {
   isNexusOperationStartedEvent,
   isNexusOperationTimedOutEvent,
   isPureWorkflowTaskFailedEvent,
+  isStartChildWorkflowExecutionFailedEvent,
   isTimerCanceledEvent,
   isTimerFiredEvent,
   isWorkflowExecutionUpdateCompletedEvent,
@@ -89,6 +90,12 @@ export const getGroupId = (event: CommonHistoryEvent): string => {
   if (isChildWorkflowExecutionTimedOutEvent(event)) {
     return String(
       event.childWorkflowExecutionTimedOutEventAttributes.initiatedEventId,
+    );
+  }
+
+  if (isStartChildWorkflowExecutionFailedEvent(event)) {
+    return String(
+      event.startChildWorkflowExecutionFailedEventAttributes.initiatedEventId,
     );
   }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Properly group StartChildWorkflowExecutionFailed event with it's matching StartChildWorkflowExecutionInitiated event

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
<img width="1728" height="909" alt="Screenshot 2026-04-23 at 9 49 46 AM" src="https://github.com/user-attachments/assets/b5260ccb-dc4b-4b2b-9938-191c58b0bb64" />

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
