### PR TITLE
feat(nexus-operations): add capability flag, guard component, and configurable table columns

### DIFF
--- a/src/lib/components/standalone-nexus-operations/standalone-nexus-operations-disabled.svelte
+++ b/src/lib/components/standalone-nexus-operations/standalone-nexus-operations-disabled.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import Alert from '$lib/holocene/alert.svelte';
+  import CodeBlock from '$lib/holocene/code-block.svelte';
+  import { translate } from '$lib/i18n/translate';
+
+  import PageTitle from '../page-title.svelte';
+
+  interface Props {
+    namespace: string;
+    href: string;
+  }
+
+  let { namespace, href }: Props = $props();
+
+  const configValues = `nexus.enableStandaloneOperations:
+  - value: true`;
+
+  const configValuesPerNamespace = $derived(`nexus.enableStandaloneOperations:
+  - value: true
+    constraints:
+      namespace: ${namespace}`);
+</script>
+
+<PageTitle
+  title="{translate(
+    'standalone-nexus-operations.standalone-nexus-operations',
+  )} | {namespace}"
+  url={href}
+/>
+
+<h1>Standalone Nexus Operations</h1>
+<Alert
+  title={translate(
+    'standalone-nexus-operations.standalone-nexus-operations-disabled',
+  )}
+  intent="info"
+  class="max-w-4xl"
+/>
+<div class="flex max-w-4xl flex-col gap-2">
+  <p>
+    {translate(
+      'standalone-nexus-operations.standalone-nexus-operations-enablement',
+    )}
+  </p>
+  <CodeBlock copyable content={configValues} />
+  <p>
+    {translate(
+      'standalone-nexus-operations.standalone-nexus-operations-enablement-per-namespace',
+    )}
+  </p>
+  <CodeBlock copyable content={configValuesPerNamespace} />
+</div>

