### PR TITLE
feat(nexus-operations): DT-4005 standalone nexus operations API integrations

### DIFF
--- a/src/lib/services/nexus-operation-counts.ts
+++ b/src/lib/services/nexus-operation-counts.ts
@@ -1,0 +1,50 @@
+import type { CountWorkflowExecutionsResponse } from '$lib/types/workflows';
+import { requestFromAPI } from '$lib/utilities/request-from-api';
+import { routeForApi } from '$lib/utilities/route-for-api';
+
+export const fetchNexusOperationCount = async (
+  namespace: string,
+  query: string,
+  request = fetch,
+): Promise<{ count: number }> => {
+  let count = 0;
+  try {
+    const countRoute = routeForApi('standalone-nexus-operations.count', {
+      namespace,
+    });
+    const result = await requestFromAPI<{ count: string }>(countRoute, {
+      params: query ? { query } : {},
+      onError: () => {},
+      handleError: () => {},
+      request,
+    });
+    count = parseInt(result?.count || '0');
+  } catch (e) {
+    // Don't fail the nexus operations call due to count
+  }
+
+  return { count };
+};
+
+type NexusOperationCountByStatusOptions = {
+  namespace: string;
+  query: string;
+};
+
+export const fetchNexusOperationCountByStatus = async ({
+  namespace,
+  query,
+}: NexusOperationCountByStatusOptions): Promise<CountWorkflowExecutionsResponse> => {
+  const groupByClause = 'GROUP BY ExecutionStatus';
+  const countRoute = routeForApi('standalone-nexus-operations.count', {
+    namespace,
+  });
+  const { count, groups } =
+    await requestFromAPI<CountWorkflowExecutionsResponse>(countRoute, {
+      params: {
+        query: query ? `${query} ${groupByClause}` : `${groupByClause}`,
+      },
+      notifyOnError: false,
+    });
+  return { count: count ?? '0', groups };
+};

