### PR TITLE
refactor: Input & DatePicker - Svelte 5 & afterLabel snippet

### DIFF
--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -226,12 +226,12 @@
     return false;
   }
 
-  const onStartDateChange = (d: CustomEvent) => {
-    start.date = startOfDay(d.detail);
+  const onStartDateChange = (d: Date) => {
+    start.date = startOfDay(d);
   };
 
-  const onEndDateChange = (d: CustomEvent) => {
-    end.date = startOfDay(d.detail);
+  const onEndDateChange = (d: Date) => {
+    end.date = startOfDay(d);
   };
 
   const applyTimeChanges = (
@@ -377,7 +377,7 @@
               <div class="flex flex-col gap-2">
                 <DatePicker
                   label={translate('common.start')}
-                  on:datechange={onStartDateChange}
+                  onDateChange={onStartDateChange}
                   selected={new Date(start.date)}
                   todayLabel={translate('common.today')}
                   closeLabel={translate('common.close')}
@@ -393,7 +393,7 @@
               <div class="flex flex-col gap-2">
                 <DatePicker
                   label={translate('common.end')}
-                  on:datechange={onEndDateChange}
+                  onDateChange={onEndDateChange}
                   selected={new Date(end.date)}
                   todayLabel={translate('common.today')}
                   closeLabel={translate('common.close')}
@@ -455,7 +455,7 @@
                   <DatePicker
                     label=""
                     labelHidden
-                    on:datechange={onStartDateChange}
+                    onDateChange={onStartDateChange}
                     selected={new Date(start.date)}
                     todayLabel={translate('common.today')}
                     closeLabel={translate('common.close')}

--- a/src/lib/components/search-attribute-filter/manual-query.svelte
+++ b/src/lib/components/search-attribute-filter/manual-query.svelte
@@ -89,7 +89,7 @@
       clearable
       copyButtonLabel={translate('common.copy-icon-title')}
       clearButtonLabel={translate('common.clear-input-button-label')}
-      on:clear={handleClearInput}
+      onClear={handleClearInput}
       bind:value={manualSearchString}
       maxLength={MAX_QUERY_LENGTH}
       hideCount={!manualSearchString ||

--- a/src/lib/components/search.svelte
+++ b/src/lib/components/search.svelte
@@ -5,18 +5,38 @@
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  export let placeholder = `${translate('common.search')}…`;
-  export let label = translate('common.search');
-  export let value = '';
-  export let name = 'query';
-  export let icon = false;
-  export let id = kebabCase(`${label}-${name}`);
+  interface Props {
+    placeholder?: string;
+    label?: string;
+    value?: string;
+    name?: string;
+    icon?: boolean;
+    id?: string;
+    'data-testid'?: string;
+    oninput?: (e: Event) => void;
+    onsubmit?: (e: SubmitEvent) => void;
+  }
 
-  let testId = $$props['data-testid'] || id;
+  let {
+    placeholder = `${translate('common.search')}…`,
+    label = translate('common.search'),
+    value = $bindable(''),
+    name = 'query',
+    icon = false,
+    id = kebabCase(`${label}-${name}`),
+    'data-testid': dataTestId,
+    oninput,
+    onsubmit,
+  }: Props = $props();
+
+  const testId = $derived(dataTestId || id);
 </script>
 
 <form
-  on:submit|preventDefault
+  onsubmit={(e) => {
+    e.preventDefault();
+    onsubmit?.(e);
+  }}
   role="search"
   class="flex items-center"
   data-testid={`${testId}-form`}
@@ -32,10 +52,12 @@
     {value}
     {placeholder}
     data-testid={`${testId}-input`}
-    on:input
+    {oninput}
   >
-    <Button slot="after-input" type="submit" data-testid={`${testId}-button`}>
-      {label}
-    </Button>
+    {#snippet afterInput()}
+      <Button type="submit" data-testid={`${testId}-button`}>
+        {label}
+      </Button>
+    {/snippet}
   </Input>
 </form>

--- a/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
+++ b/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
@@ -205,14 +205,15 @@
     error={!!$errors?.activityId}
     hintText={$errors?.activityId?.[0]}
   >
-    <Button
-      class="ml-2.5"
-      variant="secondary"
-      slot="after-input"
-      on:click={generateRandomId}
-      leadingIcon="retry"
-      >{translate('standalone-activities.form-random-uuid')}</Button
-    >
+    {#snippet afterInput()}
+      <Button
+        class="ml-2.5"
+        variant="secondary"
+        on:click={generateRandomId}
+        leadingIcon="retry"
+        >{translate('standalone-activities.form-random-uuid')}</Button
+      >
+    {/snippet}
   </Input>
 
   <Input
@@ -222,7 +223,7 @@
     bind:value={$form.taskQueue}
     error={!!$errors.taskQueue}
     hintText={$errors.taskQueue?.[0]}
-    on:blur={() => checkTaskQueue($form.taskQueue)}
+    onblur={() => checkTaskQueue($form.taskQueue)}
   />
   {#if taskQueueActive !== null}
     <Alert

--- a/src/lib/components/workflow/client-actions/batch-operation-confirmation-form.svelte
+++ b/src/lib/components/workflow/client-actions/batch-operation-confirmation-form.svelte
@@ -134,7 +134,7 @@
       : translate('batch.job-id-input-error')}
     bind:value={jobId}
     placeholder={jobIdPlaceholder}
-    on:input={handleJobIdChange}
+    oninput={handleJobIdChange}
     valid={jobIdValid}
   />
   {@render children?.()}

--- a/src/lib/components/workflow/filter-bar/manual-query.svelte
+++ b/src/lib/components/workflow/filter-bar/manual-query.svelte
@@ -73,7 +73,7 @@
       clearable
       copyButtonLabel={translate('common.copy-icon-title')}
       clearButtonLabel={translate('common.clear-input-button-label')}
-      on:clear={handleClearInput}
+      onClear={handleClearInput}
       bind:value={manualSearchString}
       maxLength={MAX_QUERY_LENGTH}
       hideCount={!manualSearchString ||

--- a/src/lib/components/workflow/filter-bar/view-modal.svelte
+++ b/src/lib/components/workflow/filter-bar/view-modal.svelte
@@ -171,7 +171,7 @@
       required
       maxLength={255}
       bind:value={name}
-      on:input={() => (touched = true)}
+      oninput={() => (touched = true)}
       valid={!touched || nameValid}
       hintText={touched && !nameValid ? nameError() : ''}
       error={touched && !nameValid}

--- a/src/lib/components/workflow/search-attribute-input/datetime-input.svelte
+++ b/src/lib/components/workflow/search-attribute-input/datetime-input.svelte
@@ -28,8 +28,8 @@
     if (!value) updateDatetime();
   });
 
-  const onDateChange = (d: CustomEvent) => {
-    date = startOfDay(d.detail);
+  const onDateChange = (d: Date) => {
+    date = startOfDay(d);
     updateDatetime();
   };
 
@@ -41,7 +41,7 @@
 <div class="flex flex-col gap-2">
   <DatePicker
     label="{translate('common.value')} ({translate('common.utc')})"
-    on:datechange={onDateChange}
+    {onDateChange}
     selected={date}
     todayLabel={translate('common.today')}
     closeLabel={translate('common.close')}

--- a/src/lib/components/workflow/workflow-advanced-search.svelte
+++ b/src/lib/components/workflow/workflow-advanced-search.svelte
@@ -70,7 +70,7 @@
       class="grow lg:w-3/4 [&_*]:border-r-0"
       clearable
       clearButtonLabel={translate('common.clear-input-button-label')}
-      on:clear={handleClearInput}
+      onClear={handleClearInput}
       bind:value={manualSearchString}
       maxLength={MAX_QUERY_LENGTH}
       hideCount={!manualSearchString ||

--- a/src/lib/components/workflow/workflow-filters.svelte
+++ b/src/lib/components/workflow/workflow-filters.svelte
@@ -92,7 +92,7 @@
       id="advanced-search"
       placeholder={translate('common.query')}
       value={query}
-      on:submit={updateQuery}
+      onsubmit={updateQuery}
     />
   {:else}
     <div
@@ -107,7 +107,7 @@
         label={translate('common.workflow-id')}
         labelHidden
         bind:value={parameters.workflowId}
-        on:input={handleParameterChange}
+        oninput={handleParameterChange}
       />
       <Input
         icon="search"
@@ -117,7 +117,7 @@
         label={translate('common.workflow-type')}
         labelHidden
         bind:value={parameters.workflowType}
-        on:input={handleParameterChange}
+        oninput={handleParameterChange}
       />
       <Select
         id="time-range-filter"

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -235,8 +235,8 @@
         label={filterInputPlaceholder}
         labelHidden
         placeholder={filterInputPlaceholder}
-        on:input={debouncedHandleFilter}
-        on:clear={handleFilter}
+        oninput={debouncedHandleFilter}
+        onClear={handleFilter}
         clearable
       />
     {/if}

--- a/src/lib/holocene/calendar.svelte
+++ b/src/lib/holocene/calendar.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
   import { getDateRows, weekDays } from '$lib/utilities/calendar';
-
-  const dispatch = createEventDispatcher();
 
   type Props = {
     date: Date;
     month: number;
     year: number;
     isAllowed?: (date: Date) => boolean;
+    onDateChange?: (date: Date) => void;
   };
 
   let {
@@ -17,10 +14,11 @@
     month,
     year,
     isAllowed = (_date: Date) => true,
+    onDateChange,
   }: Props = $props();
 
   const onChange = (selectedDay: number) => {
-    dispatch('datechange', new Date(year, month, selectedDay));
+    onDateChange?.(new Date(year, month, selectedDay));
   };
 
   const allow = (year: number, month: number, day: number | undefined) => {

--- a/src/lib/holocene/date-picker.stories.svelte
+++ b/src/lib/holocene/date-picker.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
   import { within } from '@storybook/test';
+  import type { ComponentProps } from 'svelte';
 
   import DatePicker from '$lib/holocene/date-picker.svelte';
 
@@ -40,7 +41,7 @@
         table: { category: 'Accessibility' },
       },
     },
-  } satisfies Meta<DatePicker>;
+  } satisfies Meta<ComponentProps<typeof DatePicker>>;
 </script>
 
 <script lang="ts">
@@ -60,7 +61,7 @@
 </script>
 
 <Template let:args>
-  <DatePicker {...args} on:datechange={action('date-change')} />
+  <DatePicker {...args} onDateChange={action('date-change')} />
 </Template>
 
 <Story name="Default" play={focus} />

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -13,6 +13,7 @@
     isAllowed?: (d: Date) => boolean;
     selected?: Date;
     label: string;
+    afterLabel?: Snippet;
     labelIcon?: Snippet;
     labelHidden?: boolean;
     todayLabel: string;
@@ -26,7 +27,7 @@
     isAllowed = () => true,
     selected = $bindable(new Date()),
     label,
-    labelIcon,
+    afterLabel,
     labelHidden = false,
     todayLabel,
     closeLabel,
@@ -90,7 +91,7 @@
   <Input
     id="datepicker"
     {label}
-    {labelIcon}
+    {afterLabel}
     {labelHidden}
     icon="calendar-plus"
     type="text"

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import { clickoutside } from '$lib/holocene/outside-click';
   import { translate } from '$lib/i18n/translate';
   import { getMonthName } from '$lib/utilities/calendar';
@@ -11,6 +13,7 @@
     isAllowed?: (d: Date) => boolean;
     selected?: Date;
     label: string;
+    labelIcon?: Snippet;
     labelHidden?: boolean;
     todayLabel: string;
     closeLabel: string;
@@ -23,6 +26,7 @@
     isAllowed = () => true,
     selected = $bindable(new Date()),
     label,
+    labelIcon,
     labelHidden = false,
     todayLabel,
     closeLabel,
@@ -86,11 +90,12 @@
   <Input
     id="datepicker"
     {label}
+    {labelIcon}
     {labelHidden}
     icon="calendar-plus"
     type="text"
-    on:focus={onFocus}
-    on:input={onInput}
+    onfocus={onFocus}
+    oninput={onInput}
     placeholder="MM/DD/YY"
     value={selected.toDateString()}
     clearable

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
   import { clickoutside } from '$lib/holocene/outside-click';
   import { translate } from '$lib/i18n/translate';
   import { getMonthName } from '$lib/utilities/calendar';
@@ -9,26 +7,34 @@
   import Icon from './icon/icon.svelte';
   import Input from './input/input.svelte';
 
-  const dispatch = createEventDispatcher();
-
-  export let isAllowed: (d: Date) => boolean = () => true;
-  export let selected = new Date();
-  export let label: string;
-  export let labelHidden = false;
-  export let todayLabel: string;
-  export let closeLabel: string;
-  export let clearLabel: string;
-  export let disabled = false;
-
-  let month: number | undefined;
-  let year: number | undefined;
-  let showDatePicker = false;
-
-  // so that these change with props
-  $: {
-    month = selected.getMonth();
-    year = selected.getFullYear();
+  interface Props {
+    isAllowed?: (d: Date) => boolean;
+    selected?: Date;
+    label: string;
+    labelHidden?: boolean;
+    todayLabel: string;
+    closeLabel: string;
+    clearLabel: string;
+    disabled?: boolean;
+    onDateChange?: (date: Date) => void;
   }
+
+  let {
+    isAllowed = () => true,
+    selected = $bindable(new Date()),
+    label,
+    labelHidden = false,
+    todayLabel,
+    closeLabel,
+    clearLabel,
+    disabled = false,
+    onDateChange,
+  }: Props = $props();
+
+  // derived from selected, but prev/next can override until selected changes
+  let month = $derived(selected.getMonth());
+  let year = $derived(selected.getFullYear());
+  let showDatePicker = $state(false);
 
   // handlers
   const onFocus = () => {
@@ -45,7 +51,7 @@
       const month = parseInt(inputDateSplit[0]) - 1;
       const date = parseInt(inputDateSplit[1]);
       const newDate = new Date(year, month, date);
-      dispatch('datechange', newDate);
+      onDateChange?.(newDate);
     }
   };
 
@@ -67,9 +73,9 @@
     month -= 1;
   };
 
-  const onDateChange = (d: CustomEvent) => {
+  const handleDateChange = (d: Date) => {
     showDatePicker = false;
-    dispatch('datechange', d.detail);
+    onDateChange?.(d);
   };
 
   const previousMonth = translate('date-picker.previous-month');
@@ -97,7 +103,7 @@
     >
       <div class="mx-3 my-2 flex items-center justify-around">
         <div class="flex items-center justify-center">
-          <button type="button" on:click={prev} title={previousMonth}>
+          <button type="button" onclick={prev} title={previousMonth}>
             <span class="sr-only">{previousMonth}</span>
             <Icon name="chevron-left" /></button
           >
@@ -108,7 +114,7 @@
         </div>
         <div class="flex items-center justify-center">
           <span class="sr-only">Next Month</span>
-          <button type="button" on:click={next} title={nextMonth}>
+          <button type="button" onclick={next} title={nextMonth}>
             <span class="sr-only">{nextMonth}</span>
             <Icon name="chevron-right" />
           </button>
@@ -119,20 +125,20 @@
         {year}
         date={selected}
         {isAllowed}
-        on:datechange={onDateChange}
+        onDateChange={handleDateChange}
       />
       <div class="my-1 flex justify-between px-2">
         <button
           type="button"
           class="cursor-pointer text-[12px]"
-          on:click={() => (selected = new Date())}
+          onclick={() => (selected = new Date())}
         >
           {todayLabel}
         </button>
         <button
           type="button"
           class="cursor-pointer text-[12px]"
-          on:click={() => (showDatePicker = false)}
+          onclick={() => (showDatePicker = false)}
         >
           {closeLabel}
         </button>

--- a/src/lib/holocene/input/input.stories.svelte
+++ b/src/lib/holocene/input/input.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
   import { expect, userEvent, within } from '@storybook/test';
+  import type { ComponentProps } from 'svelte';
 
   import { iconNames } from '$lib/holocene/icon';
 
@@ -68,7 +69,7 @@
         table: { category: 'Styling (Deprecated)' },
       },
     },
-  } satisfies Meta<Input>;
+  } satisfies Meta<ComponentProps<typeof Input>>;
 </script>
 
 <script lang="ts">
@@ -142,7 +143,11 @@
 
 <Story name="With Buttons" let:args let:context>
   <Input {...args} id={context.id} data-testid={context.id}>
-    <Button slot="before-input" type="button">Before</Button>
-    <Button slot="after-input" type="button">After</Button>
+    {#snippet beforeInput()}
+      <Button type="button">Before</Button>
+    {/snippet}
+    {#snippet afterInput()}
+      <Button type="button">After</Button>
+    {/snippet}
   </Input>
 </Story>

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -93,14 +93,8 @@
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
-  <div class="flex items-center justify-start gap-1">
-    <Label
-      class="grow-0 gap-[inherit]"
-      {required}
-      {label}
-      hidden={labelHidden}
-      for={id}
-    />
+  <div class="flex items-center justify-start gap-2">
+    <Label class="grow-0" {required} {label} hidden={labelHidden} for={id} />
     {@render afterLabel?.()}
   </div>
   <div class="input-group flex">

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { FullAutoFill, HTMLInputAttributes } from 'svelte/elements';
 
-  import { createEventDispatcher } from 'svelte';
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import type { IconName } from '$lib/holocene/icon';
@@ -11,10 +11,11 @@
 
   import IconButton from '../icon-button.svelte';
 
-  type BaseProps = HTMLInputAttributes & {
+  interface Props extends HTMLInputAttributes {
     id: string;
     value: string;
     label: string;
+    labelIcon?: Snippet;
     labelHidden?: boolean;
     icon?: IconName;
     suffix?: string;
@@ -23,83 +24,88 @@
     hintText?: string;
     maxLength?: number;
     hideCount?: boolean;
-    spellcheck?: boolean;
     noBorder?: boolean;
     autoFocus?: boolean;
     error?: boolean;
+    autocomplete?: FullAutoFill;
+    copyable?: boolean;
+    copyButtonLabel?: string;
+    clearable?: boolean;
+    clearButtonLabel?: string;
     'data-testid'?: string;
     class?: string;
     inputContainerClass?: string;
-  };
+    onClear?: () => void;
+    beforeInput?: Snippet<[{ disabled: boolean }]>;
+    afterInput?: Snippet<[{ disabled: boolean }]>;
+  }
 
-  type CopyableProps = BaseProps & {
-    copyable: boolean;
-    copyButtonLabel: string;
-  };
+  let {
+    id,
+    value = $bindable(),
+    label,
+    labelIcon,
+    labelHidden = false,
+    icon = null,
+    placeholder = '',
+    suffix = '',
+    prefix = '',
+    name = id,
+    copyable = false,
+    disabled = false,
+    clearable = false,
+    autocomplete = 'off',
+    valid = true,
+    hintText = '',
+    maxLength = 0,
+    hideCount = false,
+    spellcheck = null,
+    noBorder = false,
+    autoFocus = false,
+    error = false,
+    required = false,
+    copyButtonLabel = '',
+    clearButtonLabel = '',
+    class: className = '',
+    inputContainerClass = '',
+    'data-testid': dataTestId,
+    onClear,
+    onclick,
+    onkeydown,
+    beforeInput,
+    afterInput,
+    ...rest
+  }: Props = $props();
 
-  type ClearableProps = BaseProps & {
-    clearable: boolean;
-    clearButtonLabel: string;
-  };
-
-  type $$Props = BaseProps | CopyableProps | ClearableProps;
-
-  export let id: string;
-  export let value: string;
-  export let label: string;
-  export let labelHidden = false;
-  export let icon: IconName = null;
-  export let placeholder = '';
-  export let suffix = '';
-  export let prefix = '';
-  export let name = id;
-  export let copyable = false;
-  export let disabled = false;
-  export let clearable = false;
-  export let autocomplete: FullAutoFill = 'off';
-  export let valid = true;
-  export let hintText = '';
-  export let maxLength = 0;
-  export let hideCount = false;
-  export let spellcheck: boolean = null;
-  export let noBorder = false;
-  export let autoFocus = false;
-  export let error = false;
-  export let required = false;
-  export let copyButtonLabel = '';
-  export let clearButtonLabel = '';
-
-  let className = '';
-  export { className as class };
-  export let inputContainerClass = '';
-
-  let testId = $$props['data-testid'] || id;
+  const isDisabled = $derived(disabled || copyable);
+  const testId = $derived(dataTestId || id);
 
   function callFocus(input: HTMLInputElement) {
     if (autoFocus && input) input.focus();
   }
 
-  const dispatch = createEventDispatcher();
-  function onClear() {
+  function handleClear() {
     value = '';
-    dispatch('clear', {});
+    onClear?.();
   }
 
   const { copy, copied } = copyToClipboard();
-  $: disabled = disabled || copyable;
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
-  <Label {required} {label} hidden={labelHidden} for={id} />
+  <Label {required} hidden={labelHidden} for={id}>
+    <span>label</span>
+    {@render labelIcon?.()}
+  </Label>
   <div class="input-group flex">
-    <slot name="before-input" {disabled} />
+    {@render beforeInput?.({ disabled: isDisabled })}
     <div
       class={merge(
         'input-container',
         'surface-primary relative box-border inline-flex h-10 w-full items-center border border-subtle text-sm focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/70',
         inputContainerClass,
       )}
-      class:disabled
+      class:disabled={isDisabled}
       class:error
       class:noBorder
       class:invalid={!valid}
@@ -113,8 +119,8 @@
       {/if}
       <input
         class="input"
-        class:disabled
-        {disabled}
+        class:disabled={isDisabled}
+        disabled={isDisabled}
         data-lpignore="true"
         data-1p-ignore="true"
         maxlength={maxLength > 0 ? maxLength : undefined}
@@ -125,15 +131,17 @@
         {required}
         {autocomplete}
         bind:value
-        on:click|stopPropagation
-        on:input
-        on:keydown|stopPropagation
-        on:change
-        on:focus
-        on:blur
+        onclick={(e) => {
+          e.stopPropagation();
+          onclick?.(e);
+        }}
+        onkeydown={(e) => {
+          e.stopPropagation();
+          onkeydown?.(e);
+        }}
         use:callFocus
         data-testid={testId}
-        {...$$restProps}
+        {...rest}
       />
       {#if copyable}
         <div class="copy-icon-container">
@@ -142,7 +150,7 @@
             data-track-name="input-copy-button"
             data-track-intent="copy"
             data-track-text={label || copyButtonLabel}
-            on:click={(e) => copy(e, value)}
+            onclick={(e) => copy(e, value)}
           >
             {#if $copied}
               <Icon name="checkmark" />
@@ -151,7 +159,7 @@
             {/if}
           </button>
         </div>
-      {:else if disabled}
+      {:else if isDisabled}
         <div class="disabled-icon-container">
           <Icon name="lock" />
         </div>
@@ -159,7 +167,7 @@
         <div class="clear-icon-container" data-testid="clear-input">
           <IconButton
             label={clearButtonLabel}
-            on:click={onClear}
+            on:click={handleClear}
             icon="close"
           />
         </div>
@@ -170,12 +178,12 @@
         </div>
       {/if}
     </div>
-    <slot name="after-input" {disabled} />
+    {@render afterInput?.({ disabled: isDisabled })}
   </div>
 
   <div
     class="inline-flex justify-between gap-2"
-    class:hidden={!hintText && (!maxLength || disabled || hideCount)}
+    class:hidden={!hintText && (!maxLength || isDisabled || hideCount)}
   >
     <span
       class="hint-text inline-block"
@@ -185,7 +193,7 @@
     >
       {hintText}
     </span>
-    {#if maxLength && !disabled && !hideCount}
+    {#if maxLength && !isDisabled && !hideCount}
       <span
         class="invisible text-right text-xs tracking-widest group-focus-within:visible"
       >

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -15,7 +15,7 @@
     id: string;
     value: string;
     label: string;
-    labelIcon?: Snippet;
+    afterLabel?: Snippet;
     labelHidden?: boolean;
     icon?: IconName;
     suffix?: string;
@@ -44,7 +44,7 @@
     id,
     value = $bindable(),
     label,
-    labelIcon,
+    afterLabel,
     labelHidden = false,
     icon = null,
     placeholder = '',
@@ -93,10 +93,16 @@
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
-  <Label {required} hidden={labelHidden} for={id}>
-    <span>label</span>
-    {@render labelIcon?.()}
-  </Label>
+  <div class="flex items-center justify-start gap-1">
+    <Label
+      class="grow-0 gap-[inherit]"
+      {required}
+      {label}
+      hidden={labelHidden}
+      for={id}
+    />
+    {@render afterLabel?.()}
+  </div>
   <div class="input-group flex">
     {@render beforeInput?.({ disabled: isDisabled })}
     <div

--- a/src/lib/holocene/time-picker.svelte
+++ b/src/lib/holocene/time-picker.svelte
@@ -33,7 +33,7 @@
     hideCount
     error={twelveHourClock ? parseInt(hour) > 12 : parseInt(hour) > 23}
     {disabled}
-    on:input={onInput}
+    oninput={onInput}
   />
   <Input
     id="minute"
@@ -46,7 +46,7 @@
     hideCount
     error={Boolean(parseInt(hour) > 59)}
     {disabled}
-    on:input={onInput}
+    oninput={onInput}
   />
   {#if includeSeconds}
     <Input
@@ -60,7 +60,7 @@
       hideCount
       error={Boolean(parseInt(hour) > 59)}
       {disabled}
-      on:input={onInput}
+      oninput={onInput}
     />
   {/if}
   {#if twelveHourClock}

--- a/src/lib/pages/schedule-view.svelte
+++ b/src/lib/pages/schedule-view.svelte
@@ -193,12 +193,12 @@
   let endMinute = '';
   let endSecond = '';
 
-  const onStartDateChange = (d: CustomEvent) => {
-    startDate = startOfDay(d.detail);
+  const onStartDateChange = (d: Date) => {
+    startDate = startOfDay(d);
   };
 
-  const onEndDateChange = (d: CustomEvent) => {
-    endDate = startOfDay(d.detail);
+  const onEndDateChange = (d: Date) => {
+    endDate = startOfDay(d);
   };
 
   const updateDefaultBackfillTimes = () => {
@@ -514,7 +514,7 @@
         <div class="flex flex-col gap-2 p-2">
           <DatePicker
             label={translate('common.start')}
-            on:datechange={onStartDateChange}
+            onDateChange={onStartDateChange}
             selected={startDate}
             todayLabel={translate('common.today')}
             closeLabel={translate('common.close')}
@@ -528,7 +528,7 @@
           />
           <DatePicker
             label={translate('common.end')}
-            on:datechange={onEndDateChange}
+            onDateChange={onEndDateChange}
             selected={endDate}
             todayLabel={translate('common.today')}
             closeLabel={translate('common.close')}

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -264,7 +264,7 @@
         bind:value={workflowId}
         label="Workflow ID"
         class="w-full grow"
-        on:blur={(e) => onInputChange(e, 'workflowId')}
+        onblur={(e) => onInputChange(e, 'workflowId')}
       />
       <Button
         class="mt-0 md:mt-6"
@@ -280,7 +280,7 @@
         bind:value={taskQueue}
         label="Task Queue"
         class="grow"
-        on:blur={(e) => onInputChange(e, 'taskQueue')}
+        onblur={(e) => onInputChange(e, 'taskQueue')}
       />
     </div>
     {#if pollerCount !== undefined}
@@ -307,7 +307,7 @@
       required
       bind:value={workflowType}
       label="Workflow Type"
-      on:blur={(e) => onInputChange(e, 'workflowType')}
+      onblur={(e) => onInputChange(e, 'workflowType')}
     />
     <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
     {#if viewAdvancedOptions}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Refactor DatePicker and Input to Svelte 5 syntax AND add a `afterLabel` snippet prop. 

The point of the refactor is to support tooltips next to the label like this:

<img width="429" height="200" alt="Screenshot 2026-05-29 at 11 02 04 AM" src="https://github.com/user-attachments/assets/1e91833d-f24f-4ce7-a730-c747aca9607e" />

The label on inputs no longer has flex-grow on it. I didn't find any cases where it would be an issue... if I didn't remove it, I would have to render the afterLabel snippet _inside_ the `<label>` which would be wonky when it comes to click handlers and I wanted to avoid that.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ 

- Find various Inputs and a DatePickers and double check they still look correct.


## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

Requires a follow up Cloud UI PR since the Svelte 5 refactor is breaking: https://github.com/temporalio/cloud-ui/pull/2708

### Issue(s) <!-- add issue number here -->

Related to https://temporalio.atlassian.net/browse/DT-3906
and https://temporalio.atlassian.net/browse/DT-3565
