### PR TITLE
Move Create Schedule button to header row

### DIFF
--- a/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
+++ b/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
@@ -74,7 +74,7 @@
   >
     {#snippet leading()}
       {#if !$filter.attribute}
-        <Icon name="add" />
+        <Icon name="filter-lines" />
       {/if}
     {/snippet}
     {$filter.attribute || 'Search Attribute'}

--- a/src/lib/pages/schedules.svelte
+++ b/src/lib/pages/schedules.svelte
@@ -93,23 +93,12 @@
 </script>
 
 <div class="flex flex-col gap-4">
-  <h1 class="flex flex-col gap-0 md:flex-row md:items-center md:gap-2">
-    <SchedulesCount />
-  </h1>
   <div
-    class="flex flex-col gap-2 md:flex-row {showFilters
-      ? 'justify-between'
-      : 'justify-end'}"
+    class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
   >
-    {#if showFilters}
-      <SearchAttributeFilter
-        bind:filters={$scheduleFilters}
-        {searchAttributeOptions}
-        refresh={() => {
-          refresh = Date.now();
-        }}
-      />
-    {/if}
+    <h1 class="flex flex-col gap-0 md:flex-row md:items-center md:gap-2">
+      <SchedulesCount />
+    </h1>
     {#if !createDisabled}
       <Button
         data-testid="create-schedule"
@@ -120,6 +109,15 @@
       </Button>
     {/if}
   </div>
+  {#if showFilters}
+    <SearchAttributeFilter
+      bind:filters={$scheduleFilters}
+      {searchAttributeOptions}
+      refresh={() => {
+        refresh = Date.now();
+      }}
+    />
+  {/if}
 </div>
 
 {#key [namespace, query, refresh]}


### PR DESCRIPTION
This PR moves the Create Schedule button onto the same row as the page heading on the Schedules list page, matching the layout used on other pages. Purely a visual change, no functionality impacted.

| Before    | After |
| -------- | ------- |
| <img width="1916" height="221" alt="Screenshot 2026-05-12 at 7 49 40 PM" src="https://github.com/user-attachments/assets/00effedf-b61d-4fa2-87d9-2db803a9a069" /> |  <img width="1916" height="221" alt="Screenshot 2026-05-12 at 7 49 11 PM" src="https://github.com/user-attachments/assets/ca054c11-d45a-4b71-8409-0e833fb7ef5c" />  |

Also update the icon to `filter-lines` for Search Attribute button to indicate that it's a filter.


