### PR TITLE
Fix publicPath URL duplication when prefix appears as substring

### DIFF
--- a/server/server/route/public_path.go
+++ b/server/server/route/public_path.go
@@ -23,12 +23,25 @@
 package route
 
 import (
+	"regexp"
+
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
 
+// PublicPath returns middleware that strips publicPath from the start of the
+// request URL so downstream routes (registered without the prefix) can match.
+//
+// The regex is start-anchored (^) deliberately. echo's string-rule Rewrite
+// translates path+"/*" into "<path>/(.*?)$" — end-anchored but NOT
+// start-anchored — which causes any URL with publicPath as a substring past
+// position 0 (e.g. /foo/custom/bar, or asset chunks whose hashed names
+// happen to contain the literal "/custom/") to be silently rewritten to just
+// the suffix. Building the regex explicitly forces start-position matching.
 func PublicPath(path string) echo.MiddlewareFunc {
-	return middleware.Rewrite(map[string]string{
-		path + "/*": "/$1",
+	return middleware.RewriteWithConfig(middleware.RewriteConfig{
+		RegexRules: map[*regexp.Regexp]string{
+			regexp.MustCompile("^" + regexp.QuoteMeta(path) + "/(.*?)$"): "/$1",
+		},
 	})
 }

--- a/server/server/route/public_path_test.go
+++ b/server/server/route/public_path_test.go
@@ -115,3 +115,32 @@ func TestPublicPath_DoesNotMatchPrefixWithoutSeparator(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "/customfoo", rec.Body.String())
 }
+
+func TestPublicPath_EmptyPrefix_IsNoop(t *testing.T) {
+	e := newEchoWithPublicPath("")
+	for _, p := range []string{"/", "/namespaces", "/namespaces/default/workflows"} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, p, rec.Body.String(), "empty prefix must not rewrite path %q", p)
+	}
+}
+
+func TestPublicPath_QuotesRegexMetacharacters(t *testing.T) {
+	e := newEchoWithPublicPath("/foo.bar")
+
+	// The "." must not act as a wildcard — "/fooXbar/baz" should not be rewritten.
+	req := httptest.NewRequest(http.MethodGet, "/fooXbar/baz", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/fooXbar/baz", rec.Body.String(), "metacharacter in prefix must not match unrelated path")
+
+	// The literal prefix should still be stripped correctly.
+	req = httptest.NewRequest(http.MethodGet, "/foo.bar/baz", nil)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/baz", rec.Body.String())
+}

--- a/server/server/route/public_path_test.go
+++ b/server/server/route/public_path_test.go
@@ -1,0 +1,117 @@
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func newEchoWithPublicPath(prefix string) *echo.Echo {
+	e := echo.New()
+	e.Pre(PublicPath(prefix))
+	e.GET("/*", func(c echo.Context) error {
+		return c.String(http.StatusOK, c.Request().URL.Path)
+	})
+	return e
+}
+
+func TestPublicPath_StripsPrefixAtStart(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		request  string
+		expected string
+	}{
+		{
+			name:     "single segment prefix",
+			prefix:   "/custom",
+			request:  "/custom/namespaces",
+			expected: "/namespaces",
+		},
+		{
+			name:     "trailing slash only",
+			prefix:   "/custom",
+			request:  "/custom/",
+			expected: "/",
+		},
+		{
+			name:     "deep path",
+			prefix:   "/custom",
+			request:  "/custom/namespaces/default/workflows",
+			expected: "/namespaces/default/workflows",
+		},
+		{
+			name:     "multi-segment prefix",
+			prefix:   "/foo/bar",
+			request:  "/foo/bar/baz",
+			expected: "/baz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEchoWithPublicPath(tt.prefix)
+			req := httptest.NewRequest(http.MethodGet, tt.request, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.expected, rec.Body.String())
+		})
+	}
+}
+
+// Regression: echo's default Rewrite("/custom/*", "/$1") compiles to a
+// regex that is end-anchored but NOT start-anchored, so it matches the
+// prefix anywhere in the URL. Build a start-anchored regex explicitly so
+// embedded substrings are left alone.
+func TestPublicPath_DoesNotRewriteEmbeddedPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		prefix  string
+		request string
+	}{
+		{
+			name:    "prefix as middle segment",
+			prefix:  "/custom",
+			request: "/foo/custom/bar",
+		},
+		{
+			name:    "asset path containing prefix substring",
+			prefix:  "/custom",
+			request: "/_app/immutable/chunks/custom/abc.js",
+		},
+		{
+			name:    "completely unrelated path",
+			prefix:  "/custom",
+			request: "/namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := newEchoWithPublicPath(tt.prefix)
+			req := httptest.NewRequest(http.MethodGet, tt.request, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, tt.request, rec.Body.String(), "URL.Path should be unmodified")
+		})
+	}
+}
+
+func TestPublicPath_DoesNotMatchPrefixWithoutSeparator(t *testing.T) {
+	// /customfoo shares the literal prefix string but isn't a sub-path.
+	// The middleware should not rewrite it.
+	e := newEchoWithPublicPath("/custom")
+	req := httptest.NewRequest(http.MethodGet, "/customfoo", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "/customfoo", rec.Body.String())
+}

