### PR TITLE
feat: add centerButton, menuButton, and linksContent snippets to BottomNavigation

### DIFF
--- a/src/lib/components/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav.svelte
@@ -33,6 +33,14 @@
         },
       ]
     >;
+    centerButton?: Snippet<
+      [
+        {
+          open: boolean;
+          onClick: () => void;
+        },
+      ]
+    >;
     profilePicture?: Snippet;
     class?: ClassNameValue;
   }
@@ -44,6 +52,7 @@
     showNamespacePicker = true,
     children,
     nsPicker,
+    centerButton,
     profilePicture,
     class: className = '',
   }: Props = $props();
@@ -164,24 +173,31 @@
     {/if}
   </button>
   {#if showNamespacePicker}
-    <div class="namespace-wrapper">
-      <Button
-        variant="ghost"
-        data-testid="namespace-switcher"
-        leadingIcon="namespace-switcher"
-        size="xs"
-        class="grow text-white"
-        on:click={onNamespaceClick}>{truncateNamespace(namespace)}</Button
-      >
-      <div class="ml-1 h-full w-1 border-l border-subtle"></div>
-      <Button
-        variant="ghost"
-        size="xs"
-        href={routeForNamespace({ namespace })}
-        disabled={!namespaceExists}
-        ><Icon class="text-white" name="external-link" /></Button
-      >
-    </div>
+    {#if centerButton}
+      {@render centerButton({
+        open: viewNamespaces,
+        onClick: onNamespaceClick,
+      })}
+    {:else}
+      <div class="namespace-wrapper">
+        <Button
+          variant="ghost"
+          data-testid="namespace-switcher"
+          leadingIcon="namespace-switcher"
+          size="xs"
+          class="grow text-white"
+          on:click={onNamespaceClick}>{truncateNamespace(namespace)}</Button
+        >
+        <div class="ml-1 h-full w-1 border-l border-subtle"></div>
+        <Button
+          variant="ghost"
+          size="xs"
+          href={routeForNamespace({ namespace })}
+          disabled={!namespaceExists}
+          ><Icon class="text-white" name="external-link" /></Button
+        >
+      </div>
+    {/if}
   {/if}
   <button
     class="nav-button"

--- a/src/lib/components/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav.svelte
@@ -41,6 +41,22 @@
         },
       ]
     >;
+    menuButton?: Snippet<
+      [
+        {
+          open: boolean;
+          onClick: () => void;
+        },
+      ]
+    >;
+    linksContent?: Snippet<
+      [
+        {
+          open: boolean;
+          closeMenu: () => void;
+        },
+      ]
+    >;
     profilePicture?: Snippet;
     class?: ClassNameValue;
   }
@@ -53,6 +69,8 @@
     children,
     nsPicker,
     centerButton,
+    menuButton,
+    linksContent,
     profilePicture,
     class: className = '',
   }: Props = $props();
@@ -130,7 +148,9 @@
     in:slide={{ duration: 200, delay: 0 }}
     out:slide={{ duration: 200, delay: 0 }}
   >
-    {#if viewLinks}
+    {#if linksContent}
+      {@render linksContent({ open: viewLinks, closeMenu })}
+    {:else}
       <div
         class="flex h-full flex-col-reverse justify-start gap-6 overflow-auto px-4 py-8"
       >
@@ -159,19 +179,23 @@
   data-testid="top-nav"
   aria-label={translate('common.main')}
 >
-  <button
-    class="nav-button relative"
-    data-testid="nav-menu-button"
-    class:active-shadow={viewLinks}
-    type="button"
-    onclick={onLinksClick}
-  >
-    {#if viewLinks}
-      <Icon name="close" height={32} width={32} />
-    {:else}
-      <Logo height={32} width={32} />
-    {/if}
-  </button>
+  {#if menuButton}
+    {@render menuButton({ open: viewLinks, onClick: onLinksClick })}
+  {:else}
+    <button
+      class="nav-button relative"
+      data-testid="nav-menu-button"
+      class:active-shadow={viewLinks}
+      type="button"
+      onclick={onLinksClick}
+    >
+      {#if viewLinks}
+        <Icon name="close" height={32} width={32} />
+      {:else}
+        <Logo height={32} width={32} />
+      {/if}
+    </button>
+  {/if}
   {#if showNamespacePicker}
     {#if centerButton}
       {@render centerButton({

--- a/src/lib/holocene/icon/paths.ts
+++ b/src/lib/holocene/icon/paths.ts
@@ -11,6 +11,7 @@ import arrowUp from './svg/arrow-up.svelte';
 import ascending from './svg/ascending.svelte';
 import astronaut from './svg/astronaut.svelte';
 import aws from './svg/aws.svelte';
+import bars from './svg/bars.svelte';
 import batchOperation from './svg/batch-operation.svelte';
 import book from './svg/book-sparkles.svelte';
 import bookmark from './svg/bookmark.svelte';
@@ -168,6 +169,7 @@ export const icons = {
   ascending,
   astronaut,
   aws,
+  bars,
   'batch-operation': batchOperation,
   book,
   bookmark,

--- a/src/lib/holocene/icon/svg/bars.svelte
+++ b/src/lib/holocene/icon/svg/bars.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import Svg from '../svg.svelte';
+  let props = $props();
+</script>
+
+<Svg {...props}>
+  <line
+    x1="3"
+    y1="6"
+    x2="21"
+    y2="6"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <line
+    x1="3"
+    y1="12"
+    x2="21"
+    y2="12"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+  <line
+    x1="3"
+    y1="18"
+    x2="21"
+    y2="18"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  />
+</Svg>


### PR DESCRIPTION
## Summary

- Adds `centerButton` snippet to `BottomNavigation` for customizing the center button area (namespace switcher)
- Adds `menuButton` snippet for customizing the hamburger/menu button
- Adds `linksContent` snippet for customizing the links panel content
- Adds `bars` icon to the Holocene icon set

All new snippets are optional — existing behavior is preserved as the fallback.

## Test plan

- [ ] Verify `BottomNavigation` renders correctly with no new props (fallback behavior unchanged)
- [ ] Verify `centerButton` snippet overrides the namespace switcher area
- [ ] Verify `menuButton` snippet overrides the default logo/close button
- [ ] Verify `linksContent` snippet overrides the default links panel
- [ ] Verify `bars` icon renders correctly in the icon component