### PR TITLE
feat(DT-4079): miscellaneous WD UI fixes

### DIFF
--- a/src/lib/components/deployments/compute-badge.svelte
+++ b/src/lib/components/deployments/compute-badge.svelte
@@ -12,9 +12,13 @@
 </script>
 
 {#if config}
-  <div class="flex items-center gap-1 text-primary">
-    <Icon name={config.icon} class="h-4 w-4" />
-    {config.label}
+  <div class="flex items-center gap-1">
+    <span
+      class="surface-primary flex items-center rounded border border-subtle p-0.5"
+    >
+      <Icon name={config.icon} class="h-4 w-4" />
+    </span>
+    <span class="text-primary">{config.label}</span>
   </div>
 {:else}
   <span class="text-secondary">—</span>

--- a/src/lib/components/deployments/compute-badge.svelte
+++ b/src/lib/components/deployments/compute-badge.svelte
@@ -12,9 +12,7 @@
 </script>
 
 {#if config}
-  <div
-    class="flex items-center gap-1 rounded-sm border border-subtle px-1 text-primary"
-  >
+  <div class="flex items-center gap-1 text-primary">
     <Icon name={config.icon} class="h-4 w-4" />
     {config.label}
   </div>

--- a/src/lib/components/deployments/delete-deployment-modal.svelte
+++ b/src/lib/components/deployments/delete-deployment-modal.svelte
@@ -44,7 +44,9 @@
     {open}
     {error}
     title={translate('deployments.delete-deployment')}
-    description={translate('deployments.delete-deployment-description')}
+    description={translate('deployments.delete-deployment-description', {
+      name: deploymentName,
+    })}
     entityName={deploymentName}
     {onConfirm}
     {onCancel}

--- a/src/lib/components/deployments/delete-deployment-modal.svelte
+++ b/src/lib/components/deployments/delete-deployment-modal.svelte
@@ -1,23 +1,52 @@
 <script lang="ts">
   import DeleteConfirmModal from '$lib/components/delete-confirmation-modal.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
 
   interface Props {
     open: boolean;
     deploymentName: string;
+    hasVersions: boolean;
+    error?: string;
     onConfirm?: () => void;
     onCancel?: () => void;
   }
 
-  let { open, deploymentName, onConfirm, onCancel }: Props = $props();
+  let {
+    open,
+    deploymentName,
+    hasVersions,
+    error = '',
+    onConfirm,
+    onCancel,
+  }: Props = $props();
 </script>
 
-<DeleteConfirmModal
-  id="delete-deployment-modal"
-  {open}
-  title={translate('deployments.delete-deployment')}
-  description={translate('deployments.delete-deployment-description')}
-  entityName={deploymentName}
-  {onConfirm}
-  {onCancel}
-/>
+{#if hasVersions}
+  <Modal
+    id="delete-deployment-modal"
+    {open}
+    confirmText=""
+    cancelText={translate('common.close')}
+    hideConfirm
+    on:cancelModal={onCancel}
+  >
+    <h3 slot="title">{translate('deployments.cannot-delete-deployment')}</h3>
+    <div slot="content">
+      <p class="text-sm">
+        {translate('deployments.cannot-delete-deployment-body')}
+      </p>
+    </div>
+  </Modal>
+{:else}
+  <DeleteConfirmModal
+    id="delete-deployment-modal"
+    {open}
+    {error}
+    title={translate('deployments.delete-deployment')}
+    description={translate('deployments.delete-deployment-description')}
+    entityName={deploymentName}
+    {onConfirm}
+    {onCancel}
+  />
+{/if}

--- a/src/lib/components/deployments/deployment-header.svelte
+++ b/src/lib/components/deployments/deployment-header.svelte
@@ -2,6 +2,10 @@
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import Button from '$lib/holocene/button.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import MenuButton from '$lib/holocene/menu/menu-button.svelte';
+  import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
+  import MenuItem from '$lib/holocene/menu/menu-item.svelte';
+  import Menu from '$lib/holocene/menu/menu.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     routeForWorkerDeployments,
@@ -13,17 +17,17 @@
   interface Props {
     namespace: string;
     deploymentName: string;
-    hasVersions: boolean;
     showInstancesLink?: boolean;
     onDeleteClick: () => void;
+    onRampToUnversioned: () => void;
   }
 
   let {
     namespace,
     deploymentName,
-    hasVersions,
     showInstancesLink = true,
     onDeleteClick,
+    onRampToUnversioned,
   }: Props = $props();
 
   const workflowHref = $derived(
@@ -56,10 +60,7 @@
 
   <div class="flex w-full items-center justify-between">
     <h1>{deploymentName}</h1>
-    <div class="flex items-center gap-4">
-      <Button variant="secondary" href={workflowHref}>
-        {translate('deployments.view-workflows')}
-      </Button>
+    <div class="flex items-center gap-2">
       <CapabilityGuard capability="serverScaledDeployments">
         <Button
           href={routeForWorkerDeploymentVersionCreate({
@@ -70,13 +71,30 @@
           {translate('deployments.create-new-version')}
         </Button>
       </CapabilityGuard>
-      {#if !hasVersions}
-        <CapabilityGuard capability="serverScaledDeployments">
-          <Button variant="destructive" on:click={onDeleteClick}>
-            {translate('deployments.delete-deployment')}
-          </Button>
-        </CapabilityGuard>
-      {/if}
+      <MenuContainer>
+        <MenuButton
+          controls="deployment-header-actions"
+          variant="secondary"
+          hasIndicator
+        >
+          {translate('deployments.more-actions')}
+        </MenuButton>
+        <Menu id="deployment-header-actions" position="right" usePortal>
+          <MenuItem href={workflowHref}>
+            {translate('deployments.view-workflows')}
+          </MenuItem>
+          <CapabilityGuard capability="serverScaledDeployments">
+            <MenuItem onclick={onRampToUnversioned}>
+              {translate('deployments.ramp-to-unversioned')}
+            </MenuItem>
+          </CapabilityGuard>
+          <CapabilityGuard capability="serverScaledDeployments">
+            <MenuItem onclick={onDeleteClick} destructive>
+              {translate('deployments.delete-deployment')}
+            </MenuItem>
+          </CapabilityGuard>
+        </Menu>
+      </MenuContainer>
     </div>
   </div>
 </header>

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -11,7 +11,10 @@
   import MenuItem from '$lib/holocene/menu/menu-item.svelte';
   import Menu from '$lib/holocene/menu/menu.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { deleteWorkerDeployment } from '$lib/services/deployments-service';
+  import {
+    deleteWorkerDeployment,
+    fetchDeployment,
+  } from '$lib/services/deployments-service';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { WorkerDeploymentSummary } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
@@ -38,11 +41,21 @@
 
   let showDeleteModal = $state(false);
   let deleteError = $state('');
+  let conflictToken = $state<string | undefined>(undefined);
+
+  async function openDeleteModal() {
+    showDeleteModal = true;
+    const result = await fetchDeployment({
+      namespace,
+      deploymentName: deployment.name,
+    });
+    conflictToken = result.conflictToken;
+  }
 
   async function handleDelete() {
     deleteError = '';
     await deleteWorkerDeployment(
-      { namespace, deploymentName: deployment.name },
+      { namespace, deploymentName: deployment.name, conflictToken },
       (err) => {
         deleteError =
           (err as { body?: { message?: string } })?.body?.message ??
@@ -151,7 +164,7 @@
         position="right"
         usePortal
       >
-        <MenuItem onclick={() => (showDeleteModal = true)} destructive>
+        <MenuItem onclick={openDeleteModal} destructive>
           {translate('common.delete')}
         </MenuItem>
       </Menu>

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -4,8 +4,14 @@
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
+  import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import MenuButton from '$lib/holocene/menu/menu-button.svelte';
+  import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
+  import MenuItem from '$lib/holocene/menu/menu-item.svelte';
+  import Menu from '$lib/holocene/menu/menu.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { deleteWorkerDeployment } from '$lib/services/deployments-service';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { WorkerDeploymentSummary } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
@@ -15,13 +21,38 @@
   } from '$lib/utilities/route-for';
 
   import ComputeBadge from './compute-badge.svelte';
+  import DeleteDeploymentModal from './delete-deployment-modal.svelte';
   import DeploymentStatus from './deployment-status.svelte';
 
   interface Props {
     deployment: WorkerDeploymentSummary;
     columns: ConfigurableTableHeader[];
+    onChange?: () => void;
   }
-  let { deployment, columns }: Props = $props();
+  let { deployment, columns, onChange }: Props = $props();
+
+  const namespace = $derived(page.params.namespace);
+  const hasVersions = $derived(
+    !!deployment.latestVersionSummary?.deploymentVersion,
+  );
+
+  let showDeleteModal = $state(false);
+  let deleteError = $state('');
+
+  async function handleDelete() {
+    deleteError = '';
+    await deleteWorkerDeployment(
+      { namespace, deploymentName: deployment.name },
+      (err) => {
+        deleteError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.delete-deployment-confirm-error');
+      },
+    );
+    if (deleteError) return;
+    showDeleteModal = false;
+    onChange?.();
+  }
 
   const latestBuildId = $derived(
     deployment?.latestVersionSummary?.deploymentVersion?.buildId,
@@ -104,4 +135,38 @@
       </td>
     {/if}
   {/each}
+  <td class="w-24 whitespace-pre-line break-words">
+    <MenuContainer>
+      <MenuButton
+        label={translate('deployments.actions')}
+        controls="deployment-actions-{deployment.name}"
+        variant="ghost"
+        size="xs"
+        class="flex h-8 w-8 items-center justify-center"
+      >
+        <Icon name="vertical-ellipsis" class="h-4 w-4" />
+      </MenuButton>
+      <Menu
+        id="deployment-actions-{deployment.name}"
+        position="right"
+        usePortal
+      >
+        <MenuItem onclick={() => (showDeleteModal = true)} destructive>
+          {translate('common.delete')}
+        </MenuItem>
+      </Menu>
+    </MenuContainer>
+  </td>
 </tr>
+
+<DeleteDeploymentModal
+  open={showDeleteModal}
+  deploymentName={deployment.name}
+  {hasVersions}
+  error={deleteError}
+  onConfirm={handleDelete}
+  onCancel={() => {
+    showDeleteModal = false;
+    deleteError = '';
+  }}
+/>

--- a/src/lib/components/deployments/ramp-unversioned-modal.svelte
+++ b/src/lib/components/deployments/ramp-unversioned-modal.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import NumberInput from '$lib/holocene/input/number-input.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
+  import { translate } from '$lib/i18n/translate';
+
+  interface Props {
+    open: boolean;
+    percentage?: number;
+    error?: string;
+    onConfirm?: (percentage: number) => void;
+    onCancel?: () => void;
+  }
+
+  let {
+    open,
+    percentage = $bindable(0),
+    error = '',
+    onConfirm,
+    onCancel,
+  }: Props = $props();
+</script>
+
+<Modal
+  id="ramp-unversioned-modal"
+  {open}
+  confirmText={translate('common.confirm')}
+  cancelText={translate('common.cancel')}
+  on:confirmModal={() => onConfirm?.(percentage)}
+  on:cancelModal={onCancel}
+>
+  <h3 slot="title">{translate('deployments.ramp-to-unversioned')}</h3>
+  <div slot="content" class="flex flex-col gap-4">
+    <p class="text-sm">
+      {translate('deployments.ramp-to-unversioned-description')}
+    </p>
+    <NumberInput
+      id="unversioned-ramping-percentage"
+      label={translate('deployments.ramping-percentage', {
+        percentage: '',
+      }).trim()}
+      bind:value={percentage}
+      min={0}
+      max={100}
+      units="%"
+    />
+    {#if error}
+      <p class="text-sm text-danger">{error}</p>
+    {/if}
+  </div>
+</Modal>

--- a/src/lib/components/deployments/ramp-unversioned-modal.svelte
+++ b/src/lib/components/deployments/ramp-unversioned-modal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Button from '$lib/holocene/button.svelte';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -9,6 +10,7 @@
     error?: string;
     onConfirm?: (percentage: number) => void;
     onCancel?: () => void;
+    onRemove?: () => void;
   }
 
   let {
@@ -17,6 +19,7 @@
     error = '',
     onConfirm,
     onCancel,
+    onRemove,
   }: Props = $props();
 </script>
 
@@ -28,6 +31,15 @@
   on:confirmModal={() => onConfirm?.(percentage)}
   on:cancelModal={onCancel}
 >
+  <Button
+    slot="footer"
+    variant="destructive"
+    size="sm"
+    class={!onRemove ? 'invisible' : ''}
+    on:click={onRemove}
+  >
+    {translate('deployments.remove-unversioned-ramping')}
+  </Button>
   <h3 slot="title">{translate('deployments.ramp-to-unversioned')}</h3>
   <div slot="content" class="flex flex-col gap-4">
     <p class="text-sm">

--- a/src/lib/components/deployments/ramp-unversioned-modal.svelte
+++ b/src/lib/components/deployments/ramp-unversioned-modal.svelte
@@ -31,15 +31,11 @@
   on:confirmModal={() => onConfirm?.(percentage)}
   on:cancelModal={onCancel}
 >
-  <Button
-    slot="footer"
-    variant="destructive"
-    size="sm"
-    class={!onRemove ? 'invisible' : ''}
-    on:click={onRemove}
-  >
-    {translate('deployments.remove-unversioned-ramping')}
-  </Button>
+  {#if onRemove}
+    <Button slot="footer" variant="destructive" size="sm" on:click={onRemove}>
+      {translate('deployments.remove-unversioned-ramping')}
+    </Button>
+  {/if}
   <h3 slot="title">{translate('deployments.ramp-to-unversioned')}</h3>
   <div slot="content" class="flex flex-col gap-4">
     <p class="text-sm">

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -53,9 +53,11 @@
       </CapabilityGuard>
       <CapabilityGuard capability="serverScaledDeployments">
         {#if hasComputeConfig}
-          <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
-            {translate('deployments.set-as-current')}
-          </MenuItem>
+          {#if !isCurrent}
+            <MenuItem onclick={onSetCurrent}>
+              {translate('deployments.set-as-current')}
+            </MenuItem>
+          {/if}
           <MenuItem onclick={onSetRamping} disabled={isCurrent}>
             {isRamping
               ? translate('deployments.edit-ramping-percentage')
@@ -66,9 +68,11 @@
           </MenuItem>
         {/if}
         {#snippet fallback()}
-          <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
-            {translate('deployments.set-as-current')}
-          </MenuItem>
+          {#if !isCurrent}
+            <MenuItem onclick={onSetCurrent}>
+              {translate('deployments.set-as-current')}
+            </MenuItem>
+          {/if}
           <MenuItem onclick={onSetRamping} disabled={isCurrent}>
             {isRamping
               ? translate('deployments.edit-ramping-percentage')

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -16,6 +16,7 @@
     isRamping: boolean;
     onSetCurrent: () => void;
     onSetRamping: () => void;
+    onUnsetCurrent: () => void;
     onValidate: () => void;
     onDelete: () => void;
   }
@@ -29,6 +30,7 @@
     isRamping,
     onSetCurrent,
     onSetRamping,
+    onUnsetCurrent,
     onValidate,
     onDelete,
   }: Props = $props();
@@ -53,7 +55,11 @@
       </CapabilityGuard>
       <CapabilityGuard capability="serverScaledDeployments">
         {#if hasComputeConfig}
-          {#if !isCurrent}
+          {#if isCurrent}
+            <MenuItem onclick={onUnsetCurrent}>
+              {translate('deployments.unset-current')}
+            </MenuItem>
+          {:else}
             <MenuItem onclick={onSetCurrent}>
               {translate('deployments.set-as-current')}
             </MenuItem>
@@ -68,7 +74,11 @@
           </MenuItem>
         {/if}
         {#snippet fallback()}
-          {#if !isCurrent}
+          {#if isCurrent}
+            <MenuItem onclick={onUnsetCurrent}>
+              {translate('deployments.unset-current')}
+            </MenuItem>
+          {:else}
             <MenuItem onclick={onSetCurrent}>
               {translate('deployments.set-as-current')}
             </MenuItem>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -4,6 +4,7 @@
   import Copyable from '$lib/holocene/copyable/index.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     deleteWorkerDeploymentVersion,
@@ -161,6 +162,8 @@
   let expanded = $state(false);
   let showSetCurrentModal = $state(false);
   let setCurrentError = $state('');
+  let showUnsetCurrentModal = $state(false);
+  let unsetCurrentError = $state('');
   let showDeleteVersionModal = $state(false);
   let deleteVersionError = $state('');
   let showValidateModal = $state(false);
@@ -243,7 +246,17 @@
   }
 
   async function handleUnsetCurrentVersion() {
-    await unsetCurrentDeploymentVersion({ namespace, deploymentName });
+    unsetCurrentError = '';
+    await unsetCurrentDeploymentVersion(
+      { namespace, deploymentName },
+      (err) => {
+        unsetCurrentError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.unset-current-error');
+      },
+    );
+    if (unsetCurrentError) return;
+    showUnsetCurrentModal = false;
     onChange?.();
   }
 
@@ -385,7 +398,7 @@
     {isRamping}
     onSetCurrent={() => (showSetCurrentModal = true)}
     onSetRamping={openSetRamping}
-    onUnsetCurrent={handleUnsetCurrentVersion}
+    onUnsetCurrent={() => (showUnsetCurrentModal = true)}
     onValidate={handleValidateConnection}
     onDelete={() => (showDeleteVersionModal = true)}
   />
@@ -457,3 +470,23 @@
     deleteVersionError = '';
   }}
 />
+
+<Modal
+  id="unset-current-version-modal"
+  open={showUnsetCurrentModal}
+  confirmText={translate('common.confirm')}
+  cancelText={translate('common.cancel')}
+  on:confirmModal={handleUnsetCurrentVersion}
+  on:cancelModal={() => {
+    showUnsetCurrentModal = false;
+    unsetCurrentError = '';
+  }}
+>
+  <h3 slot="title">{translate('deployments.unset-current')}</h3>
+  <div slot="content" class="flex flex-col gap-4">
+    <p class="text-sm">{translate('deployments.unset-current-description')}</p>
+    {#if unsetCurrentError}
+      <p class="text-sm text-danger">{unsetCurrentError}</p>
+    {/if}
+  </div>
+</Modal>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -11,6 +11,7 @@
     removeRampingDeploymentVersion,
     setCurrentDeploymentVersion,
     setRampingDeploymentVersion,
+    unsetCurrentDeploymentVersion,
     validateWorkerDeploymentVersionComputeConfig,
   } from '$lib/services/deployments-service';
   import { toaster } from '$lib/stores/toaster';
@@ -241,6 +242,11 @@
     onChange?.();
   }
 
+  async function handleUnsetCurrentVersion() {
+    await unsetCurrentDeploymentVersion({ namespace, deploymentName });
+    onChange?.();
+  }
+
   function openSetRamping() {
     rampingPercentage = isRamping
       ? (routingConfig.rampingVersionPercentage ?? 0)
@@ -379,6 +385,7 @@
     {isRamping}
     onSetCurrent={() => (showSetCurrentModal = true)}
     onSetRamping={openSetRamping}
+    onUnsetCurrent={handleUnsetCurrentVersion}
     onValidate={handleValidateConnection}
     onDelete={() => (showDeleteVersionModal = true)}
   />

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -248,7 +248,7 @@
   async function handleUnsetCurrentVersion() {
     unsetCurrentError = '';
     await unsetCurrentDeploymentVersion(
-      { namespace, deploymentName },
+      { namespace, deploymentName, conflictToken },
       (err) => {
         unsetCurrentError =
           (err as { body?: { message?: string } })?.body?.message ??

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -62,11 +62,14 @@ export const Strings = {
   'edit-version': 'Edit Version',
   'view-workflows': 'View Workflows',
   'create-new-version': 'Create New Version',
-  'delete-deployment': 'Delete Deployment',
+  'delete-deployment': 'Delete Worker Deployment',
   'delete-deployment-description':
-    'This action cannot be undone. The deployment and all its configuration will be permanently deleted.',
+    "Deleting this deployment will permanently remove all its versions and configuration. This action can't be undone.",
   'delete-deployment-confirm-instruction': 'Type DELETE to confirm',
   'delete-deployment-confirm-error': 'Failed to delete deployment',
+  'cannot-delete-deployment': 'Cannot Delete Worker Deployment',
+  'cannot-delete-deployment-body':
+    'All Versions must be deleted before this Deployment can be removed. Delete each Version first, then try again.',
   'role-external-id': 'External ID',
   'scale-up-cooloff': 'Scale-up Cooloff',
   'backlog-threshold': 'Backlog Threshold',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -64,7 +64,7 @@ export const Strings = {
   'create-new-version': 'Create New Version',
   'delete-deployment': 'Delete Worker Deployment',
   'delete-deployment-description':
-    "Deleting this deployment will permanently remove all its versions and configuration. This action can't be undone.",
+    "Deleting {{ name }} will permanently remove all its versions and configuration. This action can't be undone.",
   'delete-deployment-confirm-instruction': 'Type DELETE to confirm',
   'delete-deployment-confirm-error': 'Failed to delete deployment',
   'cannot-delete-deployment': 'Cannot Delete Worker Deployment',
@@ -91,6 +91,9 @@ export const Strings = {
   'set-as-current': 'Set Current Version',
   'set-as-current-error': 'Failed to set version as current',
   'unset-current': 'Unset Current',
+  'unset-current-description':
+    'This will remove the current version designation from this deployment.',
+  'unset-current-error': 'Failed to unset current version',
   'set-current-version-success': '{{ buildId }} is now the current version',
   'set-ramping-version': 'Set Ramping Version',
   'edit-ramping-percentage': 'Edit Ramping Percentage',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -86,6 +86,7 @@ export const Strings = {
     'Unversioned Workers Ramping at {{ percentage }}%.',
   'set-as-current': 'Set Current Version',
   'set-as-current-error': 'Failed to set version as current',
+  'unset-current': 'Unset Current',
   'set-current-version-success': '{{ buildId }} is now the current version',
   'set-ramping-version': 'Set Ramping Version',
   'edit-ramping-percentage': 'Edit Ramping Percentage',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -77,6 +77,13 @@ export const Strings = {
   'drainage-last-changed': 'Last Changed',
   'drainage-last-checked': 'Last Checked',
   metadata: 'Metadata',
+  'more-actions': 'More Actions',
+  'ramp-to-unversioned': 'Ramp to Unversioned Workers',
+  'ramp-to-unversioned-description':
+    'This will route a percentage of new traffic to unversioned Workers.',
+  'ramp-to-unversioned-error': 'Failed to set unversioned ramping',
+  'unversioned-ramping-banner':
+    'Unversioned Workers Ramping at {{ percentage }}%.',
   'set-as-current': 'Set Current Version',
   'set-as-current-error': 'Failed to set version as current',
   'set-current-version-success': '{{ buildId }} is now the current version',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -82,6 +82,7 @@ export const Strings = {
   'ramp-to-unversioned-description':
     'This will route a percentage of new traffic to unversioned Workers.',
   'ramp-to-unversioned-error': 'Failed to set unversioned ramping',
+  'remove-unversioned-ramping': 'Remove Unversioned Ramping',
   'unversioned-ramping-banner':
     'Unversioned Workers Ramping at {{ percentage }}%.',
   'set-as-current': 'Set Current Version',

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -8,7 +8,6 @@
   import RampUnversionedModal from '$lib/components/deployments/ramp-unversioned-modal.svelte';
   import VersionTableRow from '$lib/components/deployments/version-table-row.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
   import Error from '$lib/holocene/error.svelte';
   import SkeletonTable from '$lib/holocene/skeleton/table.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/paginated.svelte';
@@ -79,8 +78,17 @@
     reload();
   }
 
-  async function handleRemoveRampUnversioned() {
-    await removeRampingUnversionedWorkers({ namespace, deploymentName });
+  async function handleRemoveRampUnversioned(conflictToken?: string) {
+    rampUnversionedError = '';
+    await removeRampingUnversionedWorkers(
+      { namespace, deploymentName, conflictToken },
+      (err) => {
+        rampUnversionedError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.ramp-to-unversioned-error');
+      },
+    );
+    if (rampUnversionedError) return;
     showRampUnversionedModal = false;
     reload();
   }
@@ -92,7 +100,7 @@
   {@const info = deployment.workerDeploymentInfo}
   {@const unversionedRampingPercentage =
     !info.routingConfig?.rampingDeploymentVersion &&
-    info.routingConfig?.rampingVersionPercentage
+    info.routingConfig?.rampingVersionPercentage != null
       ? info.routingConfig.rampingVersionPercentage
       : null}
 
@@ -178,7 +186,7 @@
       rampUnversionedError = '';
     }}
     onRemove={unversionedRampingPercentage !== null
-      ? handleRemoveRampUnversioned
+      ? () => handleRemoveRampUnversioned(deployment.conflictToken)
       : undefined}
   />
 {:catch error}

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -162,6 +162,8 @@
   <DeleteDeploymentModal
     open={showDeleteModal}
     {deploymentName}
+    hasVersions={!!info.versionSummaries?.length}
+    error={deleteError}
     onConfirm={() => handleDeleteDeployment(deployment.conflictToken)}
     onCancel={() => (showDeleteModal = false)}
   />

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -7,6 +7,7 @@
   import DeploymentHeader from '$lib/components/deployments/deployment-header.svelte';
   import RampUnversionedModal from '$lib/components/deployments/ramp-unversioned-modal.svelte';
   import VersionTableRow from '$lib/components/deployments/version-table-row.svelte';
+  import Alert from '$lib/holocene/alert.svelte';
   import Button from '$lib/holocene/button.svelte';
   import Error from '$lib/holocene/error.svelte';
   import SkeletonTable from '$lib/holocene/skeleton/table.svelte';
@@ -80,6 +81,7 @@
 
   async function handleRemoveRampUnversioned() {
     await removeRampingUnversionedWorkers({ namespace, deploymentName });
+    showRampUnversionedModal = false;
     reload();
   }
 </script>
@@ -107,34 +109,13 @@
 
   {#if unversionedRampingPercentage !== null}
     <CapabilityGuard capability="serverScaledDeployments">
-      <div
-        class="mt-4 flex items-center justify-between rounded border border-warning bg-warning/10 px-4 py-2 text-sm"
-      >
-        <span>
-          {translate('deployments.unversioned-ramping-banner', {
-            percentage: unversionedRampingPercentage,
-          })}
-        </span>
-        <div class="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="xs"
-            on:click={() => {
-              rampUnversionedPercentage = unversionedRampingPercentage;
-              showRampUnversionedModal = true;
-            }}
-          >
-            {translate('common.edit')}
-          </Button>
-          <Button
-            variant="ghost"
-            size="xs"
-            on:click={handleRemoveRampUnversioned}
-          >
-            {translate('common.delete')}
-          </Button>
-        </div>
-      </div>
+      <Alert
+        intent="warning"
+        title={translate('deployments.unversioned-ramping-banner', {
+          percentage: unversionedRampingPercentage,
+        })}
+        class="mt-4"
+      />
     </CapabilityGuard>
   {/if}
 
@@ -194,6 +175,9 @@
       showRampUnversionedModal = false;
       rampUnversionedError = '';
     }}
+    onRemove={unversionedRampingPercentage !== null
+      ? handleRemoveRampUnversioned
+      : undefined}
   />
 {:catch error}
   <Error {error} />

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -5,7 +5,9 @@
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import DeleteDeploymentModal from '$lib/components/deployments/delete-deployment-modal.svelte';
   import DeploymentHeader from '$lib/components/deployments/deployment-header.svelte';
+  import RampUnversionedModal from '$lib/components/deployments/ramp-unversioned-modal.svelte';
   import VersionTableRow from '$lib/components/deployments/version-table-row.svelte';
+  import Button from '$lib/holocene/button.svelte';
   import Error from '$lib/holocene/error.svelte';
   import SkeletonTable from '$lib/holocene/skeleton/table.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/paginated.svelte';
@@ -13,6 +15,8 @@
   import {
     deleteWorkerDeployment,
     fetchDeployment,
+    removeRampingUnversionedWorkers,
+    setRampingUnversionedWorkers,
   } from '$lib/services/deployments-service';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
@@ -54,20 +58,85 @@
       goto(routeForWorkerDeployments({ namespace }));
     }
   }
+
+  let showRampUnversionedModal = $state(false);
+  let rampUnversionedPercentage = $state(0);
+  let rampUnversionedError = $state('');
+
+  async function handleRampUnversioned(percentage: number) {
+    rampUnversionedError = '';
+    await setRampingUnversionedWorkers(
+      { namespace, deploymentName, percentage },
+      (err) => {
+        rampUnversionedError =
+          (err as { body?: { message?: string } })?.body?.message ??
+          translate('deployments.ramp-to-unversioned-error');
+      },
+    );
+    if (rampUnversionedError) return;
+    showRampUnversionedModal = false;
+    reload();
+  }
+
+  async function handleRemoveRampUnversioned() {
+    await removeRampingUnversionedWorkers({ namespace, deploymentName });
+    reload();
+  }
 </script>
 
 {#await effectiveDeploymentPromise}
   <SkeletonTable rows={15} />
 {:then deployment}
   {@const info = deployment.workerDeploymentInfo}
+  {@const unversionedRampingPercentage =
+    !info.routingConfig?.rampingDeploymentVersion &&
+    info.routingConfig?.rampingVersionPercentage
+      ? info.routingConfig.rampingVersionPercentage
+      : null}
 
   <DeploymentHeader
     {namespace}
     {deploymentName}
-    hasVersions={!!info.versionSummaries?.length}
     {showInstancesLink}
     onDeleteClick={() => (showDeleteModal = true)}
+    onRampToUnversioned={() => {
+      rampUnversionedPercentage = unversionedRampingPercentage ?? 0;
+      showRampUnversionedModal = true;
+    }}
   />
+
+  {#if unversionedRampingPercentage !== null}
+    <CapabilityGuard capability="serverScaledDeployments">
+      <div
+        class="mt-4 flex items-center justify-between rounded border border-warning bg-warning/10 px-4 py-2 text-sm"
+      >
+        <span>
+          {translate('deployments.unversioned-ramping-banner', {
+            percentage: unversionedRampingPercentage,
+          })}
+        </span>
+        <div class="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="xs"
+            on:click={() => {
+              rampUnversionedPercentage = unversionedRampingPercentage;
+              showRampUnversionedModal = true;
+            }}
+          >
+            {translate('common.edit')}
+          </Button>
+          <Button
+            variant="ghost"
+            size="xs"
+            on:click={handleRemoveRampUnversioned}
+          >
+            {translate('common.delete')}
+          </Button>
+        </div>
+      </div>
+    </CapabilityGuard>
+  {/if}
 
   <div class="mt-4">
     <PaginatedTable
@@ -114,6 +183,17 @@
     {deploymentName}
     onConfirm={() => handleDeleteDeployment(deployment.conflictToken)}
     onCancel={() => (showDeleteModal = false)}
+  />
+
+  <RampUnversionedModal
+    open={showRampUnversionedModal}
+    bind:percentage={rampUnversionedPercentage}
+    error={rampUnversionedError}
+    onConfirm={handleRampUnversioned}
+    onCancel={() => {
+      showRampUnversionedModal = false;
+      rampUnversionedError = '';
+    }}
   />
 {:catch error}
   <Error {error} />

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -61,9 +61,14 @@
         {#each columns as { label } (label)}
           <th>{label}</th>
         {/each}
+        <th>{translate('deployments.actions')}</th>
       </tr>
       {#each visibleItems as deployment}
-        <DeploymentTableRow {deployment} {columns} />
+        <DeploymentTableRow
+          {deployment}
+          {columns}
+          onChange={() => refresh.update((n) => n + 1)}
+        />
       {/each}
 
       <svelte:fragment slot="empty">

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -226,6 +226,24 @@ export const setCurrentDeploymentVersion = async (
   });
 };
 
+export const unsetCurrentDeploymentVersion = async (
+  parameters: DeploymentParameters,
+  onError?: ErrorCallback,
+): Promise<void> => {
+  const route = routeForApi(
+    'worker-deployment-set-current-version',
+    parameters,
+  );
+  await requestFromAPI<unknown>(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({ version: '' }),
+    },
+    onError,
+    notifyOnError: false,
+  });
+};
+
 export const setRampingDeploymentVersion = async (
   request: DeploymentVersionParameters & {
     rampingVersionPercentage: number;

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -271,6 +271,45 @@ export const removeRampingDeploymentVersion = async (
   });
 };
 
+export const setRampingUnversionedWorkers = async (
+  parameters: DeploymentParameters & { percentage: number },
+  onError?: ErrorCallback,
+): Promise<void> => {
+  const route = routeForApi(
+    'worker-deployment-set-ramping-version',
+    parameters,
+  );
+  await requestFromAPI<unknown>(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({
+        build_id: '',
+        percentage: parameters.percentage,
+      }),
+    },
+    onError,
+    notifyOnError: false,
+  });
+};
+
+export const removeRampingUnversionedWorkers = async (
+  parameters: DeploymentParameters,
+  onError?: ErrorCallback,
+): Promise<void> => {
+  const route = routeForApi(
+    'worker-deployment-set-ramping-version',
+    parameters,
+  );
+  await requestFromAPI<unknown>(route, {
+    options: {
+      method: 'POST',
+      body: stringifyWithBigInt({ build_id: '' }),
+    },
+    onError,
+    notifyOnError: false,
+  });
+};
+
 export const buildLambdaComputeConfig = (
   lambdaArn: string,
   iamRoleArn: string,

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -301,7 +301,7 @@ export const setRampingUnversionedWorkers = async (
     options: {
       method: 'POST',
       body: stringifyWithBigInt({
-        build_id: '',
+        buildId: '',
         percentage: parameters.percentage,
       }),
     },
@@ -311,7 +311,7 @@ export const setRampingUnversionedWorkers = async (
 };
 
 export const removeRampingUnversionedWorkers = async (
-  parameters: DeploymentParameters,
+  parameters: DeploymentParameters & { conflictToken?: string },
   onError?: ErrorCallback,
 ): Promise<void> => {
   const route = routeForApi(
@@ -321,7 +321,12 @@ export const removeRampingUnversionedWorkers = async (
   await requestFromAPI<unknown>(route, {
     options: {
       method: 'POST',
-      body: stringifyWithBigInt({ build_id: '' }),
+      body: stringifyWithBigInt({
+        buildId: '',
+        ...(parameters.conflictToken
+          ? { conflictToken: parameters.conflictToken }
+          : {}),
+      }),
     },
     onError,
     notifyOnError: false,

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -227,7 +227,7 @@ export const setCurrentDeploymentVersion = async (
 };
 
 export const unsetCurrentDeploymentVersion = async (
-  parameters: DeploymentParameters,
+  parameters: DeploymentParameters & { conflictToken?: string },
   onError?: ErrorCallback,
 ): Promise<void> => {
   const route = routeForApi(
@@ -237,7 +237,12 @@ export const unsetCurrentDeploymentVersion = async (
   await requestFromAPI<unknown>(route, {
     options: {
       method: 'POST',
-      body: stringifyWithBigInt({ version: '' }),
+      body: stringifyWithBigInt({
+        buildId: '',
+        ...(parameters.conflictToken
+          ? { conflictToken: parameters.conflictToken }
+          : {}),
+      }),
     },
     onError,
     notifyOnError: false,


### PR DESCRIPTION
## Summary
- Hide "Set Current Version" in version actions menu when the version is already Current
- Re-arrange WD detail page header: Create New Version (primary), More Actions dropdown (View Workflows, Ramp to Unversioned Workers, Delete)
- Add Ramp to Unversioned Workers modal with a percentage input; calls `set-ramping-version` API with empty `build_id`
- Show alert banner on the deployment detail page when unversioned workers are actively ramping, with inline Edit and Delete actions
- Remove border box from ComputeBadge — render as plain `[icon] label` matching the Namespace Region style
- **[DT-4077 gap]** Add "Unset Current" to the current version's actions menu — calls `set-current-version` with an empty version string, which transitions the version to Draining and eventually Drained, allowing it to be deleted. Without this, a deployment could never be fully emptied (and therefore never deleted) because one version is always pinned as current.

## Test plan
- [ ] Current version row no longer shows "Set Current Version" in its actions menu; instead shows "Unset Current"
- [ ] Clicking "Unset Current" on the current version transitions it to Draining then Drained
- [ ] Deployment detail header shows "Create New Version" (primary) + "More Actions" dropdown
- [ ] More Actions contains View Workflows, Ramp to Unversioned Workers, and Delete
- [ ] Ramp to Unversioned Workers opens a modal with percentage input; confirms and refreshes
- [ ] When unversioned workers are ramping, a yellow banner appears with Edit/Delete inline actions
- [ ] Compute provider shows as icon + label without a border box in the version list