### PR TITLE
revert: restore original create worker deployment copy

### DIFF
--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -13,7 +13,7 @@ export const Strings = {
   'error-message-fetching': 'Error fetching deployments',
   'empty-state-description':
     'Worker Deployments let you manage how Temporal invokes your Workers, including serverless functions that scale automatically.',
-  'create-serverless-deployment': 'Create Serverless Worker Deployment',
+  'create-serverless-deployment': 'Create Worker Deployment',
   'self-managed-deployment': 'Self-Managed Worker Deployment',
   name: 'Deployment Name',
   'current-version': 'Current Version',

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -103,8 +103,8 @@ export const Strings = {
     'An IAM role allowing Temporal to invoke your function',
   'serverless-empty-prereq-queue':
     'A task queue name for your serverless worker',
-  'create-serverless-worker': 'Create Serverless Worker Deployment',
-  'create-serverless-title': 'Create Serverless Worker Deployment',
+  'create-serverless-worker': 'Create Worker Deployment',
+  'create-serverless-title': 'Create Worker Deployment',
   'edit-serverless-worker': 'Edit',
   'edit-serverless-worker-title': 'Edit Serverless Worker',
   'serverless-detail-title': 'Serverless Worker Details',


### PR DESCRIPTION
## Summary

- Reverts the `create-serverless-worker` and `create-serverless-title` i18n strings back to "Create Worker Deployment" — the change to "Create Serverless Worker Deployment" shipped in #3347 by mistake.