### PR TITLE
Fix decoded object payload summaries

### DIFF
--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { twMerge as merge } from 'tailwind-merge';
+  import { type ClassNameValue, twMerge as merge } from 'tailwind-merge';
 
   import PayloadInline from '$lib/components/payload/payload-inline.svelte';
   import Badge from '$lib/holocene/badge.svelte';
@@ -16,12 +16,23 @@
 
   import EventDetailsLink from './event-details-link.svelte';
 
-  export let key: string;
-  export let value: SummaryAttribute['value'] | number | boolean | null;
-  export let attributes: CombinedAttributes;
-  export let showKey = true;
+  interface Props {
+    key: string;
+    value: SummaryAttribute['value'] | number | boolean | null;
+    attributes: CombinedAttributes;
+    showKey?: boolean;
+    class?: ClassNameValue;
+  }
 
-  $: linkType = displayLinkType(key, attributes);
+  let {
+    key,
+    value,
+    attributes,
+    showKey = true,
+    class: className = '',
+  }: Props = $props();
+
+  const linkType = $derived(displayLinkType(key, attributes));
 </script>
 
 {#if key}
@@ -37,7 +48,7 @@
       <div
         class="flex max-w-sm items-center justify-between gap-2 overflow-hidden pr-1 xl:flex-nowrap"
       >
-        <PayloadInline {value} class={merge($$props.class)} />
+        <PayloadInline {value} class={merge(className)} />
       </div>
     {:else if typeof value === 'string' && linkType !== 'none'}
       <Copyable

--- a/src/lib/components/event/event-details-row.svelte
+++ b/src/lib/components/event/event-details-row.svelte
@@ -5,16 +5,19 @@
   import Badge from '$lib/holocene/badge.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
   import { translate } from '$lib/i18n/translate';
-  import type { Payload, Payloads } from '$lib/types';
   import { isRawPayload, isRawPayloads } from '$lib/utilities/decode-payload';
   import { format } from '$lib/utilities/format-camel-case';
   import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
-  import { displayLinkType } from '$lib/utilities/get-single-attribute-for-event';
+  import {
+    displayLinkType,
+    formatSummaryAttributeDisplayValue,
+    type SummaryAttribute,
+  } from '$lib/utilities/get-single-attribute-for-event';
 
   import EventDetailsLink from './event-details-link.svelte';
 
   export let key: string;
-  export let value: string | Payload | Payloads;
+  export let value: SummaryAttribute['value'] | number | boolean | null;
   export let attributes: CombinedAttributes;
   export let showKey = true;
 
@@ -52,7 +55,7 @@
       </Copyable>
     {:else}
       <Badge type="subtle" class="block select-none truncate">
-        {value}
+        {formatSummaryAttributeDisplayValue(value)}
       </Badge>
     {/if}
   </div>

--- a/src/lib/utilities/get-single-attribute-for-event.test.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  formatSummaryAttributeDisplayValue,
   getCodeBlockValue,
   getPrimaryAttributeForEvent,
   getSummaryAttribute,
@@ -246,6 +247,26 @@ describe('getCodeBlockValue', () => {
     expect(getCodeBlockValue(1)).toBe(1);
     expect(getCodeBlockValue(null)).toBe(null);
     expect(getCodeBlockValue([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+});
+
+describe('formatSummaryAttributeDisplayValue', () => {
+  it('should return strings unchanged', () => {
+    expect(formatSummaryAttributeDisplayValue('completed')).toBe('completed');
+  });
+
+  it('should stringify decoded object values', () => {
+    expect(
+      formatSummaryAttributeDisplayValue({ status: 'completed', count: 1 }),
+    ).toBe('{"status":"completed","count":1}');
+  });
+
+  it('should render payload wrapper values as the first payload', () => {
+    expect(
+      formatSummaryAttributeDisplayValue({
+        payloads: [{ status: 'completed' }],
+      }),
+    ).toBe('{"status":"completed"}');
   });
 });
 

--- a/src/lib/utilities/get-single-attribute-for-event.ts
+++ b/src/lib/utilities/get-single-attribute-for-event.ts
@@ -23,6 +23,7 @@ import {
   isPendingActivity,
   isPendingNexusOperation,
 } from './is-pending-activity';
+import { stringifyWithBigInt } from './parse-with-big-int';
 
 export type SummaryAttribute = {
   key: string;
@@ -126,6 +127,20 @@ export const getCodeBlockValue: Parameters<typeof JSON.stringify>[0] = (
   return [value?.payloads, value?.indexedFields, value?.points, value].find(
     (v) => v !== undefined,
   );
+};
+
+export const formatSummaryAttributeDisplayValue = (value: unknown): string => {
+  let displayValue = getCodeBlockValue(value);
+  if (
+    isObject(value) &&
+    has(value, 'payloads') &&
+    Array.isArray(displayValue)
+  ) {
+    displayValue = displayValue.length ? displayValue[0] : displayValue;
+  }
+  if (typeof displayValue === 'string') return displayValue;
+
+  return stringifyWithBigInt(displayValue) ?? String(displayValue);
 };
 
 export const getStackTrace = (value: unknown) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->


- Fixes compact event history rows rendering decoded object payloads as [object Object].
- Adds a shared formatter for summary attribute display values, including decoded object payloads and payloads wrappers.
- Converts event-details-row.svelte to Svelte 5 $props and $derived.

What This Fixes
  Some decoded workflow event result payloads could arrive as plain objects in the compact event row. The detail panel displayed them correctly, but the row badge rendered the object directly, causing Svelte to coerce it to [object Object]. The row now renders those values as compact JSON instead.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="1545" height="199" alt="Screenshot 2026-06-02 at 2 29 39 PM" src="https://github.com/user-attachments/assets/7e9e946c-9155-4a1b-ae19-ad79ac7a5248" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
