### PR TITLE
fix: enable external payload download button with namespace level codec endpoint

### DIFF
--- a/src/lib/components/payload/payload-code-block.svelte
+++ b/src/lib/components/payload/payload-code-block.svelte
@@ -9,6 +9,8 @@
 </script>
 
 <script lang="ts">
+  import { page } from '$app/state';
+
   import Button from '$lib/holocene/button.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -17,7 +19,6 @@
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { downloadExternalPayloadWithCodec } from '$lib/services/data-encoder';
-  import { codecEndpoint } from '$lib/stores/data-encoder-config';
   import type { Payload, Payloads } from '$lib/types';
   import {
     isExternallyStoredRawPayload,
@@ -26,6 +27,7 @@
     type PayloadContainingObject,
   } from '$lib/utilities/decode-payload';
   import { formatBytes } from '$lib/utilities/format-bytes';
+  import { getCodecEndpoint } from '$lib/utilities/get-codec';
   import { isNetworkError } from '$lib/utilities/is-network-error';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
@@ -116,14 +118,14 @@
               <Tooltip
                 width={192}
                 top
-                hide={!!$codecEndpoint}
+                hide={!!getCodecEndpoint(page.data.settings)}
                 text="Add a codec server with a /download endpoint to download this payload."
               >
                 <Button
                   size="sm"
                   variant="ghost"
                   leadingIcon="download"
-                  disabled={!$codecEndpoint}
+                  disabled={!getCodecEndpoint(page.data.settings)}
                   loading={downloadLoading}
                   on:click={() => downloadExternalPayload(result.originalValue)}
                 >

--- a/src/lib/services/data-encoder.test.ts
+++ b/src/lib/services/data-encoder.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('$lib/utilities/core-provider', () => ({
   getAccessToken: vi.fn().mockResolvedValue(''),
   getIdToken: vi.fn().mockResolvedValue(undefined),
 }));
+
+import { page } from '$app/state';
 
 import {
   codecEndpoint,
@@ -271,5 +273,61 @@ describe('codecIncludeCredentials', () => {
     const fetchCall = vi.mocked(global.fetch).mock.calls[0];
     const requestOptions = fetchCall[1] as RequestInit;
     expect(requestOptions.credentials).toBeUndefined();
+  });
+});
+
+describe('download with namespace-level codec endpoint', () => {
+  // Regression test: the download button in payload-code-block.svelte was
+  // disabled when the browser-level $codecEndpoint store was empty, even
+  // though codeServerRequest correctly falls back to settings.codec.endpoint.
+  // These tests document the expected service-layer behaviour so a regression
+  // in data-encoder.ts would be caught immediately.
+  const payloads = { payloads: [{}] };
+  const namespaceEndpoint = 'http://namespace-codec.example.com';
+
+  beforeEach(() => {
+    // Browser store intentionally left empty — only namespace settings set.
+    codecEndpoint.set(null);
+    passAccessToken.set(false);
+    includeCredentials.set(false);
+    (page.data.settings as { codec: { endpoint: string } }).codec.endpoint =
+      namespaceEndpoint;
+  });
+
+  afterEach(() => {
+    (page.data.settings as { codec: { endpoint: string } }).codec.endpoint = '';
+    vi.clearAllMocks();
+  });
+
+  it('should use the namespace endpoint for download when browser store is not configured', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payloads),
+      } as Response),
+    );
+
+    await codeServerRequest({ type: 'download', payloads });
+
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+      `${namespaceEndpoint}/download?preserveStorageRefs=true`,
+      expect.any(Object),
+    );
+  });
+
+  it('should use the namespace endpoint for decode when browser store is not configured', async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payloads),
+      } as Response),
+    );
+
+    await codeServerRequest({ type: 'decode', payloads });
+
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith(
+      `${namespaceEndpoint}/decode?preserveStorageRefs=true`,
+      expect.any(Object),
+    );
   });
 });


### PR DESCRIPTION
## Description & motivation 💭
The download button for externally-stored payloads was gated on `$codecEndpoint` (the browser localStorage store), which is null when the codec server is configured only at the namespace/settings level. This left the button permanently disabled even though the codec server was reachable and actively serving /decode requests on the same page.

Replace the `$codecEndpoint` checks with `getCodecEndpoint(page.data.settings)`, which is already the authoritative resolver used by `codeServerRequest` for all encode/decode/download requests. It correctly falls back to `settings.codec.endpoint` when the browser-level override is not set.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="391" height="534" alt="image" src="https://github.com/user-attachments/assets/dd4747e3-f3f1-4eec-b394-aed41f0144cd" />

### Design Considerations 🎨
I just tried to follow the pattern used elsewhere that namespace-level codec endpoints are respected, using `getCodecEndpoint`

## Testing 🧪


### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️
* Run the UI with a namespace-level codec endpoint configured, supporting the external storage /download endpoint
* Run a workflow with a large payload
* Observe that you can use the download button

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed
#3419 

## Docs

### Any docs updates needed?
n/a