--- a/src/lib/components/standalone-nexus-operations/standalone-nexus-operations-guard.svelte
+++ b/src/lib/components/standalone-nexus-operations/standalone-nexus-operations-guard.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  import { temporalVersion } from '$lib/stores/versions';
+  import type {
+    DescribeNamespaceResponse,
+    NamespaceCapabilities,
+  } from '$lib/types';
+  import { minimumVersionRequired } from '$lib/utilities/version-check';
+
+  interface Props {
+    namespace: DescribeNamespaceResponse;
+    children: Snippet;
+    fallback?: Snippet;
+  }
+
+  let { namespace, children, fallback }: Props = $props();
+</script>
+
+{#if (namespace.namespaceInfo?.capabilities as NamespaceCapabilities)?.standaloneNexusOperations && minimumVersionRequired('1.31.0', $temporalVersion)}
+  {@render children()}
+{:else if fallback}
+  {@render fallback()}
+{/if}

--- a/src/lib/i18n/locales/en/index.ts
+++ b/src/lib/i18n/locales/en/index.ts
@@ -11,6 +11,7 @@ import * as Nexus from './nexus';
 import * as Schedules from './schedules';
 import * as SearchAttributes from './search-attributes';
 import * as StandaloneActivities from './standalone-activities';
+import * as StandaloneNexusOperations from './standalone-nexus-operations';
 import * as TypedErrors from './typed-errors';
 import * as Workers from './workers';
 import * as Workflows from './workflows';
@@ -33,5 +34,6 @@ export const English = {
   [Nexus.Namespace]: Nexus.Strings,
   [SearchAttributes.Namespace]: SearchAttributes.Strings,
   [StandaloneActivities.Namespace]: StandaloneActivities.Strings,
+  [StandaloneNexusOperations.Namespace]: StandaloneNexusOperations.Strings,
   [Workers.Namespace]: Workers.Strings,
 } as const;

--- a/src/lib/i18n/locales/en/standalone-nexus-operations.ts
+++ b/src/lib/i18n/locales/en/standalone-nexus-operations.ts
@@ -1,0 +1,11 @@
+export const Namespace = 'standalone-nexus-operations' as const;
+
+export const Strings = {
+  'standalone-nexus-operations': 'Standalone Nexus Operations',
+  'standalone-nexus-operations-disabled':
+    'Standalone Nexus Operations are disabled for this Namespace.',
+  'standalone-nexus-operations-enablement':
+    'If you want to enable Standalone Nexus Operations globally, please ensure the following values are set in Dynamic Config.',
+  'standalone-nexus-operations-enablement-per-namespace':
+    'If you want to enable Standalone Nexus Operations for this namespace only, include the following',
+} as const;

--- a/src/lib/stores/configurable-table-columns.ts
+++ b/src/lib/stores/configurable-table-columns.ts
@@ -41,6 +41,7 @@ export const TABLE_TYPE = {
   WORKFLOWS: 'workflows',
   SCHEDULES: 'schedules',
   ACTIVITIES: 'activities',
+  NEXUS_OPERATIONS: 'nexus-operations',
 } as const;
 
 type Keys = keyof typeof TABLE_TYPE;
@@ -137,6 +138,22 @@ export const ActivityHeaderLabels = [
 
 export type ActivityHeaderLabel = (typeof ActivityHeaderLabels)[number];
 
+export const NexusOperationHeaderLabels = [
+  'Operation ID',
+  'Run ID',
+  'Endpoint',
+  'Service',
+  'Operation',
+  'Status',
+  'Schedule Time',
+  'Close Time',
+  'Execution Duration',
+  'State Transitions',
+] as const;
+
+export type NexusOperationHeaderLabel =
+  (typeof NexusOperationHeaderLabels)[number];
+
 export const DEFAULT_ACTIVITIES_COLUMNS: ConfigurableTableHeader[] = [
   { label: 'Status' },
   { label: 'Activity ID' },
@@ -148,6 +165,22 @@ export const DEFAULT_ACTIVITIES_COLUMNS: ConfigurableTableHeader[] = [
 
 const DEFAULT_AVAILABLE_ACTIVITIES_COLUMNS: ConfigurableTableHeader[] = [
   { label: 'Run ID' },
+  { label: 'Execution Duration' },
+  { label: 'State Transitions' },
+];
+
+export const DEFAULT_NEXUS_OPERATIONS_COLUMNS: ConfigurableTableHeader[] = [
+  { label: 'Status' },
+  { label: 'Operation ID' },
+  { label: 'Endpoint' },
+  { label: 'Service' },
+  { label: 'Operation' },
+  { label: 'Schedule Time' },
+];
+
+const DEFAULT_AVAILABLE_NEXUS_OPERATIONS_COLUMNS: ConfigurableTableHeader[] = [
+  { label: 'Run ID' },
+  { label: 'Close Time' },
   { label: 'Execution Duration' },
   { label: 'State Transitions' },
 ];
@@ -167,6 +200,11 @@ export const persistedActivitiesTableColumns = persistStore<State>(
   {},
 );
 
+export const persistedNexusOperationsTableColumns = persistStore<State>(
+  'namespace-nexus-operations-table-columns',
+  {},
+);
+
 export const configurableTableColumns: Readable<TableColumns> = derived(
   [
     namespaces,
@@ -174,6 +212,7 @@ export const configurableTableColumns: Readable<TableColumns> = derived(
     persistedWorkflowTableColumns,
     persistedSchedulesTableColumns,
     persistedActivitiesTableColumns,
+    persistedNexusOperationsTableColumns,
   ],
   ([
     $namespaces,
@@ -181,6 +220,7 @@ export const configurableTableColumns: Readable<TableColumns> = derived(
     $persistedWorkflowTableColumns,
     $persistedSchedulesTableColumns,
     $persistedActivitiesTableColumns,
+    $persistedNexusOperationsTableColumns,
   ]) => {
     const state: TableColumns = {};
     const useOrAddDefaultTableColumnsToNamespace = (
@@ -211,6 +251,11 @@ export const configurableTableColumns: Readable<TableColumns> = derived(
         $persistedActivitiesTableColumns,
         namespace,
         DEFAULT_ACTIVITIES_COLUMNS,
+      ),
+      'nexus-operations': useOrAddDefaultTableColumnsToNamespace(
+        $persistedNexusOperationsTableColumns,
+        namespace,
+        DEFAULT_NEXUS_OPERATIONS_COLUMNS,
       ),
     });
 
@@ -280,6 +325,21 @@ export const availableActivityColumns: (
     ),
   );
 
+export const availableNexusOperationColumns: (
+  namespace: string,
+) => Readable<ConfigurableTableHeader[]> = (namespace) =>
+  derived(configurableTableColumns, ($configurableTableColumns) =>
+    [
+      ...DEFAULT_NEXUS_OPERATIONS_COLUMNS,
+      ...DEFAULT_AVAILABLE_NEXUS_OPERATIONS_COLUMNS,
+    ].filter(
+      (header) =>
+        !$configurableTableColumns[namespace]?.['nexus-operations']?.some(
+          (column) => column.label === header.label,
+        ),
+    ),
+  );
+
 export const availableCustomSearchAttributeColumns: (
   namespace: string,
   table?: ConfigurableTableType,
@@ -310,6 +370,8 @@ const getDefaultColumns = (table: ConfigurableTableType) => {
       return DEFAULT_SCHEDULES_COLUMNS;
     case TABLE_TYPE.ACTIVITIES:
       return DEFAULT_ACTIVITIES_COLUMNS;
+    case TABLE_TYPE.NEXUS_OPERATIONS:
+      return DEFAULT_NEXUS_OPERATIONS_COLUMNS;
   }
 };
 
@@ -359,6 +421,8 @@ const getPersistedColumns = (table: ConfigurableTableType): Writable<State> => {
       return persistedSchedulesTableColumns;
     case TABLE_TYPE.ACTIVITIES:
       return persistedActivitiesTableColumns;
+    case TABLE_TYPE.NEXUS_OPERATIONS:
+      return persistedNexusOperationsTableColumns;
   }
 };
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -16,6 +16,12 @@ export type Capabilities =
   temporal.api.workflowservice.v1.GetSystemInfoResponse.ICapabilities & {
     serverScaledDeployments?: boolean | null;
   };
+
+export type NamespaceCapabilities = NonNullable<
+  NonNullable<DescribeNamespaceResponse['namespaceInfo']>['capabilities']
+> & {
+  standaloneNexusOperations?: boolean | null;
+};
 export type GetWorkflowExecutionHistoryResponse =
   temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryResponse;
 export type GetSearchAttributesResponse =


### PR DESCRIPTION
## Motivation

Phase 2 of Standalone Nexus Operations (DT-4006). Phase 1 (DT-4005) shipped the API integrations — types, services, stores, poller, route helpers, and filters. This phase ships the feature-gating infrastructure that Phase 3 (DT-4004) will consume when rendering the actual UI.

## What changed

### Capability type extension (`src/lib/types/index.ts`)

The `standaloneNexusOperations` capability flag does not yet exist in `@temporalio/proto`. The same pattern used for `serverScaledDeployments` is applied here — a `NamespaceCapabilities` intersection type that extends the proto `ICapabilities` with the custom field:

```typescript
export type NamespaceCapabilities =
  NonNullable<
    NonNullable<DescribeNamespaceResponse['namespaceInfo']>['capabilities']
  > & {
    standaloneNexusOperations?: boolean | null;
  };
```

The guard component casts to this type when checking the flag, so the rest of the codebase remains unaffected until the proto ships.

### Guard component (`standalone-nexus-operations-guard.svelte`)

Mirrors `standalone-activities-guard.svelte`. Gates on **both** the namespace capability flag (`standaloneNexusOperations`) and server version ≥ 1.31.0. Renders `children` when both conditions are true, `fallback` (if provided) otherwise.

### Disabled state component (`standalone-nexus-operations-disabled.svelte`)

Shown by the route page when the guard renders the fallback. Displays an info alert and Dynamic Config instructions (global and per-namespace) explaining how to enable the feature.

### i18n strings (`src/lib/i18n/locales/en/standalone-nexus-operations.ts`)

New namespace with the 4 strings required by the disabled component. Registered in `src/lib/i18n/locales/en/index.ts` alongside `StandaloneActivities`.

### Configurable table columns (`src/lib/stores/configurable-table-columns.ts`)

All 8 atomic changes applied together (partial application causes `pnpm check` failures because `ConfigurableTableType` expands and all switch statements become non-exhaustive):

- `TABLE_TYPE.NEXUS_OPERATIONS = 'nexus-operations'` added to the const map
- `NexusOperationHeaderLabels` tuple and `NexusOperationHeaderLabel` type exported
- `DEFAULT_NEXUS_OPERATIONS_COLUMNS` (6 default columns) and `DEFAULT_AVAILABLE_NEXUS_OPERATIONS_COLUMNS` (4 optional columns) exported/defined
- `persistedNexusOperationsTableColumns` persist store added
- `configurableTableColumns` derived store extended with the new persist store and `'nexus-operations'` key in `getTableColumns`
- `availableNexusOperationColumns` exported derived store for the column picker UI
- `getDefaultColumns` and `getPersistedColumns` switches extended with `TABLE_TYPE.NEXUS_OPERATIONS` cases

## Testing

- [ ] `pnpm check` — zero new errors
- [ ] `pnpm lint` — zero new errors in changed files
- [ ] `pnpm test -- --run` — all 140 unit tests pass