### PR TITLE
fix(DT-4081): surface task queue not registered error in validate connection modal

### DIFF
--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -169,6 +169,15 @@
       validateLoading = false;
       return;
     }
+    const taskQueueInfos =
+      versionDetails.workerDeploymentVersionInfo.taskQueueInfos;
+    if (!taskQueueInfos?.length) {
+      validateResult = {
+        message: translate('deployments.validate-connection-no-task-queue'),
+      };
+      validateLoading = false;
+      return;
+    }
     let errorMessage: string | undefined;
     await validateWorkerDeploymentVersionComputeConfig(
       { namespace, deploymentName, buildId: versionBuildId, computeConfig },

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -19,6 +19,7 @@
     type VersionSummary,
   } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
+  import { getMilliseconds } from '$lib/utilities/format-time';
   import {
     getBuildIdFromVersion,
     getDeploymentFromVersion,
@@ -154,6 +155,8 @@
   let validateLoading = $state(false);
   let validateResult = $state<{ message?: string } | null>(null);
 
+  const newVersionGracePeriodMs = 2 * 60 * 1000;
+
   async function handleValidateConnection() {
     validateResult = null;
     validateLoading = true;
@@ -172,8 +175,16 @@
     const taskQueueInfos =
       versionDetails.workerDeploymentVersionInfo.taskQueueInfos;
     if (!taskQueueInfos?.length) {
+      const createdMs = getMilliseconds(
+        versionDetails.workerDeploymentVersionInfo.createTime,
+      );
+      const isNewlyCreated = Date.now() - createdMs < newVersionGracePeriodMs;
       validateResult = {
-        message: translate('deployments.validate-connection-no-task-queue'),
+        message: translate(
+          isNewlyCreated
+            ? 'deployments.validate-connection-no-task-queue-pending'
+            : 'deployments.validate-connection-no-task-queue',
+        ),
       };
       validateLoading = false;
       return;

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -19,7 +19,6 @@
     type VersionSummary,
   } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
-  import { getMilliseconds } from '$lib/utilities/format-time';
   import {
     getBuildIdFromVersion,
     getDeploymentFromVersion,
@@ -175,10 +174,10 @@
     const taskQueueInfos =
       versionDetails.workerDeploymentVersionInfo.taskQueueInfos;
     if (!taskQueueInfos?.length) {
-      const createdMs = getMilliseconds(
-        versionDetails.workerDeploymentVersionInfo.createTime,
-      );
-      const isNewlyCreated = Date.now() - createdMs < newVersionGracePeriodMs;
+      const createTime = versionDetails.workerDeploymentVersionInfo.createTime;
+      const isNewlyCreated =
+        Date.now() - new Date(String(createTime)).getTime() <
+        newVersionGracePeriodMs;
       validateResult = {
         message: translate(
           isNewlyCreated

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -85,6 +85,8 @@ export const Strings = {
   'validate-connection-error': 'Failed to validate connection',
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',
+  'validate-connection-no-task-queue':
+    "This Worker Deployment Version's Task Queue is not registered. The Lambda may be failing after invocation. Check the function for configuration or runtime errors, then re-run it from the AWS Console. Alternatively, create a new Version to retry.",
   'delete-version': 'Delete Worker Deployment Version',
   'delete-version-description':
     'Deleting any running Workers will finish their current tasks. No new invocations will be made.',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -86,7 +86,9 @@ export const Strings = {
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',
   'validate-connection-no-task-queue':
-    "This Worker Deployment Version's Task Queue is not registered. The Lambda may be failing after invocation. Check the function for configuration or runtime errors, then re-run it from the AWS Console. Alternatively, create a new Version to retry.",
+    "This Worker Deployment Version's Task Queue is not registered. The serverless function may be failing after invocation. Check the function for configuration or runtime errors, then re-run it from your cloud provider's console. Alternatively, create a new Version to retry.",
+  'validate-connection-no-task-queue-pending':
+    "This Worker Deployment Version's Task Queue is not registered yet. The version was recently created, so the worker may still be starting up. Wait a moment, then retry.",
   'delete-version': 'Delete Worker Deployment Version',
   'delete-version-description':
     'Deleting any running Workers will finish their current tasks. No new invocations will be made.',


### PR DESCRIPTION
## Summary

- When a Lambda invokes successfully but errors before registering its Task Queue, Validate Connection previously showed nothing (silent failure)
- Now checks `taskQueueInfos` on the fetched version details and surfaces a specific message when empty: _"This Worker Deployment Version's Task Queue is not registered. The Lambda may be failing after invocation. Check the function for configuration or runtime errors, then re-run it from the AWS Console. Alternatively, create a new Version to retry."_

## Test plan

- [ ] Create a Worker Deployment Version that has compute config but no task queues registered
- [ ] Click "Validate Connection" → should show the "Task Queue not registered" message in the modal
- [ ] Verify versions with registered task queues still proceed to the normal validation flow