### PR TITLE
Fix exports to work properly with vite8

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,6 @@
     "ui",
     ""
   ],
-  "exports": {
-    "./*.svelte": {
-      "types": "./dist/*.svelte.d.ts",
-      "svelte": "./dist/*.svelte"
-    },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "import": "./dist/*.js"
-    }
-  },
   "files": [
     "dist/**/*",
     "!dist/**/*.test.*",
@@ -67,6 +57,7 @@
     "package:patch": "pnpm version patch && svelte-package",
     "package:minor": "pnpm version minor && svelte-package",
     "package:major": "pnpm version major && svelte-package",
+    "prepack": "svelte-package && node scripts/generate-exports.mjs",
     "stories:dev": "storybook dev -p 6006",
     "stories:build": "storybook build",
     "stories:test": "test-storybook --index-json",
@@ -261,5 +252,16 @@
       "svelte-preprocess"
     ]
   },
-  "packageManager": "pnpm@10.10.0"
+  "packageManager": "pnpm@10.10.0",
+  "exports": {
+    "./_": "Wildcard entries below are replaced with explicit paths by scripts/generate-exports.mjs during prepack",
+    "./*.svelte": {
+      "types": "./dist/*.svelte.d.ts",
+      "svelte": "./dist/*.svelte"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js"
+    }
+  }
 }

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -60,11 +60,14 @@ for (const rel of allFiles) {
   const dir = dirname(file);
   let code = readFileSync(file, 'utf-8');
 
-  const rewritten = code.replace(/from '(\.[^']+\.svelte)'/g, (_, relImport) => {
-    const abs = resolve(dir, relImport);
-    const pkgRel = relative(distPath, abs).replace(/\\/g, '/');
-    return `from '${pkgName}/${pkgRel}'`;
-  });
+  const rewritten = code.replace(
+    /from '(\.[^']+\.svelte)'/g,
+    (_, relImport) => {
+      const abs = resolve(dir, relImport);
+      const pkgRel = relative(distPath, abs).replace(/\\/g, '/');
+      return `from '${pkgName}/${pkgRel}'`;
+    },
+  );
 
   if (rewritten !== code) writeFileSync(file, rewritten);
 }

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -1,0 +1,39 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'path';
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+const distPath = new URL('../dist', import.meta.url).pathname;
+const exports = {};
+
+for (const file of walk(distPath)) {
+  const rel = relative(distPath, file).replace(/\\/g, '/');
+
+  if (rel.endsWith('.svelte') && !rel.includes('.d.ts')) {
+    exports[`./${rel}`] = {
+      types: `./dist/${rel.replace(/\.svelte$/, '.svelte.d.ts')}`,
+      svelte: `./dist/${rel}`,
+    };
+  } else if (rel.endsWith('.js') && !rel.includes('.svelte.')) {
+    const base = rel.replace(/\.js$/, '');
+    exports[`./${base}`] = {
+      types: `./dist/${base}.d.ts`,
+      import: `./dist/${rel}`,
+    };
+  }
+}
+
+exports['./package.json'] = './package.json';
+
+const pkgUrl = new URL('../package.json', import.meta.url);
+const pkg = JSON.parse(readFileSync(pkgUrl));
+pkg.exports = exports;
+writeFileSync(pkgUrl, JSON.stringify(pkg, null, 2) + '\n');
+
+console.log(`Generated ${Object.keys(exports).length} explicit export entries`);

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -25,6 +25,7 @@ for (const file of walk(distPath)) {
     exports[`./${base}`] = {
       types: `./dist/${base}.d.ts`,
       import: `./dist/${rel}`,
+      default: `./dist/${rel}`,
     };
   }
 }

--- a/scripts/generate-exports.mjs
+++ b/scripts/generate-exports.mjs
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'path';
+import { dirname, join, relative, resolve } from 'node:path';
 
 function* walk(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -10,16 +10,37 @@ function* walk(dir) {
 }
 
 const distPath = new URL('../dist', import.meta.url).pathname;
+const pkgUrl = new URL('../package.json', import.meta.url);
+const pkg = JSON.parse(readFileSync(pkgUrl));
+const pkgName = pkg.name;
+
+const allFiles = new Set(
+  [...walk(distPath)].map((f) => relative(distPath, f).replace(/\\/g, '/')),
+);
+
+const isTestOrSpec = (rel) => /\.(test|spec)\./.test(rel);
+
 const exports = {};
 
-for (const file of walk(distPath)) {
-  const rel = relative(distPath, file).replace(/\\/g, '/');
+for (const rel of allFiles) {
+  if (isTestOrSpec(rel)) continue;
 
   if (rel.endsWith('.svelte') && !rel.includes('.d.ts')) {
     exports[`./${rel}`] = {
       types: `./dist/${rel.replace(/\.svelte$/, '.svelte.d.ts')}`,
       svelte: `./dist/${rel}`,
+      default: `./dist/${rel}`,
     };
+  } else if (rel.endsWith('.svelte.js')) {
+    const svelteCounterpart = rel.replace(/\.js$/, '');
+    if (!allFiles.has(svelteCounterpart)) {
+      const key = `./${rel.replace(/\.js$/, '')}`;
+      exports[key] = {
+        types: `./dist/${rel.replace(/\.js$/, '.d.ts')}`,
+        import: `./dist/${rel}`,
+        default: `./dist/${rel}`,
+      };
+    }
   } else if (rel.endsWith('.js') && !rel.includes('.svelte.')) {
     const base = rel.replace(/\.js$/, '');
     exports[`./${base}`] = {
@@ -32,8 +53,22 @@ for (const file of walk(distPath)) {
 
 exports['./package.json'] = './package.json';
 
-const pkgUrl = new URL('../package.json', import.meta.url);
-const pkg = JSON.parse(readFileSync(pkgUrl));
+for (const rel of allFiles) {
+  if (!rel.endsWith('.svelte') || rel.includes('.d.ts')) continue;
+
+  const file = join(distPath, rel);
+  const dir = dirname(file);
+  let code = readFileSync(file, 'utf-8');
+
+  const rewritten = code.replace(/from '(\.[^']+\.svelte)'/g, (_, relImport) => {
+    const abs = resolve(dir, relImport);
+    const pkgRel = relative(distPath, abs).replace(/\\/g, '/');
+    return `from '${pkgName}/${pkgRel}'`;
+  });
+
+  if (rewritten !== code) writeFileSync(file, rewritten);
+}
+
 pkg.exports = exports;
 writeFileSync(pkgUrl, JSON.stringify(pkg, null, 2) + '\n');
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
