### PR TITLE
fix(DT-4044): only use browser codec endpoint when override option is selected

### DIFF
--- a/src/lib/services/data-encoder.test.ts
+++ b/src/lib/services/data-encoder.test.ts
@@ -10,6 +10,7 @@ import { page } from '$app/state';
 import {
   codecEndpoint,
   includeCredentials,
+  overrideRemoteCodecConfiguration,
   passAccessToken,
 } from '$lib/stores/data-encoder-config';
 import { getAccessToken, getIdToken } from '$lib/utilities/core-provider';
@@ -22,10 +23,15 @@ const mockGetIdToken = vi.mocked(getIdToken);
 describe('Codec Server Requests for Decode and Encode', () => {
   const payloads = { payloads: [{}] };
 
+  beforeEach(() => {
+    overrideRemoteCodecConfiguration.set(true);
+  });
+
   afterEach(() => {
     codecEndpoint.set(null);
     passAccessToken.set(false);
     includeCredentials.set(false);
+    overrideRemoteCodecConfiguration.set(false);
     vi.clearAllMocks();
   });
 
@@ -127,10 +133,15 @@ describe('Codec Server Requests for Decode and Encode', () => {
 describe('codecPassAccessToken', () => {
   const payloads = { payloads: [{}] };
 
+  beforeEach(() => {
+    overrideRemoteCodecConfiguration.set(true);
+  });
+
   afterEach(() => {
     codecEndpoint.set(null);
     passAccessToken.set(false);
     includeCredentials.set(false);
+    overrideRemoteCodecConfiguration.set(false);
     vi.clearAllMocks();
   });
 
@@ -227,10 +238,15 @@ describe('codecPassAccessToken', () => {
 describe('codecIncludeCredentials', () => {
   const payloads = { payloads: [{}] };
 
+  beforeEach(() => {
+    overrideRemoteCodecConfiguration.set(true);
+  });
+
   afterEach(() => {
     codecEndpoint.set(null);
     passAccessToken.set(false);
     includeCredentials.set(false);
+    overrideRemoteCodecConfiguration.set(false);
     vi.clearAllMocks();
   });
 

--- a/src/lib/utilities/decode-payload.test.ts
+++ b/src/lib/utilities/decode-payload.test.ts
@@ -23,6 +23,7 @@ import {
   codecEndpoint,
   includeCredentials,
   lastDataEncoderStatus,
+  overrideRemoteCodecConfiguration,
   resetLastDataEncoderSuccess,
 } from '../stores/data-encoder-config';
 
@@ -260,10 +261,15 @@ describe('parsePayloadAttributes', () => {
 });
 
 describe('decodeEventAttributes', () => {
+  beforeEach(() => {
+    overrideRemoteCodecConfiguration.set(true);
+  });
+
   afterEach(() => {
     resetLastDataEncoderSuccess();
     codecEndpoint.set(null);
     includeCredentials.set(false);
+    overrideRemoteCodecConfiguration.set(false);
     vi.clearAllMocks();
   });
 
@@ -375,6 +381,7 @@ describe('getEventAttributes', () => {
     resetLastDataEncoderSuccess();
     resetLastDataConverterSuccess();
     codecEndpoint.set(null);
+    overrideRemoteCodecConfiguration.set(false);
   });
   it('Should convert a payload through data-converter and set the success status when the endpoint is set locally and the endpoint connects', async () => {
     vi.stubGlobal('fetch', async () => {
@@ -384,6 +391,7 @@ describe('getEventAttributes', () => {
     });
 
     codecEndpoint.set('http://localhost:1337');
+    overrideRemoteCodecConfiguration.set(true);
 
     const decodedPayload = await getEventAttributes(
       parseWithBigInt(stringifyWithBigInt(workflowStartedHistoryEvent)),

--- a/src/lib/utilities/get-codec.test.ts
+++ b/src/lib/utilities/get-codec.test.ts
@@ -160,7 +160,7 @@ describe('getCodec with configuration settings and local settings but override o
     expect(credentials).toEqual(true);
   });
 
-  it('should return codec endpoint from local setting with no settings', () => {
+  it('should return empty endpoint when no namespace-level codec is configured and override is off', () => {
     codecEndpoint.set('http://mylocalserver.dev');
     passAccessToken.set(true);
     includeCredentials.set(false);
@@ -168,8 +168,8 @@ describe('getCodec with configuration settings and local settings but override o
     const endpoint = getCodecEndpoint(settings);
     const token = getCodecPassAccessToken(settings);
     const credentials = getCodecIncludeCredentials(settings);
-    expect(endpoint).toEqual('http://mylocalserver.dev');
-    expect(token).toEqual(true);
+    expect(endpoint).toEqual('');
+    expect(token).toEqual(false);
     expect(credentials).toEqual(false);
   });
 });

--- a/src/lib/utilities/get-codec.ts
+++ b/src/lib/utilities/get-codec.ts
@@ -14,7 +14,7 @@ export const getCodecEndpoint = (
   override = overrideRemoteCodecConfiguration,
 ): string => {
   const overrideEndpoint = get(override) && get(endpoint);
-  return overrideEndpoint || settings?.codec?.endpoint || get(endpoint) || '';
+  return overrideEndpoint || settings?.codec?.endpoint || '';
 };
 
 export const getCodecPassAccessToken = (
@@ -24,10 +24,9 @@ export const getCodecPassAccessToken = (
   override = overrideRemoteCodecConfiguration,
 ): boolean => {
   const overrideEndpoint = get(override) && get(endpoint);
-  const nonOverrideOption = settings?.codec?.endpoint
-    ? !!settings?.codec?.passAccessToken
-    : !!get(passToken);
-  return overrideEndpoint ? !!get(passToken) : nonOverrideOption;
+  return overrideEndpoint
+    ? !!get(passToken)
+    : !!settings?.codec?.passAccessToken;
 };
 
 export const getCodecIncludeCredentials = (
@@ -37,8 +36,7 @@ export const getCodecIncludeCredentials = (
   override = overrideRemoteCodecConfiguration,
 ): boolean => {
   const overrideEndpoint = get(override) && get(endpoint);
-  const nonOverrideOption = settings?.codec?.endpoint
-    ? !!settings?.codec?.includeCredentials
-    : !!get(includeCreds);
-  return overrideEndpoint ? !!get(includeCreds) : nonOverrideOption;
+  return overrideEndpoint
+    ? !!get(includeCreds)
+    : !!settings?.codec?.includeCredentials;
 };


### PR DESCRIPTION
## Summary

- When the user selects "Use Namespace-level setting, where available" but no namespace codec endpoint is configured, the browser-level codec endpoint was incorrectly used as a fallback, causing decode failures on namespaces without a codec
- Fixed `getCodecEndpoint` to return `''` (no codec) in this case instead of falling back to the browser endpoint
- Fixed `getCodecPassAccessToken` and `getCodecIncludeCredentials` consistently — they no longer fall back to browser values when override is off
- Updated tests that were asserting the buggy fallback behavior; tests that exercise the browser-level endpoint now explicitly set `overrideRemoteCodecConfiguration = true`

Fixes: https://temporalio.atlassian.net/browse/DT-4044

## Test plan

- [ ] `pnpm test -- --run` passes with no new failures
- [ ] Manually verify: set a browser codec endpoint, switch to "Use Namespace-level setting", navigate to a namespace with no codec configured → payloads should not attempt to decode (no codec error)
- [ ] Verify the override option still works: set browser endpoint + enable override → local endpoint is used as before