### PR TITLE
fix(a11y): prevent horizontal scroll on login page at 320px (WCAG 1.4.10)

### DIFF
--- a/src/routes/(login)/login/+page.svelte
+++ b/src/routes/(login)/login/+page.svelte
@@ -22,7 +22,10 @@
   <FeedbackButton />
 </header>
 <section class="my-[20vh] text-center">
-  <h1 class="text-7xl font-semibold sm:text-8xl" data-testid="login-title">
+  <h1
+    class="text-5xl font-semibold sm:text-7xl md:text-8xl"
+    data-testid="login-title"
+  >
     Welcome back.
   </h1>
   <p class="my-7" data-testid="login-info">Let's get you signed in.</p>


### PR DESCRIPTION
## Summary

The login page's \"Welcome back.\" `<h1>` was sized too aggressively for mobile viewports:

- **Before**: `text-7xl` (72px) at base, `text-8xl` (96px) at `sm:`. At 72px the heading is ~520 CSS px wide → overflows a 320 CSS px viewport by ~200px and forces page-level horizontal scroll.
- **After**: `text-5xl` (48px) base → `text-7xl` (72px) `sm:` → `text-8xl` (96px) `md:`. Breakpoints shifted down one tier.

Desktop and tablet rendering effectively unchanged; mobile gets the smaller heading and no horizontal scroll.

## Audit context

- WCAG 2.2 SC **1.4.10 Reflow (Level AA)** — Serious. Affects every user on a mobile viewport encountering the login page.
- Cross-cutting with SC 1.4.4 Resize Text (extreme zoom levels also benefit).
- Issue file: `audit-output/issues/1.4.10-login-h1-reflow.md`.

## Test plan

- [x] Chrome DevTools → device-mode → 320 × 568 portrait → navigate to `/login`. No horizontal page scroll; `<h1>` fits within the viewport.
- [x] Resize browser continuously from 1280px → 320px on `/login`. No horizontal scroll at any intermediate width.
- [x] Desktop (≥768px): heading visually unchanged from before (still `text-8xl` at `md:` and up).
- [x] Tablet (640-767px): heading is `text-7xl` (was `text-8xl`) — slightly smaller, still visually prominent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)