### PR TITLE
Remove capability guard from Set Current Version menu item

### DIFF
--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -45,11 +45,9 @@
           {translate('deployments.edit')}
         </MenuItem>
       </CapabilityGuard>
-      <CapabilityGuard capability="serverScaledDeployments">
-        <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
-          {translate('deployments.set-as-current')}
-        </MenuItem>
-      </CapabilityGuard>
+      <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
+        {translate('deployments.set-as-current')}
+      </MenuItem>
       <CapabilityGuard capability="serverScaledDeployments">
         <MenuItem onclick={onValidate}>
           {translate('deployments.validate-connection')}


### PR DESCRIPTION
## Summary

- Removes the `serverScaledDeployments` capability guard from the **Set Current Version** menu item in the version actions menu, so it renders unconditionally regardless of server capability
- Adds a temporary dev override in `+layout.ts` that forces `serverScaledDeployments = false` to test the UI without the capability enabled

<img width="800" height="407" alt="CleanShot 2026-05-11 at 15 47 30" src="https://github.com/user-attachments/assets/ec6a77b7-6979-43c8-bee8-15a173ce9167" />


## Test plan

- [ ] Verify **Set Current Version** appears in the version actions menu when `serverScaledDeployments` is disabled (via the layout override)
- [ ] Verify other guarded menu items (Edit, Validate Connection, Delete) are still hidden when the capability is disabled
- [ ] Remove the `+layout.ts` override before merging if this is not intended to ship