### PR TITLE
Make input from schedule result actually a string and update tests

### DIFF
--- a/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
@@ -16,6 +16,7 @@
     base64ParsePayloadMetadata,
     isParsedPayload,
   } from '$lib/utilities/decode-payload';
+  import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   interface Props {
     input: string;
@@ -42,7 +43,7 @@
 
   const setInitialInput = (result: DecodedPayloadResult): void => {
     if (result && result[0] && isParsedPayload(result[0].decodedValue)) {
-      initialInput = result[0].decodedValue.data as string;
+      initialInput = stringifyWithBigInt(result[0].decodedValue.data) ?? '';
 
       input = initialInput;
       let currentEncoding: PayloadInputEncoding = 'json/plain';

--- a/tests/integration/schedule-edit.spec.ts
+++ b/tests/integration/schedule-edit.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import {
+  mockSchedule,
   mockScheduleApi,
   mockSchedulesApis,
   SCHEDULES_COUNT_API,
@@ -9,13 +10,36 @@ import {
 const schedulesUrl = '/namespaces/default/schedules';
 const scheduleEditUrl = '/namespaces/default/schedules/test-schedule/edit';
 
+const scheduleWithInput = (data: string) => ({
+  ...mockSchedule,
+  schedule: {
+    ...mockSchedule.schedule,
+    action: {
+      ...mockSchedule.schedule.action,
+      startWorkflow: {
+        ...mockSchedule.schedule.action.startWorkflow,
+        input: {
+          payloads: [
+            {
+              metadata: {
+                encoding: 'anNvbi9wbGFpbg==',
+              },
+              data,
+            },
+          ],
+        },
+      },
+    },
+  },
+});
+
 test.describe('Schedules List with schedules', () => {
   test.beforeEach(async ({ page }) => {
     await mockSchedulesApis(page);
-    await mockScheduleApi(page);
   });
 
   test('selects schedule and edits', async ({ page }) => {
+    await mockScheduleApi(page);
     await page.goto(schedulesUrl);
 
     await page.waitForResponse(SCHEDULES_COUNT_API);
@@ -40,6 +64,7 @@ test.describe('Schedules List with schedules', () => {
   });
 
   test('Edits existing schedule', async ({ page }) => {
+    await mockScheduleApi(page);
     await page.goto(scheduleEditUrl);
 
     const heading = page.locator('h1');
@@ -60,5 +85,49 @@ test.describe('Schedules List with schedules', () => {
     await expect(submitButton).toBeVisible();
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
+  });
+
+  test('edits an existing schedule with an object input payload', async ({
+    page,
+  }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error));
+    await mockScheduleApi(
+      page,
+      scheduleWithInput('eyJtZXNzYWdlIjoiaGVsbG8ifQ=='),
+    );
+
+    await page.goto(scheduleEditUrl);
+
+    const payloadInput = page
+      .locator('#schedule-payload-input')
+      .getByRole('textbox');
+    await expect(payloadInput).toContainText('"message"');
+
+    await page.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(payloadInput).toContainText('"message"');
+    expect(pageErrors.map(({ message }) => message).join('\n')).not.toContain(
+      'split is not a function',
+    );
+  });
+
+  test('edits an existing schedule with a string input payload', async ({
+    page,
+  }) => {
+    await mockScheduleApi(page, scheduleWithInput('ImhlbGxvIg=='));
+
+    await page.goto(scheduleEditUrl);
+
+    const payloadInput = page
+      .locator('#schedule-payload-input')
+      .getByRole('textbox');
+    await expect(payloadInput).toContainText('"hello"');
+    await expect(page.getByText('Input must be valid JSON')).toBeHidden();
+
+    await page.getByRole('button', { name: 'Edit' }).click();
+
+    await expect(payloadInput).toContainText('"hello"');
+    await expect(page.getByText('Input must be valid JSON')).toBeHidden();
   });
 });

--- a/tests/test-utilities/mock-apis.ts
+++ b/tests/test-utilities/mock-apis.ts
@@ -49,7 +49,7 @@ export {
   mockSearchAttributesApi,
   SEARCH_ATTRIBUTES_API,
 } from './mocks/search-attributes';
-export { mockScheduleApi, SCHEDULE_API } from './mocks/schedules';
+export { mockSchedule, mockScheduleApi, SCHEDULE_API } from './mocks/schedules';
 export {
   mockSchedulesCountApi,
   SCHEDULES_COUNT_API,

--- a/tests/test-utilities/mocks/schedules.ts
+++ b/tests/test-utilities/mocks/schedules.ts
@@ -133,10 +133,13 @@ export const mockSchedulesApi = (page: Page, empty = false) => {
   });
 };
 
-export const mockScheduleApi = (page: Page) => {
+export const mockScheduleApi = (
+  page: Page,
+  scheduleResponse = mockSchedule,
+) => {
   return page.route(SCHEDULE_API, (route) => {
     return route.fulfill({
-      json: mockSchedule,
+      json: scheduleResponse,
     });
   });
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Fixes schedule edit payload rendering.

When editing a schedule, decoded payload data was assigned directly to the payload editor input. Object payloads reached CodeMirror as non-string values, causing (config.doc || "").split is not a function, while string payloads rendered without JSON quotes and appeared invalid.

The fix serializes decoded payload data with stringifyWithBigInt before binding it to the editor, so all payload values are valid JSON document strings. Added schedule edit integration coverage for both object and string payload inputs.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Test creating new schedules and editing schedules with payloads.

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