--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -87,20 +87,27 @@ func buildUIIndexHandler(publicPath string, assets fs.FS) (echo.HandlerFunc, err
 	}
 
 	return func(c echo.Context) (err error) {
-		hasPublicPathPrefix := strings.HasPrefix(c.Request().RequestURI, publicPath+"/")
-		isExactPublicPath := c.Request().URL.Path == publicPath
-		missingPublicPath := hasPublicPath && !hasPublicPathPrefix && !isExactPublicPath
-
-		if missingPublicPath {
-			cleanPath := path.Clean(c.Request().URL.Path)
-			target := publicPath + cleanPath
-			if c.Request().URL.RawQuery != "" {
-				target += "?" + c.Request().URL.RawQuery
+		reqPath, rawQuery := splitRequestURI(c.Request().RequestURI)
+		if hasPublicPath && !hasPathPrefix(reqPath, publicPath) {
+			target := publicPath + path.Clean(reqPath)
+			if rawQuery != "" {
+				target += "?" + rawQuery
 			}
 			return c.Redirect(http.StatusPermanentRedirect, target)
 		}
 		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTMLBytes))
 	}, nil
+}
+
+func hasPathPrefix(p, prefix string) bool {
+	return p == prefix || strings.HasPrefix(p, prefix+"/")
+}
+
+func splitRequestURI(uri string) (reqPath, rawQuery string) {
+	if i := strings.Index(uri, "?"); i >= 0 {
+		return uri[:i], uri[i+1:]
+	}
+	return uri, ""
 }
 
 func buildUIAssetsHandler(assets fs.FS) echo.HandlerFunc {

--- a/server/server/route/ui.go
+++ b/server/server/route/ui.go
@@ -95,7 +95,7 @@ func buildUIIndexHandler(publicPath string, assets fs.FS) (echo.HandlerFunc, err
 			}
 			return c.Redirect(http.StatusPermanentRedirect, target)
 		}
-		return c.Stream(200, "text/html", bytes.NewBuffer(indexHTMLBytes))
+		return c.Stream(http.StatusOK, "text/html", bytes.NewBuffer(indexHTMLBytes))
 	}, nil
 }
 

