### PR TITLE
Date picker input field bug/kt

### DIFF
--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -52,7 +52,7 @@
     showDatePicker = true;
   };
 
-  const onInput = (e: Event) => {
+  const onBlur = (e: FocusEvent) => {
     const target = e.target as HTMLInputElement;
     const { date, error } = evaluateDatePickerInput(target.value, isAllowed);
     inputError = error;
@@ -97,7 +97,7 @@
     icon="calendar-plus"
     type="text"
     onfocus={onFocus}
-    oninput={onInput}
+    onblur={onBlur}
     placeholder={DATE_PICKER_INPUT_FORMAT}
     value={formatDatePickerInput(selected)}
     error={inputError}

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -52,21 +52,20 @@
   });
 
   // handlers
-  const onFocus = () => {
-    showDatePicker = true;
+  const commitDate = (date: Date) => {
+    selected = date;
+    onDateChange?.(date);
   };
 
-  const onInput = (e: Event) => {
-    const target = e.target as HTMLInputElement;
-    const { date } = evaluateDatePickerInput(target.value, isAllowed);
-    if (date) onDateChange?.(date);
+  const onFocus = () => {
+    showDatePicker = true;
   };
 
   const onBlur = (e: FocusEvent) => {
     const target = e.target as HTMLInputElement;
     const { date, error } = evaluateDatePickerInput(target.value, isAllowed);
     inputError = error;
-    if (date) selected = date;
+    if (date) commitDate(date);
   };
 
   const next = () => {
@@ -89,8 +88,7 @@
 
   const handleDateChange = (d: Date) => {
     showDatePicker = false;
-    selected = d;
-    onDateChange?.(d);
+    commitDate(d);
   };
 
   const previousMonth = translate('date-picker.previous-month');
@@ -107,7 +105,6 @@
     icon="calendar-plus"
     type="text"
     onfocus={onFocus}
-    oninput={onInput}
     onblur={onBlur}
     placeholder={DATE_PICKER_INPUT_FORMAT}
     value={formatDatePickerInput(selected)}
@@ -152,10 +149,7 @@
         <button
           type="button"
           class="cursor-pointer text-[12px]"
-          onclick={() => {
-            selected = new Date();
-            onDateChange?.(selected);
-          }}
+          onclick={() => commitDate(new Date())}
         >
           {todayLabel}
         </button>

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -4,6 +4,11 @@
   import { clickoutside } from '$lib/holocene/outside-click';
   import { translate } from '$lib/i18n/translate';
   import { getMonthName } from '$lib/utilities/calendar';
+  import {
+    DATE_PICKER_INPUT_FORMAT,
+    evaluateDatePickerInput,
+    formatDatePickerInput,
+  } from '$lib/utilities/date-picker-input';
 
   import Calender from './calendar.svelte';
   import Icon from './icon/icon.svelte';
@@ -40,6 +45,7 @@
   let month = $derived(selected.getMonth());
   let year = $derived(selected.getFullYear());
   let showDatePicker = $state(false);
+  let inputError = $state(false);
 
   // handlers
   const onFocus = () => {
@@ -48,16 +54,9 @@
 
   const onInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
-    const inputDate = target.value;
-    if (inputDate.length === 8) {
-      const inputDateSplit = inputDate?.split('/');
-      const yearEnd = parseInt(inputDateSplit[2]);
-      const year = 2000 + yearEnd;
-      const month = parseInt(inputDateSplit[0]) - 1;
-      const date = parseInt(inputDateSplit[1]);
-      const newDate = new Date(year, month, date);
-      onDateChange?.(newDate);
-    }
+    const { date, error } = evaluateDatePickerInput(target.value, isAllowed);
+    inputError = error;
+    if (date) onDateChange?.(date);
   };
 
   const next = () => {
@@ -80,11 +79,13 @@
 
   const handleDateChange = (d: Date) => {
     showDatePicker = false;
+    inputError = false;
     onDateChange?.(d);
   };
 
   const previousMonth = translate('date-picker.previous-month');
   const nextMonth = translate('date-picker.next-month');
+  const invalidDate = translate('date-picker.invalid-date');
 </script>
 
 <div class="relative" use:clickoutside={() => (showDatePicker = false)}>
@@ -97,8 +98,10 @@
     type="text"
     onfocus={onFocus}
     oninput={onInput}
-    placeholder="MM/DD/YY"
-    value={selected.toDateString()}
+    placeholder={DATE_PICKER_INPUT_FORMAT}
+    value={formatDatePickerInput(selected)}
+    error={inputError}
+    hintText={inputError ? invalidDate : ''}
     clearable
     clearButtonLabel={clearLabel}
     {disabled}
@@ -136,8 +139,11 @@
       <div class="my-1 flex justify-between px-2">
         <button
           type="button"
-          class="cursor-pointer text-xs"
-          onclick={() => (selected = new Date())}
+          class="cursor-pointer text-[12px]"
+          onclick={() => {
+            inputError = false;
+            selected = new Date();
+          }}
         >
           {todayLabel}
         </button>

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -64,8 +64,9 @@
 
   const onBlur = (e: FocusEvent) => {
     const target = e.target as HTMLInputElement;
-    const { error } = evaluateDatePickerInput(target.value, isAllowed);
+    const { date, error } = evaluateDatePickerInput(target.value, isAllowed);
     inputError = error;
+    if (date) selected = date;
   };
 
   const next = () => {
@@ -88,6 +89,7 @@
 
   const handleDateChange = (d: Date) => {
     showDatePicker = false;
+    selected = d;
     onDateChange?.(d);
   };
 

--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -45,18 +45,27 @@
   let month = $derived(selected.getMonth());
   let year = $derived(selected.getFullYear());
   let showDatePicker = $state(false);
-  let inputError = $state(false);
+  // resets whenever selected changes; can be overridden until then
+  let inputError = $derived.by(() => {
+    void selected;
+    return false;
+  });
 
   // handlers
   const onFocus = () => {
     showDatePicker = true;
   };
 
+  const onInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    const { date } = evaluateDatePickerInput(target.value, isAllowed);
+    if (date) onDateChange?.(date);
+  };
+
   const onBlur = (e: FocusEvent) => {
     const target = e.target as HTMLInputElement;
-    const { date, error } = evaluateDatePickerInput(target.value, isAllowed);
+    const { error } = evaluateDatePickerInput(target.value, isAllowed);
     inputError = error;
-    if (date) onDateChange?.(date);
   };
 
   const next = () => {
@@ -79,7 +88,6 @@
 
   const handleDateChange = (d: Date) => {
     showDatePicker = false;
-    inputError = false;
     onDateChange?.(d);
   };
 
@@ -97,11 +105,13 @@
     icon="calendar-plus"
     type="text"
     onfocus={onFocus}
+    oninput={onInput}
     onblur={onBlur}
     placeholder={DATE_PICKER_INPUT_FORMAT}
     value={formatDatePickerInput(selected)}
     error={inputError}
     hintText={inputError ? invalidDate : ''}
+    onClear={() => (inputError = false)}
     clearable
     clearButtonLabel={clearLabel}
     {disabled}
@@ -141,8 +151,8 @@
           type="button"
           class="cursor-pointer text-[12px]"
           onclick={() => {
-            inputError = false;
             selected = new Date();
+            onDateChange?.(selected);
           }}
         >
           {todayLabel}

--- a/src/lib/i18n/locales/en/date-picker.ts
+++ b/src/lib/i18n/locales/en/date-picker.ts
@@ -3,4 +3,5 @@ export const Namespace = 'date-picker' as const;
 export const Strings = {
   'next-month': 'Next Month',
   'previous-month': 'Previous Month',
+  'invalid-date': 'Enter a valid date as MM/DD/YYYY',
 } as const;

--- a/src/lib/utilities/date-picker-input.test.ts
+++ b/src/lib/utilities/date-picker-input.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  evaluateDatePickerInput,
+  formatDatePickerInput,
+  parseDatePickerInput,
+} from './date-picker-input';
+
+describe('formatDatePickerInput', () => {
+  test('formats a date as zero-padded MM/DD/YYYY', () => {
+    expect(formatDatePickerInput(new Date(2026, 5, 5))).toBe('06/05/2026');
+  });
+
+  test('keeps two-digit months and days without padding changes', () => {
+    expect(formatDatePickerInput(new Date(2026, 10, 25))).toBe('11/25/2026');
+  });
+
+  test('round-trips with parseDatePickerInput', () => {
+    const date = new Date(2027, 0, 1);
+    const parsed = parseDatePickerInput(formatDatePickerInput(date));
+    expect(parsed?.getFullYear()).toBe(2027);
+    expect(parsed?.getMonth()).toBe(0);
+    expect(parsed?.getDate()).toBe(1);
+  });
+});
+
+describe('parseDatePickerInput', () => {
+  test('parses a complete, valid MM/DD/YYYY date', () => {
+    const date = parseDatePickerInput('06/05/2026');
+    expect(date?.getFullYear()).toBe(2026);
+    expect(date?.getMonth()).toBe(5);
+    expect(date?.getDate()).toBe(5);
+  });
+
+  test('returns null for partial input (mid-typing)', () => {
+    expect(parseDatePickerInput('06/05/20')).toBeNull();
+    expect(parseDatePickerInput('06/05')).toBeNull();
+    expect(parseDatePickerInput('06')).toBeNull();
+  });
+
+  test('returns null for a two-digit year', () => {
+    expect(parseDatePickerInput('06/05/26')).toBeNull();
+  });
+
+  test('returns null for an out-of-range month', () => {
+    expect(parseDatePickerInput('13/01/2026')).toBeNull();
+    expect(parseDatePickerInput('00/01/2026')).toBeNull();
+  });
+
+  test('returns null for an invalid day that does not round-trip', () => {
+    expect(parseDatePickerInput('02/30/2026')).toBeNull();
+    expect(parseDatePickerInput('04/31/2026')).toBeNull();
+  });
+
+  test('returns null for non-date garbage', () => {
+    expect(parseDatePickerInput('not a date')).toBeNull();
+    expect(parseDatePickerInput('Fri Jun 05 2026')).toBeNull();
+    expect(parseDatePickerInput('')).toBeNull();
+  });
+});
+
+describe('evaluateDatePickerInput', () => {
+  test('returns the date with no error for valid full-date entry', () => {
+    const { date, error } = evaluateDatePickerInput('06/05/2026');
+    expect(error).toBe(false);
+    expect(date?.getFullYear()).toBe(2026);
+  });
+
+  test('returns no date and no error for empty input', () => {
+    expect(evaluateDatePickerInput('')).toEqual({ date: null, error: false });
+    expect(evaluateDatePickerInput('   ')).toEqual({
+      date: null,
+      error: false,
+    });
+  });
+
+  test('returns no date and no error for partial entry (no dispatch)', () => {
+    expect(evaluateDatePickerInput('06/05/20')).toEqual({
+      date: null,
+      error: true,
+    });
+  });
+
+  test('flags an invalid date like 02/30/2026 as an error', () => {
+    expect(evaluateDatePickerInput('02/30/2026')).toEqual({
+      date: null,
+      error: true,
+    });
+  });
+
+  test('rejects an out-of-range date per isAllowed', () => {
+    const noPastDates = (d: Date) => d >= new Date(2026, 0, 1);
+    const { date, error } = evaluateDatePickerInput('06/05/2020', noPastDates);
+    expect(date).toBeNull();
+    expect(error).toBe(true);
+  });
+
+  test('accepts an in-range date per isAllowed', () => {
+    const noPastDates = (d: Date) => d >= new Date(2026, 0, 1);
+    const { date, error } = evaluateDatePickerInput('06/05/2027', noPastDates);
+    expect(date?.getFullYear()).toBe(2027);
+    expect(error).toBe(false);
+  });
+
+  test('supports inline editing of the year', () => {
+    const prefilled = formatDatePickerInput(new Date(2026, 5, 5));
+    expect(prefilled).toBe('06/05/2026');
+
+    const edited = prefilled.replace('2026', '2027');
+    const { date, error } = evaluateDatePickerInput(edited);
+    expect(error).toBe(false);
+    expect(date?.getFullYear()).toBe(2027);
+    expect(date?.getMonth()).toBe(5);
+    expect(date?.getDate()).toBe(5);
+  });
+});

--- a/src/lib/utilities/date-picker-input.test.ts
+++ b/src/lib/utilities/date-picker-input.test.ts
@@ -80,7 +80,7 @@ describe('evaluateDatePickerInput', () => {
     });
   });
 
-  test('returns no date and no error for incomplete entry (no dispatch)', () => {
+  test('flags incomplete entry as an error without a date', () => {
     expect(evaluateDatePickerInput('06/05')).toEqual({
       date: null,
       error: true,

--- a/src/lib/utilities/date-picker-input.test.ts
+++ b/src/lib/utilities/date-picker-input.test.ts
@@ -32,14 +32,20 @@ describe('parseDatePickerInput', () => {
     expect(date?.getDate()).toBe(5);
   });
 
-  test('returns null for partial input (mid-typing)', () => {
-    expect(parseDatePickerInput('06/05/20')).toBeNull();
+  test('parses single-digit month and day without padding', () => {
+    const date = parseDatePickerInput('6/5/2026');
+    expect(date?.getFullYear()).toBe(2026);
+    expect(date?.getMonth()).toBe(5);
+    expect(date?.getDate()).toBe(5);
+  });
+
+  test('returns null for incomplete input (mid-typing)', () => {
     expect(parseDatePickerInput('06/05')).toBeNull();
     expect(parseDatePickerInput('06')).toBeNull();
   });
 
-  test('returns null for a two-digit year', () => {
-    expect(parseDatePickerInput('06/05/26')).toBeNull();
+  test('leniently parses a short year as entered', () => {
+    expect(parseDatePickerInput('06/05/26')?.getFullYear()).toBe(26);
   });
 
   test('returns null for an out-of-range month', () => {
@@ -74,8 +80,8 @@ describe('evaluateDatePickerInput', () => {
     });
   });
 
-  test('returns no date and no error for partial entry (no dispatch)', () => {
-    expect(evaluateDatePickerInput('06/05/20')).toEqual({
+  test('returns no date and no error for incomplete entry (no dispatch)', () => {
+    expect(evaluateDatePickerInput('06/05')).toEqual({
       date: null,
       error: true,
     });

--- a/src/lib/utilities/date-picker-input.ts
+++ b/src/lib/utilities/date-picker-input.ts
@@ -1,34 +1,16 @@
+import { format, isValid, parse } from 'date-fns';
+
 export const DATE_PICKER_INPUT_FORMAT = 'MM/DD/YYYY';
 
-export const formatDatePickerInput = (date: Date): string => {
-  const month = `${date.getMonth() + 1}`.padStart(2, '0');
-  const day = `${date.getDate()}`.padStart(2, '0');
-  const year = `${date.getFullYear()}`.padStart(4, '0');
-  return `${month}/${day}/${year}`;
-};
+const DATE_FNS_FORMAT = 'MM/dd/yyyy';
+const REFERENCE_DATE = new Date(0);
+
+export const formatDatePickerInput = (date: Date): string =>
+  format(date, DATE_FNS_FORMAT);
 
 export const parseDatePickerInput = (value: string): Date | null => {
-  const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(value.trim());
-  if (!match) return null;
-
-  const month = parseInt(match[1], 10);
-  const day = parseInt(match[2], 10);
-  const year = parseInt(match[3], 10);
-
-  if (month < 1 || month > 12) return null;
-  if (day < 1 || day > 31) return null;
-
-  const date = new Date(year, month - 1, day);
-
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month - 1 ||
-    date.getDate() !== day
-  ) {
-    return null;
-  }
-
-  return date;
+  const date = parse(value.trim(), DATE_FNS_FORMAT, REFERENCE_DATE);
+  return isValid(date) ? date : null;
 };
 
 export type DatePickerInputResult = {

--- a/src/lib/utilities/date-picker-input.ts
+++ b/src/lib/utilities/date-picker-input.ts
@@ -1,0 +1,49 @@
+export const DATE_PICKER_INPUT_FORMAT = 'MM/DD/YYYY';
+
+export const formatDatePickerInput = (date: Date): string => {
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const year = `${date.getFullYear()}`.padStart(4, '0');
+  return `${month}/${day}/${year}`;
+};
+
+export const parseDatePickerInput = (value: string): Date | null => {
+  const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(value.trim());
+  if (!match) return null;
+
+  const month = parseInt(match[1], 10);
+  const day = parseInt(match[2], 10);
+  const year = parseInt(match[3], 10);
+
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  const date = new Date(year, month - 1, day);
+
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+export type DatePickerInputResult = {
+  date: Date | null;
+  error: boolean;
+};
+
+export const evaluateDatePickerInput = (
+  value: string,
+  isAllowed: (date: Date) => boolean = () => true,
+): DatePickerInputResult => {
+  if (!value.trim()) return { date: null, error: false };
+
+  const date = parseDatePickerInput(value);
+  if (!date || !isAllowed(date)) return { date: null, error: true };
+
+  return { date, error: false };
+};


### PR DESCRIPTION
Bug: 

The Holocene date-picker.svelte component has two user-facing bugs in its onInput handler. The displayed format (MM/DD/YYYY, 4-digit year) disagrees with the parser, which only fires when input is exactly 8 chars and assumes a 2-digit year (2000 + YY).

Impact:

Editing the date inline does nothing. Changing the prefilled year (e.g. 2026→2027) produces a >8-char string, so date change never fires. The displayed value updates but the bound value silently stays at the default or last calendar-clicked date — no validation feedback. On API key creation this means the key gets an expiration the user didn't choose.

Typing a 4-digit year produces a past date. Typing 06/05/2026 triggers parsing mid-type at 06/05/20 → year 2020; the final 26 makes it 10 chars so it's never re-parsed. The key silently expires in 2020.

Fix direction: Align displayed and accepted input on MM/DD/YYYY; parse only on a complete, valid date (reject partials and invalid dates like 02/30/2026); surface invalid input instead of silently keeping a stale value; apply isAllowed to typed input.