### PR TITLE
fix(a11y): use rem-based width for expanded side-nav

### DIFF
--- a/src/lib/holocene/navigation/navigation-container.svelte
+++ b/src/lib/holocene/navigation/navigation-container.svelte
@@ -38,7 +38,7 @@
     'group grid min-h-full grid-cols-[2rem] grid-rows-[fit-content(1.5rem)] gap-2 border-r border-subtle px-2 py-4 transition-width data-[nav=open]:w-auto data-[nav=open]:grid-cols-[100%]',
     'focus-visible:[&_[role=button]]:outline-none focus-visible:[&_[role=button]]:ring-2 focus-visible:[&_[role=button]]:ring-primary/70 focus-visible:[&_a]:outline-none focus-visible:[&_a]:ring-2 focus-visible:[&_a]:ring-primary/70',
     isCloud
-      ? 'bg-gradient-to-b from-indigo-600 to-indigo-950 text-off-white data-[nav=open]:w-[210px] focus-visible:[&_[role=button]]:outline-none focus-visible:[&_[role=button]]:ring-2 focus-visible:[&_[role=button]]:ring-success focus-visible:[&_a]:ring-success'
+      ? 'bg-gradient-to-b from-indigo-600 to-indigo-950 text-off-white data-[nav=open]:w-[13.125rem] focus-visible:[&_[role=button]]:outline-none focus-visible:[&_[role=button]]:ring-2 focus-visible:[&_[role=button]]:ring-success focus-visible:[&_a]:ring-success'
       : 'surface-black',
   )}
   data-nav={$navOpen ? 'open' : 'closed'}


### PR DESCRIPTION
## Summary
- Converts the Cloud side-nav expanded width from `w-[210px]` to `w-[13.125rem]` in `navigation-container.svelte`
- Visually identical at default 16px base font size (13.125 × 16 = 210)
- Scales with user font-size preference and browser text-only zoom, preventing nav label clipping at 200%+ zoom (WCAG 2.2 SC 1.4.4 Resize Text)

## Test plan
- [x] Open Cloud deployment with side-nav expanded — confirm visual is identical to current
- [x] Firefox: View → Zoom → Zoom Text Only → 200% — confirm all nav labels remain readable without clipping
- [x] Verify OSS nav is unaffected (this class only applies to the `isCloud` branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)