### PR TITLE
Add refresh button to Workers list view

### DIFF
--- a/src/lib/components/count-refresh-button.svelte
+++ b/src/lib/components/count-refresh-button.svelte
@@ -1,17 +1,18 @@
 <script lang="ts">
+  import type { Writable } from 'svelte/store';
   import { fly } from 'svelte/transition';
 
   import { twMerge as merge } from 'tailwind-merge';
 
   import Button from '$lib/holocene/button.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { refresh } from '$lib/stores/workflows';
 
   interface Props {
     count: number;
+    refresh: Writable<number>;
   }
 
-  let { count }: Props = $props();
+  let { count, refresh }: Props = $props();
 
   const duration = 300;
 </script>

--- a/src/lib/layouts/workers-layout.svelte
+++ b/src/lib/layouts/workers-layout.svelte
@@ -3,11 +3,13 @@
 
   import { page } from '$app/state';
 
+  import CountRefreshButton from '$lib/components/count-refresh-button.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import TabList from '$lib/holocene/tab/tab-list.svelte';
   import Tab from '$lib/holocene/tab/tab.svelte';
   import Tabs from '$lib/holocene/tab/tabs.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { refresh } from '$lib/stores/workers';
   import {
     routeForWorkerDeployments,
     routeForWorkers,
@@ -39,9 +41,13 @@
 
 <header class="flex flex-col gap-2">
   <div class="flex min-h-10 flex-wrap items-center justify-between gap-2">
-    <h1 class="leading-7" data-cy="workers-title">
-      {translate('workers.workers')}
-    </h1>
+    <div class="flex flex-row flex-wrap items-start gap-2">
+      <h1 class="leading-7" data-cy="workers-title">
+        {translate('workers.workers')}
+      </h1>
+      <!-- TODO: Add count when there is a WorkersCount API available -->
+      <CountRefreshButton count={0} {refresh} />
+    </div>
     {#if headerAction}
       {@render headerAction()}
     {/if}

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -6,6 +6,7 @@
   import PaginatedTable from '$lib/holocene/table/paginated-table/api-paginated.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fetchPaginatedDeployments } from '$lib/services/deployments-service';
+  import { refresh } from '$lib/stores/workers';
   import { has } from '$lib/utilities/has';
   import { routeForWorkerDeploymentCreate } from '$lib/utilities/route-for';
 
@@ -40,7 +41,7 @@
   ];
 </script>
 
-{#key [namespace]}
+{#key [namespace, $refresh]}
   <div class="flex flex-col gap-4">
     <PaginatedTable
       let:visibleItems

--- a/src/lib/pages/workers.svelte
+++ b/src/lib/pages/workers.svelte
@@ -12,6 +12,7 @@
     workerSearchAttributeOptions,
     workerSearchAttributes,
   } from '$lib/stores/search-attributes';
+  import { refresh } from '$lib/stores/workers';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
 
   const { namespace } = $derived(page.params);
@@ -39,7 +40,7 @@
     includeNullConditions={false}
   />
 
-  {#key [namespace, query]}
+  {#key [namespace, query, $refresh]}
     <WorkersTable
       {namespace}
       onFetch={() => fetchPaginatedWorkers({ namespace, query })}

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -32,6 +32,7 @@
 
   import { page } from '$app/state';
 
+  import CountRefreshButton from '$lib/components/count-refresh-button.svelte';
   import { timestamp } from '$lib/components/timestamp.svelte';
   import BatchCancelConfirmationModal from '$lib/components/workflow/client-actions/batch-cancel-confirmation-modal.svelte';
   import BatchResetConfirmationModal from '$lib/components/workflow/client-actions/batch-reset-confirmation-modal.svelte';
@@ -40,7 +41,6 @@
   import TerminateConfirmationModal from '$lib/components/workflow/client-actions/terminate-confirmation-modal.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
   import FilterBar from '$lib/components/workflow/filter-bar/index.svelte';
-  import WorkflowCountRefresh from '$lib/components/workflow/workflow-count-refresh.svelte';
   import WorkflowCounts from '$lib/components/workflow/workflow-counts.svelte';
   import WorkflowsSummaryConfigurableTable from '$lib/components/workflow/workflows-summary-configurable-table.svelte';
   import Button from '$lib/holocene/button.svelte';
@@ -237,7 +237,7 @@
           {refreshTimeFormatted}
         </p>
       </div>
-      <WorkflowCountRefresh count={$workflowCount.newCount} />
+      <CountRefreshButton count={$workflowCount.newCount} {refresh} />
       <WorkflowCounts bind:refreshTime fetchTaskFailures />
     </div>
     {#if $$slots['header-actions'] || workflowStartEnabled}

--- a/src/lib/stores/workers.ts
+++ b/src/lib/stores/workers.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const refresh = writable(0);


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Adds a `Refresh` button to the `/workers` layout that refetches either workers or works deployments (depending on which tab is selected). 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="536" height="208" alt="Screenshot 2026-04-28 at 1 28 54 PM" src="https://github.com/user-attachments/assets/74e24899-c517-435a-86c8-878fde3351a8" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

Related to `DT-3912`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
