### PR TITLE
Scope group-hover to Tooltip component

### DIFF
--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -100,7 +100,7 @@
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div
     bind:this={wrapperElement}
-    class={merge('wrapper group relative inline-block', className)}
+    class={merge('wrapper group/tooltip relative inline-block', className)}
     on:mouseenter={() => (isHovered = true)}
     on:mouseleave={() => (isHovered = false)}
   >
@@ -131,7 +131,7 @@
     {:else}
       <div
         class={merge(
-          'tooltip absolute left-0 top-0 z-50 hidden translate-x-12 whitespace-nowrap text-xs opacity-0 transition-all group-hover:inline-block group-hover:opacity-95',
+          'tooltip absolute left-0 top-0 z-50 hidden translate-x-12 whitespace-nowrap text-xs opacity-0 transition-all group-hover/tooltip:inline-block group-hover/tooltip:opacity-95',
           show && 'inline-block opacity-95',
         )}
         class:left


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Tailwind's `group-hover:` matches any ancestor with group so                                         
  1. If a tooltip's slot content uses its own `group-hover:` utilities, hovering the tooltip wrapper triggers them.         
  2. If the tooltip is placed inside another group (a card, row, button), the tooltip wrapper inherits that hover state too.

This PR uses Tailwind's named-group syntax (`group/tooltip`) so the hover relationship is scoped to the `Tooltip` component only.                                             

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