--- a/server/server/route/ui_test.go
+++ b/server/server/route/ui_test.go
@@ -100,47 +100,45 @@ func TestBuildUIIndexHandler_WithPublicPath_RedirectsWhenPrefixMissing(t *testin
 
 	tests := []struct {
 		name           string
-		requestURI     string
-		path           string
-		query          string
+		target         string
 		expectedTarget string
 	}{
 		{
 			name:           "root path redirects to public path",
-			requestURI:     "/",
-			path:           "/",
+			target:         "/",
 			expectedTarget: "/temporal/",
 		},
 		{
 			name:           "sub page redirects with prefix",
-			requestURI:     "/namespaces",
-			path:           "/namespaces",
+			target:         "/namespaces",
 			expectedTarget: "/temporal/namespaces",
 		},
 		{
 			name:           "sub page preserves query params",
-			requestURI:     "/namespaces?ns=default",
-			path:           "/namespaces",
-			query:          "ns=default",
+			target:         "/namespaces?ns=default",
 			expectedTarget: "/temporal/namespaces?ns=default",
 		},
 		{
 			name:           "deep path redirects with prefix",
-			requestURI:     "/namespaces/default/workflows",
-			path:           "/namespaces/default/workflows",
+			target:         "/namespaces/default/workflows",
 			expectedTarget: "/temporal/namespaces/default/workflows",
+		},
+		{
+			name:           "path sharing prefix string but not a sub-path",
+			target:         "/temporalfoo",
+			expectedTarget: "/temporal/temporalfoo",
+		},
+		{
+			name:           "path sharing prefix string with query preserves both",
+			target:         "/temporalfoo?x=1",
+			expectedTarget: "/temporal/temporalfoo?x=1",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := echo.New()
-			target := tt.path
-			if tt.query != "" {
-				target += "?" + tt.query
-			}
-			req := httptest.NewRequest(http.MethodGet, target, nil)
-			req.RequestURI = tt.requestURI
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
@@ -157,48 +155,90 @@ func TestBuildUIIndexHandler_WithPublicPath_ServesWhenPrefixPresent(t *testing.T
 	assert.NoError(t, err)
 
 	tests := []struct {
-		name       string
-		requestURI string
-		path       string
+		name   string
+		target string
 	}{
 		{
-			name:       "prefixed root",
-			requestURI: "/temporal/",
-			path:       "/",
+			name:   "prefixed root",
+			target: "/temporal/",
 		},
 		{
-			name:       "prefixed sub page",
-			requestURI: "/temporal/namespaces",
-			path:       "/namespaces",
+			name:   "prefixed sub page",
+			target: "/temporal/namespaces",
 		},
 		{
-			name:       "prefixed with query",
-			requestURI: "/temporal/namespaces?ns=default",
-			path:       "/namespaces",
+			name:   "prefixed with query",
+			target: "/temporal/namespaces?ns=default",
 		},
 		{
-			name:       "exact public path",
-			requestURI: "/temporal",
-			path:       "/temporal",
+			name:   "exact public path",
+			target: "/temporal",
 		},
 		{
-			name:       "exact public path with query",
-			requestURI: "/temporal?q=1",
-			path:       "/temporal",
+			name:   "exact public path with query",
+			target: "/temporal?q=1",
+		},
+		{
+			name:   "already-prefixed path is not re-prefixed",
+			target: "/temporal/temporal/namespaces",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := echo.New()
-			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
-			req.RequestURI = tt.requestURI
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
 
 			err := handler(c)
 			assert.NoError(t, err)
 			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Contains(t, rec.Body.String(), `base: "/temporal"`)
+		})
+	}
+}
+
+// The PublicPath middleware rewrites URL.Path to strip the prefix before
+// reaching this handler, while leaving RequestURI intact. The handler must
+// not redirect in that case, otherwise the rewrite + redirect loops.
+func TestBuildUIIndexHandler_WithPublicPath_HandlesMiddlewareRewrittenPath(t *testing.T) {
+	handler, err := buildUIIndexHandler("/temporal", newTestAssets(testIndexHTML))
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		requestURI string
+		urlPath    string
+	}{
+		{
+			name:       "prefixed sub page rewritten by middleware",
+			requestURI: "/temporal/namespaces",
+			urlPath:    "/namespaces",
+		},
+		{
+			name:       "prefixed root rewritten by middleware",
+			requestURI: "/temporal/",
+			urlPath:    "/",
+		},
+		{
+			name:       "prefixed with query rewritten by middleware",
+			requestURI: "/temporal/namespaces?ns=default",
+			urlPath:    "/namespaces",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, tt.urlPath, nil)
+			req.RequestURI = tt.requestURI
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			err := handler(c)
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusOK, rec.Code, "handler should serve index, not redirect")
 			assert.Contains(t, rec.Body.String(), `base: "/temporal"`)
 		})
 	}

--- a/server/server/route/ui_test.go
+++ b/server/server/route/ui_test.go
@@ -133,6 +133,11 @@ func TestBuildUIIndexHandler_WithPublicPath_RedirectsWhenPrefixMissing(t *testin
 			target:         "/temporalfoo?x=1",
 			expectedTarget: "/temporal/temporalfoo?x=1",
 		},
+		{
+			name:           "trailing slash is normalized away by path.Clean",
+			target:         "/namespaces/",
+			expectedTarget: "/temporal/namespaces",
+		},
 	}
 
 	for _, tt := range tests {

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -426,6 +426,26 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
     },
   );
 
