### PR TITLE
refactor(DT-3906): Migrate schedule view components to runes (carved from #3370 - Part 2)

### DIFF
--- a/src/lib/components/schedule/schedule-day-of-month-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-month-view.svelte
@@ -5,7 +5,7 @@
 
   import SchedulesTimeView from './schedules-time-view.svelte';
 
-  type Props = {
+  interface Props {
     daysOfMonth: number[];
     months: string[];
     hour: string;

--- a/src/lib/components/schedule/schedule-day-of-month-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-month-view.svelte
@@ -11,7 +11,7 @@
     hour: string;
     minute: string;
     timezoneName: string;
-  };
+  }
 
   let {
     daysOfMonth = $bindable(),

--- a/src/lib/components/schedule/schedule-day-of-month-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-month-view.svelte
@@ -5,11 +5,21 @@
 
   import SchedulesTimeView from './schedules-time-view.svelte';
 
-  export let daysOfMonth: number[];
-  export let months: string[];
-  export let hour: string;
-  export let minute: string;
-  export let timezoneName: string;
+  type Props = {
+    daysOfMonth: number[];
+    months: string[];
+    hour: string;
+    minute: string;
+    timezoneName: string;
+  };
+
+  let {
+    daysOfMonth = $bindable(),
+    months = $bindable(),
+    hour = $bindable(),
+    minute = $bindable(),
+    timezoneName,
+  }: Props = $props();
 </script>
 
 <div class="flex flex-col gap-4">

--- a/src/lib/components/schedule/schedule-day-of-week-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-week-view.svelte
@@ -9,7 +9,7 @@
     hour: string;
     minute: string;
     timezoneName: string;
-  };
+  }
 
   let {
     daysOfWeek = $bindable(),

--- a/src/lib/components/schedule/schedule-day-of-week-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-week-view.svelte
@@ -4,10 +4,19 @@
 
   import SchedulesTimeView from './schedules-time-view.svelte';
 
-  export let daysOfWeek: string[];
-  export let hour: string;
-  export let minute: string;
-  export let timezoneName: string;
+  type Props = {
+    daysOfWeek: string[];
+    hour: string;
+    minute: string;
+    timezoneName: string;
+  };
+
+  let {
+    daysOfWeek = $bindable(),
+    hour = $bindable(),
+    minute = $bindable(),
+    timezoneName,
+  }: Props = $props();
 </script>
 
 <div class="flex flex-col gap-4">

--- a/src/lib/components/schedule/schedule-day-of-week-view.svelte
+++ b/src/lib/components/schedule/schedule-day-of-week-view.svelte
@@ -4,7 +4,7 @@
 
   import SchedulesTimeView from './schedules-time-view.svelte';
 
-  type Props = {
+  interface Props {
     daysOfWeek: string[];
     hour: string;
     minute: string;

--- a/src/lib/components/schedule/schedules-interval-view.svelte
+++ b/src/lib/components/schedule/schedules-interval-view.svelte
@@ -5,7 +5,7 @@
   import { translate } from '$lib/i18n/translate';
   import type { ScheduleOffsetUnit } from '$lib/types/schedule';
 
-  type Props = {
+  interface Props {
     days?: string;
     hour?: string;
     minute?: string;

--- a/src/lib/components/schedule/schedules-interval-view.svelte
+++ b/src/lib/components/schedule/schedules-interval-view.svelte
@@ -5,21 +5,31 @@
   import { translate } from '$lib/i18n/translate';
   import type { ScheduleOffsetUnit } from '$lib/types/schedule';
 
-  export let days = '';
-  export let hour = '';
-  export let minute = '';
-  export let second = '';
-  export let phase = '';
+  type Props = {
+    days?: string;
+    hour?: string;
+    minute?: string;
+    second?: string;
+    phase?: string;
+  };
 
-  let offset = '';
-  let offsetUnit: ScheduleOffsetUnit = 'min';
+  let {
+    days = $bindable(''),
+    hour = $bindable(''),
+    minute = $bindable(''),
+    second = $bindable(''),
+    phase = $bindable(''),
+  }: Props = $props();
+
+  let offset = $state('');
+  let offsetUnit = $state<ScheduleOffsetUnit>('min');
 
   const error = (x: string) => {
     if (x) return isNaN(parseInt(x));
     return false;
   };
 
-  $: {
+  $effect(() => {
     if (offset) {
       if (offsetUnit === 'days') {
         phase = (parseInt(offset) * 60 * 60 * 24).toString() + 's';
@@ -31,7 +41,7 @@
         phase = parseInt(offset).toString() + 's';
       }
     }
-  }
+  });
 </script>
 
 <div class="flex flex-col gap-4">

--- a/src/lib/components/schedule/schedules-interval-view.svelte
+++ b/src/lib/components/schedule/schedules-interval-view.svelte
@@ -11,7 +11,7 @@
     minute?: string;
     second?: string;
     phase?: string;
-  };
+  }
 
   let {
     days = $bindable(''),

--- a/src/lib/components/schedule/schedules-time-view.svelte
+++ b/src/lib/components/schedule/schedules-time-view.svelte
@@ -3,7 +3,7 @@
   import TimePicker from '$lib/holocene/time-picker.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  type Props = {
+  interface Props {
     hour?: string;
     minute?: string;
     timezoneName: string;

--- a/src/lib/components/schedule/schedules-time-view.svelte
+++ b/src/lib/components/schedule/schedules-time-view.svelte
@@ -7,7 +7,7 @@
     hour?: string;
     minute?: string;
     timezoneName: string;
-  };
+  }
 
   let {
     hour = $bindable(''),

--- a/src/lib/components/schedule/schedules-time-view.svelte
+++ b/src/lib/components/schedule/schedules-time-view.svelte
@@ -3,14 +3,23 @@
   import TimePicker from '$lib/holocene/time-picker.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  export let hour = '';
-  export let minute = '';
-  export let timezoneName: string;
+  type Props = {
+    hour?: string;
+    minute?: string;
+    timezoneName: string;
+  };
 
-  $: timezoneHint =
+  let {
+    hour = $bindable(''),
+    minute = $bindable(''),
+    timezoneName,
+  }: Props = $props();
+
+  const timezoneHint = $derived(
     timezoneName.toLowerCase() === 'utc'
       ? 'Universal Standard Time (UTC)'
-      : timezoneName;
+      : timezoneName,
+  );
 </script>
 
 <div class="flex flex-col gap-4">


### PR DESCRIPTION
## Summary

Migrates the 4 \`schedule/*-view.svelte\` components to Svelte 5 runes. Identical pattern across all four — review one, the rest are mechanical.

**Files:**
- \`schedule/schedule-day-of-month-view.svelte\`
- \`schedule/schedule-day-of-week-view.svelte\`
- \`schedule/schedules-interval-view.svelte\`
- \`schedule/schedules-time-view.svelte\`

4 files, +61 / -23. Carved out of #3370.

## Test plan

- [x] \`pnpm check\` passes (0 errors)
- [ ] CI green
- [ ] Verify schedule create/edit flows render the four views correctly

## Context

Part of [DT-3906](https://temporal.atlassian.net/browse/DT-3906) Svelte 4→5 migration.

[DT-3906]: https://temporalio.atlassian.net/browse/DT-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