### PR TITLE
feat(DT-4077): add delete Worker Deployment action

### DIFF
--- a/src/lib/components/deployments/delete-deployment-modal.svelte
+++ b/src/lib/components/deployments/delete-deployment-modal.svelte
@@ -1,23 +1,52 @@
 <script lang="ts">
   import DeleteConfirmModal from '$lib/components/delete-confirmation-modal.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
 
   interface Props {
     open: boolean;
     deploymentName: string;
+    hasVersions: boolean;
+    error?: string;
     onConfirm?: () => void;
     onCancel?: () => void;
   }
 
-  let { open, deploymentName, onConfirm, onCancel }: Props = $props();
+  let {
+    open,
+    deploymentName,
+    hasVersions,
+    error = '',
+    onConfirm,
+    onCancel,
+  }: Props = $props();
 </script>
 
-<DeleteConfirmModal
-  id="delete-deployment-modal"
-  {open}
-  title={translate('deployments.delete-deployment')}
-  description={translate('deployments.delete-deployment-description')}
-  entityName={deploymentName}
-  {onConfirm}
-  {onCancel}
-/>
+{#if hasVersions}
+  <Modal
+    id="delete-deployment-modal"
+    {open}
+    confirmText=""
+    cancelText={translate('common.close')}
+    hideConfirm
+    on:cancelModal={onCancel}
+  >
+    <h3 slot="title">{translate('deployments.cannot-delete-deployment')}</h3>
+    <div slot="content">
+      <p class="text-sm">
+        {translate('deployments.cannot-delete-deployment-body')}
+      </p>
+    </div>
+  </Modal>
+{:else}
+  <DeleteConfirmModal
+    id="delete-deployment-modal"
+    {open}
+    {error}
+    title={translate('deployments.delete-deployment')}
+    description={translate('deployments.delete-deployment-description')}
+    entityName={deploymentName}
+    {onConfirm}
+    {onCancel}
+  />
+{/if}

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -4,8 +4,14 @@
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
+  import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import MenuButton from '$lib/holocene/menu/menu-button.svelte';
+  import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
+  import MenuItem from '$lib/holocene/menu/menu-item.svelte';
+  import Menu from '$lib/holocene/menu/menu.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { deleteWorkerDeployment } from '$lib/services/deployments-service';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { WorkerDeploymentSummary } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
@@ -15,13 +21,38 @@
   } from '$lib/utilities/route-for';
 
   import ComputeBadge from './compute-badge.svelte';
+  import DeleteDeploymentModal from './delete-deployment-modal.svelte';
   import DeploymentStatus from './deployment-status.svelte';
 
   interface Props {
     deployment: WorkerDeploymentSummary;
     columns: ConfigurableTableHeader[];
+    onChange?: () => void;
   }
-  let { deployment, columns }: Props = $props();
+  let { deployment, columns, onChange }: Props = $props();
+
+  const namespace = $derived(page.params.namespace);
+  const hasVersions = $derived(
+    !!deployment.latestVersionSummary?.deploymentVersion,
+  );
+
+  let showDeleteModal = $state(false);
+  let deleteError = $state('');
+
+  async function handleDelete() {
+    deleteError = '';
+    await deleteWorkerDeployment(
+      { namespace, deploymentName: deployment.name },
+      (err) => {
+        deleteError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.delete-deployment-confirm-error');
+      },
+    );
+    if (deleteError) return;
+    showDeleteModal = false;
+    onChange?.();
+  }
 
   const latestBuildId = $derived(
     deployment?.latestVersionSummary?.deploymentVersion?.buildId,
@@ -104,4 +135,38 @@
       </td>
     {/if}
   {/each}
+  <td class="w-24 whitespace-pre-line break-words">
+    <MenuContainer>
+      <MenuButton
+        label={translate('deployments.actions')}
+        controls="deployment-actions-{deployment.name}"
+        variant="ghost"
+        size="xs"
+        class="flex h-8 w-8 items-center justify-center"
+      >
+        <Icon name="vertical-ellipsis" class="h-4 w-4" />
+      </MenuButton>
+      <Menu
+        id="deployment-actions-{deployment.name}"
+        position="right"
+        usePortal
+      >
+        <MenuItem onclick={() => (showDeleteModal = true)} destructive>
+          {translate('common.delete')}
+        </MenuItem>
+      </Menu>
+    </MenuContainer>
+  </td>
 </tr>
+
+<DeleteDeploymentModal
+  open={showDeleteModal}
+  deploymentName={deployment.name}
+  {hasVersions}
+  error={deleteError}
+  onConfirm={handleDelete}
+  onCancel={() => {
+    showDeleteModal = false;
+    deleteError = '';
+  }}
+/>

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -62,11 +62,14 @@ export const Strings = {
   'edit-version': 'Edit Version',
   'view-workflows': 'View Workflows',
   'create-new-version': 'Create New Version',
-  'delete-deployment': 'Delete Deployment',
+  'delete-deployment': 'Delete Worker Deployment',
   'delete-deployment-description':
-    'This action cannot be undone. The deployment and all its configuration will be permanently deleted.',
+    "Deleting this deployment will permanently remove all its versions and configuration. This action can't be undone.",
   'delete-deployment-confirm-instruction': 'Type DELETE to confirm',
   'delete-deployment-confirm-error': 'Failed to delete deployment',
+  'cannot-delete-deployment': 'Cannot Delete Worker Deployment',
+  'cannot-delete-deployment-body':
+    'All Versions must be deleted before this Deployment can be removed. Delete each Version first, then try again.',
   'role-external-id': 'External ID',
   'scale-up-cooloff': 'Scale-up Cooloff',
   'backlog-threshold': 'Backlog Threshold',

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -181,6 +181,8 @@
   <DeleteDeploymentModal
     open={showDeleteModal}
     {deploymentName}
+    hasVersions={!!info.versionSummaries?.length}
+    error={deleteError}
     onConfirm={() => handleDeleteDeployment(deployment.conflictToken)}
     onCancel={() => (showDeleteModal = false)}
   />

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -61,9 +61,14 @@
         {#each columns as { label } (label)}
           <th>{label}</th>
         {/each}
+        <th>{translate('deployments.actions')}</th>
       </tr>
       {#each visibleItems as deployment}
-        <DeploymentTableRow {deployment} {columns} />
+        <DeploymentTableRow
+          {deployment}
+          {columns}
+          onChange={() => refresh.update((n) => n + 1)}
+        />
       {/each}
 
       <svelte:fragment slot="empty">


### PR DESCRIPTION
## Summary
- Adds a kebab actions menu to the Worker Deployments list with a Delete item
- Shows a blocked modal ("Cannot Delete Worker Deployment") when the deployment has versions, directing the user to delete each version first
- Shows a destructive confirm modal (requiring the user to type `DELETE`) when all versions have been removed
- Refreshes the deployments list after a successful delete

## Notes
- Deleting the current version to reach an empty deployment requires unsetting it to "unversioned" first — that path will be addressed in DT-4079

## Test plan
- [ ] Deployments list shows a ⋮ actions column with a Delete item per row
- [ ] Clicking Delete on a deployment with versions shows the blocked modal (no confirm button)
- [ ] Clicking Delete on a deployment with no versions shows the destructive confirm modal
- [ ] Typing `DELETE` and confirming removes the deployment and refreshes the list
- [ ] Errors from the API surface in the modal