### PR TITLE
fix(a11y): accept autocomplete prop on NumberInput, ChipInput, and Combobox

### DIFF
--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -545,7 +545,7 @@
             className,
           )}
           role="combobox"
-          autocomplete="off"
+          autocomplete={rest.autocomplete ?? 'off'}
           autocapitalize="off"
           spellcheck="false"
           data-lpignore="true"

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { FullAutoFill } from 'svelte/elements';
+
   import { twMerge as merge } from 'tailwind-merge';
 
   import Chip from '$lib/holocene/chip.svelte';
@@ -20,6 +22,7 @@
     maxLength?: number;
     class?: string;
     scrollTo?: boolean;
+    autocomplete?: FullAutoFill;
   };
 
   let {
@@ -38,6 +41,7 @@
     maxLength = 0,
     class: className = '',
     scrollTo = false,
+    autocomplete = 'off',
   }: Props = $props();
 
   let displayValue = $state('');
@@ -133,7 +137,7 @@
     <input
       data-lpignore="true"
       data-1p-ignore="true"
-      autocomplete="off"
+      {autocomplete}
       class:cursor-not-allowed={disabled}
       {disabled}
       {placeholder}

--- a/src/lib/holocene/input/number-input.svelte
+++ b/src/lib/holocene/input/number-input.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { FullAutoFill } from 'svelte/elements';
+
   import { twMerge as merge } from 'tailwind-merge';
 
   import type { IconName } from '$lib/holocene/icon';
@@ -20,6 +22,7 @@
   export let min: number = undefined;
   export let step: number = 1;
   export let search = false;
+  export let autocomplete: FullAutoFill = 'off';
 
   let valid = true;
 
@@ -62,7 +65,7 @@
         {id}
         {name}
         {step}
-        autocomplete="off"
+        {autocomplete}
         spellcheck="false"
         bind:value
         on:input


### PR DESCRIPTION
## Summary
- Adds an `autocomplete` prop to `NumberInput`, `ChipInput`, and `Combobox` primitives, matching the existing pattern on `Input`
- All three previously hardcoded `autocomplete="off"`, preventing consumers from passing WCAG-defined purpose tokens like `cc-number`, `email`, or `country-name` (SC 1.3.5 Identify Input Purpose)
- Default remains `"off"` — no existing consumer behavior changes
- Uses `FullAutoFill` type from `svelte/elements` for type safety, consistent with `Input`

## Test plan
- [ ] Confirm existing consumers render identically (no behavior change with default `"off"`)
- [ ] Verify a consumer can pass `autocomplete="email"` to `ChipInput` and the DOM attribute is present
- [ ] Verify a consumer can pass `autocomplete="cc-number"` to `NumberInput` and the DOM attribute is present
- [ ] Verify a consumer can pass `autocomplete="country-name"` to `Combobox` and the DOM attribute is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A11y-Audit-Ref: 1.3.5-input-autocomplete-props-batch
