### PR TITLE
fix(a11y): use empty alt on decorative SDK logo image

### DIFF
--- a/src/lib/components/lines-and-dots/sdk-logo.svelte
+++ b/src/lib/components/lines-and-dots/sdk-logo.svelte
@@ -49,7 +49,7 @@
 <p class="flex w-full items-center gap-2">
   {#if logo}
     <span class="relative flex w-6 shrink-0 items-center" aria-hidden="true">
-      <img src={logo} alt="SDK Icon" class="absolute h-6 w-6" />
+      <img src={logo} alt="" class="absolute h-6 w-6" />
     </span>
   {/if}
   <span class="truncate">


### PR DESCRIPTION
## Summary
- Changes `alt="SDK Icon"` to `alt=""` on the decorative SDK logo `<img>` in `sdk-logo.svelte`
- The image sits inside `aria-hidden="true"` so the alt text is already excluded from the accessibility tree, but `alt="SDK Icon"` is misleading and could become a real WCAG 1.1.1 defect if the wrapper is ever refactored
- The sibling text node (`{sdk} {version}`) already provides the SDK identity to screen readers

## Test plan
- [x] Open a workflow detail page showing the SDK badge (any running workflow)
- [x] Confirm the SDK logo image renders identically (no visual change)
- [x] With VoiceOver/NVDA: confirm the SDK identity is announced once from the text node, not from the image alt

🤖 Generated with [Claude Code](https://claude.com/claude-code)