### PR TITLE
Fix null conditionals in search attribute filter

### DIFF
--- a/src/lib/components/workflow/filter-bar/dropdown-filter-chip.svelte
+++ b/src/lib/components/workflow/filter-bar/dropdown-filter-chip.svelte
@@ -326,7 +326,7 @@
         active={localFilter.conditional === option.value}
         on:click={() => {
           if (isNullConditional(option.value)) {
-            localFilter.value = '';
+            localFilter.value = null;
           } else if (isNullFilter) {
             localFilter.value = filter.value;
           }

--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -202,6 +202,38 @@ describe('toListWorkflowQueryFromFilters', () => {
     );
   });
 
+  it.each([
+    ['null', null],
+    ['empty string', ''],
+    ['undefined', undefined],
+  ])(
+    'should convert a Keyword filter with is null conditional when value is %s',
+    (_, value) => {
+      const filters = [
+        {
+          attribute: 'CustomKeywordField',
+          type: 'Keyword',
+          conditional: 'is',
+          operator: '',
+          parenthesis: '',
+          value,
+        },
+        {
+          attribute: 'CustomKeywordField',
+          type: 'Keyword',
+          conditional: 'is not',
+          operator: '',
+          parenthesis: '',
+          value,
+        },
+      ];
+      const query = toListWorkflowQueryFromFilters(combineFilters(filters));
+      expect(query).toBe(
+        '`CustomKeywordField` is null AND `CustomKeywordField` is not null',
+      );
+    },
+  );
+
   it('should convert a KeywordList filter', () => {
     const filters = [
       {

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -32,7 +32,8 @@ const filterKeys: Readonly<Record<string, QueryKey>> = {
 } as const;
 
 const isValid = (value: unknown, conditional: string): boolean => {
-  if (value === null && !isNullConditional(conditional)) return false;
+  if (isNullConditional(conditional)) return true;
+  if (value === null) return false;
   if (value === undefined) return false;
   if (value === '') return false;
   if (typeof value === 'string' && value === 'undefined') return false;
@@ -87,7 +88,7 @@ const toFilterQueryStatement = (
   }
 
   if (isNullConditional(conditional)) {
-    return `\`${queryKey}\` ${conditional} ${value}`;
+    return `\`${queryKey}\` ${conditional} null`;
   }
 
   if (isDuration(value) || isDurationString(value)) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

When selecting `Is null` / `Is not null` in the Workflow search attribute filter it should now create the correct query. The filter was either being dropped (because `value === ''`) or emitting a malformed statement with the empty value interpolated in it.

Behavior was introduced when value was set to empty string [here](https://github.com/temporalio/ui/pull/3236/changes#diff-340e6397a2f250727f71de58746d9ef34d63774f0736fb02d133b24982cdb22aR329).
   
### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

Go to `/workflows` > `+ Add Filter` > select a `Keyword` search attribute
   - [ ] Select `Is null` and verify it updates the query correctly
   - [ ] Select `Is not null` and verify it updates the query correctly

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
