### PR TITLE
fix: portal maximizable to body to escape stacking context

### DIFF
--- a/src/lib/holocene/maximizable/maximizable.svelte
+++ b/src/lib/holocene/maximizable/maximizable.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { type Snippet } from 'svelte';
+  import { onDestroy, type Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
+
+  import { portal } from '$lib/holocene/portal/portal-action';
 
   import MaximizeButton from './button.svelte';
 
@@ -40,11 +42,45 @@
       maximized = false;
     }
   };
+
+  let wrapperEl: HTMLElement | undefined = $state();
+  let originalParent: ParentNode | null = null;
+  let originalNextSibling: ChildNode | null = null;
+  let portalElement: ReturnType<typeof portal> | null = null;
+
+  $effect(() => {
+    if (!wrapperEl) return;
+
+    if (maximized) {
+      originalParent = wrapperEl.parentNode;
+      originalNextSibling = wrapperEl.nextSibling;
+      portalElement = portal(wrapperEl, document.body);
+    } else if (portalElement) {
+      portalElement.destroy();
+      portalElement = null;
+      if (originalParent) {
+        originalParent.insertBefore(wrapperEl, originalNextSibling);
+        originalParent = null;
+        originalNextSibling = null;
+      }
+    }
+  });
+
+  onDestroy(() => {
+    if (portalElement && wrapperEl) {
+      if (originalParent) {
+        originalParent.insertBefore(wrapperEl, originalNextSibling);
+      }
+      portalElement.destroy();
+      portalElement = null;
+    }
+  });
 </script>
 
 <svelte:window onkeydown={escapeListener} />
 
 <div
+  bind:this={wrapperEl}
   class={merge(
     'relative',
     maximized &&

--- a/src/lib/holocene/maximizable/maximizable.svelte
+++ b/src/lib/holocene/maximizable/maximizable.svelte
@@ -45,19 +45,20 @@
   };
 
   let wrapperEl: HTMLElement | undefined = $state();
+  let portalElement: ReturnType<typeof portal> | null = null;
 
   $effect(() => {
     if (!wrapperEl || !maximized) return;
 
-    const el = wrapperEl;
-    const parent = el.parentNode;
-    const nextSibling = el.nextSibling;
-    const pe = portal(el, document.body);
+    const originalParent = wrapperEl.parentNode;
+    const originalNextSibling = wrapperEl.nextSibling;
+    portalElement = portal(wrapperEl, document.body);
 
     return () => {
-      pe?.destroy();
-      if (parent) {
-        parent.insertBefore(el, nextSibling);
+      portalElement?.destroy();
+      portalElement = null;
+      if (originalParent?.isConnected) {
+        originalParent.insertBefore(wrapperEl!, originalNextSibling);
       }
     };
   });

--- a/src/lib/holocene/maximizable/maximizable.svelte
+++ b/src/lib/holocene/maximizable/maximizable.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { onDestroy, type Snippet } from 'svelte';
+  import { type Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import { portal } from '$lib/holocene/portal/portal-action';
+  import { focusTrap } from '$lib/utilities/focus-trap';
 
   import MaximizeButton from './button.svelte';
 
@@ -44,36 +45,21 @@
   };
 
   let wrapperEl: HTMLElement | undefined = $state();
-  let originalParent: ParentNode | null = null;
-  let originalNextSibling: ChildNode | null = null;
-  let portalElement: ReturnType<typeof portal> | null = null;
 
   $effect(() => {
-    if (!wrapperEl) return;
+    if (!wrapperEl || !maximized) return;
 
-    if (maximized) {
-      originalParent = wrapperEl.parentNode;
-      originalNextSibling = wrapperEl.nextSibling;
-      portalElement = portal(wrapperEl, document.body);
-    } else if (portalElement) {
-      portalElement.destroy();
-      portalElement = null;
-      if (originalParent) {
-        originalParent.insertBefore(wrapperEl, originalNextSibling);
-        originalParent = null;
-        originalNextSibling = null;
-      }
-    }
-  });
+    const el = wrapperEl;
+    const parent = el.parentNode;
+    const nextSibling = el.nextSibling;
+    const pe = portal(el, document.body);
 
-  onDestroy(() => {
-    if (portalElement && wrapperEl) {
-      if (originalParent) {
-        originalParent.insertBefore(wrapperEl, originalNextSibling);
+    return () => {
+      pe?.destroy();
+      if (parent) {
+        parent.insertBefore(el, nextSibling);
       }
-      portalElement.destroy();
-      portalElement = null;
-    }
+    };
   });
 </script>
 
@@ -88,6 +74,7 @@
     className,
   )}
   onfocusout={handleFocusOut}
+  use:focusTrap={maximized}
 >
   {@render children()}
 


### PR DESCRIPTION
## Summary

- The `Maximizable` component's full-screen mode (`fixed z-100`) was rendering behind the side nav and header because `content-wrapper` (`relative overflow-auto`) creates a browser stacking context, trapping `z-100` within it — below the side nav's `z-30` at the root level
- Fixed by using the existing `portal` action from `portal-action.ts` to move the wrapper element to `document.body` when maximized, so `z-100` competes at the root stacking context level
- On minimize, the element is inserted back to its original DOM position using the saved parent/sibling references
- Uses the same `portalElement` naming convention as `drawer.svelte` and `portal.svelte`

## Test plan

- [ ] Navigate to `/namespaces/default/workers/deployments/create`
- [ ] Click the expand icon on the CloudFormation template code block — should go full screen covering nav and header
- [ ] Click minimize (or press Escape) — should return to the inline panel position
- [ ] Verify other `Maximizable` code blocks elsewhere (event history, workflow payloads) expand and minimize correctly