### PR TITLE
Use pageSize instead of maximumPageSize for Workers list API requests

### DIFF
--- a/src/lib/services/deployments-service.test.ts
+++ b/src/lib/services/deployments-service.test.ts
@@ -55,7 +55,7 @@ describe('deployments service', () => {
         `${origin}${base}/api/v1/namespaces/${encodedNamespace}/worker-deployments`,
         expect.objectContaining({
           params: {
-            maximumPageSize: '50',
+            pageSize: '50',
             nextPageToken: 'token123',
           },
           onError: expect.any(Function),
@@ -76,7 +76,7 @@ describe('deployments service', () => {
         `${origin}${base}/api/v1/namespaces/${encodedNamespace}/worker-deployments`,
         expect.objectContaining({
           params: {
-            maximumPageSize: '100',
+            pageSize: '100',
             nextPageToken: '',
             query: 'some-query',
           },

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -31,7 +31,7 @@ export const fetchPaginatedDeployments = async (
     const route = routeForApi('worker-deployments', { namespace });
     return requestFromAPI<ListWorkerDeploymentsResponse>(route, {
       params: {
-        maximumPageSize: String(pageSize),
+        pageSize: String(pageSize),
         nextPageToken: token,
         ...(query ? { query } : {}),
       },

--- a/src/lib/services/worker-service.ts
+++ b/src/lib/services/worker-service.ts
@@ -26,7 +26,7 @@ export const fetchPaginatedWorkers = async (
     return requestFromAPI<ListWorkersResponse>(route, {
       request,
       params: {
-        maximumPageSize: String(pageSize),
+        pageSize: String(pageSize),
         nextPageToken: token,
         ...(parameters.query && { query: parameters.query }),
       },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

[ListWorkersRequest](https://github.com/temporalio/api/blob/57de820b3952b02f7302a1a46a28fd94cee1007a/temporal/api/workflowservice/v1/request_response.proto#L2925) and [ListDeploymentsRequest](https://github.com/temporalio/api/blob/57de820b3952b02f7302a1a46a28fd94cee1007a/temporal/api/workflowservice/v1/request_response.proto#L2443) are expecting `pageSize` not `maximumPageSize`. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
