### PR TITLE
fix(a11y): announce workflow / event status on timeline graph nodes (WCAG 1.4.1)

### DIFF
--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { translate } from '$lib/i18n/translate';
   import type {
     EventGroup,
     EventGroups,
@@ -69,9 +70,27 @@
         : (undefined as EventTypeCategory | 'pending' | undefined),
   );
   const reverseSort = $derived($eventFilterSort === 'descending');
+
+  const classificationLabel = $derived(
+    classification
+      ? translate(`events.event-classification.${classification.toLowerCase()}`)
+      : translate('common.unknown'),
+  );
+
+  const accessibleName = $derived(
+    translate('events.row-accessible-name', {
+      eventType: event?.eventType ?? translate('common.unknown'),
+      classification: classificationLabel,
+    }),
+  );
 </script>
 
-<g role="button" tabindex="0" class="relative cursor-pointer">
+<g
+  role="button"
+  tabindex="0"
+  aria-label={accessibleName}
+  class="relative cursor-pointer"
+>
   {#if connectLine}
     <Line
       startPoint={[canvasWidth, y]}

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -71,15 +71,45 @@
   );
   const reverseSort = $derived($eventFilterSort === 'descending');
 
+  const CLASSIFICATION_LABEL_KEY = {
+    Unspecified: 'events.event-classification.unspecified',
+    Scheduled: 'events.event-classification.scheduled',
+    Open: 'events.event-classification.open',
+    New: 'events.event-classification.new',
+    Started: 'events.event-classification.started',
+    Initiated: 'events.event-classification.initiated',
+    Running: 'events.event-classification.running',
+    Completed: 'events.event-classification.completed',
+    Fired: 'events.event-classification.fired',
+    CancelRequested: 'events.event-classification.cancelrequested',
+    TimedOut: 'events.event-classification.timedout',
+    Signaled: 'events.event-classification.signaled',
+    Canceled: 'events.event-classification.canceled',
+    Failed: 'events.event-classification.failed',
+    Terminated: 'events.event-classification.terminated',
+    pending: 'events.event-classification.pending',
+    Retrying: 'events.event-classification.retrying',
+  } as const;
+
   const classificationLabel = $derived(
-    classification
-      ? translate(`events.event-classification.${classification.toLowerCase()}`)
+    classification && classification in CLASSIFICATION_LABEL_KEY
+      ? translate(
+          CLASSIFICATION_LABEL_KEY[
+            classification as keyof typeof CLASSIFICATION_LABEL_KEY
+          ],
+        )
+      : translate('common.unknown'),
+  );
+
+  const eventTypeLabel = $derived(
+    event && 'eventType' in event
+      ? event.eventType
       : translate('common.unknown'),
   );
 
   const accessibleName = $derived(
     translate('events.row-accessible-name', {
-      eventType: event?.eventType ?? translate('common.unknown'),
+      eventType: eventTypeLabel,
       classification: classificationLabel,
     }),
   );

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -10,6 +10,7 @@
     EventTypeCategory,
     WorkflowEventWithPending,
   } from '$lib/types/events';
+  import { getStatusLabel } from '$lib/utilities/get-status-label';
   import {
     isPendingActivity,
     isPendingNexusOperation,
@@ -71,43 +72,19 @@
   );
   const reverseSort = $derived($eventFilterSort === 'descending');
 
-  const CLASSIFICATION_LABEL_KEY = {
-    Unspecified: 'events.event-classification.unspecified',
-    Scheduled: 'events.event-classification.scheduled',
-    Open: 'events.event-classification.open',
-    New: 'events.event-classification.new',
-    Started: 'events.event-classification.started',
-    Initiated: 'events.event-classification.initiated',
-    Running: 'events.event-classification.running',
-    Completed: 'events.event-classification.completed',
-    Fired: 'events.event-classification.fired',
-    CancelRequested: 'events.event-classification.cancelrequested',
-    TimedOut: 'events.event-classification.timedout',
-    Signaled: 'events.event-classification.signaled',
-    Canceled: 'events.event-classification.canceled',
-    Failed: 'events.event-classification.failed',
-    Terminated: 'events.event-classification.terminated',
-    pending: 'events.event-classification.pending',
-    retrying: 'events.event-classification.retrying',
-  } as const;
-
   const isRetrying = $derived(
     !!group?.pendingActivity && Number(group.pendingActivity.attempt) > 1,
   );
 
-  const labelClassification = $derived(
-    isRetrying ? 'retrying' : classification,
+  const statusForLabel = $derived(
+    isRetrying
+      ? 'Retrying'
+      : classification === 'pending'
+        ? 'Pending'
+        : classification,
   );
 
-  const classificationLabel = $derived(
-    labelClassification && labelClassification in CLASSIFICATION_LABEL_KEY
-      ? translate(
-          CLASSIFICATION_LABEL_KEY[
-            labelClassification as keyof typeof CLASSIFICATION_LABEL_KEY
-          ],
-        )
-      : translate('common.unknown'),
-  );
+  const classificationLabel = $derived(getStatusLabel(statusForLabel));
 
   const eventTypeLabel = $derived(
     event && 'eventType' in event

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -88,7 +88,6 @@
     Failed: 'events.event-classification.failed',
     Terminated: 'events.event-classification.terminated',
     pending: 'events.event-classification.pending',
-    Retrying: 'events.event-classification.retrying',
   } as const;
 
   const classificationLabel = $derived(

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -88,13 +88,22 @@
     Failed: 'events.event-classification.failed',
     Terminated: 'events.event-classification.terminated',
     pending: 'events.event-classification.pending',
+    retrying: 'events.event-classification.retrying',
   } as const;
 
+  const isRetrying = $derived(
+    !!group?.pendingActivity && Number(group.pendingActivity.attempt) > 1,
+  );
+
+  const labelClassification = $derived(
+    isRetrying ? 'retrying' : classification,
+  );
+
   const classificationLabel = $derived(
-    classification && classification in CLASSIFICATION_LABEL_KEY
+    labelClassification && labelClassification in CLASSIFICATION_LABEL_KEY
       ? translate(
           CLASSIFICATION_LABEL_KEY[
-            classification as keyof typeof CLASSIFICATION_LABEL_KEY
+            labelClassification as keyof typeof CLASSIFICATION_LABEL_KEY
           ],
         )
       : translate('common.unknown'),

--- a/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
+++ b/src/lib/components/lines-and-dots/svg/history-graph-row-visual.svelte
@@ -10,7 +10,7 @@
     EventTypeCategory,
     WorkflowEventWithPending,
   } from '$lib/types/events';
-  import { getStatusLabel } from '$lib/utilities/get-status-label';
+  import { getEventClassificationLabel } from '$lib/utilities/get-status-label';
   import {
     isPendingActivity,
     isPendingNexusOperation,
@@ -84,7 +84,9 @@
         : classification,
   );
 
-  const classificationLabel = $derived(getStatusLabel(statusForLabel));
+  const classificationLabel = $derived(
+    getEventClassificationLabel(statusForLabel),
+  );
 
   const eventTypeLabel = $derived(
     event && 'eventType' in event

--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -15,7 +15,7 @@
   } from '$lib/utilities/decode-local-activity';
   import { getMillisecondDuration } from '$lib/utilities/format-time';
   import type { SummaryAttribute } from '$lib/utilities/get-single-attribute-for-event';
-  import { getStatusLabel } from '$lib/utilities/get-status-label';
+  import { getEventClassificationLabel } from '$lib/utilities/get-status-label';
   import {
     isActivityTaskScheduledEvent,
     isActivityTaskStartedEvent,
@@ -59,7 +59,7 @@
   const accessibleName = $derived(
     translate('events.row-accessible-name', {
       eventType: group.displayName,
-      classification: getStatusLabel(
+      classification: getEventClassificationLabel(
         group.finalClassification || group.classification,
       ),
     }),

--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -15,6 +15,7 @@
   } from '$lib/utilities/decode-local-activity';
   import { getMillisecondDuration } from '$lib/utilities/format-time';
   import type { SummaryAttribute } from '$lib/utilities/get-single-attribute-for-event';
+  import { getStatusLabel } from '$lib/utilities/get-status-label';
   import {
     isActivityTaskScheduledEvent,
     isActivityTaskStartedEvent,
@@ -54,6 +55,15 @@
 
   const timelineWidth = $derived(canvasWidth - 2 * gutter);
   const pendingActivity = $derived(group?.pendingActivity);
+
+  const accessibleName = $derived(
+    translate('events.row-accessible-name', {
+      eventType: group.displayName,
+      classification: getStatusLabel(
+        group.finalClassification || group.classification,
+      ),
+    }),
+  );
   const pauseTime = $derived(
     pendingActivity && pendingActivity.pauseInfo?.pauseTime,
   );
@@ -197,6 +207,7 @@
 <g
   role="button"
   tabindex="0"
+  aria-label={accessibleName}
   onclick={onClick}
   onkeypress={onClick}
   onmouseenter={onMouseEnter}

--- a/src/lib/components/lines-and-dots/svg/workflow-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/workflow-row.svelte
@@ -3,6 +3,7 @@
   import { translate } from '$lib/i18n/translate';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { isWorkflowDelayed } from '$lib/utilities/delayed-workflows';
+  import { getStatusLabel } from '$lib/utilities/get-status-label';
 
   import { TimelineConfig } from '../constants';
 
@@ -22,29 +23,10 @@
   const start = $derived(gutter);
   const end = $derived(start + length - 2 * gutter);
 
-  const STATUS_LABEL_KEY = {
-    Running: 'workflows.running',
-    TimedOut: 'workflows.timed-out',
-    Completed: 'workflows.completed',
-    Failed: 'workflows.failed',
-    ContinuedAsNew: 'workflows.continued-as-new',
-    Canceled: 'workflows.canceled',
-    Terminated: 'workflows.terminated',
-    Paused: 'workflows.paused',
-  } as const;
-
-  const statusLabel = $derived(
-    workflow.status && workflow.status in STATUS_LABEL_KEY
-      ? translate(
-          STATUS_LABEL_KEY[workflow.status as keyof typeof STATUS_LABEL_KEY],
-        )
-      : translate('common.unknown'),
-  );
-
   const accessibleName = $derived(
     translate('workflows.row-accessible-name', {
       workflowId: workflow.id,
-      status: statusLabel,
+      status: getStatusLabel(workflow.status),
     }),
   );
 </script>

--- a/src/lib/components/lines-and-dots/svg/workflow-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/workflow-row.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Icon from '$lib/holocene/icon/icon.svelte';
+  import { translate } from '$lib/i18n/translate';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { isWorkflowDelayed } from '$lib/utilities/delayed-workflows';
 
@@ -20,9 +21,35 @@
 
   const start = $derived(gutter);
   const end = $derived(start + length - 2 * gutter);
+
+  const workflowStatusKey = (status: WorkflowExecution['status']) => {
+    if (!status) return 'unknown';
+    if (status === 'TimedOut') return 'timed-out';
+    if (status === 'ContinuedAsNew') return 'continued-as-new';
+    return status.toLowerCase();
+  };
+
+  const statusLabel = $derived(
+    workflow.status
+      ? translate(`workflows.${workflowStatusKey(workflow.status)}`)
+      : translate('common.unknown'),
+  );
+
+  const accessibleName = $derived(
+    translate('workflows.row-accessible-name', {
+      workflowId: workflow.id,
+      status: statusLabel,
+    }),
+  );
 </script>
 
-<g role="button" tabindex="0" class="relative cursor-pointer" {height}>
+<g
+  role="button"
+  tabindex="0"
+  aria-label={accessibleName}
+  class="relative cursor-pointer"
+  {height}
+>
   <Line
     startPoint={[start, y]}
     endPoint={[end, y]}

--- a/src/lib/components/lines-and-dots/svg/workflow-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/workflow-row.svelte
@@ -3,7 +3,7 @@
   import { translate } from '$lib/i18n/translate';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { isWorkflowDelayed } from '$lib/utilities/delayed-workflows';
-  import { getStatusLabel } from '$lib/utilities/get-status-label';
+  import { getWorkflowStatusLabel } from '$lib/utilities/get-status-label';
 
   import { TimelineConfig } from '../constants';
 
@@ -26,7 +26,7 @@
   const accessibleName = $derived(
     translate('workflows.row-accessible-name', {
       workflowId: workflow.id,
-      status: getStatusLabel(workflow.status),
+      status: getWorkflowStatusLabel(workflow.status),
     }),
   );
 </script>

--- a/src/lib/components/lines-and-dots/svg/workflow-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/workflow-row.svelte
@@ -22,16 +22,22 @@
   const start = $derived(gutter);
   const end = $derived(start + length - 2 * gutter);
 
-  const workflowStatusKey = (status: WorkflowExecution['status']) => {
-    if (!status) return 'unknown';
-    if (status === 'TimedOut') return 'timed-out';
-    if (status === 'ContinuedAsNew') return 'continued-as-new';
-    return status.toLowerCase();
-  };
+  const STATUS_LABEL_KEY = {
+    Running: 'workflows.running',
+    TimedOut: 'workflows.timed-out',
+    Completed: 'workflows.completed',
+    Failed: 'workflows.failed',
+    ContinuedAsNew: 'workflows.continued-as-new',
+    Canceled: 'workflows.canceled',
+    Terminated: 'workflows.terminated',
+    Paused: 'workflows.paused',
+  } as const;
 
   const statusLabel = $derived(
-    workflow.status
-      ? translate(`workflows.${workflowStatusKey(workflow.status)}`)
+    workflow.status && workflow.status in STATUS_LABEL_KEY
+      ? translate(
+          STATUS_LABEL_KEY[workflow.status as keyof typeof STATUS_LABEL_KEY],
+        )
       : translate('common.unknown'),
   );
 

--- a/src/lib/components/workflow-status.svelte
+++ b/src/lib/components/workflow-status.svelte
@@ -8,18 +8,9 @@
   import Spinner from '$lib/holocene/icon/svg/spinner.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
-  import type { EventClassification } from '$lib/models/event-history/get-event-classification';
-  import type { ScheduleStatus } from '$lib/types/schedule';
-  import type { WorkflowStatus } from '$lib/types/workflows';
+  import { getStatusLabel, type Status } from '$lib/utilities/get-status-label';
 
   import HeartBeat from './heart-beat-indicator.svelte';
-
-  type Status =
-    | WorkflowStatus
-    | ScheduleStatus
-    | EventClassification
-    | 'Pending'
-    | 'Retrying';
 
   interface Props {
     delay?: number;
@@ -44,28 +35,6 @@
     taskFailure = false,
     'test-id': testId,
   }: Props = $props();
-
-  const label: Record<Status, string> = {
-    Running: translate('workflows.running'),
-    TimedOut: translate('workflows.timed-out'),
-    Completed: translate('workflows.completed'),
-    Failed: translate('workflows.failed'),
-    ContinuedAsNew: translate('workflows.continued-as-new'),
-    Canceled: translate('workflows.canceled'),
-    Terminated: translate('workflows.terminated'),
-    Paused: translate('workflows.paused'),
-    Scheduled: translate('events.event-classification.scheduled'),
-    Started: translate('events.event-classification.started'),
-    Unspecified: translate('events.event-classification.unspecified'),
-    Open: translate('events.event-classification.open'),
-    New: translate('events.event-classification.new'),
-    Initiated: translate('events.event-classification.initiated'),
-    Fired: translate('events.event-classification.fired'),
-    CancelRequested: translate('events.event-classification.cancelrequested'),
-    Signaled: translate('events.event-classification.signaled'),
-    Pending: translate('events.event-classification.pending'),
-    Retrying: translate('events.event-classification.retrying'),
-  };
 
   const workflowStatus = cva(
     [
@@ -135,7 +104,7 @@
         {count.toLocaleString()}
       {/if}
 
-      {label[status]}
+      {getStatusLabel(status)}
       {#if status === 'Running' && !delayed && !taskFailure}
         <HeartBeat {delay} />
       {/if}

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -66,6 +66,7 @@ export const Strings = {
   'event-history-import-error': 'Could not create event history from JSON',
   'event-history-load-error': 'Could not parse JSON',
   'event-classification-label': 'Event Classification',
+  'row-accessible-name': 'Event {{eventType}}: {{classification}}',
   'event-classification': {
     unspecified: 'Unspecified',
     scheduled: 'Scheduled',

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -41,6 +41,7 @@ export const Strings = {
   'configure-headers-description':
     'Add (<1></1>), re-arrange (<2></2>), and remove (<3></3>), {{type}} to personalize the {{title}} Table.',
   'all-statuses': 'All Statuses',
+  'row-accessible-name': 'Workflow {{workflowId}}: {{status}}',
   running: 'Running',
   'timed-out': 'Timed Out',
   completed: 'Completed',

--- a/src/lib/utilities/get-status-label.test.ts
+++ b/src/lib/utilities/get-status-label.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getStatusLabel, type Status } from './get-status-label';
+
+describe('getStatusLabel', () => {
+  it('translates workflow statuses', () => {
+    expect(getStatusLabel('Running')).toBe('Running');
+    expect(getStatusLabel('TimedOut')).toBe('Timed Out');
+    expect(getStatusLabel('Completed')).toBe('Completed');
+    expect(getStatusLabel('Failed')).toBe('Failed');
+    expect(getStatusLabel('ContinuedAsNew')).toBe('Continued as New');
+    expect(getStatusLabel('Canceled')).toBe('Canceled');
+    expect(getStatusLabel('Terminated')).toBe('Terminated');
+    expect(getStatusLabel('Paused')).toBe('Paused');
+  });
+
+  it('translates event classifications', () => {
+    expect(getStatusLabel('Scheduled')).toBe('Scheduled');
+    expect(getStatusLabel('CancelRequested')).toBe('Cancel Requested');
+    expect(getStatusLabel('Signaled')).toBe('Signaled');
+    expect(getStatusLabel('Fired')).toBe('Fired');
+  });
+
+  it('translates pending and retrying states', () => {
+    expect(getStatusLabel('Pending')).toBe('Pending');
+    expect(getStatusLabel('Retrying')).toBe('Retrying');
+  });
+
+  it('falls back to "Unknown" for undefined or unmapped values', () => {
+    expect(getStatusLabel(undefined)).toBe('Unknown');
+    expect(getStatusLabel('NotAStatus' as Status)).toBe('Unknown');
+  });
+});

--- a/src/lib/utilities/get-status-label.test.ts
+++ b/src/lib/utilities/get-status-label.test.ts
@@ -1,33 +1,59 @@
 import { describe, expect, it } from 'vitest';
 
-import { getStatusLabel, type Status } from './get-status-label';
+import {
+  getEventClassificationLabel,
+  getStatusLabel,
+  getWorkflowStatusLabel,
+  type Status,
+} from './get-status-label';
 
-describe('getStatusLabel', () => {
-  it('translates workflow statuses', () => {
-    expect(getStatusLabel('Running')).toBe('Running');
-    expect(getStatusLabel('TimedOut')).toBe('Timed Out');
+describe('getWorkflowStatusLabel', () => {
+  it('translates workflow / schedule statuses', () => {
+    expect(getWorkflowStatusLabel('Running')).toBe('Running');
+    expect(getWorkflowStatusLabel('TimedOut')).toBe('Timed Out');
+    expect(getWorkflowStatusLabel('ContinuedAsNew')).toBe('Continued as New');
+    expect(getWorkflowStatusLabel('Paused')).toBe('Paused');
+  });
+
+  it('falls back to "Unknown" for null / undefined / event-only names', () => {
+    expect(getWorkflowStatusLabel(undefined)).toBe('Unknown');
+    expect(getWorkflowStatusLabel(null)).toBe('Unknown');
+    // Event-only classification is not part of the workflow domain.
+    expect(getWorkflowStatusLabel('Signaled' as never)).toBe('Unknown');
+  });
+});
+
+describe('getEventClassificationLabel', () => {
+  it('translates event classifications, pending and retrying', () => {
+    expect(getEventClassificationLabel('Scheduled')).toBe('Scheduled');
+    expect(getEventClassificationLabel('CancelRequested')).toBe(
+      'Cancel Requested',
+    );
+    expect(getEventClassificationLabel('Pending')).toBe('Pending');
+    expect(getEventClassificationLabel('Retrying')).toBe('Retrying');
+  });
+
+  it('resolves overlapping names via the event namespace', () => {
+    // Same English today, but routed through events.* — not workflows.*.
+    expect(getEventClassificationLabel('Completed')).toBe('Completed');
+    expect(getEventClassificationLabel('Failed')).toBe('Failed');
+  });
+
+  it('falls back to "Unknown" for undefined / unmapped values', () => {
+    expect(getEventClassificationLabel(undefined)).toBe('Unknown');
+  });
+});
+
+describe('getStatusLabel (combined, workflow-domain precedence)', () => {
+  it('labels both workflow statuses and event classifications', () => {
     expect(getStatusLabel('Completed')).toBe('Completed');
-    expect(getStatusLabel('Failed')).toBe('Failed');
-    expect(getStatusLabel('ContinuedAsNew')).toBe('Continued as New');
-    expect(getStatusLabel('Canceled')).toBe('Canceled');
-    expect(getStatusLabel('Terminated')).toBe('Terminated');
-    expect(getStatusLabel('Paused')).toBe('Paused');
-  });
-
-  it('translates event classifications', () => {
-    expect(getStatusLabel('Scheduled')).toBe('Scheduled');
-    expect(getStatusLabel('CancelRequested')).toBe('Cancel Requested');
     expect(getStatusLabel('Signaled')).toBe('Signaled');
-    expect(getStatusLabel('Fired')).toBe('Fired');
-  });
-
-  it('translates pending and retrying states', () => {
     expect(getStatusLabel('Pending')).toBe('Pending');
-    expect(getStatusLabel('Retrying')).toBe('Retrying');
   });
 
-  it('falls back to "Unknown" for undefined or unmapped values', () => {
+  it('falls back to "Unknown" for null / undefined / unmapped values', () => {
     expect(getStatusLabel(undefined)).toBe('Unknown');
+    expect(getStatusLabel(null)).toBe('Unknown');
     expect(getStatusLabel('NotAStatus' as Status)).toBe('Unknown');
   });
 });

--- a/src/lib/utilities/get-status-label.ts
+++ b/src/lib/utilities/get-status-label.ts
@@ -1,0 +1,39 @@
+import type { I18nKey } from '$lib/i18n';
+import { translate } from '$lib/i18n/translate';
+import type { EventClassification } from '$lib/models/event-history/get-event-classification';
+import type { ScheduleStatus } from '$lib/types/schedule';
+import type { WorkflowStatus } from '$lib/types/workflows';
+
+export type Status =
+  | WorkflowStatus
+  | ScheduleStatus
+  | EventClassification
+  | 'Pending'
+  | 'Retrying';
+
+const statusLabelKeys: Record<Status, I18nKey> = {
+  Running: 'workflows.running',
+  TimedOut: 'workflows.timed-out',
+  Completed: 'workflows.completed',
+  Failed: 'workflows.failed',
+  ContinuedAsNew: 'workflows.continued-as-new',
+  Canceled: 'workflows.canceled',
+  Terminated: 'workflows.terminated',
+  Paused: 'workflows.paused',
+  Scheduled: 'events.event-classification.scheduled',
+  Started: 'events.event-classification.started',
+  Unspecified: 'events.event-classification.unspecified',
+  Open: 'events.event-classification.open',
+  New: 'events.event-classification.new',
+  Initiated: 'events.event-classification.initiated',
+  Fired: 'events.event-classification.fired',
+  CancelRequested: 'events.event-classification.cancelrequested',
+  Signaled: 'events.event-classification.signaled',
+  Pending: 'events.event-classification.pending',
+  Retrying: 'events.event-classification.retrying',
+};
+
+export const getStatusLabel = (status: Status | undefined): string =>
+  status && status in statusLabelKeys
+    ? translate(statusLabelKeys[status])
+    : translate('common.unknown');

--- a/src/lib/utilities/get-status-label.ts
+++ b/src/lib/utilities/get-status-label.ts
@@ -11,7 +11,11 @@ export type Status =
   | 'Pending'
   | 'Retrying';
 
-const statusLabelKeys: Record<Status, I18nKey> = {
+type WorkflowDomainStatus = NonNullable<WorkflowStatus | ScheduleStatus>;
+type EventDomainStatus = EventClassification | 'Pending' | 'Retrying';
+
+// Workflow / schedule statuses resolve to the workflows.* namespace.
+const workflowStatusLabelKeys: Record<WorkflowDomainStatus, I18nKey> = {
   Running: 'workflows.running',
   TimedOut: 'workflows.timed-out',
   Completed: 'workflows.completed',
@@ -20,20 +24,67 @@ const statusLabelKeys: Record<Status, I18nKey> = {
   Canceled: 'workflows.canceled',
   Terminated: 'workflows.terminated',
   Paused: 'workflows.paused',
-  Scheduled: 'events.event-classification.scheduled',
-  Started: 'events.event-classification.started',
+};
+
+// Event classifications resolve to the events.event-classification.* namespace,
+// including names (Running, Completed, …) that also exist as workflow statuses.
+const eventClassificationLabelKeys: Record<EventDomainStatus, I18nKey> = {
   Unspecified: 'events.event-classification.unspecified',
+  Scheduled: 'events.event-classification.scheduled',
   Open: 'events.event-classification.open',
   New: 'events.event-classification.new',
+  Started: 'events.event-classification.started',
   Initiated: 'events.event-classification.initiated',
+  Running: 'events.event-classification.running',
+  Completed: 'events.event-classification.completed',
   Fired: 'events.event-classification.fired',
   CancelRequested: 'events.event-classification.cancelrequested',
+  TimedOut: 'events.event-classification.timedout',
   Signaled: 'events.event-classification.signaled',
+  Canceled: 'events.event-classification.canceled',
+  Failed: 'events.event-classification.failed',
+  Terminated: 'events.event-classification.terminated',
   Pending: 'events.event-classification.pending',
   Retrying: 'events.event-classification.retrying',
 };
 
-export const getStatusLabel = (status: Status | undefined): string =>
-  status && status in statusLabelKeys
-    ? translate(statusLabelKeys[status])
+const isWorkflowStatus = (status: string): status is WorkflowDomainStatus =>
+  status in workflowStatusLabelKeys;
+
+const isEventClassification = (status: string): status is EventDomainStatus =>
+  status in eventClassificationLabelKeys;
+
+/** Label a workflow or schedule status (workflows.* namespace). */
+export const getWorkflowStatusLabel = (
+  status: WorkflowStatus | ScheduleStatus | undefined,
+): string =>
+  status && isWorkflowStatus(status)
+    ? translate(workflowStatusLabelKeys[status])
     : translate('common.unknown');
+
+/** Label an event classification (events.event-classification.* namespace). */
+export const getEventClassificationLabel = (
+  classification: EventDomainStatus | undefined,
+): string =>
+  classification && isEventClassification(classification)
+    ? translate(eventClassificationLabelKeys[classification])
+    : translate('common.unknown');
+
+/**
+ * Polymorphic resolver for WorkflowStatus.svelte, which renders one badge for
+ * any status — a workflow execution status, a schedule status, or an event
+ * classification — and cannot tell the domain from the value alone. Names
+ * shared by both domains (Running, Completed, Failed, Canceled, Terminated,
+ * TimedOut) resolve to the workflow label, preserving the component's
+ * historical behavior. Domain-specific callers should prefer
+ * getWorkflowStatusLabel / getEventClassificationLabel instead.
+ */
+export const getStatusLabel = (status: Status | undefined): string => {
+  if (status && isWorkflowStatus(status)) {
+    return translate(workflowStatusLabelKeys[status]);
+  }
+  if (status && isEventClassification(status)) {
+    return translate(eventClassificationLabelKeys[status]);
+  }
+  return translate('common.unknown');
+};

--- a/tests/integration/timeline-graph-accessible-names.spec.ts
+++ b/tests/integration/timeline-graph-accessible-names.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+import { mockWorkflowApis } from '~/test-utilities/mock-apis';
+import { mockWorkflow } from '~/test-utilities/mocks/workflow';
+
+const { workflowId, runId } = mockWorkflow.workflowExecutionInfo.execution;
+const timelineUrl = `/namespaces/default/workflows/${workflowId}/${runId}/timeline`;
+
+// The timeline graph renders SVG `<g role="button">` nodes (workflow-row and
+// timeline-graph-row). Without an aria-label these announce as a bare "button"
+// to screen readers; these assertions fail if that label regresses.
+test.describe('Timeline graph node accessible names', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockWorkflowApis(page);
+    await page.goto(timelineUrl);
+  });
+
+  test('workflow node announces its id and status', async ({ page }) => {
+    await expect(
+      page.getByRole('button', { name: `Workflow ${workflowId}: Running` }),
+    ).toBeVisible();
+  });
+
+  test('event nodes announce their type and classification', async ({
+    page,
+  }) => {
+    await expect(
+      page.getByRole('button', { name: 'Event LongActivity: Scheduled' }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Event customSignal: Signaled' }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds `aria-label` to each SVG `<g role="button">` wrapper on the timeline-graph nodes so screen readers announce the workflow's id and status (or the event's type and classification) instead of bare "button".

```diff
 <g
   role="button"
   tabindex="0"
+  aria-label={translate('workflows.row-accessible-name', {
+    workflowId: workflow.id,
+    status: statusLabel,
+  })}
   class="relative cursor-pointer"
   {height}
 >
```

Previously, terminal statuses on the timeline graph (Completed, Failed, Canceled, TimedOut, Fired, Signaled) were distinguishable **only by node color**. The legend that decodes those colors lives inside a `<Tooltip>` — keyboard- and AT-reachable since PR #3429, but still requires the user to leave the graph, decode the color in the legend, and come back to identify each node. This change makes the graph self-describing at the node level.

## Audit context

- WCAG 2.2 SC **1.4.1 Use of Color (Level A)** — Serious. Affects every workflow timeline view, which is the most-trafficked product surface for workflow investigation.
- Issue file: `audit-output/issues/1.4.1-timeline-graph-status.md` (this is Option A — the recommended fix).
- The sibling 1.4.1 fix (label required indicator) shipped in PR #3439.

## Cross-cutting wins

- Closes the SC **4.1.2 Name, Role, Value** missing-accessible-name defect on the same `<g role="button">` widgets.
- Closes the SC **1.3.1 Info and Relationships** matrix-row item d (deferred to the Robust wave).

## New i18n keys

- `workflows.row-accessible-name`: `"Workflow {{workflowId}}: {{status}}"`
- `events.row-accessible-name`: `"Event {{eventType}}: {{classification}}"`

## Test plan

- [x] Open a workflow with failed/completed children. Tab into the timeline graph; with VoiceOver/NVDA, confirm each node announces `"Workflow {id}: {status}, button"` instead of just `"button"`.
- [x] On the event history graph: tab to each dot; AT announces `"Event {eventType}: {classification}, button"`.
- [x] Right-click → Inspect a node to confirm the `<g>` has the expected `aria-label` attribute.
- [ ] axe-core `svg-img-alt` rule should no longer flag the timeline graph rows.
- [x] Zero visual change for sighted users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A11y-Audit-Ref: 1.4.1-timeline-graph-status
