### PR TITLE
feat(DT-4078): Add Set Ramping Version to Worker Deployment Versions

### DIFF
--- a/src/lib/components/deployments/set-ramping-version-modal.svelte
+++ b/src/lib/components/deployments/set-ramping-version-modal.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import Button from '$lib/holocene/button.svelte';
+  import NumberInput from '$lib/holocene/input/number-input.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
+  import { translate } from '$lib/i18n/translate';
+
+  interface Props {
+    buildId: string;
+    deploymentName: string;
+    open: boolean;
+    hasActivePollers: boolean;
+    isRamping: boolean;
+    existingRampingBuildId?: string;
+    existingRampingPercentage?: number;
+    percentage: number;
+    error?: string;
+    onConfirm: () => void;
+    onRemove: () => void;
+    onCancel: () => void;
+  }
+
+  let {
+    buildId,
+    deploymentName,
+    open,
+    hasActivePollers,
+    isRamping,
+    existingRampingBuildId,
+    existingRampingPercentage,
+    percentage = $bindable(),
+    error = '',
+    onConfirm,
+    onRemove,
+    onCancel,
+  }: Props = $props();
+</script>
+
+{#if !hasActivePollers}
+  <Modal
+    id="set-ramping-version-modal-{buildId}"
+    {open}
+    confirmText=""
+    cancelText={translate('common.close')}
+    hideConfirm
+    on:cancelModal={onCancel}
+  >
+    <h3 slot="title">
+      {translate('deployments.set-ramping-no-pollers-title')}
+    </h3>
+    <div slot="content">
+      <p class="text-sm">
+        {translate('deployments.set-ramping-no-pollers-body')}
+      </p>
+    </div>
+  </Modal>
+{:else}
+  <Modal
+    id="set-ramping-version-modal-{buildId}"
+    {open}
+    {error}
+    confirmText={translate('deployments.set-ramping-version')}
+    cancelText={translate('common.cancel')}
+    confirmDisabled={Number.isNaN(percentage) ||
+      percentage < 0 ||
+      percentage > 100}
+    on:confirmModal={onConfirm}
+    on:cancelModal={onCancel}
+  >
+    <h3 slot="title">{translate('deployments.set-ramping-version')}</h3>
+    <div slot="content" class="flex flex-col gap-4">
+      <p class="text-sm">
+        This will route a percentage of new traffic to Build ID
+        <span class="font-mono font-medium">{buildId}</span>
+        for <strong>{deploymentName}</strong>. The Current Version will continue
+        to receive the remaining traffic.
+      </p>
+      {#if existingRampingBuildId && existingRampingBuildId !== buildId}
+        <p class="text-sm">
+          Worker Deployment Version
+          <span class="font-mono font-medium">{existingRampingBuildId}</span>
+          is currently ramping at {existingRampingPercentage ?? 0}%.
+        </p>
+      {/if}
+      <NumberInput
+        id="ramping-percentage-{buildId}"
+        bind:value={percentage}
+        min={0}
+        max={100}
+        units="%"
+        label={translate('deployments.ramping-percentage-label')}
+      />
+    </div>
+    <svelte:fragment slot="footer">
+      {#if isRamping}
+        <Button variant="destructive" on:click={onRemove}>
+          {translate('deployments.remove-ramping')}
+        </Button>
+      {/if}
+    </svelte:fragment>
+  </Modal>
+{/if}

--- a/src/lib/components/deployments/set-ramping-version-modal.svelte
+++ b/src/lib/components/deployments/set-ramping-version-modal.svelte
@@ -10,9 +10,11 @@
     open: boolean;
     hasActivePollers: boolean;
     isRamping: boolean;
-    existingRampingBuildId?: string;
+    existingRampingVersion?: string;
     existingRampingPercentage?: number;
+    currentPercentage?: number;
     percentage: number;
+    loading?: boolean;
     error?: string;
     onConfirm: () => void;
     onRemove: () => void;
@@ -25,9 +27,11 @@
     open,
     hasActivePollers,
     isRamping,
-    existingRampingBuildId,
+    existingRampingVersion,
     existingRampingPercentage,
+    currentPercentage,
     percentage = $bindable(),
+    loading = false,
     error = '',
     onConfirm,
     onRemove,
@@ -61,24 +65,27 @@
     confirmText={translate('deployments.set-ramping-version')}
     cancelText={translate('common.cancel')}
     confirmDisabled={Number.isNaN(percentage) ||
-      percentage < 0 ||
-      percentage > 100}
+      percentage <= 0 ||
+      percentage > 100 ||
+      (currentPercentage !== undefined && percentage === currentPercentage)}
+    {loading}
     on:confirmModal={onConfirm}
     on:cancelModal={onCancel}
   >
     <h3 slot="title">{translate('deployments.set-ramping-version')}</h3>
     <div slot="content" class="flex flex-col gap-4">
       <p class="text-sm">
-        This will route a percentage of new traffic to Build ID
-        <span class="font-mono font-medium">{buildId}</span>
-        for <strong>{deploymentName}</strong>. The Current Version will continue
-        to receive the remaining traffic.
+        {translate('deployments.set-ramping-body', {
+          buildId,
+          deploymentName,
+        })}
       </p>
-      {#if existingRampingBuildId && existingRampingBuildId !== buildId}
+      {#if existingRampingVersion}
         <p class="text-sm">
-          Worker Deployment Version
-          <span class="font-mono font-medium">{existingRampingBuildId}</span>
-          is currently ramping at {existingRampingPercentage ?? 0}%.
+          {translate('deployments.set-ramping-existing', {
+            version: existingRampingVersion,
+            percentage: existingRampingPercentage ?? 0,
+          })}
         </p>
       {/if}
       <NumberInput
@@ -86,6 +93,7 @@
         bind:value={percentage}
         min={0}
         max={100}
+        step={0.1}
         units="%"
         label={translate('deployments.ramping-percentage-label')}
       />

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -56,13 +56,11 @@
           <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
             {translate('deployments.set-as-current')}
           </MenuItem>
-          {#if !isCurrent}
-            <MenuItem onclick={onSetRamping}>
-              {isRamping
-                ? translate('deployments.edit-ramping-percentage')
-                : translate('deployments.set-ramping-version')}
-            </MenuItem>
-          {/if}
+          <MenuItem onclick={onSetRamping} disabled={isCurrent}>
+            {isRamping
+              ? translate('deployments.edit-ramping-percentage')
+              : translate('deployments.set-ramping-version')}
+          </MenuItem>
           <MenuItem onclick={onValidate}>
             {translate('deployments.validate-connection')}
           </MenuItem>
@@ -71,13 +69,11 @@
           <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
             {translate('deployments.set-as-current')}
           </MenuItem>
-          {#if !isCurrent}
-            <MenuItem onclick={onSetRamping}>
-              {isRamping
-                ? translate('deployments.edit-ramping-percentage')
-                : translate('deployments.set-ramping-version')}
-            </MenuItem>
-          {/if}
+          <MenuItem onclick={onSetRamping} disabled={isCurrent}>
+            {isRamping
+              ? translate('deployments.edit-ramping-percentage')
+              : translate('deployments.set-ramping-version')}
+          </MenuItem>
         {/snippet}
       </CapabilityGuard>
       <MenuItem href={workflowHref}>

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -13,7 +13,9 @@
     workflowHref: string;
     isCurrent: boolean;
     hasComputeConfig: boolean;
+    isRamping: boolean;
     onSetCurrent: () => void;
+    onSetRamping: () => void;
     onValidate: () => void;
     onDelete: () => void;
   }
@@ -24,7 +26,9 @@
     workflowHref,
     isCurrent,
     hasComputeConfig,
+    isRamping,
     onSetCurrent,
+    onSetRamping,
     onValidate,
     onDelete,
   }: Props = $props();
@@ -52,6 +56,13 @@
           <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
             {translate('deployments.set-as-current')}
           </MenuItem>
+          {#if !isCurrent}
+            <MenuItem onclick={onSetRamping}>
+              {isRamping
+                ? translate('deployments.edit-ramping-percentage')
+                : translate('deployments.set-ramping-version')}
+            </MenuItem>
+          {/if}
           <MenuItem onclick={onValidate}>
             {translate('deployments.validate-connection')}
           </MenuItem>
@@ -60,6 +71,13 @@
           <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
             {translate('deployments.set-as-current')}
           </MenuItem>
+          {#if !isCurrent}
+            <MenuItem onclick={onSetRamping}>
+              {isRamping
+                ? translate('deployments.edit-ramping-percentage')
+                : translate('deployments.set-ramping-version')}
+            </MenuItem>
+          {/if}
         {/snippet}
       </CapabilityGuard>
       <MenuItem href={workflowHref}>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -148,7 +148,7 @@
     }),
   );
 
-  const hasActivePollers = $derived(
+  const canRampToVersion = $derived(
     parseVersionStatus(drainageStatus).status !== 'Created',
   );
   const otherVersionRamping = $derived(
@@ -233,21 +233,24 @@
   async function handleSetRamping() {
     setRampingError = '';
     setRampingLoading = true;
-    await setRampingDeploymentVersion(
-      {
-        namespace,
-        deploymentName,
-        buildId: versionBuildId,
-        rampingVersionPercentage: rampingPercentage,
-        conflictToken,
-      },
-      (err) => {
-        setRampingError =
-          (err as { body?: { message?: string } })?.body?.message ??
-          translate('deployments.set-ramping-error');
-      },
-    );
-    setRampingLoading = false;
+    try {
+      await setRampingDeploymentVersion(
+        {
+          namespace,
+          deploymentName,
+          buildId: versionBuildId,
+          rampingVersionPercentage: rampingPercentage,
+          conflictToken,
+        },
+        (err) => {
+          setRampingError =
+            (err as { body?: { message?: string } })?.body?.message ??
+            translate('deployments.set-ramping-error');
+        },
+      );
+    } finally {
+      setRampingLoading = false;
+    }
     if (setRampingError) return;
     showSetRampingModal = false;
     toaster.push({
@@ -263,15 +266,18 @@
   async function handleRemoveRamping() {
     setRampingError = '';
     setRampingLoading = true;
-    await removeRampingDeploymentVersion(
-      { namespace, deploymentName, conflictToken },
-      (err) => {
-        setRampingError =
-          (err as { body?: { message?: string } })?.body?.message ??
-          translate('deployments.remove-ramping-error');
-      },
-    );
-    setRampingLoading = false;
+    try {
+      await removeRampingDeploymentVersion(
+        { namespace, deploymentName, conflictToken },
+        (err) => {
+          setRampingError =
+            (err as { body?: { message?: string } })?.body?.message ??
+            translate('deployments.remove-ramping-error');
+        },
+      );
+    } finally {
+      setRampingLoading = false;
+    }
     if (setRampingError) return;
     showSetRampingModal = false;
     toaster.push({
@@ -390,7 +396,7 @@
   open={showSetRampingModal}
   error={setRampingError}
   loading={setRampingLoading}
-  {hasActivePollers}
+  hasActivePollers={canRampToVersion}
   {isRamping}
   existingRampingVersion={otherVersionRamping}
   existingRampingPercentage={routingConfig.rampingVersionPercentage}

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -152,7 +152,9 @@
     parseVersionStatus(drainageStatus).status !== 'Created',
   );
   const otherVersionRamping = $derived(
-    rampingBuildId && !isRamping ? rampingBuildId : undefined,
+    rampingBuildId && !isRamping
+      ? `${rampingDeploymentName}.${rampingBuildId}`
+      : undefined,
   );
 
   let expanded = $state(false);
@@ -165,6 +167,7 @@
   let validateResult = $state<{ message?: string } | null>(null);
   let showSetRampingModal = $state(false);
   let setRampingError = $state('');
+  let setRampingLoading = $state(false);
   let rampingPercentage = $state(0);
 
   async function handleValidateConnection() {
@@ -229,12 +232,14 @@
 
   async function handleSetRamping() {
     setRampingError = '';
+    setRampingLoading = true;
     await setRampingDeploymentVersion(
       {
         namespace,
         deploymentName,
         buildId: versionBuildId,
         rampingVersionPercentage: rampingPercentage,
+        conflictToken,
       },
       (err) => {
         setRampingError =
@@ -242,6 +247,7 @@
           translate('deployments.set-ramping-error');
       },
     );
+    setRampingLoading = false;
     if (setRampingError) return;
     showSetRampingModal = false;
     toaster.push({
@@ -256,14 +262,16 @@
 
   async function handleRemoveRamping() {
     setRampingError = '';
+    setRampingLoading = true;
     await removeRampingDeploymentVersion(
-      { namespace, deploymentName },
+      { namespace, deploymentName, conflictToken },
       (err) => {
         setRampingError =
           (err as { body?: { message?: string } })?.body?.message ??
           translate('deployments.remove-ramping-error');
       },
     );
+    setRampingLoading = false;
     if (setRampingError) return;
     showSetRampingModal = false;
     toaster.push({
@@ -381,10 +389,14 @@
   {deploymentName}
   open={showSetRampingModal}
   error={setRampingError}
+  loading={setRampingLoading}
   {hasActivePollers}
   {isRamping}
-  existingRampingBuildId={otherVersionRamping}
+  existingRampingVersion={otherVersionRamping}
   existingRampingPercentage={routingConfig.rampingVersionPercentage}
+  currentPercentage={isRamping
+    ? (routingConfig.rampingVersionPercentage ?? undefined)
+    : undefined}
   bind:percentage={rampingPercentage}
   onConfirm={handleSetRamping}
   onRemove={handleRemoveRamping}

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -8,7 +8,9 @@
   import {
     deleteWorkerDeploymentVersion,
     fetchDeploymentVersion,
+    removeRampingDeploymentVersion,
     setCurrentDeploymentVersion,
+    setRampingDeploymentVersion,
     validateWorkerDeploymentVersionComputeConfig,
   } from '$lib/services/deployments-service';
   import { toaster } from '$lib/stores/toaster';
@@ -34,6 +36,7 @@
   import DeleteVersionModal from './delete-version-modal.svelte';
   import DeploymentStatus from './deployment-status.svelte';
   import SetCurrentVersionModal from './set-current-version-modal.svelte';
+  import SetRampingVersionModal from './set-ramping-version-modal.svelte';
   import ValidateConnectionModal from './validate-connection-modal.svelte';
   import VersionActionsMenu from './version-actions-menu.svelte';
   import VersionRowDetails from './version-row-details.svelte';
@@ -145,6 +148,13 @@
     }),
   );
 
+  const hasActivePollers = $derived(
+    parseVersionStatus(drainageStatus).status !== 'Created',
+  );
+  const otherVersionRamping = $derived(
+    rampingBuildId && !isRamping ? rampingBuildId : undefined,
+  );
+
   let expanded = $state(false);
   let showSetCurrentModal = $state(false);
   let setCurrentError = $state('');
@@ -153,6 +163,9 @@
   let showValidateModal = $state(false);
   let validateLoading = $state(false);
   let validateResult = $state<{ message?: string } | null>(null);
+  let showSetRampingModal = $state(false);
+  let setRampingError = $state('');
+  let rampingPercentage = $state(0);
 
   async function handleValidateConnection() {
     validateResult = null;
@@ -200,6 +213,62 @@
     toaster.push({
       variant: 'primary',
       message: translate('deployments.set-current-version-success', {
+        buildId: versionBuildId,
+      }),
+    });
+    onChange?.();
+  }
+
+  function openSetRamping() {
+    rampingPercentage = isRamping
+      ? (routingConfig.rampingVersionPercentage ?? 0)
+      : 0;
+    setRampingError = '';
+    showSetRampingModal = true;
+  }
+
+  async function handleSetRamping() {
+    setRampingError = '';
+    await setRampingDeploymentVersion(
+      {
+        namespace,
+        deploymentName,
+        buildId: versionBuildId,
+        rampingVersionPercentage: rampingPercentage,
+      },
+      (err) => {
+        setRampingError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.set-ramping-error');
+      },
+    );
+    if (setRampingError) return;
+    showSetRampingModal = false;
+    toaster.push({
+      variant: 'primary',
+      message: translate('deployments.set-ramping-success', {
+        buildId: versionBuildId,
+        percentage: rampingPercentage,
+      }),
+    });
+    onChange?.();
+  }
+
+  async function handleRemoveRamping() {
+    setRampingError = '';
+    await removeRampingDeploymentVersion(
+      { namespace, deploymentName },
+      (err) => {
+        setRampingError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.remove-ramping-error');
+      },
+    );
+    if (setRampingError) return;
+    showSetRampingModal = false;
+    toaster.push({
+      variant: 'primary',
+      message: translate('deployments.remove-ramping-success', {
         buildId: versionBuildId,
       }),
     });
@@ -274,7 +343,9 @@
     hasComputeConfig={isVersionSummaryNew(version)
       ? !!version.computeConfig
       : true}
+    {isRamping}
     onSetCurrent={() => (showSetCurrentModal = true)}
+    onSetRamping={openSetRamping}
     onValidate={handleValidateConnection}
     onDelete={() => (showDeleteVersionModal = true)}
   />
@@ -302,6 +373,24 @@
   onCancel={() => {
     showSetCurrentModal = false;
     setCurrentError = '';
+  }}
+/>
+
+<SetRampingVersionModal
+  buildId={versionBuildId}
+  {deploymentName}
+  open={showSetRampingModal}
+  error={setRampingError}
+  {hasActivePollers}
+  {isRamping}
+  existingRampingBuildId={otherVersionRamping}
+  existingRampingPercentage={routingConfig.rampingVersionPercentage}
+  bind:percentage={rampingPercentage}
+  onConfirm={handleSetRamping}
+  onRemove={handleRemoveRamping}
+  onCancel={() => {
+    showSetRampingModal = false;
+    setRampingError = '';
   }}
 />
 

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -80,6 +80,21 @@ export const Strings = {
   'set-as-current': 'Set Current Version',
   'set-as-current-error': 'Failed to set version as current',
   'set-current-version-success': '{{ buildId }} is now the current version',
+  'set-ramping-version': 'Set Ramping Version',
+  'edit-ramping-percentage': 'Edit Ramping Percentage',
+  'remove-ramping': 'Remove Ramping',
+  'set-ramping-no-pollers-title': 'Cannot Set Ramping Version',
+  'set-ramping-no-pollers-body':
+    'This Worker Deployment Version has no active pollers. Ensure Workers are running before setting a ramping percentage',
+  'set-ramping-body':
+    'This will route a percentage of new traffic to Build ID {{ buildId }} for {{ deploymentName }}. The Current Version will continue to receive the remaining traffic.',
+  'set-ramping-existing':
+    'Worker Deployment Version {{ buildId }} is currently ramping at {{ percentage }}%.',
+  'ramping-percentage-label': 'Ramping Percentage',
+  'set-ramping-success': '{{ buildId }} is now ramping at {{ percentage }}%',
+  'set-ramping-error': 'Failed to set ramping version',
+  'remove-ramping-success': 'Ramping removed from {{ buildId }}',
+  'remove-ramping-error': 'Failed to remove ramping version',
   edit: 'Edit',
   'validate-connection': 'Validate Connection for',
   'validate-connection-error': 'Failed to validate connection',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -89,7 +89,7 @@ export const Strings = {
   'set-ramping-body':
     'This will route a percentage of new traffic to Build ID {{ buildId }} for {{ deploymentName }}. The Current Version will continue to receive the remaining traffic.',
   'set-ramping-existing':
-    'Worker Deployment Version {{ buildId }} is currently ramping at {{ percentage }}%.',
+    'Worker Deployment Version {{ version }} is currently ramping at {{ percentage }}%.',
   'ramping-percentage-label': 'Ramping Percentage',
   'set-ramping-success': '{{ buildId }} is now ramping at {{ percentage }}%',
   'set-ramping-error': 'Failed to set ramping version',

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -227,7 +227,10 @@ export const setCurrentDeploymentVersion = async (
 };
 
 export const setRampingDeploymentVersion = async (
-  request: DeploymentVersionParameters & { rampingVersionPercentage: number },
+  request: DeploymentVersionParameters & {
+    rampingVersionPercentage: number;
+    conflictToken?: string;
+  },
   onError?: ErrorCallback,
 ): Promise<void> => {
   const route = routeForApi('worker-deployment-set-ramping-version', {
@@ -238,8 +241,11 @@ export const setRampingDeploymentVersion = async (
     options: {
       method: 'POST',
       body: stringifyWithBigInt({
-        build_id: request.buildId,
+        buildId: request.buildId,
         percentage: request.rampingVersionPercentage,
+        ...(request.conflictToken
+          ? { conflictToken: request.conflictToken }
+          : {}),
       }),
     },
     onError,
@@ -247,14 +253,19 @@ export const setRampingDeploymentVersion = async (
 };
 
 export const removeRampingDeploymentVersion = async (
-  request: DeploymentParameters,
+  request: DeploymentParameters & { conflictToken?: string },
   onError?: ErrorCallback,
 ): Promise<void> => {
   const route = routeForApi('worker-deployment-set-ramping-version', request);
   await requestFromAPI<unknown>(route, {
     options: {
       method: 'POST',
-      body: stringifyWithBigInt({ build_id: '' }),
+      body: stringifyWithBigInt({
+        buildId: '',
+        ...(request.conflictToken
+          ? { conflictToken: request.conflictToken }
+          : {}),
+      }),
     },
     onError,
   });

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -238,8 +238,8 @@ export const setRampingDeploymentVersion = async (
     options: {
       method: 'POST',
       body: stringifyWithBigInt({
-        version: `${request.deploymentName}.${request.buildId}`,
-        rampingVersionPercentage: request.rampingVersionPercentage,
+        build_id: request.buildId,
+        percentage: request.rampingVersionPercentage,
       }),
     },
     onError,
@@ -254,7 +254,7 @@ export const removeRampingDeploymentVersion = async (
   await requestFromAPI<unknown>(route, {
     options: {
       method: 'POST',
-      body: stringifyWithBigInt({ version: '' }),
+      body: stringifyWithBigInt({ build_id: '' }),
     },
     onError,
   });

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -226,6 +226,40 @@ export const setCurrentDeploymentVersion = async (
   });
 };
 
+export const setRampingDeploymentVersion = async (
+  request: DeploymentVersionParameters & { rampingVersionPercentage: number },
+  onError?: ErrorCallback,
+): Promise<void> => {
+  const route = routeForApi('worker-deployment-set-ramping-version', {
+    namespace: request.namespace,
+    deploymentName: request.deploymentName,
+  });
+  await requestFromAPI<unknown>(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({
+        version: `${request.deploymentName}.${request.buildId}`,
+        rampingVersionPercentage: request.rampingVersionPercentage,
+      }),
+    },
+    onError,
+  });
+};
+
+export const removeRampingDeploymentVersion = async (
+  request: DeploymentParameters,
+  onError?: ErrorCallback,
+): Promise<void> => {
+  const route = routeForApi('worker-deployment-set-ramping-version', request);
+  await requestFromAPI<unknown>(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({ version: '' }),
+    },
+    onError,
+  });
+};
+
 export const buildLambdaComputeConfig = (
   lambdaArn: string,
   iamRoleArn: string,

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -57,7 +57,8 @@ export type NexusAPIRoutePath = 'nexus-endpoint' | 'nexus-endpoint.update';
 export type WorkerDeploymentsAPIRoutePath = 'worker-deployments';
 export type WorkerDeploymentAPIRoutePath =
   | 'worker-deployment'
-  | 'worker-deployment-set-current-version';
+  | 'worker-deployment-set-current-version'
+  | 'worker-deployment-set-ramping-version';
 export type WorkerDeploymentVersionAPIRoutePath =
   | 'worker-deployment-version'
   | 'worker-deployment-version-compute-config'

--- a/src/lib/utilities/route-for-api.ts
+++ b/src/lib/utilities/route-for-api.ts
@@ -190,6 +190,7 @@ export function pathForApi(
     'worker-deployment-version-compute-config': `/namespaces/${parameters?.namespace}/worker-deployment-versions/${parameters?.deploymentName}/${parameters?.buildId}/update-compute-config`,
     'worker-deployment-version-validate-compute-config': `/namespaces/${parameters?.namespace}/worker-deployment-versions/${parameters?.deploymentName}/${parameters?.buildId}/validate-compute-config`,
     'worker-deployment-set-current-version': `/namespaces/${parameters?.namespace}/worker-deployments/${parameters?.deploymentName}/set-current-version`,
+    'worker-deployment-set-ramping-version': `/namespaces/${parameters?.namespace}/worker-deployments/${parameters?.deploymentName}/set-ramping-version`,
     'standalone-activity': `/namespaces/${parameters?.namespace}/activities/${parameters?.activityId}`,
     'standalone-activities': `/namespaces/${parameters?.namespace}/activities`,
     'standalone-activities.count': `/namespaces/${parameters?.namespace}/activity-count`,


### PR DESCRIPTION
## Summary

- Adds **Set Ramping Version** action to the Worker Deployment Version actions menu, matching CLI parity
- New `SetRampingVersionModal` with percentage input (0–100%), a no-active-pollers guard modal, a remove-ramping destructive button, and a warning when replacing an existing ramping version
- New `setRampingDeploymentVersion` and `removeRampingDeploymentVersion` service functions posting to the `set-ramping-version` API endpoint
- Extends `VersionActionsMenu` with a context-sensitive menu item ("Set Ramping Version" or "Edit Ramping Percentage")

<img width="800" height="547" alt="CleanShot 2026-06-08 at 13 41 29" src="https://github.com/user-attachments/assets/47f82841-8cfa-4065-842e-5f36c561d23b" />

## Test plan

- [ ] Version with no active pollers → menu item opens info modal explaining pollers are required
- [ ] Version with active pollers → modal shows percentage input and "Set Ramping Version" confirm
- [ ] Setting a ramping percentage shows success toast and refreshes the table
- [ ] When a different version is already ramping, modal warns about the replacement
- [ ] "Remove Ramping" button appears only for the currently-ramping version and removes it on click
- [ ] "Edit Ramping Percentage" label shown for the currently-ramping version
- [ ] `confirmDisabled` when percentage is NaN, < 0, or > 100
- [ ] Current version does not show the ramping menu item