### PR TITLE
refactor(DT-3906): Migrate holocene primitives + layout components to runes (carved from #3370 - Part 6)

### DIFF
--- a/src/lib/holocene/calendar.svelte
+++ b/src/lib/holocene/calendar.svelte
@@ -5,26 +5,35 @@
 
   const dispatch = createEventDispatcher();
 
-  export let date: Date | undefined;
-  export let month: number | undefined;
-  export let year: number | undefined;
-  export let isAllowed = (_date: Date) => true;
-
-  let cells = [];
-
-  const onChange = (date: number) => {
-    dispatch('datechange', new Date(year, month, date));
+  type Props = {
+    date: Date;
+    month: number;
+    year: number;
+    isAllowed?: (date: Date) => boolean;
   };
 
-  const allow = (year: number, month: number, date: number) => {
-    if (!date) return true;
-    return isAllowed(new Date(year, month, date));
+  let {
+    date,
+    month,
+    year,
+    isAllowed = (_date: Date) => true,
+  }: Props = $props();
+
+  const onChange = (selectedDay: number) => {
+    dispatch('datechange', new Date(year, month, selectedDay));
   };
 
-  $: cells = getDateRows(month, year).map((c) => ({
-    value: c,
-    allowed: allow(year, month, c),
-  }));
+  const allow = (year: number, month: number, day: number | undefined) => {
+    if (!day) return true;
+    return isAllowed(new Date(year, month, day));
+  };
+
+  const cells = $derived(
+    getDateRows(month, year).map((c) => ({
+      value: c,
+      allowed: allow(year, month, c),
+    })),
+  );
 </script>
 
 <div class="container">
@@ -39,7 +48,7 @@
       {#if value}
         <button
           type="button"
-          on:click={allowed && value ? () => onChange(value) : () => {}}
+          onclick={allowed && value ? () => onChange(value) : () => {}}
           class="cell"
           class:highlight={allowed && value}
           class:disabled={!allowed}

--- a/src/lib/holocene/filter-or-copy-buttons.svelte
+++ b/src/lib/holocene/filter-or-copy-buttons.svelte
@@ -4,18 +4,31 @@
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { copyToClipboard } from '$lib/utilities/copy-to-clipboard';
 
-  export let show = false;
-  export let filterable = true;
-  export let copyable = true;
-  export let content: string;
-  export let onFilter: () => void = () => {};
-  export let filtered = false;
-  export let copyIconTitle: string;
-  export let copySuccessIconTitle: string;
-  export let filterIconTitle: string;
+  type Props = {
+    show?: boolean;
+    filterable?: boolean;
+    copyable?: boolean;
+    content: string;
+    onFilter?: () => void;
+    filtered?: boolean;
+    copyIconTitle: string;
+    copySuccessIconTitle: string;
+    filterIconTitle: string;
+    class?: string;
+  };
 
-  let className = '';
-  export { className as class };
+  let {
+    show = false,
+    filterable = true,
+    copyable = true,
+    content,
+    onFilter = () => {},
+    filtered = false,
+    copyIconTitle,
+    copySuccessIconTitle,
+    filterIconTitle,
+    class: className = '',
+  }: Props = $props();
 
   const { copy, copied } = copyToClipboard();
 </script>
@@ -24,7 +37,11 @@
   <div class={merge('copy-or-filter', className)}>
     {#if filterable}
       <button
-        on:click|preventDefault|stopPropagation={onFilter}
+        onclick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onFilter();
+        }}
         class="copy-or-filter-button"
         class:filtered
         id="filter-button"
@@ -37,7 +54,11 @@
     {#if copyable}
       <button
         class="copy-or-filter-button"
-        on:click|preventDefault|stopPropagation={(e) => copy(e, content)}
+        onclick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          copy(e, content);
+        }}
         id="copy-button"
       >
         <Icon

--- a/src/lib/holocene/main-content-container.svelte
+++ b/src/lib/holocene/main-content-container.svelte
@@ -1,7 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  type Props = {
+    children?: Snippet;
+    main?: Snippet;
+    footer?: Snippet;
+  };
+
+  let { children, main, footer }: Props = $props();
+</script>
+
 <div id="content-wrapper" class="relative h-full w-max flex-auto overflow-auto">
-  <slot />
+  {@render children?.()}
   <main id="content" class="pb-16 md:pb-0">
-    <slot name="main" />
+    {@render main?.()}
   </main>
-  <slot name="footer" />
+  {@render footer?.()}
 </div>

--- a/src/lib/holocene/orderable-list/orderable-list-item.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list-item.svelte
@@ -13,47 +13,57 @@
     currentTarget: EventTarget & HTMLLIElement;
   };
 
-  type BaseProps = {
+  type Props = {
     label: string;
     index?: number;
     totalItems?: number;
-  };
+  } & (
+    | {
+        readonly: true;
+        static?: never;
+        addButtonLabel?: never;
+        moveUpButtonLabel?: never;
+        moveDownButtonLabel?: never;
+        removeButtonLabel?: never;
+      }
+    | {
+        readonly?: false;
+        static: true;
+        addButtonLabel: string;
+        moveUpButtonLabel?: never;
+        moveDownButtonLabel?: never;
+        removeButtonLabel?: never;
+      }
+    | {
+        readonly?: false;
+        static?: false;
+        moveUpButtonLabel: string;
+        moveDownButtonLabel: string;
+        addButtonLabel: string;
+        removeButtonLabel: string;
+      }
+  );
 
-  type ReadonlyProps = BaseProps & {
-    readonly: boolean;
-  };
-
-  type StaticProps = BaseProps & {
-    static: boolean;
-  } & Pick<I18nProps, 'addButtonLabel'>;
-
-  type I18nProps = {
-    moveUpButtonLabel: string;
-    moveDownButtonLabel: string;
-    addButtonLabel: string;
-    removeButtonLabel: string;
-  };
-
-  type $$Props = (BaseProps & I18nProps) | ReadonlyProps | StaticProps;
-
-  let isStatic = false;
-  export { isStatic as static };
-  export let label: string;
-  export let readonly = false;
-  export let index = 0;
-  export let totalItems = 0;
-  export let moveUpButtonLabel = '';
-  export let moveDownButtonLabel = '';
-  export let addButtonLabel = '';
-  export let removeButtonLabel = '';
+  let {
+    label,
+    index = 0,
+    totalItems = 0,
+    readonly = false,
+    static: isStatic = false,
+    moveUpButtonLabel = '',
+    moveDownButtonLabel = '',
+    addButtonLabel = '',
+    removeButtonLabel = '',
+  }: Props = $props();
 
   const handleDragStart = (event: ExtendedDragEvent, index: number) => {
-    if (isStatic || readonly) return;
+    if (isStatic || readonly || !event.dataTransfer) return;
     event.dataTransfer.setData('text/plain', index.toString());
     event.dataTransfer.dropEffect = 'move';
   };
 
   const handleDrop = (event: ExtendedDragEvent, to: number) => {
+    if (!event.dataTransfer) return;
     event.currentTarget.classList.remove('dragging-over');
     const from = parseInt(event.dataTransfer.getData('text/plain'));
     dispatch('moveItem', { from, to });
@@ -69,11 +79,25 @@
   draggable={!isStatic && !readonly}
   class="orderable-item group"
   class:readonly
-  on:dragstart={(e) => handleDragStart(e, index)}
-  on:drop|preventDefault={(e) => handleDrop(e, index)}
-  on:dragenter|preventDefault|stopPropagation={handleDragEnter}
-  on:dragleave|preventDefault|stopPropagation={handleDragLeave}
-  on:dragover|preventDefault|stopPropagation
+  ondragstart={(e) => handleDragStart(e, index)}
+  ondrop={(e) => {
+    e.preventDefault();
+    handleDrop(e, index);
+  }}
+  ondragenter={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleDragEnter(e);
+  }}
+  ondragleave={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    handleDragLeave(e);
+  }}
+  ondragover={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }}
   data-testid="orderable-list-item-{label}"
 >
   <div class="flex flex-row items-center gap-2">

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { beforeNavigate, goto } from '$app/navigation';
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import EventHistoryLegend from '$lib/components/lines-and-dots/event-history-legend.svelte';
   import EventTypeFilter from '$lib/components/lines-and-dots/event-type-filter.svelte';
