### PR TITLE
[DT-4065] Turn top navigation background colour red

### DIFF
--- a/src/lib/components/top-nav.svelte
+++ b/src/lib/components/top-nav.svelte
@@ -22,7 +22,7 @@
 {#if md.current}
   <nav
     class={merge(
-      'surface-primary',
+      'bg-red-600 text-white',
       'sticky top-0 z-40',
       'flex',
       'w-full',


### PR DESCRIPTION
## Summary

Changes the top navigation bar background colour to red (Claude demo ticket). Swaps the `surface-primary` design token for `bg-red-600 text-white` in the shared `top-nav.svelte` component. The nav is a single shared component across project and non-project views, so one change covers both code paths.

## Jira

https://temporalio.atlassian.net/browse/DT-4065

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm check` — no new type errors
- [x] `pnpm test -- --run` — 2025 passed
- [ ] Visual check: red nav, legible text (light/dark, Cloud/self-hosted)