### PR TITLE
fix: unset splash screen color

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,24 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
-    <style>
-      html {
-        background-color: #f8fafc;
-        color: #141414;
-      }
-      body {
-        margin: 0;
-        background-color: #f8fafc;
-        color: #141414;
-      }
-      @media (prefers-color-scheme: dark) {
-        html,
-        body {
-          background-color: #141414;
-          color: #f8fafc;
-        }
-      }
-    </style>
     %sveltekit.head%
   </head>
 


### PR DESCRIPTION

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

[This PR](https://github.com/temporalio/ui/pull/3353) sets colors for the splash screen, but it will cause an unexpected color difference for people whose OS theme is dark and app theme is light.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

current behavior:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b585063b-d9a0-44ae-a11f-c438f4c60352" />

keep the `color-scheme` meta only. it still works for the previous PR’s requirement:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/19c198c1-9ad6-48de-bbbf-f89d228051b5" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
