### PR TITLE
Add background to text labels in event history timeline

### DIFF
--- a/src/lib/components/lines-and-dots/svg/text.svelte
+++ b/src/lib/components/lines-and-dots/svg/text.svelte
@@ -22,6 +22,12 @@
     config?: GraphConfig;
     label?: boolean;
     children?: Snippet;
+    /**
+     * Pass any value that captures the rendered content (e.g. the decoded text).
+     * Whenever it changes, the text bbox is re-measured so the background rect
+     * stays sized to the actual text.
+     */
+    contentKey?: unknown;
   };
 
   let {
@@ -37,6 +43,7 @@
     config = undefined,
     label = false,
     children,
+    contentKey,
   }: Props = $props();
 
   const [x, y] = $derived(point);
@@ -44,7 +51,11 @@
   let textElement: SVGTextElement = $state();
 
   const showIcon = $derived(icon && config);
-  const textBBox = $derived(textElement?.getBBox());
+  let textBBox = $state<DOMRect | undefined>();
+  $effect(() => {
+    void contentKey;
+    if (textElement) textBBox = textElement.getBBox();
+  });
   const textWidth = $derived(textBBox?.width || 0);
   const textHeight = $derived(textBBox?.height || 0);
   const backdropWidth = $derived(showIcon ? textWidth + 36 : textWidth + 12);

--- a/src/lib/components/lines-and-dots/svg/text.svelte
+++ b/src/lib/components/lines-and-dots/svg/text.svelte
@@ -48,9 +48,9 @@
 
   const [x, y] = $derived(point);
 
-  let textElement: SVGTextElement = $state();
+  let textElement: SVGTextElement | undefined = $state();
 
-  const showIcon = $derived(icon && config);
+  const iconInfo = $derived(icon && config ? { icon, config } : undefined);
   let textBBox = $state<DOMRect | undefined>();
   $effect(() => {
     void contentKey;
@@ -58,9 +58,9 @@
   });
   const textWidth = $derived(textBBox?.width || 0);
   const textHeight = $derived(textBBox?.height || 0);
-  const backdropWidth = $derived(showIcon ? textWidth + 36 : textWidth + 12);
+  const backdropWidth = $derived(iconInfo ? textWidth + 36 : textWidth + 12);
   const textX = $derived(
-    showIcon && textAnchor === 'start' ? x + config.radius * 2 : x,
+    iconInfo && textAnchor === 'start' ? x + iconInfo.config.radius * 2 : x,
   );
 </script>
 
@@ -72,9 +72,9 @@
     strokeWidth={backdropHeight}
   />
 {/if}
-{#if showIcon}
+{#if iconInfo}
   <Icon
-    name={icon}
+    name={iconInfo.icon}
     x={textAnchor === 'end' ? x - textWidth - backdropHeight : x}
     y={y - 8}
     class={!backdrop ? 'text-primary' : 'text-white'}

--- a/src/lib/components/lines-and-dots/svg/text.svelte
+++ b/src/lib/components/lines-and-dots/svg/text.svelte
@@ -44,7 +44,9 @@
   let textElement: SVGTextElement = $state();
 
   const showIcon = $derived(icon && config);
-  const textWidth = $derived(textElement?.getBBox()?.width || 0);
+  const textBBox = $derived(textElement?.getBBox());
+  const textWidth = $derived(textBBox?.width || 0);
+  const textHeight = $derived(textBBox?.height || 0);
   const backdropWidth = $derived(showIcon ? textWidth + 36 : textWidth + 12);
   const textX = $derived(
     showIcon && textAnchor === 'start' ? x + config.radius * 2 : x,
@@ -68,6 +70,16 @@
   />
 {/if}
 {#key textX}
+  {#if !backdrop}
+    <rect
+      x={textBBox?.x ?? 0}
+      y={y - textHeight / 2}
+      width={textWidth}
+      height={textHeight}
+      class="text-background"
+      pointer-events="none"
+    />
+  {/if}
   <text
     bind:this={textElement}
     class="cursor-pointer select-none outline-none {category} text-primary"
@@ -91,6 +103,10 @@
     stroke: none;
     dominant-baseline: middle;
     alignment-baseline: baseline;
+  }
+
+  rect.text-background {
+    fill: rgb(var(--color-surface-primary));
   }
 
   text.backdrop {

--- a/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/timeline-graph-row.svelte
@@ -286,6 +286,7 @@
             icon={(pendingActivity && !pendingActivity.paused) || retried
               ? 'retry'
               : undefined}
+            contentKey={decodedValue}
           >
             {#if pendingActivity}
               {translate('workflows.attempt')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Text labels on the event-history timeline graph overlap the dotted vertical gridlines, making them hard to read.

This PR renders a small surface-colored SVG `<rect>` behind each non-backdrop timeline label, sized to the text's bounding box, so the text reads cleanly against the gridlines.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
| Before | After |
|-|-|
|<img width="546" height="423" alt="Screenshot 2026-06-10 at 10 11 03 AM" src="https://github.com/user-attachments/assets/74836eab-78bb-43bb-a3e9-8e3ba3c3dbd4" />|<img width="373" height="260" alt="Screenshot 2026-06-10 at 8 57 58 AM" src="https://github.com/user-attachments/assets/a60e7cee-2c61-47df-8eae-85a74f33a345" />|
|<img width="472" height="438" alt="Screenshot 2026-06-10 at 10 10 37 AM" src="https://github.com/user-attachments/assets/94260989-e1fd-42c3-b375-c94fa99cb99d" />|<img width="480" height="395" alt="Screenshot 2026-06-10 at 10 02 20 AM" src="https://github.com/user-attachments/assets/23f24bf7-e1fc-4467-86e8-d12b31bd3fa3" />|


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

  - [ ] Verify text labels are readable against the dotted gridlines on the timeline graph.
  - [ ] Expand a group row and confirm the background rect for labels in shifted rows tracks the text position. Background rectangles shouldn't appear on top of the expanded details.
  - [ ] Toggle dark mode and confirm the background fill matches the timeline background in both themes.
  - [ ] On events that have a `userMetadata.summary` confirm the background resizes to fit the decoded summary text after it loads.
  - [ ] Confirm hover/click on labeled timeline events still works as before (rect should not intercept events).
  - [ ] Verify existing `backdrop=true` case renders unchanged.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-4153`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
