### PR TITLE
fix(workers): soften no-workers-polling alert for serverless worker deployments

### DIFF
--- a/src/lib/components/workers/no-workers-polling-alert.svelte
+++ b/src/lib/components/workers/no-workers-polling-alert.svelte
@@ -20,37 +20,38 @@
 
   let serverlessDeployment = $state(false);
   let deploymentChecked = $state(false);
-  let lastCheckedDeployment: string | undefined = undefined;
 
   $effect(() => {
     if (!runningWithNoWorkers || !deployment) {
       serverlessDeployment = false;
       deploymentChecked = true;
-      lastCheckedDeployment = undefined;
       return;
     }
 
-    if (lastCheckedDeployment === deployment) return;
-    lastCheckedDeployment = deployment;
-
     deploymentChecked = false;
+    const controller = new AbortController();
+
     fetchDeployment(
       { namespace, deploymentName: deployment },
       fetch,
       () => {},
       false,
+      controller.signal,
     )
       .then((response) => {
+        if (controller.signal.aborted) return;
         serverlessDeployment = deploymentHasComputeConfig(
           response?.workerDeploymentInfo,
         );
+        deploymentChecked = true;
       })
       .catch(() => {
+        if (controller.signal.aborted) return;
         serverlessDeployment = false;
-      })
-      .finally(() => {
         deploymentChecked = true;
       });
+
+    return () => controller.abort();
   });
 </script>
 

--- a/src/lib/components/workers/no-workers-polling-alert.svelte
+++ b/src/lib/components/workers/no-workers-polling-alert.svelte
@@ -20,16 +20,26 @@
 
   let serverlessDeployment = $state(false);
   let deploymentChecked = $state(false);