--- a/src/lib/services/standalone-nexus-operations.ts
+++ b/src/lib/services/standalone-nexus-operations.ts
@@ -1,0 +1,300 @@
+import { nexusOperationError } from '$lib/stores/nexus-operations';
+import type { Payload, SearchAttribute } from '$lib/types';
+import type {
+  NexusOperationExecution,
+  NexusOperationExecutionListInfo,
+  NexusOperationIdConflictPolicy,
+  NexusOperationIdReusePolicy,
+  StartNexusOperationExecutionRequest,
+  StartNexusOperationExecutionResponse,
+} from '$lib/types/nexus-operation-execution';
+import { encodePayloads } from '$lib/utilities/encode-payload';
+import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
+import {
+  type ErrorCallback,
+  requestFromAPI,
+} from '$lib/utilities/request-from-api';
+import { routeForApi } from '$lib/utilities/route-for-api';
+
+import { setSearchAttributes } from './workflow-service';
+
+export type ListNexusOperationsResponse = {
+  operations: NexusOperationExecutionListInfo[];
+  nextPageToken: string;
+};
+
+export type PaginatedNexusOperationsPromise = (
+  pageSize?: number,
+  token?: string,
+) => Promise<{
+  items: NexusOperationExecutionListInfo[];
+  nextPageToken: string;
+}>;
+
+export const fetchPaginatedNexusOperations = async (
+  namespace: string,
+  query: string = '',
+  request = fetch,
+): Promise<PaginatedNexusOperationsPromise> => {
+  return (pageSize = 100, token = '') => {
+    nexusOperationError.set('');
+
+    const onError: ErrorCallback = (err) => {
+      nexusOperationError.set(
+        err?.body?.message ||
+          'An error occurred while querying Nexus operations.',
+      );
+    };
+
+    const route = routeForApi('standalone-nexus-operations', { namespace });
+
+    return requestFromAPI<ListNexusOperationsResponse>(route, {
+      params: {
+        pageSize: String(pageSize),
+        nextPageToken: token,
+        ...(query ? { query } : {}),
+      },
+      request,
+      onError,
+      handleError: onError,
+    }).then((response) => {
+      const { operations = [], nextPageToken = '' } = response || {};
+      return {
+        items: operations,
+        nextPageToken: nextPageToken ? String(nextPageToken) : '',
+      };
+    });
+  };
+};
+
+export type StartNexusOperationFormData = {
+  namespace: string;
+  identity: string;
+  operationId: string;
+  endpoint: string;
+  service: string;
+  operation: string;
+  input?: string;
+  encoding?: string;
+  messageType?: string;
+  scheduleToCloseTimeout?: string;
+  scheduleToStartTimeout?: string;
+  startToCloseTimeout?: string;
+  idReusePolicy?: NexusOperationIdReusePolicy;
+  idConflictPolicy?: NexusOperationIdConflictPolicy;
+  nexusHeader?: Record<string, string>;
+  searchAttributes?: Record<string, unknown>[];
+  summary?: string;
+  details?: string;
+};
+
+const toStartNexusOperationRequest = async (
+  formData: StartNexusOperationFormData,
+): Promise<StartNexusOperationExecutionRequest> => {
+  let inputPayload: Payload | undefined = undefined;
+  let summaryPayload: Payload | null = null;
+  let detailsPayload: Payload | null = null;
+  let searchAttributes: SearchAttribute | null = null;
+
+  if (formData.input) {
+    const { input, encoding, messageType } = formData;
+    try {
+      const payloads = await encodePayloads({
+        input,
+        encoding: encoding as 'json/plain' | 'json/protobuf',
+        messageType,
+      });
+      if (payloads && payloads[0]) {
+        inputPayload = payloads[0];
+      }
+    } catch {
+      throw new Error(
+        'Could not encode input for starting Nexus operation execution',
+      );
+    }
+  }
+
+  if (formData.summary) {
+    try {
+      const payloads = await encodePayloads({
+        input: stringifyWithBigInt(formData.summary),
+        encoding: 'json/plain',
+      });
+      if (payloads && payloads[0]) {
+        summaryPayload = payloads[0];
+      }
+    } catch {
+      throw new Error(
+        'Could not encode summary for starting Nexus operation execution',
+      );
+    }
+  }
+
+  if (formData.details) {
+    try {
+      const payloads = await encodePayloads({
+        input: stringifyWithBigInt(formData.details),
+        encoding: 'json/plain',
+      });
+      if (payloads && payloads[0]) {
+        detailsPayload = payloads[0];
+      }
+    } catch {
+      throw new Error(
+        'Could not encode details for starting Nexus operation execution',
+      );
+    }
+  }
+
+  if (formData.searchAttributes) {
+    searchAttributes = {
+      indexedFields: {
+        ...setSearchAttributes(formData.searchAttributes),
+      },
+    };
+  }
+
+  return {
+    namespace: formData.namespace,
+    identity: formData.identity,
+    requestId: crypto.randomUUID(),
+    operationId: formData.operationId,
+    endpoint: formData.endpoint,
+    service: formData.service,
+    operation: formData.operation,
+    ...(inputPayload && { input: inputPayload }),
+    ...(formData.scheduleToCloseTimeout && {
+      scheduleToCloseTimeout: formData.scheduleToCloseTimeout,
+    }),
+    ...(formData.scheduleToStartTimeout && {
+      scheduleToStartTimeout: formData.scheduleToStartTimeout,
+    }),
+    ...(formData.startToCloseTimeout && {
+      startToCloseTimeout: formData.startToCloseTimeout,
+    }),
+    ...(formData.idReusePolicy && { idReusePolicy: formData.idReusePolicy }),
+    ...(formData.idConflictPolicy && {
+      idConflictPolicy: formData.idConflictPolicy,
+    }),
+    ...(formData.nexusHeader && { nexusHeader: formData.nexusHeader }),
+    ...(searchAttributes && { searchAttributes }),
+    ...(summaryPayload || detailsPayload
+      ? {
+          userMetadata: {
+            summary: summaryPayload,
+            details: detailsPayload,
+          },
+        }
+      : {}),
+  };
+};
+
+export const startStandaloneNexusOperation = async (
+  formData: StartNexusOperationFormData,
+): Promise<StartNexusOperationExecutionResponse> => {
+  const { operationId, namespace } = formData;
+
+  const route = routeForApi('standalone-nexus-operation', {
+    namespace,
+    operationId,
+  });
+
+  const request = await toStartNexusOperationRequest(formData);
+
+  return requestFromAPI(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt(request),
+    },
+  });
+};
+
+export const getNexusOperationExecution = (
+  namespace: string,
+  operationId: string,
+): Promise<NexusOperationExecution> => {
+  const route = routeForApi('standalone-nexus-operation', {
+    namespace,
+    operationId,
+  });
+
+  const params = new URLSearchParams({
+    includeInput: 'true',
+    includeOutcome: 'true',
+  });
+
+  return requestFromAPI(route, { params });
+};
+
+export const pollNexusOperationExecution = (
+  namespace: string,
+  operationId: string,
+  token: string,
+  signal: AbortSignal,
+): Promise<NexusOperationExecution> => {
+  const route = routeForApi('standalone-nexus-operation', {
+    namespace,
+    operationId,
+  });
+
+  const params = new URLSearchParams({
+    includeInput: 'false',
+    includeOutcome: 'true',
+    longPollToken: token,
+  });
+
+  return requestFromAPI(route, {
+    params,
+    notifyOnError: false,
+    options: { signal },
+  });
+};
+
+export const cancelNexusOperationExecution = async (
+  namespace: string,
+  operationId: string,
+  reason?: string,
+  identity?: string,
+): Promise<void> => {
+  const route = routeForApi('standalone-nexus-operation.cancel', {
+    namespace,
+    operationId,
+  });
+
+  return requestFromAPI(route, {
+    notifyOnError: false,
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({
+        namespace,
+        operationId,
+        requestId: crypto.randomUUID(),
+        ...(reason && { reason }),
+        ...(identity && { identity }),
+      }),
+    },
+  });
+};
+
+export const terminateNexusOperationExecution = async (
+  namespace: string,
+  operationId: string,
+  reason?: string,
+  identity?: string,
+): Promise<void> => {
+  const route = routeForApi('standalone-nexus-operation.terminate', {
+    namespace,
+    operationId,
+  });
+
+  return requestFromAPI(route, {
+    notifyOnError: false,
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({
+        reason: reason || '',
+        ...(identity && { identity }),
+      }),
+    },
+  });
+};

