### PR TITLE
feat(DT-4069): Update modal backdrop to 50% opaque

### DIFF
--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -162,6 +162,10 @@
 
   .body::backdrop {
     @apply cursor-pointer bg-black/50 transition-opacity duration-200;
+
+    :global([data-theme='dark']) & {
+      background-color: rgb(var(--color-surface-background) / 50%);
+    }
   }
 
   .body.hightlightNav::backdrop {

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -161,7 +161,7 @@
   }
 
   .body::backdrop {
-    @apply cursor-pointer transition-opacity duration-200;
+    @apply cursor-pointer bg-black/50 transition-opacity duration-200;
   }
 
   .body.hightlightNav::backdrop {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Update modal backdrop to 50% opaque black. Was previously relying on browser defaults.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="1474" height="1019" alt="Screenshot 2026-06-02 at 11 23 30 AM" src="https://github.com/user-attachments/assets/ce07458f-a37a-48b1-8d26-e32e0d8ed212" />

<img width="1474" height="1019" alt="Screenshot 2026-06-02 at 11 23 38 AM" src="https://github.com/user-attachments/assets/57aacd0f-f63a-47b5-a3da-ff8c806eef26" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