@@ -28,58 +28,64 @@
   import { getWorkflowTaskFailedEvent } from '$lib/utilities/get-workflow-task-failed-event';
   import { orderGroupsByPending } from '$lib/utilities/order-groups-by-pending';
 
-  $: ({ namespace } = $page.params);
-  $: ({ workflow } = $workflowRun);
-  $: pendingActivities = workflow?.pendingActivities;
-  $: pendingNexusOperations = workflow?.pendingNexusOperations;
+  const namespace = $derived(page.params.namespace);
+  const workflow = $derived($workflowRun.workflow);
+  const pendingActivities = $derived(workflow?.pendingActivities);
+  const pendingNexusOperations = $derived(workflow?.pendingNexusOperations);
 
-  $: urlParams = parseEventFilterParams($page.url);
-  $: {
+  const urlParams = $derived(parseEventFilterParams(page.url));
+
+  $effect(() => {
     $eventFilterSort = urlParams.sort;
     $pauseLiveUpdates = urlParams.refresh_off;
-  }
+  });
 
-  $: reverseSort = $eventFilterSort === 'descending';
+  const reverseSort = $derived($eventFilterSort === 'descending');
 
-  $: ascendingGroups = groupEvents(
-    $filteredEventHistory,
-    'ascending',
-    pendingActivities,
-    pendingNexusOperations,
+  const ascendingGroups = $derived(
+    groupEvents(
+      $filteredEventHistory,
+      'ascending',
+      pendingActivities,
+      pendingNexusOperations,
+    ),
   );
 
-  $: groups = orderGroupsByPending(
-    reverseSort ? [...ascendingGroups].reverse() : ascendingGroups,
-    reverseSort,
+  const groups = $derived(
+    orderGroupsByPending(
+      reverseSort ? [...ascendingGroups].reverse() : ascendingGroups,
+      reverseSort,
+    ),
   );
 
-  $: workflowTaskFailedError = getWorkflowTaskFailedEvent(
-    $currentEventHistory,
-    'ascending',
+  const workflowTaskFailedError = $derived(
+    getWorkflowTaskFailedEvent($currentEventHistory, 'ascending'),
   );
 
-  $: isNotPending = workflow && !workflow?.isRunning && !workflow?.isPaused;
+  const isNotPending = $derived(
+    Boolean(workflow && !workflow?.isRunning && !workflow?.isPaused),
+  );
 
   beforeNavigate(() => {
     clearActives();
   });
 
-  $: {
+  $effect(() => {
     if (isNotPending && $pauseLiveUpdates) {
       $pauseLiveUpdates = false;
     }
-  }
+  });
 
-  let showDownloadPrompt = false;
+  let showDownloadPrompt = $state(false);
 
   const onSort = () => {
     const newSort = reverseSort ? 'ascending' : 'descending';
-    updateEventFilterParams($page.url, { sort: newSort }, goto);
+    updateEventFilterParams(page.url, { sort: newSort }, goto);
   };
 
   const onAutoRefreshToggle = () => {
     updateEventFilterParams(
-      $page.url,
+      page.url,
       { refresh_off: !$pauseLiveUpdates },
       goto,
     );
@@ -144,18 +150,22 @@
       </ToggleButtons>
     </div>
   </div>
-  <div class="flex w-full flex-col">
-    <TimelineGraph
-      {workflow}
-      {groups}
-      viewportHeight={undefined}
-      error={Boolean(workflowTaskFailedError)}
-    />
-  </div>
+  {#if workflow}
+    <div class="flex w-full flex-col">
+      <TimelineGraph
+        {workflow}
+        {groups}
+        viewportHeight={undefined}
+        error={Boolean(workflowTaskFailedError)}
+      />
+    </div>
+  {/if}
 </div>
-<DownloadEventHistoryModal
-  bind:open={showDownloadPrompt}
-  {namespace}
-  workflowId={workflow.id}
-  runId={workflow.runId}
-/>
+{#if workflow}
+  <DownloadEventHistoryModal
+    bind:open={showDownloadPrompt}
+    {namespace}
+    workflowId={workflow.id}
+    runId={workflow.runId}
+  />
+{/if}

--- a/src/lib/pages/workflow-history-json.svelte
+++ b/src/lib/pages/workflow-history-json.svelte
@@ -1,3 +1,5 @@
+<svelte:options runes />
+
 <script lang="ts">
   import WorkflowJsonNavigator from '$lib/components/workflow/workflow-json-navigator.svelte';
   import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -350,22 +350,22 @@
       {/if}
       <UserMenu {logout} />
     </TopNavigation>
-    <div
-      slot="main"
-      class="flex h-[calc(100%-2.5rem)] w-full flex-col gap-4 p-4 md:p-8"
-    >
-      <ErrorBoundary>
-        {@render children()}
-      </ErrorBoundary>
-    </div>
-    <BottomNavigation
-      slot="footer"
-      sections={[linkList, linkListForSecondGroup]}
-      {namespaceList}
-      {isCloud}
-      {showNamespacePicker}
-    >
-      <UserMenuMobile {logout} />
-    </BottomNavigation>
+    {#snippet main()}
+      <div class="flex h-[calc(100%-2.5rem)] w-full flex-col gap-4 p-4 md:p-8">
+        <ErrorBoundary>
+          {@render children()}
+        </ErrorBoundary>
+      </div>
+    {/snippet}
+    {#snippet footer()}
+      <BottomNavigation
+        sections={[linkList, linkListForSecondGroup]}
+        {namespaceList}
+        {isCloud}
+        {showNamespacePicker}
+      >
+        <UserMenuMobile {logout} />
+      </BottomNavigation>
+    {/snippet}
   </MainContentContainer>
 </div>


### PR DESCRIPTION
## Summary

Migrates 7 widely-used primitives and the app layout to Svelte 5 runes. **Broadest blast radius** of the #3370 carve-outs — these primitives are consumed across the app, so review with that in mind.

**Files:**
- \`holocene/calendar.svelte\`
- \`holocene/filter-or-copy-buttons.svelte\`
- \`holocene/main-content-container.svelte\`
- \`holocene/orderable-list/orderable-list-item.svelte\`
- \`layouts/workflow-timeline-layout.svelte\`
- \`pages/workflow-history-json.svelte\`
- \`routes/(app)/+layout.svelte\`

7 files, +203 / -125. Carved out of #3370.

## Test plan

- [x] \`pnpm check\` passes (0 errors)
- [ ] CI green
- [ ] App layout renders (top nav, side nav, footer); no regression in any authenticated route
- [ ] Calendar picker (e.g. schedule/filter date pickers) opens and selects dates
- [ ] Filter-or-copy buttons render in places that use them
- [ ] Orderable list (configurable table headers drawer) drag-reorder still works
- [ ] Workflow timeline layout renders the timeline view
- [ ] Workflow history JSON view renders raw history

## Context

Part of [DT-3906](https://temporal.atlassian.net/browse/DT-3906) Svelte 4→5 migration. Final carve-out from #3370.

[DT-3906]: https://temporalio.atlassian.net/browse/DT-3906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