+  it.each(prefixedCases)(
+    '%s should insert prefix between base and route without altering the rest',
+    (_name, fn) => {
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => '',
+      });
+      const unprefixed = fn();
+      if (unprefixed === undefined) return;
+
+      initCoreProvider({
+        getAccessToken: async () => '',
+        getRoutePrefix: () => prefix,
+      });
+      const prefixed = fn();
+
+      expect(prefixed).toBe(`${base}${prefix}${unprefixed.slice(base.length)}`);
+    },
+  );
+
   it.each(authCases)(
     '%s should NOT include prefix (auth routes excluded)',
     (_name, fn) => {

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -16,10 +16,13 @@ import { toURL } from '$lib/utilities/to-url';
 
 import { getRoutePrefix } from './core-provider';
 
-const withPrefix = (path: ResolvedPathname): ResolvedPathname => {
+const withPrefix = (
+  route: string,
+  params: Record<string, string>,
+): ResolvedPathname => {
   const prefix = getRoutePrefix();
-  if (!prefix) return path;
-  return `${base}${prefix}${path.slice(base.length)}` as ResolvedPathname;
+  if (!prefix) return resolve(route, params);
+  return resolve(`${prefix}${route}`, params);
 };
 
 interface RouteParameters {
@@ -84,11 +87,11 @@ export interface StartActivityExecutionQueryParams {
 }
 
 export const routeForNamespaces = (): ResolvedPathname => {
-  return withPrefix(resolve('/namespaces', {}));
+  return withPrefix('/namespaces', {});
 };
 
 export const routeForNexus = (): ResolvedPathname => {
-  return withPrefix(resolve('/nexus', {}));
+  return withPrefix('/nexus', {});
 };
 
 export const routeForCommonErrors = (): ResolvedPathname => {
@@ -96,25 +99,25 @@ export const routeForCommonErrors = (): ResolvedPathname => {
 };
 
 export const routeForNexusEndpoint = (id: string): ResolvedPathname => {
-  return withPrefix(resolve('/nexus/[id]', { id }));
+  return withPrefix('/nexus/[id]', { id });
 };
 
 export const routeForNexusEndpointEdit = (id: string): ResolvedPathname => {
-  return withPrefix(resolve('/nexus/[id]/edit', { id }));
+  return withPrefix('/nexus/[id]/edit', { id });
 };
 
 export const routeForNexusEndpointCreate = (): ResolvedPathname => {
-  return withPrefix(resolve('/nexus/create', {}));
+  return withPrefix('/nexus/create', {});
 };
 
 export const routeForNamespace = ({
   namespace,
 }: NamespaceParameter): ResolvedPathname => {
-  return withPrefix(resolve('/namespaces/[namespace]', { namespace }));
+  return withPrefix('/namespaces/[namespace]', { namespace });
 };
 
 export const routeForNamespaceSelector = (): ResolvedPathname => {
-  return withPrefix(resolve('/select-namespace', {}));
+  return withPrefix('/select-namespace', {});
 };
 
 export const routeForWorkflows = (
@@ -366,11 +369,9 @@ export const routeForWorkerDeployments = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return withPrefix(
-    resolve('/namespaces/[namespace]/workers/deployments', {
-      namespace,
-    }),
-  );
+  return withPrefix('/namespaces/[namespace]/workers/deployments', {
+    namespace,
+  });
 };
 
 export const routeForWorkerInstance = ({
@@ -381,12 +382,10 @@ export const routeForWorkerInstance = ({
   workerInstanceKey: string;
 }): ResolvedPathname => {
   const workerInstanceKeyEncoded = encodeURIForSvelte(workerInstanceKey);
-  return withPrefix(
-    resolve('/namespaces/[namespace]/workers/[workerInstanceKey]', {
-      namespace,
-      workerInstanceKey: workerInstanceKeyEncoded,
-    }),
-  );
+  return withPrefix('/namespaces/[namespace]/workers/[workerInstanceKey]', {
+    namespace,
+    workerInstanceKey: workerInstanceKeyEncoded,
+  });
 };
 
 export const routeForWorkerDeployment = ({
@@ -398,10 +397,11 @@ export const routeForWorkerDeployment = ({
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
   return withPrefix(
-    resolve('/namespaces/[namespace]/workers/deployments/[deployment]', {
+    '/namespaces/[namespace]/workers/deployments/[deployment]',
+    {
       namespace,
       deployment: deploymentName,
-    }),
+    },
   );
 };
 
@@ -429,13 +429,11 @@ export const routeForWorkerDeploymentVersionCreate = ({
 }): ResolvedPathname => {
   const deploymentName = encodeURIForSvelte(deployment);
   return withPrefix(
-    resolve(
-      '/namespaces/[namespace]/workers/deployments/[deployment]/versions/create',
-      {
-        namespace,
-        deployment: deploymentName,
-      },
-    ),
+    '/namespaces/[namespace]/workers/deployments/[deployment]/versions/create',
+    {
+      namespace,
+      deployment: deploymentName,
+    },
   );
 };
 
@@ -451,14 +449,12 @@ export const routeForWorkerDeploymentVersionEdit = ({
   const deploymentName = encodeURIForSvelte(deployment);
   const buildIdEncoded = encodeURIForSvelte(buildId);
   return withPrefix(
-    resolve(
-      '/namespaces/[namespace]/workers/deployments/[deployment]/versions/[buildId]/edit',
-      {
-        namespace,
-        deployment: deploymentName,
-        buildId: buildIdEncoded,
-      },
-    ),
+    '/namespaces/[namespace]/workers/deployments/[deployment]/versions/[buildId]/edit',
+    {
+      namespace,
+      deployment: deploymentName,
+      buildId: buildIdEncoded,
+    },
   );
 };
 
@@ -467,11 +463,9 @@ export const routeForWorkerDeploymentCreate = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return withPrefix(
-    resolve('/namespaces/[namespace]/workers/deployments/create', {
-      namespace,
-    }),
-  );
+  return withPrefix('/namespaces/[namespace]/workers/deployments/create', {
+    namespace,
+  });
 };
 
 export const routeForRelationships = (
@@ -585,13 +579,14 @@ export const routeForEventHistoryImport = (
 ): ResolvedPathname => {
   if (namespace && view) {
     return withPrefix(
-      resolve('/import/events/[namespace]/workflow/run/history/[view]', {
+      '/import/events/[namespace]/workflow/run/history/[view]',
+      {
         namespace,
         view,
-      }),
+      },
     );
   }
-  return withPrefix(resolve('/import/events', {}));
+  return withPrefix('/import/events', {});
 };
 
 export const routeForBatchOperations = ({
@@ -599,11 +594,9 @@ export const routeForBatchOperations = ({
 }: {
   namespace: string;
 }): ResolvedPathname => {
-  return withPrefix(
-    resolve('/namespaces/[namespace]/batch-operations', {
-      namespace,
-    }),
-  );
+  return withPrefix('/namespaces/[namespace]/batch-operations', {
+    namespace,
+  });
 };
 
 export const routeForBatchOperation = ({
@@ -615,12 +608,10 @@ export const routeForBatchOperation = ({
 }): ResolvedPathname => {
   const jId = encodeURIForSvelte(jobId);
 
-  return withPrefix(
-    resolve('/namespaces/[namespace]/batch-operations/[jobId]', {
-      namespace,
-      jobId: jId,
-    }),
-  );
+  return withPrefix('/namespaces/[namespace]/batch-operations/[jobId]', {
+    namespace,
+    jobId: jId,
+  });
 };
 
 export const hasParameters =

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -95,7 +95,7 @@ export const routeForNexus = (): ResolvedPathname => {
 };
 
 export const routeForCommonErrors = (): ResolvedPathname => {
-  return resolve('/common-errors', {});
+  return withPrefix('/common-errors', {});
 };
 
 export const routeForNexusEndpoint = (id: string): ResolvedPathname => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The substring `/custom` is short and generic enough to appear inside a URL path other than at position 0 (e.g. asset chunks like `/_app/immutable/chunks/custom-XXXXX.js`). Any time the middleware saw a request whose `RequestURI` contained `/custom` somewhere past position 0, it rewrote the `req.URL` to just the suffix and threw away the prefix. That mangled `URL.Path` then drove the redirect logic in `buildUIIndexHandler`.

This PRs fixes this by
* Always reading `RequestURI`(which middleware doesn't touch) instead of a mix of `RequestURI` and `URL.Path`
* Consolidating prefix check via `hasPathPrefix`(handles exact paths and sub-paths)
* Anchoring the rewrite regex at the start by changing `route.PublicPath` to use `middleware.RewriteWithConfig{ RegexRules: ... }` with an explicitly-anchored pattern (`^/custom/(.*?)$`) to prevent the substring matching

It also inlines `resolve()` into `withPrefix()` so deprecated `base` path is no longer needed.

**Note:** 308 is cached aggressively by browsers. Once a wrong redirect target is cached, the doubled URL sticks around until cache is cleared.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

`pnpm test src/lib/utilities/route-for-base-path.test.ts`

`pnpm test src/lib/utilities/route-for.test.ts`

` cd server && go test ./server/route/...`

Run the following ⬇️ 
```
cd server

pnpm build:server 
pnpm dev:ui-server

docker build -t temporal-ui-local .
docker run -p 5252:8080 -e TEMPORAL_UI_PUBLIC_PATH=/custom -e TEMPORAL_ADDRESS=host.docker.internal:7233 temporal-ui-local

```

Then go to http://localhost:5252
 - [ ] Verify it redirects to  `/custom` and does not cause an infinite loop
 - [ ] Verify `/namespaces` redirects to `/custom/namespaces`

Clear browser cache and then run the following (**without** a `publicPath` set)  ⬇️ 

```
docker run -p 5252:8080 -e TEMPORAL_ADDRESS=host.docker.internal:7233 temporal-ui-local
```

Then go to http://localhost:5252
 - [ ] Verify the route works as expected
 


## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
