### PR TITLE
fix(DT-4080): surface error when validate connection has no compute config, warn on set current

### DIFF
--- a/src/lib/components/deployments/set-current-version-modal.svelte
+++ b/src/lib/components/deployments/set-current-version-modal.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import Alert from '$lib/holocene/alert.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -10,7 +9,6 @@
     deploymentName: string;
     open: boolean;
     error?: string;
-    hasComputeConfig?: boolean;
     onConfirm: () => void;
     onCancel: () => void;
   }
@@ -21,7 +19,6 @@
     deploymentName,
     open,
     error = '',
-    hasComputeConfig = true,
     onConfirm,
     onCancel,
   }: Props = $props();
@@ -38,12 +35,6 @@
 >
   <h3 slot="title">{translate('deployments.set-as-current')}</h3>
   <div slot="content" class="flex flex-col gap-4">
-    {#if !hasComputeConfig}
-      <Alert
-        intent="warning"
-        title={translate('deployments.set-current-no-config-warning')}
-      />
-    {/if}
     <p class="text-sm">
       This will set Build ID <span class="font-mono font-medium">{buildId}</span
       >

--- a/src/lib/components/deployments/set-current-version-modal.svelte
+++ b/src/lib/components/deployments/set-current-version-modal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Alert from '$lib/holocene/alert.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -9,6 +10,7 @@
     deploymentName: string;
     open: boolean;
     error?: string;
+    hasComputeConfig?: boolean;
     onConfirm: () => void;
     onCancel: () => void;
   }
@@ -19,6 +21,7 @@
     deploymentName,
     open,
     error = '',
+    hasComputeConfig = true,
     onConfirm,
     onCancel,
   }: Props = $props();
@@ -35,6 +38,12 @@
 >
   <h3 slot="title">{translate('deployments.set-as-current')}</h3>
   <div slot="content" class="flex flex-col gap-4">
+    {#if !hasComputeConfig}
+      <Alert
+        intent="warning"
+        title={translate('deployments.set-current-no-config-warning')}
+      />
+    {/if}
     <p class="text-sm">
       This will set Build ID <span class="font-mono font-medium">{buildId}</span
       >

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -12,6 +12,7 @@
     editHref: string;
     workflowHref: string;
     isCurrent: boolean;
+    hasComputeConfig: boolean;
     onSetCurrent: () => void;
     onValidate: () => void;
     onDelete: () => void;
@@ -22,6 +23,7 @@
     editHref,
     workflowHref,
     isCurrent,
+    hasComputeConfig,
     onSetCurrent,
     onValidate,
     onDelete,
@@ -45,14 +47,16 @@
           {translate('deployments.edit')}
         </MenuItem>
       </CapabilityGuard>
-      <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
-        {translate('deployments.set-as-current')}
-      </MenuItem>
-      <CapabilityGuard capability="serverScaledDeployments">
-        <MenuItem onclick={onValidate}>
-          {translate('deployments.validate-connection')}
+      {#if hasComputeConfig}
+        <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
+          {translate('deployments.set-as-current')}
         </MenuItem>
-      </CapabilityGuard>
+        <CapabilityGuard capability="serverScaledDeployments">
+          <MenuItem onclick={onValidate}>
+            {translate('deployments.validate-connection')}
+          </MenuItem>
+        </CapabilityGuard>
+      {/if}
       <MenuItem href={workflowHref}>
         {translate('deployments.view-workflows')}
       </MenuItem>

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -47,16 +47,21 @@
           {translate('deployments.edit')}
         </MenuItem>
       </CapabilityGuard>
-      {#if hasComputeConfig}
-        <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
-          {translate('deployments.set-as-current')}
-        </MenuItem>
-        <CapabilityGuard capability="serverScaledDeployments">
+      <CapabilityGuard capability="serverScaledDeployments">
+        {#if hasComputeConfig}
+          <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
+            {translate('deployments.set-as-current')}
+          </MenuItem>
           <MenuItem onclick={onValidate}>
             {translate('deployments.validate-connection')}
           </MenuItem>
-        </CapabilityGuard>
-      {/if}
+        {/if}
+        {#snippet fallback()}
+          <MenuItem onclick={onSetCurrent} disabled={isCurrent}>
+            {translate('deployments.set-as-current')}
+          </MenuItem>
+        {/snippet}
+      </CapabilityGuard>
       <MenuItem href={workflowHref}>
         {translate('deployments.view-workflows')}
       </MenuItem>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -271,6 +271,9 @@
     {editHref}
     {workflowHref}
     {isCurrent}
+    hasComputeConfig={isVersionSummaryNew(version)
+      ? !!version.computeConfig
+      : true}
     onSetCurrent={() => (showSetCurrentModal = true)}
     onValidate={handleValidateConnection}
     onDelete={() => (showDeleteVersionModal = true)}

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -298,9 +298,6 @@
   {deploymentName}
   open={showSetCurrentModal}
   error={setCurrentError}
-  hasComputeConfig={isVersionSummaryNew(version)
-    ? !!version.computeConfig
-    : true}
   onConfirm={handleSetCurrentVersion}
   onCancel={() => {
     showSetCurrentModal = false;

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -166,6 +166,9 @@
     const computeConfig =
       versionDetails.workerDeploymentVersionInfo.computeConfig;
     if (!computeConfig) {
+      validateResult = {
+        message: translate('deployments.validate-connection-no-config'),
+      };
       validateLoading = false;
       return;
     }
@@ -292,6 +295,9 @@
   {deploymentName}
   open={showSetCurrentModal}
   error={setCurrentError}
+  hasComputeConfig={isVersionSummaryNew(version)
+    ? !!version.computeConfig
+    : true}
   onConfirm={handleSetCurrentVersion}
   onCancel={() => {
     showSetCurrentModal = false;

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -85,6 +85,10 @@ export const Strings = {
   'validate-connection-error': 'Failed to validate connection',
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',
+  'validate-connection-no-config':
+    'This version has no compute configuration. It may have been created outside the UI without the required IAM details.',
+  'set-current-no-config-warning':
+    'This version has no compute configuration and may not function correctly as the current version.',
   'delete-version': 'Delete Worker Deployment Version',
   'delete-version-description':
     'Deleting any running Workers will finish their current tasks. No new invocations will be made.',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -86,9 +86,7 @@ export const Strings = {
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',
   'validate-connection-no-config':
-    'This version has no compute configuration. It may have been created outside the UI without the required IAM details.',
-  'set-current-no-config-warning':
-    'This version has no compute configuration and may not function correctly as the current version.',
+    'This version is missing compute configuration. It may have been created outside the UI without the required IAM details.',
   'delete-version': 'Delete Worker Deployment Version',
   'delete-version-description':
     'Deleting any running Workers will finish their current tasks. No new invocations will be made.',


### PR DESCRIPTION
## Summary
- **Validate Connection empty pop-up**: When a version has no compute config (created outside the UI without IAM details), the modal now shows an actionable error message instead of a blank pop-up
- **Set Current warning**: When attempting to set a version with no compute config as current, a warning alert is shown in the confirmation modal

## Test plan
- [ ] Validate Connection on a version with no compute config shows "This version has no compute configuration..." error instead of empty modal
- [ ] Validate Connection on a valid version still shows pass/fail result as before
- [ ] Set Current Version modal shows a warning alert when the version lacks a compute configuration
- [ ] Set Current Version modal shows no warning for versions with valid compute config