### PR TITLE
fix(standalone-activities): decode failure encodedAttributes in activity detail

### DIFF
--- a/src/lib/components/standalone-activities/activity-input-and-outcome.svelte
+++ b/src/lib/components/standalone-activities/activity-input-and-outcome.svelte
@@ -21,7 +21,7 @@
   <div class="flex flex-col gap-2">
     <h5>Result</h5>
     {#if has(outcome, 'failure')}
-      <CodeBlock content={JSON.stringify(outcome.failure, null, 2)} />
+      <PayloadCodeBlock value={outcome.failure} />
     {:else if has(outcome, 'result')}
       <PayloadCodeBlock value={outcome.result} />
     {:else}

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -349,13 +349,7 @@
               <p class="font-medium text-secondary">
                 {translate('standalone-activities.last-failure')}
               </p>
-              <CodeBlock
-                content={JSON.stringify(
-                  $activityExecution.info.lastFailure,
-                  null,
-                  2,
-                )}
-              />
+              <PayloadCodeBlock value={$activityExecution.info.lastFailure} />
             </div>
           {/if}
           {#if $activityExecution.info.retryPolicy}


### PR DESCRIPTION
## Description & motivation 💭

On the **Standalone Activity** detail page, failures are rendered with a plain `CodeBlock` and `JSON.stringify`, which bypasses codec decoding entirely — in **two** places:

- **Result** panel — `outcome.failure` (`activity-input-and-outcome.svelte`)
- **Last Failure** panel — `info.lastFailure` (`standalone-activity-details.svelte`)

When the SDK's failure converter is configured with `EncodeCommonAttributes`, the error **message** and **stack trace** are stored in the failure's `encodedAttributes` payload. Because that payload is never sent to the codec server, both panels show raw, e.g.:

```json
{
  "message": "Encoded failure",
  "source": "GoSDK",
  "encodedAttributes": {
    "metadata": { "encoding": "YmluYXJ5L3psaWI=" },
    "data": "eJziEuPiSM1Lzk/..."
  },
  "applicationFailureInfo": {}
}
```

The **Input** panel (and the successful **Result** panel) already use `PayloadCodeBlock` and decode correctly — so on the same page, input decodes but failures do not.

### Fix

Render both failures with `PayloadCodeBlock`, the same component used for input/result. For a non-`Payload`/`Payloads` object it routes through `decodeEventAttributes`, which recursively decodes both `payloads` and `encodedAttributes` via the codec server — matching how the workflow event-history view already renders failures.

```diff
 // activity-input-and-outcome.svelte (Result panel)
 {#if has(outcome, 'failure')}
-  <CodeBlock content={JSON.stringify(outcome.failure, null, 2)} />
+  <PayloadCodeBlock value={outcome.failure} />

 // standalone-activity-details.svelte (Last Failure panel)
-<CodeBlock content={JSON.stringify($activityExecution.info.lastFailure, null, 2)} />
+<PayloadCodeBlock value={$activityExecution.info.lastFailure} />
```

### Screenshots (if applicable) 📸

Before (current UI, no change applied — with a codec server configured): the failure `encodedAttributes.data` is shown as raw base64 in the Result and Last Failure panels.
<img width="2385" height="1278" alt="Screenshot 2026-06-06 at 2 38 19 PM" src="https://github.com/user-attachments/assets/de961713-42e6-43bd-995e-efe81b6a07db" />


After (with this change applied): `encodedAttributes` is decoded to `{ "message": "...", "stack_trace": "..." }`, consistent with the decoded Input.
<img width="2518" height="1157" alt="Screenshot 2026-06-06 at 2 38 28 PM" src="https://github.com/user-attachments/assets/2357a135-ae6b-4f87-b1e5-4e5fde15467c" />


## Testing 🧪

Verified end-to-end against a local stack: a Temporal SDK worker with a `PayloadCodec` data converter + failure converter (`EncodeCommonAttributes: true`), a failing Standalone Activity, a codec server, and the UI pointed at it. Both the Result and Last Failure panels render the decoded message/stack.

This is a Svelte template change (swapping in the same `PayloadCodeBlock` the Input/Result panels already use), and there's no component-render harness here to unit-test it directly, so it was verified manually + E2E.

- full unit suite (`pnpm test`) -> green
- `pnpm check` (svelte-check) -> 0 errors
- Prettier + ESLint clean on changed files

### Steps for others to test 🚶

1. Run a Temporal SDK worker whose client sets a `PayloadCodec` data converter **and** a failure converter with `EncodeCommonAttributes: true`.
2. Execute a Standalone Activity that fails.
3. Point the UI at a codec server (`--ui-codec-endpoint`, or set it in the UI settings).
4. Open the failed Standalone Activity detail page. The Result and Last Failure panels now show the decoded message/stack instead of raw `encodedAttributes`.

## Docs

### Any docs updates needed?

No.


