### PR TITLE
[DT-4039] Workflow query builder doesn't work with numeric search attributes

### DIFF
--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -234,6 +234,74 @@ describe('toListWorkflowQueryFromFilters', () => {
     },
   );
 
+  it('should convert an Int filter without quoting the value', () => {
+    const filters = [
+      {
+        attribute: 'CustomIntField',
+        type: 'Int',
+        conditional: '=',
+        operator: '',
+        parenthesis: '',
+        value: '1',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`CustomIntField`=1');
+  });
+
+  it('should convert a Double filter without quoting the value', () => {
+    const filters = [
+      {
+        attribute: 'CustomDoubleField',
+        type: 'Double',
+        conditional: '>',
+        operator: '',
+        parenthesis: '',
+        value: '1.5',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`CustomDoubleField`>1.5');
+  });
+
+  it('should convert numeric filters alongside keyword filters', () => {
+    const filters = [
+      {
+        attribute: 'CustomIntField',
+        type: 'Int',
+        conditional: '>=',
+        operator: '',
+        parenthesis: '',
+        value: '10',
+      },
+      {
+        attribute: 'WorkflowId',
+        type: 'Keyword',
+        conditional: '=',
+        operator: '',
+        parenthesis: '',
+        value: 'abcd',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(combineFilters(filters));
+    expect(query).toBe('`CustomIntField`>=10 AND `WorkflowId`="abcd"');
+  });
+
+  it('should convert an Int filter with is null conditional', () => {
+    const filters = [
+      {
+        attribute: 'CustomIntField',
+        type: 'Int',
+        conditional: 'is',
+        operator: '',
+        parenthesis: '',
+        value: null,
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`CustomIntField` is null');
+  });
+
   it('should convert a KeywordList filter', () => {
     const filters = [
       {

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -59,6 +59,12 @@ const formatValue = ({
   ) {
     return value;
   }
+  if (
+    type === SEARCH_ATTRIBUTE_TYPE.INT ||
+    type === SEARCH_ATTRIBUTE_TYPE.DOUBLE
+  ) {
+    return value;
+  }
   return `"${value}"`;
 };
 

--- a/src/lib/utilities/query/to-list-workflow-filters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.test.ts
@@ -45,6 +45,8 @@ const attributes = {
   'Custom Keyword Field': 'Keyword',
   'Custom Bool Field': 'Bool',
   CustomKeywordListField: 'KeywordList',
+  CustomIntField: 'Int',
+  CustomDoubleField: 'Double',
 };
 
 describe('toListWorkflowFilters', () => {
@@ -265,6 +267,39 @@ describe('toListWorkflowFilters', () => {
         operator: '',
         parenthesis: '',
         value: 'true',
+      },
+    ];
+    expect(result).toMatchObject(expectedFilters);
+  });
+
+  it('should parse a query with an unquoted Int value', () => {
+    const result = toListWorkflowFilters('`CustomIntField`=1', attributes);
+    const expectedFilters = [
+      {
+        attribute: 'CustomIntField',
+        type: 'Int',
+        conditional: '=',
+        operator: '',
+        parenthesis: '',
+        value: '1',
+      },
+    ];
+    expect(result).toMatchObject(expectedFilters);
+  });
+
+  it('should parse a query with an unquoted Double value and a comparison operator', () => {
+    const result = toListWorkflowFilters(
+      '`CustomDoubleField`>=1.5',
+      attributes,
+    );
+    const expectedFilters = [
+      {
+        attribute: 'CustomDoubleField',
+        type: 'Double',
+        conditional: '>=',
+        operator: '',
+        parenthesis: '',
+        value: '1.5',
       },
     ];
     expect(result).toMatchObject(expectedFilters);

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -129,7 +129,7 @@ export const toListWorkflowFilters = (
             console.error('Error parsing Datetime field from query');
           }
         } else if (isBoolStatement(filter.type)) {
-          filter.value = nextToken.replace('=', '');
+          filter.value = tokenTwoAhead;
           filter.conditional = '=';
         } else {
           filter.value = tokenTwoAhead;

--- a/src/lib/utilities/query/tokenize.test.ts
+++ b/src/lib/utilities/query/tokenize.test.ts
@@ -101,7 +101,8 @@ describe('tokenize', () => {
       'some workflow',
       'AND',
       'Custom Boolean',
-      '=true',
+      '=',
+      'true',
     ]);
   });
 

--- a/src/lib/utilities/query/tokenize.ts
+++ b/src/lib/utilities/query/tokenize.ts
@@ -11,6 +11,10 @@ import {
 
 type Tokens = string[];
 
+const OPERATOR_CONDITIONALS = new Set(['>=', '<=', '!=', '==']);
+const isOperatorConditional = (value: string): boolean =>
+  OPERATOR_CONDITIONALS.has(value);
+
 export const tokenize = (string: string): Tokens => {
   const tokens: Tokens = [];
   const addBufferToTokens = (): void => {
@@ -91,9 +95,11 @@ export const tokenize = (string: string): Tokens => {
       isConditional(minConditional) &&
       (isSpace(string[cursor + 2]) ||
         isQuote(string[cursor + 2]) ||
-        isParenthesis(string[cursor + 2]))
+        isParenthesis(string[cursor + 2]) ||
+        isOperatorConditional(minConditional))
     ) {
-      // To prevent false positives like "inspect" being a "in" conditional, check for space, quote, or parenthesis after the midConditional
+      // To prevent false positives like "inspect" being a "in" conditional, check for space, quote, or parenthesis after the midConditional.
+      // Operator-style conditionals like >=, <=, != never collide with identifiers, so accept them even without a trailing space.
       buffer += minConditional;
       addBufferToTokens();
       cursor += 2;
@@ -101,6 +107,7 @@ export const tokenize = (string: string): Tokens => {
     } else if (isConditional(character)) {
       addBufferToTokens();
       buffer += character;
+      addBufferToTokens();
       cursor++;
       continue;
     }

--- a/tests/integration/workflows-search-attribute-filter.desktop.spec.ts
+++ b/tests/integration/workflows-search-attribute-filter.desktop.spec.ts
@@ -163,9 +163,7 @@ test('it should filter by HistoryLength (number)', async ({ page }) => {
     .fill('10');
   await page.getByTestId('apply-filter-button').click();
 
-  await expect
-    .poll(() => getQueryParam(page.url()))
-    .toBe('`HistoryLength`="10"');
+  await expect.poll(() => getQueryParam(page.url())).toBe('`HistoryLength`=10');
 });
 
 test('it should combine filters', async ({ page }) => {
@@ -188,7 +186,7 @@ test('it should combine filters', async ({ page }) => {
 
   await expect
     .poll(() => getQueryParam(page.url()))
-    .toBe('`ExecutionStatus`="Completed" AND `HistoryLength`="10"');
+    .toBe('`ExecutionStatus`="Completed" AND `HistoryLength`=10');
 
   await page.getByTestId('add-filter-button').click();
   await page.getByRole('menuitem', { name: 'WorkflowType Keyword' }).click();
@@ -202,7 +200,7 @@ test('it should combine filters', async ({ page }) => {
   await expect
     .poll(() => getQueryParam(page.url()))
     .toBe(
-      '`ExecutionStatus`="Completed" AND `HistoryLength`="10" AND `WorkflowType`="ExampleWorkflow"',
+      '`ExecutionStatus`="Completed" AND `HistoryLength`=10 AND `WorkflowType`="ExampleWorkflow"',
     );
 });
 
@@ -226,7 +224,7 @@ test('it should combine filters and then clear them all', async ({ page }) => {
 
   await expect
     .poll(() => getQueryParam(page.url()))
-    .toBe('`ExecutionStatus`="Completed" AND `HistoryLength`="10"');
+    .toBe('`ExecutionStatus`="Completed" AND `HistoryLength`=10');
 
   await page.getByTestId('add-filter-button').click();
   await page.getByRole('menuitem', { name: 'WorkflowType Keyword' }).click();
@@ -240,7 +238,7 @@ test('it should combine filters and then clear them all', async ({ page }) => {
   await expect
     .poll(() => getQueryParam(page.url()))
     .toBe(
-      '`ExecutionStatus`="Completed" AND `HistoryLength`="10" AND `WorkflowType`="ExampleWorkflow"',
+      '`ExecutionStatus`="Completed" AND `HistoryLength`=10 AND `WorkflowType`="ExampleWorkflow"',
     );
 
   await page.getByTestId('clear-all-filters-button').click();

--- a/tests/integration/workflows-search-attribute-filter.mobile.spec.ts
+++ b/tests/integration/workflows-search-attribute-filter.mobile.spec.ts
@@ -177,9 +177,7 @@ test('it should filter by HistoryLength (number)', async ({ page }) => {
     .fill('10');
   await page.getByTestId('apply-filter-button').click();
 
-  await expect
-    .poll(() => getQueryParam(page.url()))
-    .toBe('`HistoryLength`="10"');
+  await expect.poll(() => getQueryParam(page.url())).toBe('`HistoryLength`=10');
 });
 
 test('it should combine filters and then clear them all', async ({ page }) => {


### PR DESCRIPTION
## Summary

The workflow list query builder wrapped `Int` and `Double` search attribute values in double quotes (e.g. `Foo="1"`), can cause problems in open source with SQL db. The builder now emits `Foo=1`.

While fixing the serializer, the tokenizer also needed adjustment: it merged unquoted values with their conditional (e.g. `Foo=1` → tokens `Foo`, `=1`) and split 2-char operators like `>=` across two tokens with the second piece glued to the value. Boolean parsing had a local workaround for this; for numeric, the 2-char operators (`>=`, `<=`, `!=`) made that workaround insufficient. The tokenizer now emits the conditional as its own token and accepts operator-style 2-char conditionals without a trailing space. The boolean parser is simplified to match the new token shape.

Slack thread: https://temporaltechnologies.slack.com/archives/C048BE2NVRB/p1779408194209509

### BEFORE

<img width="423" height="193" alt="Screenshot 2026-05-22 at 3 08 20 PM" src="https://github.com/user-attachments/assets/42467740-3eb3-4691-b9ac-6fe8a5e8a707" />

### AFTER

<img width="433" height="185" alt="Screenshot 2026-05-22 at 3 09 05 PM" src="https://github.com/user-attachments/assets/db1a6b6e-753d-4f53-a920-77bcc4cbc305" />

### To Test

Use the preview link on this PR https://github.com/temporalio/cloud-ui/pull/2645 which combines this change with cloud-ui for easier previewing.

Notice no more double quotes on ints and doubles
<img width="681" height="303" alt="Screenshot 2026-05-22 at 3 50 55 PM" src="https://github.com/user-attachments/assets/b9b4969a-ff71-4c93-a2ab-5de05030d375" />



## Jira

https://temporalio.atlassian.net/browse/DT-4039

## Test plan

- [x] Create or use an existing numeric custom search attribute (`Int` and/or `Double`)
- [x] Start a workflow with that attribute set
- [x] On the workflow list page, filter via the query builder using `=`, `>`, `>=`, `<=`, `<`, `!=` — confirm the URL shows `Foo=1` (not `Foo="1"`) and the list returns matching workflows
- [x] Refresh the page; confirm the filter chip rehydrates correctly
- [x] Confirm boolean and keyword filters still work unchanged