### PR TITLE
Increase gap between page title and timestamp

### DIFF
--- a/src/lib/pages/standalone-activities.svelte
+++ b/src/lib/pages/standalone-activities.svelte
@@ -88,7 +88,7 @@
             <Translate key="standalone-activities.recent-activities" />
           {/if}
         </h1>
-        <p class="text-xs text-secondary">
+        <p class="mt-2 text-xs text-secondary">
           {refreshTimeFormatted}
         </p>
       </div>

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -246,7 +246,7 @@
             <Translate key="workflows.recent-workflows" />
           {/if}
         </h1>
-        <p class="text-xs text-secondary">
+        <p class="mt-2 text-xs text-secondary">
           {refreshTimeFormatted}
         </p>
       </div>


### PR DESCRIPTION
The timestamp is a bit too close to the page title. Adding some spacing to give it breathing room.

| Before    | After |
| -------- | ------- |
| <img width="577" height="221" alt="Screenshot 2026-05-13 at 10 59 42 AM" src="https://github.com/user-attachments/assets/3e79a303-b10c-4784-9819-54f4b778cf7c" /> |   <img width="577" height="221" alt="Screenshot 2026-05-13 at 11 06 16 AM" src="https://github.com/user-attachments/assets/10c81be5-cff3-4c90-a2a4-0068bbf4b23d" /> |


