### PR TITLE
chore: ensure the empty app.html respects the user's light/dark settings

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,25 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <style>
+      html {
+        background-color: #f8fafc;
+        color: #141414;
+      }
+      body {
+        margin: 0;
+        background-color: #f8fafc;
+        color: #141414;
+      }
+      @media (prefers-color-scheme: dark) {
+        html,
+        body {
+          background-color: #141414;
+          color: #f8fafc;
+        }
+      }
+    </style>
     %sveltekit.head%
   </head>
 


### PR DESCRIPTION
## Description & motivation 💭 

The `app.html`  renders before the svelte app. This can persist for a few seconds. However, this bare html
doesn't respect the system's light/dark settings. This change prevents users from seeing a glaring bright screen
which is an undesirable experience in the wee hours of the morning.

### Screenshots (if applicable) 📸 

<img width="816" height="594" alt="image" src="https://github.com/user-attachments/assets/59888fb0-2777-4a71-971c-1f93e4bd454b" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

The html page uses the same bg color (`#141414`) used in the css throughout this codebase.

## Testing 🧪

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Open the app.html page directly
2. Ensure it respects the user/browser/system light/dark settings.
3. When the app's js loads, it takes over styling and the issue is no longer manifest. 

## Checklists

### Issue(s) closed

No related issue.

## Docs

No documentation updates required.
