### PR TITLE
Improve API request auth error handling without package-level login redirects

### DIFF
--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -50,19 +50,12 @@ import type {
   WorkflowExecution,
   WorkflowIdentifier,
 } from '$lib/types/workflows';
-import {
-  decodePayloadAndParseDataToJSON,
-  type PotentiallyDecodable,
-} from '$lib/utilities/decode-payload';
+import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
 import {
   encodePayloads,
   setBase64Payload,
 } from '$lib/utilities/encode-payload';
-import {
-  handleUnauthorizedOrForbiddenError,
-  isForbidden,
-  isUnauthorized,
-} from '$lib/utilities/handle-error';
+import { isForbidden, isUnauthorized } from '$lib/utilities/handle-error';
 import { paginated } from '$lib/utilities/paginated';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
@@ -176,8 +169,6 @@ export const fetchAllWorkflows = async (
 
   let error = '';
   const onError: ErrorCallback = (err) => {
-    // Kick out to login if 401/403
-    handleUnauthorizedOrForbiddenError(err);
     if (err?.body?.message || err?.status) {
       error =
         err?.body?.message ??
@@ -1119,8 +1110,6 @@ export const fetchPaginatedWorkflows = async (
     workflowError.set('');
 
     const onError: ErrorCallback = (err) => {
-      handleUnauthorizedOrForbiddenError(err);
-
       if (get(hideWorkflowQueryErrors)) {
         workflowError.set(translate('workflows.workflows-error-querying'));
       } else {
@@ -1155,9 +1144,7 @@ export const fetchPaginatedArchivedWorkflows = async (
   request = fetch,
 ): Promise<PaginatedWorkflowsPromise> => {
   return (pageSize = 100, token = '') => {
-    const onError: ErrorCallback = (err) => {
-      handleUnauthorizedOrForbiddenError(err);
-    };
+    const onError: ErrorCallback = () => {};
 
     const route = routeForApi('workflows.archived', { namespace });
     return requestFromAPI<ListWorkflowExecutionsResponse>(route, {

--- a/src/lib/utilities/api-request-manager.ts
+++ b/src/lib/utilities/api-request-manager.ts
@@ -1,0 +1,168 @@
+import type { NetworkError } from '$lib/types/global';
+
+import { has } from './has';
+import { isObject, isString } from './is';
+import { isNetworkError } from './is-network-error';
+
+export type TemporalAPIError = {
+  code: number;
+  message: string;
+  details: unknown[];
+};
+
+export type APIErrorBody = Partial<TemporalAPIError> & {
+  message?: string;
+  error?: unknown;
+  [key: string]: unknown;
+};
+
+export type APIErrorResponse = {
+  status: number;
+  statusText: string;
+  statusCode?: number;
+  body: APIErrorBody;
+  response?: Response;
+  message?: string;
+};
+
+export type ErrorCallback = (error: APIErrorResponse) => void;
+
+export type RequestErrorHandler = (error: unknown) => void;
+
+export class APIRequestError extends Error implements NetworkError {
+  statusCode: number;
+  statusText: string;
+  response: Response;
+  body: APIErrorBody;
+
+  constructor(response: Response, body: unknown) {
+    const normalizedBody = toAPIErrorBody(body);
+    super(errorMessage(response, normalizedBody));
+    this.name = 'APIRequestError';
+    this.statusCode = response.status;
+    this.statusText = response.statusText;
+    this.response = response;
+    this.body = normalizedBody;
+  }
+}
+
+export const isAPIRequestError = (error: unknown): error is APIRequestError => {
+  return error instanceof APIRequestError;
+};
+
+export const isAuthenticationError = (error: unknown): boolean => {
+  return hasStatusCode(error, 401) || hasStatusCode(error, 403);
+};
+
+export const parseResponseBody = async (
+  response: Response,
+): Promise<unknown> => {
+  if (typeof response.text === 'function') {
+    const text = await response.text();
+    if (!text) return undefined;
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { message: text };
+    }
+  }
+
+  if (typeof response.json === 'function') {
+    try {
+      return await response.json();
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
+};
+
+export const toAPIErrorResponse = (
+  response: Response,
+  body: unknown,
+): APIErrorResponse => {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    body: toAPIErrorBody(body),
+  };
+};
+
+export const toAPIRequestError = (
+  response: Response,
+  body: unknown,
+): APIRequestError => {
+  return new APIRequestError(response, body);
+};
+
+export const handleCaughtRequestError = (
+  error: unknown,
+  options: {
+    notifyOnError: boolean;
+    handleError: RequestErrorHandler;
+  },
+): never | void => {
+  if (!options.notifyOnError) {
+    throw error;
+  }
+
+  if (isAuthenticationError(error)) {
+    throw error;
+  }
+
+  options.handleError(error);
+};
+
+export const normalizeHeaders = (
+  headers: HeadersInit | undefined,
+): Record<string, string> => {
+  const normalized: Record<string, string> = {};
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    headers.forEach((value, key) => {
+      normalized[key] = value;
+    });
+  } else if (Array.isArray(headers)) {
+    for (const [key, value] of headers) {
+      normalized[key] = value;
+    }
+  } else if (headers) {
+    Object.assign(normalized, headers);
+  }
+
+  normalized['Caller-Type'] = 'operator';
+  return normalized;
+};
+
+const toAPIErrorBody = (body: unknown): APIErrorBody => {
+  if (isObject(body)) return body as APIErrorBody;
+  if (isString(body)) return { message: body };
+  return {};
+};
+
+const errorMessage = (response: Response, body: APIErrorBody): string => {
+  if (isString(body.message)) return body.message;
+  if (isString(body.error)) return body.error;
+  return response.statusText;
+};
+
+const hasStatusCode = (
+  error: unknown,
+  statusCode: number | string,
+): boolean => {
+  if (has(error, 'statusCode')) {
+    return error.statusCode === statusCode;
+  }
+
+  if (has(error, 'status')) {
+    return error.status === statusCode;
+  }
+
+  if (isNetworkError(error)) {
+    return error.statusCode === statusCode;
+  }
+
+  return false;
+};

--- a/src/lib/utilities/handle-error.test.ts
+++ b/src/lib/utilities/handle-error.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { handleError } from './handle-error';
+import {
+  handleError,
+  handleUnauthorizedOrForbiddenError,
+} from './handle-error';
 import { routeForLoginPage } from './route-for';
 
 const realLocation = window.location.assign;
@@ -20,7 +23,7 @@ describe('handleError', () => {
     vi.clearAllMocks();
   });
 
-  it('should redirect if it is an unauthorized error with status', () => {
+  it('should not redirect if it is an unauthorized error with status', () => {
     const error = {
       status: 401,
       statusText: 'Unauthorized',
@@ -28,10 +31,10 @@ describe('handleError', () => {
     };
 
     expect(() => handleError(error)).toThrowError();
-    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
-  it('should redirect if it is an unauthorized error with statusCode', () => {
+  it('should not redirect if it is an unauthorized error with statusCode', () => {
     const error = {
       statusCode: 401,
       statusText: 'Unauthorized',
@@ -39,10 +42,10 @@ describe('handleError', () => {
     };
 
     expect(() => handleError(error)).toThrowError();
-    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
-  it('should redirect if it is a forbidden error with status', () => {
+  it('should not redirect if it is a forbidden error with status', () => {
     const error = {
       statusCode: 403,
       statusText: 'Forbidden',
@@ -50,10 +53,10 @@ describe('handleError', () => {
     };
 
     expect(() => handleError(error)).toThrowError();
-    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
-  it('should redirect if it is a forbidden error with statusCode', () => {
+  it('should not redirect if it is a forbidden error with statusCode', () => {
     const error = {
       status: 403,
       statusText: 'Forbidden',
@@ -61,7 +64,35 @@ describe('handleError', () => {
     };
 
     expect(() => handleError(error)).toThrowError();
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('should redirect unauthorized errors when explicitly requested', () => {
+    const error = {
+      status: 401,
+      statusText: 'Unauthorized',
+      body: { message: 'Unauthorized' },
+    };
+
+    handleUnauthorizedOrForbiddenError(error, true, {
+      redirectToLogin: true,
+    });
+
     expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+  });
+
+  it('should not redirect forbidden errors when explicitly requested', () => {
+    const error = {
+      status: 403,
+      statusText: 'Forbidden',
+      body: { message: 'Forbidden' },
+    };
+
+    handleUnauthorizedOrForbiddenError(error, true, {
+      redirectToLogin: true,
+    });
+
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   it('should not redirect if not 401/403', () => {

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -4,9 +4,9 @@ import { networkError } from '$lib/stores/error';
 import { toaster } from '$lib/stores/toaster';
 import type { NetworkError } from '$lib/types/global';
 
+import type { APIErrorResponse, TemporalAPIError } from './api-request-manager';
 import { has } from './has';
 import { isNetworkError } from './is-network-error';
-import type { APIErrorResponse, TemporalAPIError } from './request-from-api';
 import { routeForLoginPage } from './route-for';
 
 interface NetworkErrorWithReport extends NetworkError {
@@ -17,7 +17,7 @@ export const handleError = (
   error: unknown,
   toasts = toaster,
   errors = networkError,
-  isBrowser = BROWSER,
+  _isBrowser = BROWSER,
 ): void => {
   if (error instanceof DOMException && error.name === 'AbortError') {
     return;
@@ -33,14 +33,6 @@ export const handleError = (
     toasts.push({ variant: 'error', message: error.message });
   }
 
-  if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
-  }
-
-  if (isForbidden(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
-  }
-
   if (isNetworkError(error)) {
     toasts.push({
       variant: 'error',
@@ -53,18 +45,19 @@ export const handleError = (
   throw error;
 };
 
+type AuthErrorHandlingOptions = {
+  redirectToLogin?: boolean;
+};
+
 export const handleUnauthorizedOrForbiddenError = (
   error: APIErrorResponse,
   isBrowser = BROWSER,
+  options: AuthErrorHandlingOptions = {},
 ): void => {
-  if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
-    return;
-  }
+  if (!options.redirectToLogin || !isBrowser) return;
 
-  if (isForbidden(error) && isBrowser) {
+  if (isUnauthorized(error)) {
     window.location.assign(routeForLoginPage());
-    return;
   }
 };
 

--- a/src/lib/utilities/request-from-api.401-retry.test.ts
+++ b/src/lib/utilities/request-from-api.401-retry.test.ts
@@ -11,7 +11,7 @@ vi.mock('./core-provider', () => ({
 
 import { runPostResponse, runPreRequest } from './core-provider';
 import { handleError } from './handle-error';
-import { requestFromAPI } from './request-from-api';
+import { isAuthenticationError, requestFromAPI } from './request-from-api';
 
 const mockRunPreRequest = vi.mocked(runPreRequest);
 const mockRunPostResponse = vi.mocked(runPostResponse);
@@ -158,8 +158,12 @@ describe('requestFromAPI with hooks', () => {
         body: { message: 'unauthorized' },
       });
 
-      await requestFromAPI(endpoint, { request, isBrowser: false });
+      const error = await requestFromAPI(endpoint, {
+        request,
+        isBrowser: false,
+      }).catch((error) => error);
 
+      expect(isAuthenticationError(error)).toBe(true);
       expect(mockRunPostResponse).not.toHaveBeenCalled();
     });
 
@@ -244,8 +248,11 @@ describe('requestFromAPI with hooks', () => {
         return res;
       });
 
-      await requestFromAPI(endpoint, { request });
+      const error = await requestFromAPI(endpoint, { request }).catch(
+        (error) => error,
+      );
 
+      expect(isAuthenticationError(error)).toBe(true);
       expect(mockRunPostResponse).toHaveBeenCalledTimes(1);
       expect(request).toHaveBeenCalledTimes(2);
     });

--- a/src/lib/utilities/request-from-api.test.ts
+++ b/src/lib/utilities/request-from-api.test.ts
@@ -1,9 +1,13 @@
 import { URLSearchParams } from 'url';
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { handleError } from './handle-error';
-import { isTemporalAPIError, requestFromAPI } from './request-from-api';
+import {
+  isAuthenticationError,
+  isTemporalAPIError,
+  requestFromAPI,
+} from './request-from-api';
 import { routeForApi } from './route-for-api';
 
 import listWorkflowResponse from '$fixtures/list-workflows.json';
@@ -63,6 +67,10 @@ describe('requestFromAPI', () => {
         ...response,
       });
     }) as unknown as typeof fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('should fetch the endpoint', async () => {
     const request = fetchMock();
@@ -183,9 +191,9 @@ describe('requestFromAPI', () => {
     expect((error as unknown as ErrorResponse).statusCode).toBe(status);
   });
 
-  it('should call handleError if onError is not provided', async () => {
-    const status = 403;
-    const statusText = 'Unauthorized';
+  it('should call handleError for non-authentication errors if onError is not provided', async () => {
+    const status = 500;
+    const statusText = 'Internal Server Error';
     const body = { error: statusText };
     const ok = false;
 
@@ -195,5 +203,20 @@ describe('requestFromAPI', () => {
     });
 
     expect(handleError).toHaveBeenCalled();
+  });
+
+  it('should throw authentication errors without calling handleError', async () => {
+    const status = 403;
+    const statusText = 'Forbidden';
+    const body = { error: statusText };
+    const ok = false;
+
+    const request = fetchMock(body, { status, ok, statusText });
+    const error = await requestFromAPI(endpoint, { request }).catch(
+      (error) => error,
+    );
+
+    expect(isAuthenticationError(error)).toBe(true);
+    expect(handleError).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/utilities/request-from-api.ts
+++ b/src/lib/utilities/request-from-api.ts
@@ -1,7 +1,15 @@
 import { BROWSER } from 'esm-env';
 
-import type { NetworkError } from '$lib/types/global';
-
+import {
+  type ErrorCallback,
+  handleCaughtRequestError,
+  normalizeHeaders,
+  parseResponseBody,
+  type RequestErrorHandler,
+  type TemporalAPIError,
+  toAPIErrorResponse,
+  toAPIRequestError,
+} from './api-request-manager';
 import {
   type RequestContext,
   runPostResponse,
@@ -11,22 +19,21 @@ import { handleError as handleRequestError } from './handle-error';
 import { isFunction } from './is-function';
 import { toURL } from './to-url';
 
-export type TemporalAPIError = {
-  code: number;
-  message: string;
-  details: unknown[];
-};
+export type {
+  APIErrorBody,
+  APIErrorResponse,
+  ErrorCallback,
+  RequestErrorHandler,
+  TemporalAPIError,
+} from './api-request-manager';
+
+export {
+  APIRequestError,
+  isAPIRequestError,
+  isAuthenticationError,
+} from './api-request-manager';
 
 export type RetryCallback = (retriesRemaining: number) => void;
-
-export type APIErrorResponse = {
-  status: number;
-  statusText: string;
-  statusCode?: number;
-  body: TemporalAPIError;
-};
-
-export type ErrorCallback = (error: APIErrorResponse) => void;
 
 type toURLParams = Parameters<typeof toURL>;
 
@@ -37,7 +44,7 @@ type RequestFromAPIOptions = {
   token?: string;
   onError?: ErrorCallback;
   notifyOnError?: boolean;
-  handleError?: typeof handleRequestError;
+  handleError?: RequestErrorHandler;
   isBrowser?: boolean;
   signal?: AbortController['signal'];
 };
@@ -92,7 +99,8 @@ export const requestFromAPI = async <T>(
   try {
     const baseOptions: RequestInit = {
       ...init.options,
-      headers: withCallerType(init.options?.headers),
+      signal: init.signal ?? init.options?.signal,
+      headers: normalizeHeaders(init.options?.headers),
     };
 
     const queryIsTooLong = [...query.values()].some(
@@ -126,7 +134,8 @@ export const requestFromAPI = async <T>(
             url,
             options: {
               ...init.options,
-              headers: withCallerType(init.options?.headers),
+              signal: init.signal ?? init.options?.signal,
+              headers: normalizeHeaders(init.options?.headers),
             },
           };
           retryContext = await runPreRequest(retryContext);
@@ -135,36 +144,18 @@ export const requestFromAPI = async <T>(
       });
     }
 
-    const { status, statusText } = response;
-    const body = await response.json();
+    const body = await parseResponseBody(response);
 
     if (!response.ok) {
       if (onError && isFunction(onError)) {
-        onError({ status, statusText, body });
+        onError(toAPIErrorResponse(response, body));
       } else {
-        throw {
-          statusCode: response.status,
-          statusText: response.statusText,
-          response,
-          message: body?.message ?? response.statusText,
-        } as NetworkError;
+        throw toAPIRequestError(response, body);
       }
     }
 
-    return body;
+    return body as T;
   } catch (error: unknown) {
-    if (notifyOnError) {
-      handleError(error);
-    } else {
-      throw error;
-    }
+    handleCaughtRequestError(error, { notifyOnError, handleError });
   }
-};
-
-const withCallerType = (
-  headers: HeadersInit | undefined,
-): Record<string, string> => {
-  const h: Record<string, string> = (headers as Record<string, string>) ?? {};
-  h['Caller-Type'] = 'operator';
-  return h;
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Summary
  This changes requestFromAPI so auth failures are surfaced to consumers as structured request errors instead of triggering Temporal UI login navigation as a side effect. Successful response return values remain unchanged: callers still receive the parsed response body.

### What Changed

  - Added src/lib/utilities/api-request-manager.ts
      - Introduces APIRequestError.
      - Adds isAPIRequestError and isAuthenticationError.
      - Centralizes response body parsing, error normalization, header normalization, and caught-error handling.
      - Handles empty/non-JSON responses more safely.
  - Reworked src/lib/utilities/request-from-api.ts
      - Keeps successful return behavior the same.
      - Throws structured APIRequestError for non-OK responses when no onError is supplied.
      - Prevents 401/403 from flowing into the default app-level handleError.
      - Preserves existing onError behavior for compatibility.
      - Preserves auth refresh hook behavior and retry flow.
      - Normalizes Headers, header arrays, and plain header objects while still adding Caller-Type.
  - Updated src/lib/utilities/handle-error.ts
      - Removed default redirect behavior from generic error handling.
      - Made login redirect explicit via handleUnauthorizedOrForbiddenError(..., { redirectToLogin:
        true }).
      - Redirect helper now redirects only for 401, not 403.
  - Updated src/lib/services/workflow-service.ts
      - Removed workflow list fetch paths that explicitly kicked users to login on 401/403.
      - Leaves permission/auth errors available to caller/UI handling.

### Behavior Notes

  - 401: surfaced as an auth error unless an app explicitly opts into redirect behavior.
  - 403: surfaced as forbidden/unauthorized-to-access, not treated as “go login again.”
  - Package consumers can now catch and inspect statusCode, statusText, body, and response.
  - Existing callers using onError still get the callback shape they had before.

### Tests Updated

  - Request wrapper tests now assert auth errors are thrown without calling default handleError.
  - Workflow service tests still pass.

### Verification

  - pnpm vitest run src/lib/utilities/request-from-api.test.ts src/lib/utilities/request-from-api.401-
    retry.test.ts src/lib/utilities/request-from-api.integration.test.ts src/lib/utilities/request-from-
    api.with-access-token.test.ts src/lib/utilities/handle-error.test.ts src/lib/utilities/oss-
    provider.test.ts src/lib/services/workflow-service.test.ts
      - 7 files passed, 62 tests passed
  - pnpm check
      - 0 errors, existing warnings only
  - Commit hook ran eslint --fix and prettier --write
  - Working tree is clean.
### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->
