### PR TITLE
a11y(1.4.4): date-picker — replace pixel-locked text-[12px] with rem-based text-xs

### DIFF
--- a/src/lib/holocene/date-picker.svelte
+++ b/src/lib/holocene/date-picker.svelte
@@ -136,14 +136,14 @@
       <div class="my-1 flex justify-between px-2">
         <button
           type="button"
-          class="cursor-pointer text-[12px]"
+          class="cursor-pointer text-xs"
           onclick={() => (selected = new Date())}
         >
           {todayLabel}
         </button>
         <button
           type="button"
-          class="cursor-pointer text-[12px]"
+          class="cursor-pointer text-xs"
           onclick={() => (showDatePicker = false)}
         >
           {closeLabel}


### PR DESCRIPTION
## Description

Fixes WCAG 2.2 SC 1.4.4 (Resize Text) in `src/lib/holocene/date-picker.svelte`.

The "Today" and "Close" buttons inside the DatePicker popover used `text-[12px]` — a pixel-locked font size that bypasses browser text-size preferences and Firefox text-only zoom. Under those settings the buttons stay fixed at 12 px while surrounding text scales, breaking the 200% resize requirement.

Replacing with `text-xs` emits `font-size: 0.75rem` — visually identical at the browser default (16 px root = 12 px rendered), but scales correctly with user preferences.

## Screenshots

_No visual change at default zoom. Difference is only observable under Firefox text-only zoom or a non-default root font size._

## Design

No design change. `0.75rem` equals `12px` at the browser default; the intent of the original value is preserved.

## Testing

- [ ] Open any page with a DatePicker (workflow filter date range, schedule create form, usage chart date picker) and open the calendar popover.
- [ ] Inspect the "Today" and "Close" buttons in DevTools — confirm `font-size: 0.75rem` (not `12px`).
- [ ] Firefox → View → Zoom → Zoom Text Only → Cmd+= to 200% — confirm both buttons scale proportionally with the calendar grid.
- [ ] At default zoom: confirm the visual is identical to before.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have read the [contributor guidelines](https://github.com/temporalio/ui/blob/main/CONTRIBUTING.md)

## Docs

No documentation changes required.

A11y-Audit-Ref: 1.4.4-date-picker-text-size