--- a/src/lib/stores/filters.ts
+++ b/src/lib/stores/filters.ts
@@ -84,6 +84,21 @@ export const activityFilters = writable<SearchAttributeFilter[]>(
   updateActivityFilters,
 );
 
+const updateNexusOperationFilters: StartStopNotifier<
+  SearchAttributeFilter[]
+> = (set) => {
+  return parameters.subscribe(({ query }) => {
+    if (!query && get(nexusOperationFilters).length) {
+      set([]);
+    }
+  });
+};
+
+export const nexusOperationFilters = writable<SearchAttributeFilter[]>(
+  [],
+  updateNexusOperationFilters,
+);
+
 const updateWorkerFilters: StartStopNotifier<SearchAttributeFilter[]> = (
   set,
 ) => {

--- a/src/lib/stores/nexus-operations.ts
+++ b/src/lib/stores/nexus-operations.ts
@@ -1,0 +1,14 @@
+import { writable } from 'svelte/store';
+
+export const nexusOperationRefresh = writable(0);
+export const nexusOperationLoading = writable(true);
+export const nexusOperationUpdating = writable(true);
+
+export const nexusOperationCount = writable({
+  count: 0,
+  newCount: 0,
+});
+
+export const nexusOperationError = writable('');
+export const nexusOperationsQuery = writable<string>('');
+export const nexusOperationsSearchParams = writable<string>('');

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -71,6 +71,15 @@ export type StandaloneActivityAPIRoutePath =
   | 'standalone-activity.cancel'
   | 'standalone-activity.terminate';
 
+export type StandaloneNexusOperationsAPIRoutePath =
+  | 'standalone-nexus-operations'
+  | 'standalone-nexus-operations.count';
+export type StandaloneNexusOperationAPIRoutePath =
+  | 'standalone-nexus-operation'
+  | 'standalone-nexus-operation.poll'
+  | 'standalone-nexus-operation.cancel'
+  | 'standalone-nexus-operation.terminate';
+
 export type APIRoutePath =
   | ParameterlessAPIRoutePath
   | ScheduleAPIRoutePath
@@ -92,7 +101,9 @@ export type APIRoutePath =
   | WorkerDeploymentVersionAPIRoutePath
   | WorkerDeploymentVersionsAPIRoutePath
   | StandaloneActivityAPIRoutePath
-  | StandaloneActivitiesAPIRoutePath;
+  | StandaloneActivitiesAPIRoutePath
+  | StandaloneNexusOperationAPIRoutePath
+  | StandaloneNexusOperationsAPIRoutePath;
 
 export interface APIRouteParameters {
   namespace: string;
@@ -106,6 +117,7 @@ export interface APIRouteParameters {
   signalName: string;
   updateName: string;
   activityId: string;
+  operationId: string;
   endpointId: string;
   deploymentName: string;
   buildId: string;
@@ -194,4 +206,13 @@ export type WorkerDeploymentRouteParameters = Pick<
 export type WorkerDeploymentVersionRouteParameters = Pick<
   APIRouteParameters,
   'namespace' | 'deploymentName' | 'buildId'
+>;
+
+export type StandaloneNexusOperationsParameters = Pick<
+  APIRouteParameters,
+  'namespace'
+>;
+export type StandaloneNexusOperationParameters = Pick<
+  APIRouteParameters,
+  'namespace' | 'operationId'
 >;

--- a/src/lib/types/nexus-operation-execution.ts
+++ b/src/lib/types/nexus-operation-execution.ts
@@ -1,0 +1,136 @@
+import type {
+  EventLink,
+  Failure,
+  Payload,
+  SearchAttribute,
+  UserMetadata,
+} from '.';
+import type { WorkflowSearchAttributes } from './workflows';
+
+export type NexusOperationExecutionStatus =
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_UNSPECIFIED'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_RUNNING'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_FAILED'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_CANCELED'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_TERMINATED'
+  | 'NEXUS_OPERATION_EXECUTION_STATUS_TIMED_OUT';
+
+export const NEXUS_OPERATION_ID_REUSE_POLICIES = [
+  'NEXUS_OPERATION_ID_REUSE_POLICY_UNSPECIFIED',
+  'NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE',
+  'NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY',
+  'NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE',
+] as const;
+
+export const NEXUS_OPERATION_ID_CONFLICT_POLICIES = [
+  'NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED',
+  'NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL',
+  'NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING',
+] as const;
+
+export type NexusOperationIdReusePolicy =
+  (typeof NEXUS_OPERATION_ID_REUSE_POLICIES)[number];
+export type NexusOperationIdConflictPolicy =
+  (typeof NEXUS_OPERATION_ID_CONFLICT_POLICIES)[number];
+
+export const nexusOperationIdReusePolicyOptions =
+  NEXUS_OPERATION_ID_REUSE_POLICIES.filter(
+    (policy) => policy !== 'NEXUS_OPERATION_ID_REUSE_POLICY_UNSPECIFIED',
+  );
+export const nexusOperationIdConflictPolicyOptions =
+  NEXUS_OPERATION_ID_CONFLICT_POLICIES.filter(
+    (policy) => policy !== 'NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED',
+  );
+
+export interface NexusOperationExecutionCancellationInfo {
+  requestedTime: string;
+  state: string;
+  attempt: number;
+  lastAttemptCompleteTime: string;
+  lastAttemptFailure?: Failure;
+  nextAttemptScheduleTime: string;
+  blockedReason: string;
+  reason: string;
+}
+
+export type NexusOperationExecutionOutcome =
+  | { result: Payload }
+  | { failure: Failure };
+
+export interface NexusOperationExecutionInfo {
+  operationId: string;
+  runId: string;
+  endpoint: string;
+  service: string;
+  operation: string;
+  status: NexusOperationExecutionStatus;
+  state: string;
+  scheduleToCloseTimeout: string;
+  scheduleToStartTimeout: string;
+  startToCloseTimeout: string;
+  attempt: number;
+  scheduleTime: string;
+  expirationTime: string;
+  closeTime: string;
+  lastAttemptCompleteTime: string;
+  lastAttemptFailure?: Failure;
+  nextAttemptScheduleTime: string;
+  executionDuration: string;
+  cancellationInfo?: NexusOperationExecutionCancellationInfo;
+  blockedReason: string;
+  requestId: string;
+  operationToken: string;
+  stateTransitionCount: string;
+  searchAttributes: WorkflowSearchAttributes;
+  nexusHeader: Record<string, string>;
+  userMetadata: UserMetadata;
+  links: EventLink[];
+  identity: string;
+}
+
+export interface NexusOperationExecutionListInfo {
+  operationId: string;
+  runId: string;
+  endpoint: string;
+  service: string;
+  operation: string;
+  scheduleTime: string;
+  closeTime: string;
+  status: NexusOperationExecutionStatus;
+  searchAttributes: WorkflowSearchAttributes;
+  stateTransitionCount: string;
+  executionDuration: string;
+}
+
+export interface NexusOperationExecution {
+  runId: string;
+  info: NexusOperationExecutionInfo;
+  input?: Payload;
+  outcome?: NexusOperationExecutionOutcome;
+  longPollToken?: string;
+}
+
+export interface StartNexusOperationExecutionRequest {
+  namespace: string;
+  identity: string;
+  requestId: string;
+  operationId: string;
+  endpoint: string;
+  service: string;
+  operation: string;
+  scheduleToCloseTimeout?: string;
+  scheduleToStartTimeout?: string;
+  startToCloseTimeout?: string;
+  input?: Payload;
+  idReusePolicy?: NexusOperationIdReusePolicy;
+  idConflictPolicy?: NexusOperationIdConflictPolicy;
+  searchAttributes?: SearchAttribute;
+  nexusHeader?: Record<string, string>;
+  userMetadata?: UserMetadata;
+}
+
+export interface StartNexusOperationExecutionResponse {
+  runId: string;
+  started: boolean;
+}

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -23,6 +23,10 @@ import type {
   StandaloneActivitiesParameters,
   StandaloneActivityAPIRoutePath,
   StandaloneActivityParameters,
+  StandaloneNexusOperationAPIRoutePath,
+  StandaloneNexusOperationParameters,
+  StandaloneNexusOperationsAPIRoutePath,
+  StandaloneNexusOperationsParameters,
   TaskQueueAPIRoutePath,
   TaskQueueRouteParameters,
   WorkerAPIRoutePath,
@@ -124,6 +128,7 @@ const encode = (
       batchJobId: '',
       runId: '',
       activityId: '',
+      operationId: '',
       endpointId: '',
       deploymentName: '',
       buildId: '',
@@ -195,6 +200,12 @@ export function pathForApi(
     'standalone-activities.count': `/namespaces/${parameters?.namespace}/activity-count`,
     'standalone-activity.cancel': `/namespaces/${parameters?.namespace}/activities/${parameters?.activityId}/cancel`,
     'standalone-activity.terminate': `/namespaces/${parameters?.namespace}/activities/${parameters?.activityId}/terminate`,
+    'standalone-nexus-operations': `/namespaces/${parameters?.namespace}/nexus-operations`,
+    'standalone-nexus-operation': `/namespaces/${parameters?.namespace}/nexus-operations/${parameters?.operationId}`,
+    'standalone-nexus-operation.poll': `/namespaces/${parameters?.namespace}/nexus-operations/${parameters?.operationId}/poll`,
+    'standalone-nexus-operation.cancel': `/namespaces/${parameters?.namespace}/nexus-operations/${parameters?.operationId}/cancel`,
+    'standalone-nexus-operation.terminate': `/namespaces/${parameters?.namespace}/nexus-operations/${parameters?.operationId}/terminate`,
+    'standalone-nexus-operations.count': `/namespaces/${parameters?.namespace}/nexus-operation-count`,
   };
 
   return getPath(routes[route]);
@@ -301,6 +312,16 @@ export function routeForApi(
 export function routeForApi(
   route: WorkerDeploymentVersionsAPIRoutePath,
   parameters: WorkerDeploymentRouteParameters,
+  shouldEncode?: boolean,
+): string;
+export function routeForApi(
+  route: StandaloneNexusOperationsAPIRoutePath,
+  parameters: StandaloneNexusOperationsParameters,
+  shouldEncode?: boolean,
+): string;
+export function routeForApi(
+  route: StandaloneNexusOperationAPIRoutePath,
+  parameters: StandaloneNexusOperationParameters,
   shouldEncode?: boolean,
 ): string;
 export function routeForApi(route: ParameterlessAPIRoutePath): string;

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -36,7 +36,13 @@ import {
   routeForStandaloneActivityMetadata,
   routeForStandaloneActivitySearchAttributes,
   routeForStandaloneActivityWorkers,
+  routeForStandaloneNexusOperationDetails,
+  routeForStandaloneNexusOperationMetadata,
+  routeForStandaloneNexusOperations,
+  routeForStandaloneNexusOperationSearchAttributes,
+  routeForStandaloneNexusOperationsWithQuery,
   routeForStartStandaloneActivity,
+  routeForStartStandaloneNexusOperation,
   routeForTaskQueue,
   routeForTimeline,
   routeForUserMetadata,
@@ -73,6 +79,11 @@ describe('routeFor functions should resolve the base path exactly once', () => {
     namespace: 'default',
     activityId: 'act-1',
     runId: 'run-1',
+  };
+
+  const nexusOperationParams = {
+    namespace: 'default',
+    operationId: 'op-1',
   };
 
   const cases: [string, () => string | undefined][] = [
@@ -180,6 +191,35 @@ describe('routeFor functions should resolve the base path exactly once', () => {
       () => routeForStandaloneActivityMetadata(activityParams),
     ],
     [
+      'routeForStandaloneNexusOperations',
+      () => routeForStandaloneNexusOperations(namespaceParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationsWithQuery',
+      () =>
+        routeForStandaloneNexusOperationsWithQuery(
+          namespaceParams,
+          'test-query',
+        ),
+    ],
+    [
+      'routeForStartStandaloneNexusOperation',
+      () => routeForStartStandaloneNexusOperation(namespaceParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationDetails',
+      () => routeForStandaloneNexusOperationDetails(nexusOperationParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationSearchAttributes',
+      () =>
+        routeForStandaloneNexusOperationSearchAttributes(nexusOperationParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationMetadata',
+      () => routeForStandaloneNexusOperationMetadata(nexusOperationParams),
+    ],
+    [
       'routeForWorkflowStart',
       () => routeForWorkflowStart({ namespace: 'default' }),
     ],
@@ -275,6 +315,11 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
     namespace: 'default',
     activityId: 'act-1',
     runId: 'run-1',
+  };
+
+  const nexusOperationParams = {
+    namespace: 'default',
+    operationId: 'op-1',
   };
 
   afterEach(() => {
@@ -387,6 +432,35 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
     [
       'routeForStandaloneActivityMetadata',
       () => routeForStandaloneActivityMetadata(activityParams),
+    ],
+    [
+      'routeForStandaloneNexusOperations',
+      () => routeForStandaloneNexusOperations(namespaceParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationsWithQuery',
+      () =>
+        routeForStandaloneNexusOperationsWithQuery(
+          namespaceParams,
+          'test-query',
+        ),
+    ],
+    [
+      'routeForStartStandaloneNexusOperation',
+      () => routeForStartStandaloneNexusOperation(namespaceParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationDetails',
+      () => routeForStandaloneNexusOperationDetails(nexusOperationParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationSearchAttributes',
+      () =>
+        routeForStandaloneNexusOperationSearchAttributes(nexusOperationParams),
+    ],
+    [
+      'routeForStandaloneNexusOperationMetadata',
+      () => routeForStandaloneNexusOperationMetadata(nexusOperationParams),
     ],
     [
       'routeForWorkflowStart',

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -187,6 +187,54 @@ export const routeForStandaloneActivityMetadata = (
   return `${routeForStandaloneActivityBase(parameters)}/metadata`;
 };
 
+export const routeForStandaloneNexusOperations = (
+  parameters: NamespaceParameter,
+): ResolvedPathname => {
+  return `${routeForNamespace(parameters)}/nexus-operations`;
+};
+
+export const routeForStandaloneNexusOperationsWithQuery = (
+  parameters: NamespaceParameter,
+  queryString: string,
+): ResolvedPathname => {
+  const params = new URLSearchParams();
+  params.set('query', queryString);
+
+  return toURL(routeForStandaloneNexusOperations(parameters), params);
+};
+
+export const routeForStartStandaloneNexusOperation = (
+  parameters: NamespaceParameter,
+): ResolvedPathname => {
+  return `${routeForStandaloneNexusOperations(parameters)}/start`;
+};
+
+const routeForStandaloneNexusOperationBase = (
+  parameters: NamespaceParameter & { operationId: string },
+): ResolvedPathname => {
+  const operationId = encodeURIForSvelte(parameters.operationId);
+
+  return `${routeForStandaloneNexusOperations(parameters)}/${operationId}`;
+};
+
+export const routeForStandaloneNexusOperationDetails = (
+  parameters: NamespaceParameter & { operationId: string },
+): ResolvedPathname => {
+  return `${routeForStandaloneNexusOperationBase(parameters)}/details`;
+};
+
+export const routeForStandaloneNexusOperationSearchAttributes = (
+  parameters: NamespaceParameter & { operationId: string },
+): ResolvedPathname => {
+  return `${routeForStandaloneNexusOperationBase(parameters)}/search-attributes`;
+};
+
+export const routeForStandaloneNexusOperationMetadata = (
+  parameters: NamespaceParameter & { operationId: string },
+): ResolvedPathname => {
+  return `${routeForStandaloneNexusOperationBase(parameters)}/metadata`;
+};
+
 type StartWorkflowParameters = NamespaceParameter &
   Partial<{
     workflowId: string;

--- a/src/lib/utilities/standalone-nexus-operation-poller.svelte.ts
+++ b/src/lib/utilities/standalone-nexus-operation-poller.svelte.ts
@@ -1,0 +1,97 @@
+import { writable, type Writable } from 'svelte/store';
+
+import {
+  getNexusOperationExecution,
+  pollNexusOperationExecution,
+} from '$lib/services/standalone-nexus-operations';
+import type { NexusOperationExecution } from '$lib/types/nexus-operation-execution';
+
+import { isEmptyObject } from './is';
+
+export const nexusOperationExecution: Writable<
+  NexusOperationExecution | undefined
+> = writable();
+
+export class StandaloneNexusOperationPoller {
+  private abortController: AbortController;
+  private namespace: string;
+  private operationId: string;
+  private token: string;
+  private onUpdate: (nexusOperationExecution: NexusOperationExecution) => void;
+  private onError: (error: Error) => void;
+
+  constructor(
+    namespace: string,
+    operationId: string,
+    abortController: AbortController,
+    onUpdate: (nexusOperationExecution: NexusOperationExecution) => void,
+    onError: (error: Error) => void,
+  ) {
+    this.namespace = namespace;
+    this.operationId = operationId;
+    this.abortController = abortController;
+    this.onUpdate = onUpdate;
+    this.onError = onError;
+  }
+
+  async start() {
+    let nexusOperationExecution: NexusOperationExecution | undefined =
+      undefined;
+    try {
+      nexusOperationExecution = await getNexusOperationExecution(
+        this.namespace,
+        this.operationId,
+      );
+    } catch (error) {
+      this.onError(error);
+    }
+
+    this.onUpdate(nexusOperationExecution);
+
+    if (
+      nexusOperationExecution.info.status ===
+      'NEXUS_OPERATION_EXECUTION_STATUS_RUNNING'
+    ) {
+      this.token = nexusOperationExecution.longPollToken;
+
+      while (!this.abortController.signal.aborted) {
+        try {
+          const polledNexusOperationExecution =
+            await pollNexusOperationExecution(
+              this.namespace,
+              this.operationId,
+              this.token,
+              this.abortController.signal,
+            );
+
+          if (
+            polledNexusOperationExecution &&
+            !isEmptyObject(polledNexusOperationExecution)
+          ) {
+            this.token = polledNexusOperationExecution.longPollToken;
+            this.onUpdate(polledNexusOperationExecution);
+          }
+        } catch (error) {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return;
+          }
+
+          this.onError(error);
+          break;
+        }
+      }
+    }
+  }
+
+  async fetchOnce() {
+    const nexusOperationExecution = await getNexusOperationExecution(
+      this.namespace,
+      this.operationId,
+    );
+    this.onUpdate(nexusOperationExecution);
+  }
+
+  abort() {
+    this.abortController.abort();
+  }
+}


### PR DESCRIPTION
## Description & motivation 💭

Adds the API integration layer for the Standalone Nexus Operations feature — namespace-scoped Nexus operation executions invoked directly (not from workflows). This is Phase 1 of the Standalone Nexus Operations epic (DT-4001), mirroring the existing Standalone Activities pattern.

**New files:**
- `src/lib/types/nexus-operation-execution.ts` — domain types: status enum, reuse/conflict policies, execution info (full + list subset), start request/response
- `src/lib/services/standalone-nexus-operations.ts` — service functions: list (paginated), start, describe, poll (long-poll), cancel, terminate
- `src/lib/services/nexus-operation-counts.ts` — count and count-by-status service functions
- `src/lib/stores/nexus-operations.ts` — writable stores: refresh, loading, updating, count, error, query, searchParams
- `src/lib/utilities/standalone-nexus-operation-poller.svelte.ts` — `StandaloneNexusOperationPoller` class with initial fetch + continuous long-poll loop and AbortController teardown

**Modified files:**
- `src/lib/types/api.ts` — adds `operationId` to `APIRouteParameters`; adds new nexus operation route path types
- `src/lib/utilities/route-for-api.ts` — registers 6 new API routes: `standalone-nexus-operations`, `standalone-nexus-operation`, `standalone-nexus-operation.poll`, `standalone-nexus-operation.cancel`, `standalone-nexus-operation.terminate`, `standalone-nexus-operations.count`
- `src/lib/utilities/route-for.ts` — adds 7 route helpers mirroring `routeForStandaloneActivity*`
- `src/lib/stores/filters.ts` — adds `nexusOperationFilters` store

**Key differences from Standalone Activities:**
- Input is a single `Payload` (not `Payloads`)
- Routes use only `operationId` (no compound `activityId/runId`)
- Supports both Cancel and Terminate (activities only have Terminate)
- No retryPolicy field — server handles retries internally
- `idReusePolicy` and `idConflictPolicy` are Nexus-specific enums
- `nexusHeader` map for tracing propagation

### Screenshots (if applicable) 📸

N/A — this PR is data/service layer only, no UI changes.

### Design Considerations 🎨

None at this layer.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

Unit and integration tests are scoped to Phase 7 (DT-4007) after all feature phases ship. This PR is types/services/stores only with no rendered UI.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Type-check and lint pass with no regressions:
```bash
pnpm check   # should report 0 new errors (2 pre-existing errors in package/ dir unrelated to this PR)
pnpm lint    # should pass cleanly
```

## Checklists

### Draft Checklist

### Merge Checklist

- [ ] Phase 2 (DT-4006: feature flag + guard) merged first or this PR ships standalone as foundation

### Issue(s) closed

DT-4005

## Docs

No docs updates needed for this layer. Docs will be relevant when the list/detail pages ship.