### PR TITLE
fix(archival): use WorkflowTypeName attribute when filtering

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
@@ -93,7 +93,7 @@
 {#if filterableLabels.includes(label) || isCustomKeywordOrTextAttribute}
   {#if label === 'Type'}
     {@render renderFilterableTableCell({
-      attribute: 'WorkflowType',
+      attribute: archival ? 'WorkflowTypeName' : 'WorkflowType',
       value: workflow.name,
       href: routeForWorkflow({
         namespace,


### PR DESCRIPTION
  archived workflows by type


## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The archival page now searching for "WorkflowType" but the actual name of the field inside the archival is "WorkflowTypeName"

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
