### PR TITLE
[DT-4100] Holocene → Table: allow pinned bottom "total"-style row

### DIFF
--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -209,6 +209,8 @@
 
   <slot visibleItems={$store.visibleItems} />
 
+  <slot name="footer" slot="footer" visibleItems={$store.visibleItems} />
+
   <svelte:fragment slot="empty">
     {#if $store.loading}
       <slot name="loading">

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -27,7 +27,7 @@
   export { className as class };
 
   let tableContainer: HTMLDivElement;
-  let footerBarHeight = 0;
+  let actionBarHeight = 0;
 
   $: tableOffset = tableContainer?.offsetTop
     ? tableContainer.offsetTop + 32
@@ -47,7 +47,7 @@
   bind:this={tableContainer}
   style="max-height: {maxHeight || `calc(100vh - ${tableOffset}px)`};
 
-  --table-header-h: 2.25rem; --table-footer-bottom: {footerBarHeight}px;"
+  --table-header-h: 2.25rem; --table-footer-bottom: {actionBarHeight}px;"
 >
   {#if loading}
     {#if $$slots.loading}
@@ -64,7 +64,7 @@
     </Table>
     {#if visibleItems.length}
       <div
-        bind:clientHeight={footerBarHeight}
+        bind:clientHeight={actionBarHeight}
         class="surface-primary sticky bottom-0 left-0 flex w-full grow items-center justify-between gap-2 border-t border-subtle px-4 py-2"
       >
         <slot name="actions-start" />

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -27,6 +27,7 @@
   export { className as class };
 
   let tableContainer: HTMLDivElement;
+  let footerBarHeight = 0;
 
   $: tableOffset = tableContainer?.offsetTop
     ? tableContainer.offsetTop + 32
@@ -46,7 +47,7 @@
   bind:this={tableContainer}
   style="max-height: {maxHeight || `calc(100vh - ${tableOffset}px)`};
 
-  --table-header-h: 2.25rem;"
+  --table-header-h: 2.25rem; --table-footer-bottom: {footerBarHeight}px;"
 >
   {#if loading}
     {#if $$slots.loading}
@@ -59,9 +60,11 @@
       <slot slot="caption" name="caption" />
       <slot slot="headers" name="headers" {visibleItems} />
       <slot />
+      <slot slot="footer" name="footer" {visibleItems} />
     </Table>
     {#if visibleItems.length}
       <div
+        bind:clientHeight={footerBarHeight}
         class="surface-primary sticky bottom-0 left-0 flex w-full grow items-center justify-between gap-2 border-t border-subtle px-4 py-2"
       >
         <slot name="actions-start" />

--- a/src/lib/holocene/table/paginated-table/paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/paginated.svelte
@@ -111,6 +111,8 @@
   <slot name="headers" slot="headers" visibleItems={$store.items} />
   <slot visibleItems={$store.items} />
 
+  <slot name="footer" slot="footer" visibleItems={$store.items} />
+
   <svelte:fragment slot="actions-start">
     <FilterSelect
       label={perPageLabel}

--- a/src/lib/holocene/table/table.stories.svelte
+++ b/src/lib/holocene/table/table.stories.svelte
@@ -81,13 +81,7 @@
 
 <Story name="Pinned Total Row, Above Footer Bar">
   <div class="flex h-72 flex-col overflow-auto border border-subtle">
-    <Table
-      class="w-full"
-      bordered={false}
-      style="
-
---table-footer-bottom: 2.75rem;"
-    >
+    <Table class="w-full [--table-footer-bottom:2.75rem]" bordered={false}>
       <tr slot="headers">
         <th>Name</th>
         <th>Requests</th>

--- a/src/lib/holocene/table/table.stories.svelte
+++ b/src/lib/holocene/table/table.stories.svelte
@@ -23,6 +23,14 @@
 
 <script lang="ts">
   import { Story, Template } from '@storybook/addon-svelte-csf';
+
+  const totalRows = Array.from({ length: 40 }, (_, i) => ({
+    name: `Item ${i + 1}`,
+    requests: (i + 1) * 100,
+    storage: (i + 1) * 3,
+  }));
+  const totalRequests = totalRows.reduce((sum, row) => sum + row.requests, 0);
+  const totalStorage = totalRows.reduce((sum, row) => sum + row.storage, 0);
 </script>
 
 <Template let:args let:context>
@@ -45,3 +53,62 @@
 <Story name="Primary" args={{ variant: 'primary' }} />
 
 <Story name="Primary, Updating" args={{ updating: true, variant: 'primary' }} />
+
+<Story name="Pinned Total Row">
+  <div class="h-72 overflow-auto border border-subtle">
+    <Table class="w-full" bordered={false}>
+      <tr slot="headers">
+        <th>Name</th>
+        <th>Requests</th>
+        <th>Storage (GB)</th>
+      </tr>
+      {#each totalRows as row (row.name)}
+        <tr>
+          <td>{row.name}</td>
+          <td>{row.requests.toLocaleString()}</td>
+          <td>{row.storage.toLocaleString()}</td>
+        </tr>
+      {/each}
+      <tr slot="footer">
+        <td>Total</td>
+        <td>{totalRequests.toLocaleString()}</td>
+        <td>{totalStorage.toLocaleString()}</td>
+      </tr>
+    </Table>
+  </div>
+</Story>
+
+<Story name="Pinned Total Row, Above Footer Bar">
+  <div class="flex h-72 flex-col overflow-auto border border-subtle">
+    <Table
+      class="w-full"
+      bordered={false}
+      style="
+
+--table-footer-bottom: 2.75rem;"
+    >
+      <tr slot="headers">
+        <th>Name</th>
+        <th>Requests</th>
+        <th>Storage (GB)</th>
+      </tr>
+      {#each totalRows as row (row.name)}
+        <tr>
+          <td>{row.name}</td>
+          <td>{row.requests.toLocaleString()}</td>
+          <td>{row.storage.toLocaleString()}</td>
+        </tr>
+      {/each}
+      <tr slot="footer">
+        <td>Total</td>
+        <td>{totalRequests.toLocaleString()}</td>
+        <td>{totalStorage.toLocaleString()}</td>
+      </tr>
+    </Table>
+    <div
+      class="surface-primary sticky bottom-0 left-0 flex h-11 w-full shrink-0 items-center justify-end gap-2 border-t border-subtle px-4"
+    >
+      <span class="text-sm text-secondary">Pagination controls</span>
+    </div>
+  </div>
+</Story>

--- a/src/lib/holocene/table/table.stories.svelte
+++ b/src/lib/holocene/table/table.stories.svelte
@@ -65,14 +65,15 @@
       {#each totalRows as row (row.name)}
         <tr>
           <td>{row.name}</td>
-          <td>{row.requests.toLocaleString()}</td>
-          <td>{row.storage.toLocaleString()}</td>
+          <td class="font-mono tabular-nums">{row.requests.toLocaleString()}</td
+          >
+          <td class="font-mono tabular-nums">{row.storage.toLocaleString()}</td>
         </tr>
       {/each}
       <tr slot="footer">
         <td>Total</td>
-        <td>{totalRequests.toLocaleString()}</td>
-        <td>{totalStorage.toLocaleString()}</td>
+        <td class="font-mono tabular-nums">{totalRequests.toLocaleString()}</td>
+        <td class="font-mono tabular-nums">{totalStorage.toLocaleString()}</td>
       </tr>
     </Table>
   </div>
@@ -95,14 +96,15 @@
       {#each totalRows as row (row.name)}
         <tr>
           <td>{row.name}</td>
-          <td>{row.requests.toLocaleString()}</td>
-          <td>{row.storage.toLocaleString()}</td>
+          <td class="font-mono tabular-nums">{row.requests.toLocaleString()}</td
+          >
+          <td class="font-mono tabular-nums">{row.storage.toLocaleString()}</td>
         </tr>
       {/each}
       <tr slot="footer">
         <td>Total</td>
-        <td>{totalRequests.toLocaleString()}</td>
-        <td>{totalStorage.toLocaleString()}</td>
+        <td class="font-mono tabular-nums">{totalRequests.toLocaleString()}</td>
+        <td class="font-mono tabular-nums">{totalStorage.toLocaleString()}</td>
       </tr>
     </Table>
     <div

--- a/src/lib/holocene/table/table.svelte
+++ b/src/lib/holocene/table/table.svelte
@@ -39,6 +39,11 @@
   <tbody class="holocene-table-body">
     <slot />
   </tbody>
+  {#if $$slots.footer}
+    <tfoot class="holocene-table-footer">
+      <slot name="footer" />
+    </tfoot>
+  {/if}
 </table>
 
 <style lang="postcss">
@@ -79,6 +84,21 @@
 
     :global(tr > th) {
       @apply h-9 border-b border-subtle px-2 text-left text-sm font-medium;
+    }
+  }
+
+  .holocene-table-footer {
+    @apply sticky z-10;
+
+    bottom: var(--table-footer-bottom, 0);
+
+    :global(tr) {
+      @apply surface-table-header;
+    }
+
+    :global(tr > th),
+    :global(tr > td) {
+      @apply h-9 border-t border-subtle px-2 text-left text-sm font-medium;
     }
   }
 

--- a/src/lib/holocene/table/table.svelte
+++ b/src/lib/holocene/table/table.svelte
@@ -93,12 +93,12 @@
     bottom: var(--table-footer-bottom, 0);
 
     :global(tr) {
-      @apply surface-table-header;
+      @apply surface-background;
     }
 
     :global(tr > th),
     :global(tr > td) {
-      @apply h-9 border-t border-subtle px-2 text-left text-sm font-medium;
+      @apply h-8 border-t border-subtle px-2 text-left text-sm;
     }
   }
 


### PR DESCRIPTION
## Summary

<img width="1507" height="524" alt="Screenshot 2026-06-08 at 4 55 40 PM" src="https://github.com/user-attachments/assets/5a43e0b3-e23d-4f70-b0a5-64da3dac12fc" />

Adds an optional `footer` slot to the Holocene `Table` component, rendered in a sticky `<tfoot>` that mirrors the existing sticky header so a "Total"-style row stays pinned at the bottom of the scroll viewport — always visible just above the pagination controls instead of requiring a scroll to the end of the rows.

- New `footer` named slot, only rendered when content is provided (existing tables unchanged).
- Sticky footer styled like a normal striped body row (`surface-background`), opaque so rows don't bleed through while scrolling.
- `bottom: var(--table-footer-bottom, 0)` lets consumers lift the row above a fixed bottom bar (e.g. pagination controls).
- Storybook stories: standalone pinned total row, and one pinned above a pagination-style bar (also demonstrating consumer-side `font-mono tabular-nums` numerals).

Component-only change in this repo; consuming it on the cloud-ui usage page is a separate follow-up.

## Jira

https://temporalio.atlassian.net/browse/DT-4100

## Test plan

- [ ] Storybook: **Table → Pinned Total Row** — total row stays pinned while scrolling
- [ ] Storybook: **Table → Pinned Total Row, Above Footer Bar** — total row pins above the bar
- [ ] Tables without a `footer` slot render unchanged
- [ ] No regressions in adjacent table flows