### PR TITLE
fix(a11y): filter hidden nav items in mobile bottom-nav (WCAG 4.1.2)

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -360,13 +360,17 @@
     {#snippet footer()}
       <BottomNavigation {namespaceList} {isCloud} {showNamespacePicker}>
         {#snippet linksSnippet()}
-          {#each [...linkListForSecondGroup].filter((item) => !item.hidden).reverse() as link, i (i)}
+          {#each [...linkListForSecondGroup]
+            .filter((item) => !item.hidden)
+            .reverse() as link, i (i)}
             <NavigationItem {...link} link={link.href} />
           {/each}
 
           <hr class="border-subtle" />
 
-          {#each [...linkList].filter((item) => !item.hidden).reverse() as link, i (i)}
+          {#each [...linkList]
+            .filter((item) => !item.hidden)
+            .reverse() as link, i (i)}
             <NavigationItem {...link} link={link.href} />
           {/each}
         {/snippet}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -360,13 +360,13 @@
     {#snippet footer()}
       <BottomNavigation {namespaceList} {isCloud} {showNamespacePicker}>
         {#snippet linksSnippet()}
-          {#each [...linkListForSecondGroup].reverse() as link, i (i)}
+          {#each [...linkListForSecondGroup].filter((item) => !item.hidden).reverse() as link, i (i)}
             <NavigationItem {...link} link={link.href} />
           {/each}
 
           <hr class="border-subtle" />
 
-          {#each [...linkList].reverse() as link, i (i)}
+          {#each [...linkList].filter((item) => !item.hidden).reverse() as link, i (i)}
             <NavigationItem {...link} link={link.href} />
           {/each}
         {/snippet}

--- a/tests/integration/bottom-nav-capability-gating.mobile.spec.ts
+++ b/tests/integration/bottom-nav-capability-gating.mobile.spec.ts
@@ -1,0 +1,64 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import {
+  mockClusterApi,
+  mockSystemInfoApi,
+  mockWorkflowsApis,
+  waitForWorkflowsApis,
+} from '~/test-utilities/mock-apis';
+
+const openBottomNavDrawer = async (page: Page) => {
+  await page.goto('/namespaces/default/workflows');
+  await waitForWorkflowsApis(page, false);
+  await page.getByTestId('nav-menu-button').click();
+};
+
+test.beforeEach(async ({ page }) => {
+  await mockWorkflowsApis(page);
+});
+
+test('hides the Nexus link when the server lacks the nexus capability', async ({
+  page,
+}) => {
+  await mockClusterApi(page, { serverVersion: '1.31.0' });
+  await mockSystemInfoApi(page, { capabilities: { nexus: false } });
+
+  await openBottomNavDrawer(page);
+
+  await expect(page.getByRole('link', { name: 'Nexus' })).toHaveCount(0);
+});
+
+test('shows the Nexus link when the server supports nexus', async ({
+  page,
+}) => {
+  await mockClusterApi(page, { serverVersion: '1.31.0' });
+  await mockSystemInfoApi(page, { capabilities: { nexus: true } });
+
+  await openBottomNavDrawer(page);
+
+  await expect(page.getByRole('link', { name: 'Nexus' })).toBeVisible();
+});
+
+test('hides the Standalone Activities link on servers older than 1.30.0', async ({
+  page,
+}) => {
+  await mockClusterApi(page, { serverVersion: '1.29.0' });
+
+  await openBottomNavDrawer(page);
+
+  await expect(
+    page.getByRole('link', { name: 'Standalone Activities' }),
+  ).toHaveCount(0);
+});
+
+test('shows the Standalone Activities link on servers 1.30.0 and newer', async ({
+  page,
+}) => {
+  await mockClusterApi(page, { serverVersion: '1.30.0' });
+
+  await openBottomNavDrawer(page);
+
+  await expect(
+    page.getByRole('link', { name: 'Standalone Activities' }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

The mobile bottom-nav drawer renders `NavigationItem`s directly inside `+layout.svelte`'s `linksSnippet`, **bypassing `NavSection`'s `!item.hidden` filter**. As a result, capability-gated nav links still render as focusable links for keyboard and screen-reader users on servers that don't support them:

- **Standalone Activities** — `hidden` when the server is `< 1.30.0`
- **Nexus** — `hidden` when `systemInfo.capabilities.nexus` is absent

The desktop side-nav already hides these correctly (it routes through `NavSection`), so this is a mobile-only regression.

## Root cause — interaction of two prior PRs

- **#3434** added the `navItems.filter((item) => !item.hidden)` filter, but only to `NavSection`.
- **#3445** refactored the bottom-nav to accept a `linksSnippet` instead of `sections`, flattening `NavSection` into a snippet of raw `NavigationItem`s in `+layout.svelte` — which never picked up that filter.

So the `hidden` flag (set at `+layout.svelte` for Activities/Nexus) was being ignored on the mobile bottom nav.

## Fix

Apply the same `!item.hidden` predicate `NavSection` uses to both bottom-nav groups:

```diff
- {#each linkList as link, i (i)}
+ {#each linkList.filter((item) => !item.hidden) as link, i (i)}
    <NavigationItem {...link} link={link.href} />
  {/each}

  <hr class="border-subtle" />

- {#each linkListForSecondGroup as link, i (i)}
+ {#each linkListForSecondGroup.filter((item) => !item.hidden) as link, i (i)}
    <NavigationItem {...link} link={link.href} />
  {/each}
```

The static `feedback` item in the side-nav `bottom()` snippet has no `hidden` flag and is unaffected.

> **Note on overlap with #3441:** that PR also edits this same `linksSnippet` (reordering for WCAG 1.3.2). The two changes are independent but touch the same lines, so whichever merges second will resolve to the combined form, e.g. `[...linkList].filter((item) => !item.hidden).reverse()`.

## Test plan

- [ ] On a Temporal server **lacking Nexus capability**: open the mobile bottom-nav drawer (DevTools device mode) — the **Nexus** link should not appear, and should not be reachable via Tab or screen reader.
- [ ] On a server **`< 1.30.0`**: the **Standalone Activities** link should not appear in the bottom-nav drawer.
- [ ] On a fully-capable server: all nav links still appear (no over-filtering).
- [ ] Desktop side-nav behavior is unchanged.

A11y-Audit-Ref: 4.1.2-nav-hidden-flag-ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)