+  let lastCheckedDeployment: string | undefined = undefined;
 
   $effect(() => {
     if (!runningWithNoWorkers || !deployment) {
       serverlessDeployment = false;
       deploymentChecked = true;
+      lastCheckedDeployment = undefined;
       return;
     }
 
+    if (lastCheckedDeployment === deployment) return;
+    lastCheckedDeployment = deployment;
+
     deploymentChecked = false;
-    fetchDeployment({ namespace, deploymentName: deployment }, fetch, () => {})
+    fetchDeployment(
+      { namespace, deploymentName: deployment },
+      fetch,
+      () => {},
+      false,
+    )
       .then((response) => {
         serverlessDeployment = deploymentHasComputeConfig(
           response?.workerDeploymentInfo,

--- a/src/lib/components/workers/no-workers-polling-alert.svelte
+++ b/src/lib/components/workers/no-workers-polling-alert.svelte
@@ -1,32 +1,88 @@
 <script lang="ts">
+  import { page } from '$app/state';
+
   import Alert from '$lib/holocene/alert.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { fetchDeployment } from '$lib/services/deployments-service';
   import { workflowRun } from '$lib/stores/workflow-run';
+  import { deploymentHasComputeConfig } from '$lib/utilities/deployment-has-compute-config';
   import { isRunningWithNoWorkers } from '$lib/utilities/is-running-with-no-workers';
+  import { routeForWorkerDeployment } from '$lib/utilities/route-for';
 
   const { workflow } = $derived($workflowRun);
   const runningWithNoWorkers = $derived(isRunningWithNoWorkers($workflowRun));
+  const namespace = $derived(page.params.namespace);
+  const deployment = $derived(
+    workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'],
+  );
+
+  let serverlessDeployment = $state(false);
+  let deploymentChecked = $state(false);
+
+  $effect(() => {
+    if (!runningWithNoWorkers || !deployment) {
+      serverlessDeployment = false;
+      deploymentChecked = true;
+      return;
+    }
+
+    deploymentChecked = false;
+    fetchDeployment({ namespace, deploymentName: deployment }, fetch, () => {})
+      .then((response) => {
+        serverlessDeployment = deploymentHasComputeConfig(
+          response?.workerDeploymentInfo,
+        );
+      })
+      .catch(() => {
+        serverlessDeployment = false;
+      })
+      .finally(() => {
+        deploymentChecked = true;
+      });
+  });
 </script>
 
-<Alert
-  icon="warning"
-  intent="warning"
-  title={translate('workflows.workflow-error-no-workers-title')}
-  class="max-w-screen-lg xl:w-2/3"
-  hidden={!runningWithNoWorkers}
->
-  {translate('workflows.workflow-error-no-workers-description', {
-    taskQueue: workflow?.taskQueue ?? '',
-  })}
-  {translate('workflows.workers-alert-description')}
-  <Link
-    href="https://docs.temporal.io/develop/worker-performance"
-    newTab
-    class="mt-2 flex items-center gap-1"
+{#if serverlessDeployment && deployment}
+  <Alert
+    icon="info"
+    intent="info"
+    title={translate('workflows.workflow-error-no-workers-serverless-title')}
+    class="max-w-screen-lg xl:w-2/3"
+    hidden={!runningWithNoWorkers}
   >
-    {translate('workers.troubleshooting-workers-link')}
-    <Icon name="arrow-right" />
-  </Link>
-</Alert>
+    {translate('workflows.workflow-error-no-workers-serverless-description', {
+      taskQueue: workflow?.taskQueue ?? '',
+      deployment,
+    })}
+    <Link
+      href={routeForWorkerDeployment({ namespace, deployment })}
+      class="mt-2 flex items-center gap-1"
+    >
+      {translate('workflows.view-worker-deployment')}
+      <Icon name="arrow-right" />
+    </Link>
+  </Alert>
+{:else}
+  <Alert
+    icon="warning"
+    intent="warning"
+    title={translate('workflows.workflow-error-no-workers-title')}
+    class="max-w-screen-lg xl:w-2/3"
+    hidden={!runningWithNoWorkers || !deploymentChecked}
+  >
+    {translate('workflows.workflow-error-no-workers-description', {
+      taskQueue: workflow?.taskQueue ?? '',
+    })}
+    {translate('workflows.workers-alert-description')}
+    <Link
+      href="https://docs.temporal.io/develop/worker-performance"
+      newTab
+      class="mt-2 flex items-center gap-1"
+    >
+      {translate('workers.troubleshooting-workers-link')}
+      <Icon name="arrow-right" />
+    </Link>
+  </Alert>
+{/if}

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -161,6 +161,10 @@ export const Strings = {
     'There are no workers polling the {{taskQueue}} task queue.',
   'workers-alert-description':
     'Check your deployment or orchestration system (Kubernetes, ECS, etc.). Review worker logs for crash information. Restart or redeploy workers.',
+  'workflow-error-no-workers-serverless-title': 'No workers currently polling',
+  'workflow-error-no-workers-serverless-description':
+    'The {{taskQueue}} task queue is served by the serverless worker deployment {{deployment}}, which scales down to zero when idle. Workers will start automatically when there are tasks to process.',
+  'view-worker-deployment': 'View Worker Deployment',
   'workflow-error-no-compatible-workers-title': 'No Compatible Workers Running',
   'workflow-error-no-compatible-workers-description':
     'There are no compatible Workers polling the {{taskQueue}} Task Queue.',

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -70,12 +70,10 @@ export const fetchDeployment = async (
   parameters: DeploymentParameters,
   request = fetch,
   onError?: ErrorCallback,
+  notifyOnError = true,
 ): Promise<WorkerDeploymentResponse> => {
   const route = routeForApi('worker-deployment', parameters);
-  return requestFromAPI(route, {
-    request,
-    ...(onError ? { onError, notifyOnError: false } : {}),
-  });
+  return requestFromAPI(route, { request, onError, notifyOnError });
 };
 
 export const fetchDeploymentVersion = async (

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -69,9 +69,13 @@ export const createWorkerDeployment = async (
 export const fetchDeployment = async (
   parameters: DeploymentParameters,
   request = fetch,
+  onError?: ErrorCallback,
 ): Promise<WorkerDeploymentResponse> => {
   const route = routeForApi('worker-deployment', parameters);
-  return requestFromAPI(route, { request });
+  return requestFromAPI(route, {
+    request,
+    ...(onError ? { onError, notifyOnError: false } : {}),
+  });
 };
 
 export const fetchDeploymentVersion = async (

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -71,9 +71,15 @@ export const fetchDeployment = async (
   request = fetch,
   onError?: ErrorCallback,
   notifyOnError = true,
+  signal?: AbortSignal,
 ): Promise<WorkerDeploymentResponse> => {
   const route = routeForApi('worker-deployment', parameters);
-  return requestFromAPI(route, { request, onError, notifyOnError });
+  return requestFromAPI(route, {
+    request,
+    onError,
+    notifyOnError,
+    options: { signal },
+  });
 };
 
 export const fetchDeploymentVersion = async (

--- a/src/lib/utilities/deployment-has-compute-config.test.ts
+++ b/src/lib/utilities/deployment-has-compute-config.test.ts
@@ -64,11 +64,11 @@ describe('deploymentHasComputeConfig', () => {
     ).toBe(true);
   });
 
-  it('returns true when the latest version summary has a compute config', () => {
+  it('returns true when the ramping version summary has a compute config', () => {
     expect(
       deploymentHasComputeConfig({
         ...baseDeployment,
-        latestVersionSummary: {
+        rampingVersionSummary: {
           version: 'loan-underwriting-app.build-2',
           createTime: undefined,
           computeConfig,
@@ -77,30 +77,20 @@ describe('deploymentHasComputeConfig', () => {
     ).toBe(true);
   });
 
-  it('returns true when a version summary has a compute config', () => {
+  it('ignores compute configs on inactive versions', () => {
     expect(
       deploymentHasComputeConfig({
         ...baseDeployment,
+        latestVersionSummary: {
+          version: 'loan-underwriting-app.build-2',
+          createTime: undefined,
+          computeConfig,
+        },
         versionSummaries: [
           {
-            version: 'loan-underwriting-app.build-1',
+            version: 'loan-underwriting-app.build-0',
             createTime: undefined,
             computeConfig,
-          },
-        ],
-      }),
-    ).toBe(true);
-  });
-
-  it('returns false when version summaries are the old shape without compute config', () => {
-    expect(
-      deploymentHasComputeConfig({
-        ...baseDeployment,
-        versionSummaries: [
-          {
-            version: 'loan-underwriting-app.build-1',
-            createTime: undefined,
-            drainageStatus: 'DRAINAGE_STATUS_UNSPECIFIED',
           },
         ],
       }),

--- a/src/lib/utilities/deployment-has-compute-config.test.ts
+++ b/src/lib/utilities/deployment-has-compute-config.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  ComputeConfig,
+  WorkerDeploymentInfo,
+} from '$lib/types/deployments';
+
+import { deploymentHasComputeConfig } from './deployment-has-compute-config';
+
+const computeConfig: ComputeConfig = {
+  scalingGroups: {
+    default: {
+      taskQueueTypes: ['TASK_QUEUE_TYPE_WORKFLOW', 'TASK_QUEUE_TYPE_ACTIVITY'],
+      provider: { type: 'aws-lambda' },
+    },
+  },
+};
+
+const baseDeployment = {
+  name: 'loan-underwriting-app',
+  createTime: undefined,
+  routingConfig: {},
+  lastModifierIdentity: 'test',
+  versionSummaries: [],
+  currentVersionSummary: {
+    version: 'loan-underwriting-app.build-1',
+    createTime: undefined,
+  },
+} as unknown as WorkerDeploymentInfo;
+
+describe('deploymentHasComputeConfig', () => {
+  it('returns false for undefined deployment', () => {
+    expect(deploymentHasComputeConfig(undefined)).toBe(false);
+  });
+
+  it('returns false when no compute config exists', () => {
+    expect(deploymentHasComputeConfig(baseDeployment)).toBe(false);
+  });
+
+  it('returns false when compute config has no scaling groups', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        computeConfig: { scalingGroups: {} },
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when the deployment has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({ ...baseDeployment, computeConfig }),
+    ).toBe(true);
+  });
+
+  it('returns true when the current version summary has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        currentVersionSummary: {
+          ...baseDeployment.currentVersionSummary,
+          computeConfig,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when the latest version summary has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        latestVersionSummary: {
+          version: 'loan-underwriting-app.build-2',
+          createTime: undefined,
+          computeConfig,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when a version summary has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        versionSummaries: [
+          {
+            version: 'loan-underwriting-app.build-1',
+            createTime: undefined,
+            computeConfig,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when version summaries are the old shape without compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        versionSummaries: [
+          {
+            version: 'loan-underwriting-app.build-1',
+            createTime: undefined,
+            drainageStatus: 'DRAINAGE_STATUS_UNSPECIFIED',
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/lib/utilities/deployment-has-compute-config.ts
+++ b/src/lib/utilities/deployment-has-compute-config.ts
@@ -1,0 +1,25 @@
+import type {
+  ComputeConfig,
+  WorkerDeploymentInfo,
+} from '$lib/types/deployments';
+
+const hasScalingGroups = (config?: ComputeConfig): boolean =>
+  Object.keys(config?.scalingGroups ?? {}).length > 0;
+
+export const deploymentHasComputeConfig = (
+  deployment?: WorkerDeploymentInfo,
+): boolean => {
+  if (!deployment) return false;
+
+  const versionConfigs = (deployment.versionSummaries ?? []).map((summary) =>
+    'computeConfig' in summary ? summary.computeConfig : undefined,
+  );
+
+  return [
+    deployment.computeConfig,
+    deployment.latestVersionSummary?.computeConfig,
+    deployment.currentVersionSummary?.computeConfig,
+    deployment.rampingVersionSummary?.computeConfig,
+    ...versionConfigs,
+  ].some(hasScalingGroups);
+};

--- a/src/lib/utilities/deployment-has-compute-config.ts
+++ b/src/lib/utilities/deployment-has-compute-config.ts
@@ -11,15 +11,9 @@ export const deploymentHasComputeConfig = (
 ): boolean => {
   if (!deployment) return false;
 
-  const versionConfigs = (deployment.versionSummaries ?? []).map((summary) =>
-    'computeConfig' in summary ? summary.computeConfig : undefined,
-  );
-
   return [
     deployment.computeConfig,
-    deployment.latestVersionSummary?.computeConfig,
     deployment.currentVersionSummary?.computeConfig,
     deployment.rampingVersionSummary?.computeConfig,
-    ...versionConfigs,
   ].some(hasScalingGroups);
 };


### PR DESCRIPTION
## What was changed

When a running workflow's task queue has no pollers but is served by a worker deployment with a compute config (serverless workers), the "No workers polling" warning is replaced with an informational alert instead of the alarming "check Kubernetes/ECS, restart workers" guidance.

<img width="1551" height="1273" alt="CleanShot 2026-06-10 at 13 49 42" src="https://github.com/user-attachments/assets/276917ae-9b55-4f6f-934c-fea0d319b5c0" />

- `no-workers-polling-alert.svelte`: when the no-workers condition triggers and the workflow has a `TemporalWorkerDeployment` search attribute, fetch the deployment and check for a compute config. If found, render an info-intent alert explaining the deployment scales to zero when idle and workers start automatically, linking to the deployment page. The warning variant is held hidden until the deployment check resolves so the harsh copy never flashes first.
- `deployment-has-compute-config.ts` (+ tests): checks deployment-level compute config plus current/ramping/latest and per-version summaries for non-empty scaling groups, so a pinned older build with a compute config still counts.
- `deployments-service.ts`: `fetchDeployment` accepts an optional `onError` that suppresses the global error toast — a failed background check just falls back to the existing warning.
- New i18n keys for the serverless title, description, and deployment link.

## Why?

Serverless worker deployments scale to zero when idle, so an empty poller list from `DescribeTaskQueue` is an expected state, not a sign that workers crashed. The existing warning told users to check their orchestration system and restart workers, which is misleading for deployments Temporal manages.

Reported by Brandon: the alert appeared on a running workflow pinned to a serverless deployment (`loan-underwriting-app` / `build-1`) even though the deployment was handling tasks.

## Checklist

1. Closes [DT-4158]

2. How was this tested:

- Unit tests for `deploymentHasComputeConfig` covering deployment-level, current/latest/per-version summaries, and old-shape summaries
- `pnpm check`, `pnpm lint`, and full unit suite pass

3. Any docs updates needed?

No

[DT-4158]: https://temporalio.atlassian.net/browse/DT-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