### PR TITLE
fix(a11y): add focusin/focusout to saved-query nav hover tooltip (WCAG 2.1.1)

### DIFF
--- a/src/lib/components/standalone-activities/saved-views.svelte
+++ b/src/lib/components/standalone-activities/saved-views.svelte
@@ -227,7 +227,7 @@
     tooltipY = Math.round(rect.top + 16);
   };
 
-  const onQueryBtnEnter = (e: MouseEvent, name: string) => {
+  const onQueryBtnEnter = (e: MouseEvent | FocusEvent, name: string) => {
     if ($savedQueryNavOpen) return;
     const el = e.currentTarget as HTMLElement;
     tooltipText = name;
@@ -235,7 +235,7 @@
     showTooltip = true;
   };
 
-  const onQueryBtnMove = (e: MouseEvent) => {
+  const onQueryBtnMove = (e: MouseEvent | FocusEvent) => {
     if (!showTooltip) return;
     const el = e.currentTarget as HTMLElement;
     positionTooltipFrom(el);
@@ -364,6 +364,8 @@
     onmouseenter={(e) => onQueryBtnEnter(e, view.name)}
     onmousemove={onQueryBtnMove}
     onmouseleave={onQueryBtnLeave}
+    onfocusin={(e) => onQueryBtnEnter(e, view.name)}
+    onfocusout={onQueryBtnLeave}
   >
     <Button
       variant="ghost"

--- a/src/lib/pages/saved-query-views.svelte
+++ b/src/lib/pages/saved-query-views.svelte
@@ -225,7 +225,7 @@
     tooltipY = Math.round(rect.top + 16);
   };
 
-  const onQueryBtnEnter = (e: MouseEvent, name: string) => {
+  const onQueryBtnEnter = (e: MouseEvent | FocusEvent, name: string) => {
     if ($savedQueryNavOpen) return;
     const el = e.currentTarget as HTMLElement;
     tooltipText = name;
@@ -233,7 +233,7 @@
     showTooltip = true;
   };
 
-  const onQueryBtnMove = (e: MouseEvent) => {
+  const onQueryBtnMove = (e: MouseEvent | FocusEvent) => {
     if (!showTooltip) return;
     const el = e.currentTarget as HTMLElement;
     positionTooltipFrom(el);
@@ -373,6 +373,14 @@
       )}
     onmousemove={onQueryBtnMove}
     onmouseleave={onQueryBtnLeave}
+    onfocusin={(e) =>
+      onQueryBtnEnter(
+        e,
+        view.id === TASK_FAILURES_VIEW.id
+          ? `${view.name} • ${view.count ?? 0}`
+          : view.name,
+      )}
+    onfocusout={onQueryBtnLeave}
   >
     <Button
       variant="ghost"


### PR DESCRIPTION
## Summary

The saved-query nav rail and its standalone-activities sibling render query buttons with mouse-only tooltip handlers. When the rail is collapsed, query-button labels are truncated — mouse users see the full label in the floating tooltip but **keyboard users tabbing through the rail see only icons**.

This PR adds `onfocusin` / `onfocusout` alongside the existing mouse handlers so the same `onQueryBtnEnter` / `onQueryBtnLeave` callbacks fire on keyboard focus. Handler signatures widen from `MouseEvent` to `MouseEvent | FocusEvent`.

```diff
   <div
     class="w-full"
     role="menuitem"
     tabindex="-1"
     onmouseenter={(e) => onQueryBtnEnter(e, view.name)}
     onmousemove={onQueryBtnMove}
     onmouseleave={onQueryBtnLeave}
+    onfocusin={(e) => onQueryBtnEnter(e, view.name)}
+    onfocusout={onQueryBtnLeave}
   >
```

## How it works

- `focusin` / `focusout` bubble from descendants (unlike `focus` / `blur`)
- The wrapper has `tabindex="-1"` (not itself a focus stop); focus on the inner `<Button>` bubbles to the wrapper where the handlers are attached
- `e.currentTarget` resolves to the wrapper for both mouse and focus events, so `positionTooltipFrom(el)` computes the same bounding rect either way
- The existing `if ($savedQueryNavOpen) return;` guard short-circuits when the nav is expanded, so no tooltip is shown on focus when the inline label is sufficient (matches today's mouse-side behavior)

## Audit context

- WCAG 2.2 SC **2.1.1 Keyboard (Level A)** — Medium remediation priority.
- Pattern matches existing precedent in 3 Holocene table-body-cell components (`workflows`, `activities`, `workers`) that already pair `onmouseover` with `onfocusin` for hover-OR-focus UI reveal.

## Test plan

- [x] Collapse the saved-query nav (workflows page, saved-views drawer). Tab through each query-button. The floating tooltip should appear next to the focused button with the full (untruncated) name.
- [x] Tab order is unchanged — only the inner `<Button>` is a focus stop; the wrapper stays `tabindex="-1"`.
- [x] Repeat on `saved-views.svelte` (standalone activities surface).
- [x] Expand the nav and Tab through again — no tooltip should appear (inline label is sufficient; matches today's mouse behavior).
- [x] Mouse hover still shows and hides the tooltip identically to today (regression check).
- [x] Screen reader smoke test: confirm `<Button>` accessible name continues to announce normally.

## Out of scope

- Escape-to-dismiss for the hand-rolled tooltip (deferred to a future migration onto the upgraded `Tooltip` primitive from PR #3429)
- `aria-describedby` linkage between trigger and tooltip (separate 4.1.2 concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

A11y-Audit-Ref: 2.1.1-saved-query-nav-hover-tooltip
