### PR TITLE
fix(deployments): align version/status/compute badges in worker deployments table

### DIFF
--- a/src/lib/components/deployments/compute-badge.svelte
+++ b/src/lib/components/deployments/compute-badge.svelte
@@ -13,7 +13,7 @@
 
 {#if config}
   <div
-    class="inline-flex items-center gap-1 rounded-sm border border-subtle px-2 py-0.5 text-sm text-primary"
+    class="flex items-center gap-1 rounded-sm border border-subtle px-1 text-primary"
   >
     <Icon name={config.icon} class="h-4 w-4" />
     {config.label}

--- a/src/lib/components/deployments/deployment-status.svelte
+++ b/src/lib/components/deployments/deployment-status.svelte
@@ -33,7 +33,7 @@
 
   const deploymentStatus = cva(
     [
-      'flex items-center gap-1 px-1 transition-colors rounded-sm border border-subtle',
+      'flex items-center justify-center gap-1 px-1 min-w-24 transition-colors rounded-sm border border-subtle',
     ],
     {
       variants: {

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -68,6 +68,7 @@
         {#if latestBuildId}
           <div class="flex items-center gap-2">
             <Copyable
+              container-class="min-w-32 shrink-0"
               content={latestBuildId}
               copyIconTitle={translate('common.copy-icon-title')}
               copySuccessIconTitle={translate('common.copy-success-icon-title')}


### PR DESCRIPTION
## Problem

On the worker deployments page, the **Latest Version (Build ID)** cell lays out the version link, status badge, and compute badge in a `flex` row with no width constraints. Because the version text (`v0.0.1-runbook` vs `1.0.0`) and the status text (`Current` vs `Drained` vs `Created`) have different widths, every badge starts at a different x-position from row to row, so the column reads as ragged. The compute provider badge was also taller than the status badge, adding vertical inconsistency.

## Fix

Give the two left-hand items consistent widths so the items after them always start at the same x, and align the badge heights:

- Pin the version link to a min-width via `Copyable`'s `container-class` (`min-w-32 shrink-0`).
- Give the status badge a min-width with centered content (`min-w-24 justify-center`).
- Drop the compute badge's larger padding and `text-sm` (`px-2 py-0.5 text-sm` → `px-1`) so it matches the status badge height.

Now each row resolves to the same three positions — version → status → compute badge — so they line up as columns of equal height. Using `min-w` rather than a fixed width keeps the common case aligned while letting an unusually long build ID grow its own cell gracefully instead of overflowing into the status badge.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/temporalio/ui/assets-deployment-badge-alignment/before.png) | ![after](https://raw.githubusercontent.com/temporalio/ui/assets-deployment-badge-alignment/after.png) |

> The screenshots are rendered from a standalone harness that reuses the exact markup and Tailwind classes from `deployment-table-row.svelte`, `deployment-status.svelte`, and `compute-badge.svelte`, toggled only by the styling change.

## Testing

- `pnpm lint` — clean (pre-commit lint-staged also ran eslint/prettier/stylelint).
- `pnpm check` — no new errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
