### PR TITLE
feat: improve local-temporal skill score (90% → 94%)

### DIFF
--- a/.claude/skills/local-temporal/SKILL.md
+++ b/.claude/skills/local-temporal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-temporal
-description: Instructions for running the UI against a local Temporal server build instead of the built-in CLI dev server. Use when asked how to start the dev environment, run the UI locally, or connect to a local Temporal repo.
+description: "Set up and connect the Temporal UI to a locally built Temporal server by starting the server via make start, running pnpm dev:local-temporal, and syncing go.temporal.io/api proto versions between the server branch and server/go.mod. Use when asked how to start the dev environment, run the UI locally, connect to a local Temporal repo, or troubleshoot proto version mismatches."
 ---
 
 # Local Temporal Dev Setup
@@ -37,13 +37,11 @@ This loads `.env.local-temporal` which points the UI at the local server instead
 
 ## Why not `pnpm dev`?
 
-`pnpm dev` (aliased to `pnpm dev:ui-server`) starts a bundled Temporal server alongside the UI. `pnpm dev:local-temporal` skips that and connects to whatever is already running on the configured ports.
+`pnpm dev` starts a bundled Temporal server alongside the UI. `pnpm dev:local-temporal` skips that and connects to whatever is already running on the configured ports.
 
-## Keeping the ui-server in sync with the Temporal server branch
+## Keeping the ui-server proto versions in sync
 
-This is **critical** when working on unreleased features. The ui-server (`server/`) is a separate Go binary that acts as a grpc-gateway — it decodes HTTP/JSON into proto messages and forwards them to the Temporal server over gRPC. Its proto descriptors are baked in at compile time from its own `server/go.mod`.
-
-If the Temporal server branch uses a newer `go.temporal.io/api` version than `server/go.mod`, the ui-server will reject any new HTTP fields as "unknown field" before the request ever reaches the Temporal server.
+**Critical when working on unreleased features.** The ui-server (`server/`) bakes proto descriptors from its own `server/go.mod` at compile time. If the Temporal server branch uses a newer `go.temporal.io/api` than `server/go.mod`, the ui-server rejects new HTTP fields as "unknown field" before they reach the server.
 
 **When switching to a Temporal branch with API changes:**
 


### PR DESCRIPTION
Hey @Alex-Tideman 👋

truly impressive work. Four skills for auth testing, Svelte migration, worktree setup, and local Temporal dev. The fact that you already have a claude.yml in your workflows tells me you're serious about AI-assisted development, and the Svelte migration skill especially is the kind of thing that saves real time.

ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| local-temporal | 90% | 94% | +4% |

<details>
<summary>Changes made</summary>

**Description improvement (main impact):**
- **local-temporal**: Expanded the frontmatter description from a general summary to list specific concrete actions - `make start`, `pnpm dev:local-temporal`, and syncing `go.temporal.io/api` proto versions. Added "proto version mismatches" as an additional trigger term so the skill activates when developers hit the common "unknown field" error.

**Content tightening:**
- Removed the redundant `(aliased to pnpm dev:ui-server)` clause from the "Why not pnpm dev?" section
- Condensed the proto sync explanation - collapsed the grpc-gateway architecture paragraph into a single sentence while preserving the critical "unknown field" diagnostic insight
- Renamed the section header from "Keeping the ui-server in sync with the Temporal server branch" to "Keeping the ui-server proto versions in sync" for scannability

</details>

---

also stress-tested your `local-temporal` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/temporalio/ui/setup-worktree/evals) and it held up really well on the proto version mismatch debugging scenario. The 4-step sync workflow is exactly what a developer needs when they hit "unknown field" errors after switching branches. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.
