### PR TITLE
fix(a11y): cap ZoomSvg container height to viewport

### DIFF
--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -93,7 +93,7 @@
   class="relative overflow-hidden"
   bind:clientWidth={width}
   bind:clientHeight={height}
-  style="height: {containerHeight}px"
+  style="height: min({containerHeight}px, calc(100dvh - 8rem));"
 >
   <div class="absolute right-4 top-4 z-20 flex items-center gap-2">
     <slot name="controls" />


### PR DESCRIPTION
## Summary
- Caps the `ZoomSvg` container height to the lesser of `containerHeight` (default 600px) or `100dvh - 8rem` using CSS `min()`
- On a 320×500 landscape phone, the container shrinks from 600px to ~370px, fitting within the viewport instead of forcing unnecessary vertical scroll
- On desktop (height > 728px), behavior is unchanged
- This is an optional UX enhancement — not a strict WCAG 1.4.10 defect (vertical scrolling is allowed), but improves the experience on narrow viewports

## Test plan
- [x] Open a workflow with a family tree (Relationships tab) on desktop — confirm no visual change
- [x] DevTools → device mode → 320×500 landscape — confirm the ZoomSvg container fits within the viewport
- [x] Verify the Center button and pan/zoom controls remain functional at both sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A11y-Audit-Ref: 1.4.10-zoomsvg-container-height-optional
