### PR TITLE
fix(DT-3968): Make Workflow Table Tooltips render in portal

### DIFF
--- a/src/lib/components/workflow/start-workflow-button.svelte
+++ b/src/lib/components/workflow/start-workflow-button.svelte
@@ -21,7 +21,11 @@
   });
 </script>
 
-<Tooltip text={translate('workflows.start-workflow-like-this-one')} topLeft>
+<Tooltip
+  usePortal
+  text={translate('workflows.start-workflow-like-this-one')}
+  topLeft
+>
   <Button
     size="xs"
     variant="ghost"

--- a/src/lib/components/workflow/workflows-summary-configurable-table/filterable-table-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/filterable-table-cell.svelte
@@ -63,11 +63,11 @@
 </script>
 
 {#if href}
-  <Tooltip text={value} top class="min-w-0" hide={hideTooltip}>
+  <Tooltip usePortal text={value} top class="min-w-0" hide={hideTooltip}>
     <Link {href}>{truncate ? truncateValue(value) : value}</Link>
   </Tooltip>
 {:else}
-  <Tooltip text={value} top class="min-w-0" hide={hideTooltip}>
+  <Tooltip usePortal text={value} top class="min-w-0" hide={hideTooltip}>
     {truncate ? truncateValue(value) : value}
   </Tooltip>
 {/if}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
@@ -226,6 +226,7 @@
       />
     {:else if label === 'Task Queue'}
       <Tooltip
+        usePortal
         text={workflow.taskQueue}
         top
         class="min-w-0"
@@ -235,6 +236,7 @@
       </Tooltip>
     {:else if label === 'Parent Namespace'}
       <Tooltip
+        usePortal
         text={workflow?.parentNamespaceId ?? ''}
         top
         class="min-w-0"
@@ -265,6 +267,7 @@
       {parseInt(workflow.historyEvents, 10) > 0 ? workflow.historyEvents : ''}
     {:else if label === 'Scheduled By ID'}
       <Tooltip
+        usePortal
         text={workflow.searchAttributes?.indexedFields?.TemporalScheduledById ??
           ''}
         top
@@ -302,7 +305,13 @@
       {:else if $customSearchAttributes[label] === SEARCH_ATTRIBUTE_TYPE.BOOL}
         <Badge>{content}</Badge>
       {:else}
-        <Tooltip text={content} top class="min-w-0" hide={hideTooltip(content)}>
+        <Tooltip
+          usePortal
+          text={content}
+          top
+          class="min-w-0"
+          hide={hideTooltip(content)}
+        >
           {truncate ? truncateValue(content) : content}
         </Tooltip>
       {/if}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
@@ -108,6 +108,7 @@
             class={$tableDensity === 'dense' ? 'mt-1 h-5 w-5' : ''}
           >
             <Tooltip
+              usePortal
               text={childrenShown
                 ? translate('workflows.children', { count: childCount ?? 0 })
                 : translate('workflows.show-children')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Tooltips rooted within the workflow table get cut off if they extend beyond the perimeter of the table element. Using a portal for the tooltips lets them extend pass the table and remain visible.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

https://github.com/user-attachments/assets/493e0024-d5fc-4d3b-9299-903c0f2d4788

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
