### PR TITLE
feat(history): show Nexus operation name in compact view 

### DIFF
--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -286,7 +286,7 @@ describe('getSummaryEvent', () => {
     });
   });
 
-  it('should return the operation name for a NexusOperationScheduled event', async () => {
+  it('should return the input for a NexusOperationScheduled event', async () => {
     const nexusEvent = {
       eventId: '5',
       eventTime: '2024-07-11T17:42:53.326959Z',
@@ -310,8 +310,13 @@ describe('getSummaryEvent', () => {
     };
     const event = await toEvent(nexusEvent);
     expect(getSummaryAttribute(event)).toStrictEqual({
-      key: 'operation',
-      value: 'custom-op',
+      key: 'input',
+      value: {
+        data: 'InN0YXJ0LWFzeW5jIg==',
+        metadata: {
+          encoding: 'anNvbi9wbGFpbg==',
+        },
+      },
     });
   });
 });

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -286,7 +286,7 @@ describe('getSummaryEvent', () => {
     });
   });
 
-  it('should return expected payload for a Nexus single payload', async () => {
+  it('should return the operation name for a NexusOperationScheduled event', async () => {
     const nexusEvent = {
       eventId: '5',
       eventTime: '2024-07-11T17:42:53.326959Z',
@@ -310,13 +310,8 @@ describe('getSummaryEvent', () => {
     };
     const event = await toEvent(nexusEvent);
     expect(getSummaryAttribute(event)).toStrictEqual({
-      key: 'input',
-      value: {
-        metadata: {
-          encoding: 'anNvbi9wbGFpbg==',
-        },
-        data: 'InN0YXJ0LWFzeW5jIg==',
-      },
+      key: 'operation',
+      value: 'custom-op',
     });
   });
 });

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -17,6 +17,7 @@ import { has } from './has';
 import { isObject } from './is';
 import {
   isLocalActivityMarkerEvent,
+  isNexusOperationScheduledEvent,
   isWorkflowExecutionUpdateAcceptedEvent,
 } from './is-event-type';
 import {
@@ -321,6 +322,15 @@ export const getEventSummaryAttribute = (
       return {
         key: 'name',
         value: event.attributes.acceptedRequest.input.name,
+      };
+    }
+  }
+
+  if (isNexusOperationScheduledEvent(event)) {
+    if (event.attributes?.operation) {
+      return {
+        key: 'operation',
+        value: event.attributes.operation,
       };
     }
   }

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -17,7 +17,6 @@ import { has } from './has';
 import { isObject } from './is';
 import {
   isLocalActivityMarkerEvent,
-  isNexusOperationScheduledEvent,
   isWorkflowExecutionUpdateAcceptedEvent,
 } from './is-event-type';
 import {
@@ -265,6 +264,7 @@ const preferredSummaryKeys = [
   'identity',
   'parentInitiatedEventId',
   'endpointId',
+  'operation',
 ] as const;
 
 /**
@@ -322,15 +322,6 @@ export const getEventSummaryAttribute = (
       return {
         key: 'name',
         value: event.attributes.acceptedRequest.input.name,
-      };
-    }
-  }
-
-  if (isNexusOperationScheduledEvent(event)) {
-    if (event.attributes?.operation) {
-      return {
-        key: 'operation',
-        value: event.attributes.operation,
       };
     }
   }


### PR DESCRIPTION
## Show Nexus operation name in compact view alongside Activity and Update DT-3903

# Testing
Used nexusScheduledOperation
<img width="1115" height="348" alt="Screenshot 2026-05-14 at 11 37 01 AM" src="https://github.com/user-attachments/assets/d287e8e8-c181-4f3d-8e64-b237f7311c31" />
 ## Summary

  Show the Nexus operation name in the workflow history compact view, the same way
  Activity name and Update name appear today.

  ## Why

  Internal ask: the compact history view shows the operation/type name for
  Activity and Update rows, but Nexus operation rows fell back to `endpointId` instead
  — making it hard to tell which Nexus operation a row represents without expanding it.
   This adds the operation name so you can read the full picture at a glance.

  Before: `Nexus Operation` row showed `EndpointId: <endpoint-id>`
  After: `Nexus Operation` row shows `Operation: <operation-name>`

  Mirrors the existing pattern — Activity shows `ActivityType`, Update shows `Name`,
  Nexus now shows `Operation`.

  ## What changed

  - `src/lib/utilities/get-single-attribute-for-event.ts` — added a
  `NexusOperationScheduled` branch in `getEventSummaryAttribute` that returns `{ key:
  'operation', value: event.attributes.operation }`, placed right after the existing
  Update branch so it wins over the `endpointId` fallback in `preferredSummaryKeys`.
  - `src/lib/utilities/get-single-attribute-for-event.test.ts` — updated the existing
  Nexus test to assert the new contract.

  No changes to the row component itself — `event-summary-row.svelte` already routes
  everything through `getPrimaryAttributeForEvent` and reads from `event.initialEvent`
  for grouped events, so the operation name surfaces automatically for both the
  standalone scheduled event and the grouped Nexus operation row.

  Pending Nexus operation rows (`pending-nexus-summary-row.svelte`) are intentionally
  **out of scope** for this PR — they can be a separate change if desired.

  ## Testing

  - `pnpm lint` — clean (no new errors/warnings)
  - `pnpm check` — clean
  - `pnpm test -- --run` — 1964 tests pass, including the updated Nexus assertion
  - Manual: ran the UI against a local workflow with Nexus operation events, toggled to
   Compact view, confirmed the operation name renders on the Nexus row