### PR TITLE
fix(markdown): allow nested lists to render as block

### DIFF
--- a/src/markdown.reset.css
+++ b/src/markdown.reset.css
@@ -68,7 +68,7 @@ li {
   list-style-position: inside;
 }
 
-li * {
+li > p {
   display: inline;
 }
 


### PR DESCRIPTION
## Summary

- Scope the markdown reset's inline-display rule from `li *` to `li > p`, so nested `<ul>`/`<ol>` inside a list item no longer collapse to `display: inline`.
- Workflow "Current Details" now renders nested lists correctly instead of flattening every level onto a single line.

The original `li * { display: inline }` was meant to keep paragraph wrappers (mdast emits `<p>` inside `<li>` for loose lists) on the same line as the bullet. Narrowing the selector to direct `<p>` children preserves that behavior while letting nested lists fall back to their default block layout.

Reported in [DT-4047](https://temporalio.atlassian.net/browse/DT-4047). Fixes the nested-list portion; the separate `&nbsp;` literal-render report on the same ticket is still pending repro.

## Test plan

- [x] `pnpm lint` (stylelint clean on the changed file)
- [x] Verified via `/render` endpoint that the markdown pipeline emits nested `<ul>` inside `<li>` — with the fix, the browser's default `display: block` on `<ul>` now applies.
- [ ] Visual confirmation in deploy preview: workflow Current Details panel with a markdown nested list renders as a hierarchical list rather than a flat run-on line.

[DT-4047]: https://temporalio.atlassian.net/browse/DT-4047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