### PR TITLE
Fix pauseLiveUpdate logic and remove currentEventHistory store

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -20,7 +20,6 @@
   import { clearActives } from '$lib/stores/active-events';
   import { eventFilterSort, eventViewType } from '$lib/stores/event-view';
   import {
-    currentEventHistory,
     filteredEventHistory,
     fullEventHistory,
     pauseLiveUpdates,
@@ -69,7 +68,7 @@
   );
 
   const workflowTaskFailedError = $derived(
-    getWorkflowTaskFailedEvent($currentEventHistory, 'ascending'),
+    getWorkflowTaskFailedEvent($fullEventHistory, 'ascending'),
   );
 
   const isNotPending = $derived(

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -18,11 +18,7 @@
   import { fetchWorkflow } from '$lib/services/workflow-service';
   import { resetLastDataEncoderSuccess } from '$lib/stores/data-encoder-config';
   import { eventFilterSort, type EventSortOrder } from '$lib/stores/event-view';
-  import {
-    fullEventHistory,
-    pauseLiveUpdates,
-    timelineEvents,
-  } from '$lib/stores/events';
+  import { fullEventHistory, timelineEvents } from '$lib/stores/events';
   import {
     initialWorkflowRun,
     refresh,
@@ -47,6 +43,7 @@
   let workflowId = $derived(page.params.workflow);
   let runId = $derived(page.params.run);
   let showJson = $derived(page.url.searchParams.has('json'));
+  let pauseLiveUpdates = $derived(parseEventFilterParams(page.url).refresh_off);
   let fullJson = $derived({ ...$workflowRun, eventHistory: $fullEventHistory });
 
   let workflowError: NetworkError | null = $state(null);
@@ -90,7 +87,6 @@
     workflowId: string,
     runId: string,
   ) => {
-    const { settings } = page.data;
     const { workflow, error } = await fetchWorkflow({
       namespace,
       workflowId,
@@ -114,6 +110,7 @@
     $workflowRun = { ...$workflowRun, workflow, workers, workersLoaded: true };
 
     workflowRunController = new AbortController();
+    const signal = pauseLiveUpdates ? undefined : workflowRunController.signal;
 
     if (workflow.isRunning && workers?.pollers?.length) {
       getWorkflowMetadata(
@@ -124,20 +121,24 @@
             runId,
           },
         },
-        $pauseLiveUpdates ? undefined : workflowRunController.signal,
+        signal,
       ).then((metadata) => {
         $workflowRun.metadata = metadata;
       });
     }
 
-    $fullEventHistory = await fetchAllEvents({
+    const events = await fetchAllEvents({
       namespace,
       workflowId,
       runId,
       sort: 'ascending',
-      signal: $pauseLiveUpdates ? undefined : workflowRunController.signal,
+      signal,
       historySize: workflow.historyEvents,
     });
+
+    if (signal?.aborted) return;
+
+    $fullEventHistory = events;
   };
 
   const getOnlyWorkflowWithPendingActivities = async (
@@ -196,7 +197,10 @@
 
   $effect(() => {
     const refreshValue = $refresh;
-    const pause = $pauseLiveUpdates;
+    const pause = pauseLiveUpdates;
+    if (pause && workflowRunController) {
+      workflowRunController.abort();
+    }
     untrack(() => {
       getOnlyWorkflowWithPendingActivities(refreshValue, pause);
     });

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -19,7 +19,6 @@
   import { resetLastDataEncoderSuccess } from '$lib/stores/data-encoder-config';
   import { eventFilterSort, type EventSortOrder } from '$lib/stores/event-view';
   import {
-    currentEventHistory,
     fullEventHistory,
     pauseLiveUpdates,
     timelineEvents,
@@ -34,6 +33,7 @@
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { copyToClipboard } from '$lib/utilities/copy-to-clipboard';
   import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
+  import { parseEventFilterParams } from '$lib/utilities/event-filter-params';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   interface Props {
@@ -124,7 +124,7 @@
             runId,
           },
         },
-        workflowRunController.signal,
+        $pauseLiveUpdates ? undefined : workflowRunController.signal,
       ).then((metadata) => {
         $workflowRun.metadata = metadata;
       });
@@ -135,7 +135,7 @@
       workflowId,
       runId,
       sort: 'ascending',
-      signal: workflowRunController.signal,
+      signal: $pauseLiveUpdates ? undefined : workflowRunController.signal,
       historySize: workflow.historyEvents,
     });
   };
@@ -147,7 +147,6 @@
     const shouldFetch =
       refresh.timestamp &&
       (refresh.action || (!pause && $workflowRun?.workflow?.isRunning));
-
     if (shouldFetch) {
       const { workflow, error } = await fetchWorkflow({
         namespace,
@@ -201,12 +200,6 @@
     untrack(() => {
       getOnlyWorkflowWithPendingActivities(refreshValue, pause);
     });
-  });
-
-  $effect(() => {
-    if (!$pauseLiveUpdates) {
-      $currentEventHistory = $fullEventHistory;
-    }
   });
 
   onMount(() => {

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -16,8 +16,8 @@
   import { clearActives } from '$lib/stores/active-events';
   import { eventFilterSort } from '$lib/stores/event-view';
   import {
-    currentEventHistory,
     filteredEventHistory,
+    fullEventHistory,
     pauseLiveUpdates,
   } from '$lib/stores/events';
   import { workflowRun } from '$lib/stores/workflow-run';
@@ -59,7 +59,7 @@
   );
 
   const workflowTaskFailedError = $derived(
-    getWorkflowTaskFailedEvent($currentEventHistory, 'ascending'),
+    getWorkflowTaskFailedEvent($fullEventHistory, 'ascending'),
   );
 
   const isNotPending = $derived(

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -53,10 +53,9 @@ export const timelineEvents = writable(null);
 export const fullEventHistory = writable<WorkflowEvents>([]);
 
 export const pauseLiveUpdates = writable(false);
-export const currentEventHistory = writable<WorkflowEvents>([]);
 
 export const filteredEventHistory = derived(
-  [currentEventHistory, eventTypeFilter],
+  [fullEventHistory, eventTypeFilter],
   ([$history, $types]) => {
     return $history.filter((event) => {
       if (isLocalActivityMarkerEvent(event)) {

--- a/tests/integration/workflow-event-history.spec.ts
+++ b/tests/integration/workflow-event-history.spec.ts
@@ -43,6 +43,21 @@ test.describe('Workflow History', () => {
     );
   });
 
+  test('Workflow Execution loads event history when live updates are paused from the URL', async ({
+    page,
+  }) => {
+    await mockWorkflowApis(page);
+    await page.goto(`${workflowUrl}?refresh_off=true`);
+
+    await expect(page.getByTestId('pause')).toContainText('Auto Refresh Off');
+    await expect(
+      page
+        .getByTestId('event-summary-row')
+        .filter({ hasText: 'Workflow Execution Started' })
+        .first(),
+    ).toBeVisible();
+  });
+
   test('Workflow Execution links to specific event', async ({ page }) => {
     await mockWorkflowApis(page);
     await expect(page.getByTestId('workflow-id-heading')).toHaveText(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR updates workflow run loading so live polling respects pauseLiveUpdates.

When live updates are paused, workflow history and metadata requests are made without the live polling abort signal, which prevents the event history endpoint from using `waitNewEvent=true`. The layout also aborts any existing live polling controller when pause is enabled so an already-running long poll does not continue in the background. 

It also removes currentEventHistory store: currentEventHistory was a workaround for the older behavior: keep the rendered event list frozen while fullEventHistory continued to update in the background. Now the fix is at the source: when pauseLiveUpdates is true, live polling is not started, and any in-flight polling controller is aborted. With the guard:

if (signal?.aborted) return;

The aborted fetch no longer writes [] back into $fullEventHistory.

## Why

The history page correctly stopped updating when `pauseLiveUpdates` was enabled, but an in-flight workflow run poll could still continue after the user paused live updates. This caused background history refetch behavior even though the UI indicated auto refresh was off. Also, if a user refreshed the page with refresh_off=true, the history would not load, showing only pending events.

This change makes the pause state apply consistently to workflow details, metadata, and event history loading.

  - Verified `/history?refresh_off=true` still loads initial event history.
  - Verified pausing live updates stops live polling/refetch behavior.
  - Verified workflow details and history remain usable while live updates are
  paused.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
Pause Live Updates during a running workflow and ensure no new events render and the workflow doesn't update. 

Pause Live Updates during a running workflow and then unpause and ensur new events render and the workflow does update. 

Pause Live Updates during a running workflow, wait, and refresh the page. Ensure new events are rendered from the pause to the refresh, but ensure no new events render.


### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
