### PR TITLE
fix(DT-3967): Visibly toggle the view children button even with a parent has 0

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -73,7 +73,7 @@
   const toggleChildrenVisibility = async (workflow: WorkflowExecution) => {
     const visibleChildren = visibleChildrenMap.get(workflow.runId);
 
-    if (visibleChildren?.length) {
+    if (visibleChildren?.length != null) {
       // we are collapsing the children so if there is an inflight request
       // we don't want its resolution to reopen the children.
       inFlightChildRequests.delete(workflow.runId);
@@ -125,7 +125,7 @@
   type VisibleRow =
     | {
         rowType: 'root';
-        childCount: number;
+        childCount: number | undefined;
         value: WorkflowExecution;
       }
     | {
@@ -135,17 +135,17 @@
       };
   const visibleRows: VisibleRow[] = $derived.by(() => {
     return visiblePaginatedItems.flatMap((workflow) => {
-      const visibleChildren = visibleChildrenMap.get(workflow.runId) ?? [];
+      const visibleChildren = visibleChildrenMap.get(workflow.runId);
 
       const rootRow = {
         rowType: 'root' as const,
-        childCount: visibleChildren.length,
+        childCount: visibleChildren?.length,
         value: workflow,
       };
 
       return [
         rootRow,
-        ...visibleChildren.map((c) => ({
+        ...(visibleChildren || []).map((c) => ({
           rowType: 'child' as const,
           parentRow: rootRow,
           value: c,
@@ -233,7 +233,7 @@
       <TableRow
         workflow={row.value}
         {toggleChildrenVisibility}
-        childCount={!isChildRow && row.childCount > 0
+        childCount={!isChildRow && row.childCount != null
           ? row.childCount
           : undefined}
         child={isChildRow}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The [shift+click multi select feature](https://github.com/temporalio/ui/pull/3344) introduced a regression where if a parent workflow had no children, clicking the View Children button would have no visible effect. This gave the impression it wasn't working. It was working except that there were no children to show.

The fix is to still visibly toggle the view children button even when there are no children to show.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

https://github.com/user-attachments/assets/da91f746-8f26-4c3c-9db4-b2e41e70f2ef

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
