### PR TITLE
fix(a11y): pair Toast variant background with a severity icon (WCAG 1.4.1)

### DIFF
--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -4,6 +4,7 @@
   import { createEventDispatcher } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
+  import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import type { ToastVariant } from '$lib/types/holocene';
 
@@ -15,6 +16,14 @@
     error: 'bg-danger',
     info: 'bg-information',
     warning: 'bg-warning',
+  };
+
+  const variantIcon: Readonly<Record<ToastVariant, IconName | null>> = {
+    primary: null,
+    success: 'success',
+    error: 'error',
+    info: 'info',
+    warning: 'warning',
   };
 
   export let id: string;
@@ -34,6 +43,9 @@
   )}
   transition:fly={{ x: 250 }}
 >
+  {#if variantIcon[variant]}
+    <Icon name={variantIcon[variant]} class="shrink-0" />
+  {/if}
   <p class="text-sm">
     <slot />
   </p>

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -30,6 +30,8 @@
   export let variant: keyof typeof variants;
   export let closeButtonLabel: string;
 
+  $: icon = variantIcon[variant];
+
   const handleDismiss = () => {
     dispatch('dismiss', { id });
   };
@@ -43,8 +45,8 @@
   )}
   transition:fly={{ x: 250 }}
 >
-  {#if variantIcon[variant]}
-    <Icon name={variantIcon[variant]} class="shrink-0" />
+  {#if icon}
+    <Icon name={icon} class="shrink-0" />
   {/if}
   <p class="text-sm">
     <slot />


### PR DESCRIPTION
## Summary

Toast variants (`success`/`error`/`info`/`warning`) previously distinguished severity exclusively by background color. Sighted users with color-vision differences (deuteranopia, protanopia, achromatopsia) could not distinguish a success toast from an error toast on the surface itself — only `bg-success` versus `bg-danger`.

This PR adds a leading `Icon` keyed to the variant via a `variantIcon` lookup. The neutral `primary` variant (no severity intent) renders no icon. Icon names mirror the established `alert.svelte` pattern.

```diff
+  const variantIcon: Readonly<Record<ToastVariant, IconName | null>> = {
+    primary: null,
+    success: 'success',
+    error: 'error',
+    info: 'info',
+    warning: 'warning',
+  };
...
+  {#if variantIcon[variant]}
+    <Icon name={variantIcon[variant]} class="shrink-0" />
+  {/if}
   <p class="text-sm">
     <slot />
   </p>
```

## Before / After

| Before — color-only severity | After — color + icon severity |
|------------------------------|-------------------------------|
| <img width="420" height="460" alt="image" src="https://github.com/user-attachments/assets/26b61369-db50-42bf-b5cb-36cce6031720" /> | <img width="420" height="460" alt="image" src="https://github.com/user-attachments/assets/d96122a5-8452-410d-9eaf-60b603d36b19" />            |

`success`, `error`, `info`, `warning` each gain a leading severity icon. The neutral `primary` variant renders no icon (no severity intent). Background colors and message text are unchanged.

The accessible announcement is unchanged — Toaster's `role="log"` still carries the message text via the slot. The new icon is purely decorative.

## Audit context

- WCAG 2.2 SC **1.4.1 Use of Color (Level A)** — High remediation priority.
- Toasts are the product's primary confirmation channel for write operations (cancel, terminate, reset, signal, pause, batch action, deployment edit). Misreading a failure as a success here degrades operational trust.
- Issue file: `audit-output/issues/1.4.1-toast-severity-icon.md` (part of the Wave 2 Holocene severity-primitive bundle — Toast is the first of four; Badge / Chip / Banner ship as separate PRs).

## Affected callsites (all benefit automatically)

Every `toaster.push({ variant, message })` consumer inherits the fix. No per-consumer change required. Includes activity-options-update, activity reset/cancel/terminate confirmations, all workflow client-actions (batch cancel/terminate/reset, pause/unpause, signal, update), event-history import, deployment edits, and file upload.

## Test plan

- [x] Storybook: visual diff in `toaster.stories.svelte` — all 5 variants render correctly; `primary` shows no icon.
- [x] Screen reader smoke test (VoiceOver/NVDA): the message text continues to announce via `role="log"`; the decorative icon does not double-announce.
- [x] Trigger a cancel-confirmation flow (success toast) and a terminate-failure flow (error toast); confirm the icons render and are visually distinguishable.
- [x] Color-blind simulator (deuteranopia, protanopia, achromatopsia): the variant icon shape is perceptible against each variant background.
- [x] axe-core: no new violations.

## Out of scope

- Upgrading `role="log"` → `role="alert"` for error toasts (that's SC 4.1.3 Status Messages).
- Migrating to a title-plus-body structured layout.
- Toast deduplication, queue limits, animation tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A11y-Audit-Ref: 1.4.1-holocene-severity-primitives-wave2
