### PR TITLE
Set display contents in wrapper div if no afterLabel in Input component

### DIFF
--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -93,7 +93,12 @@
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
-  <div class="flex items-center justify-start gap-2">
+  <div
+    class={merge(
+      'flex items-center justify-start gap-2',
+      !afterLabel && 'contents',
+    )}
+  >
     <Label class="grow-0" {required} {label} hidden={labelHidden} for={id} />
     {@render afterLabel?.()}
   </div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

In the `Input` component when there's no `afterLabel` (added in https://github.com/temporalio/ui/pull/3479) the wrapper should disappear so the `sr-only` Label belongs directly to the outer `flex flex-col gap-1`.  Since `sr-only` makes the Label `position: absolute`, it's removed from the flex flow and no `gap-1` is added for it.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|--|--|
|<img width="437" height="311" alt="Screenshot 2026-06-08 at 1 38 15 PM" src="https://github.com/user-attachments/assets/ba516b58-6604-417a-93da-b134261d0694" />|<img width="449" height="314" alt="Screenshot 2026-06-08 at 2 08 42 PM" src="https://github.com/user-attachments/assets/2d6e4b34-030f-42d0-bd3a-076f0e33728f" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
