### PR TITLE
fix(query): quote ExecutionDuration Go duration strings in visibility SQL

### DIFF
--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -302,6 +302,36 @@ describe('toListWorkflowQueryFromFilters', () => {
     expect(query).toBe('`CustomIntField` is null');
   });
 
+  it('should quote ExecutionDuration Go duration strings', () => {
+    const filters = [
+      {
+        attribute: 'ExecutionDuration',
+        type: 'Int',
+        conditional: '>=',
+        operator: '',
+        parenthesis: '',
+        value: '30s',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`ExecutionDuration`>="30s"');
+  });
+
+  it('should not quote ExecutionDuration nanosecond integers', () => {
+    const filters = [
+      {
+        attribute: 'ExecutionDuration',
+        type: 'Int',
+        conditional: '>=',
+        operator: '',
+        parenthesis: '',
+        value: '30000000000',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`ExecutionDuration`>=30000000000');
+  });
+
   it('should convert a KeywordList filter', () => {
     const filters = [
       {

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -97,6 +97,14 @@ const toFilterQueryStatement = (
     return `\`${queryKey}\` ${conditional} null`;
   }
 
+  if (attribute === 'ExecutionDuration') {
+    const isNanoseconds = /^\d+$/.test(String(value));
+    if (isNanoseconds) {
+      return `\`${queryKey}\`${conditional}${value}`;
+    }
+    return `\`${queryKey}\`${conditional}"${value}"`;
+  }
+
   if (isDuration(value) || isDurationString(value)) {
     if (archived || get(supportsAdvancedVisibility)) {
       return `${queryKey} ${conditional} "${toDate(value)}"`;


### PR DESCRIPTION
## Summary

- `ExecutionDuration` is typed as `INT` in the search attributes store, so PR #3435 (DT-4039)'s explicit unquoted-INT path sends `30s` to the backend without quotes
- The Temporal visibility SQL parser (vitess) rejects unquoted `30s` — it's neither a string literal nor a numeric literal
- Added an `ExecutionDuration` guard in `toFilterQueryStatement` before the INT/duration paths: Go duration strings (e.g. `30s`, `1m30s`) are quoted; plain integers (nanoseconds) pass through unquoted

## Test plan

- [ ] Two new unit tests added: `ExecutionDuration>="30s"` (duration string → quoted) and `ExecutionDuration>=30000000000` (nanosecond int → unquoted)
- [ ] All 142 test files pass (`pnpm test -- --run`)