### PR TITLE
fix(copy): Add "for" to validate connection modal title

### DIFF
--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -81,7 +81,7 @@ export const Strings = {
   'set-as-current-error': 'Failed to set version as current',
   'set-current-version-success': '{{ buildId }} is now the current version',
   edit: 'Edit',
-  'validate-connection': 'Validate Connection',
+  'validate-connection': 'Validate Connection for',
   'validate-connection-error': 'Failed to validate connection',
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',


### PR DESCRIPTION
The Worker Deployment Version's Validate Connection modal title now reads "Validate Connection **for** <version>" instead of "Validate Connection <version>".