### PR TITLE
Remove icon from Start Workflow button

### DIFF
--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -244,9 +244,7 @@
       <div class="flex items-center gap-4">
         <slot name="header-actions" />
         {#if workflowStartEnabled}
-          <Button
-            leadingIcon="lightning-bolt"
-            href={routeForWorkflowStart({ namespace })}
+          <Button href={routeForWorkflowStart({ namespace })}
             >{translate('workflows.start-workflow')}</Button
           >
         {/if}


### PR DESCRIPTION
We have been removing icons from our buttons, especially at page-level. This PR removes one of the last remaining ones. A follow up PR will be in `cloud-ui` repo for the Connect button.