### PR TITLE
add loading state to payload code block

### DIFF
--- a/src/lib/components/payload/payload-code-block.svelte
+++ b/src/lib/components/payload/payload-code-block.svelte
@@ -5,6 +5,7 @@
     PayloadContainingObject,
     PotentiallyDecodable,
   } from '$lib/utilities/decode-payload';
+  import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   import PayloadDecoder from './payload-decoder.svelte';
 
@@ -19,6 +20,16 @@
 </script>
 
 <PayloadDecoder {value}>
+  {#snippet loading()}
+    <CodeBlock
+      content={stringifyWithBigInt(value)}
+      {maxHeight}
+      copyIconTitle={translate('common.copy-icon-title')}
+      copySuccessIconTitle={translate('common.copy-success-icon-title')}
+      {testId}
+      language="json"
+    />
+  {/snippet}
   {#snippet children(decodedValue)}
     <div class="space-y-2">
       {#each decodedValue as data, index (index)}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
This PR effectively reinstates behavior that regressed when #3299 was merged, just in a different way.

See [here](https://github.com/temporalio/ui/pull/3299/changes#diff-f5df298e3cf10bab6f20ce354a1c5e425bf2f7e174a88ca006a11fd0e21d8f83L23) where the `decodedValue` state was initiated with the raw payload value, then re-assigned when decoding completed. Adding a `Codeblock` with the raw payload value in the `loading` snippet exposed by `PayloadDecoder` accomplishes the same.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
