### PR TITLE
a11y(2.1.1): event summary row — add keyboard-accessible expand control alongside the mouse-only <tr onclick>

### DIFF
--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -9,6 +9,7 @@
   import Badge from '$lib/holocene/badge.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
+  import IconButton from '$lib/holocene/icon-button.svelte';
   import Link from '$lib/holocene/link.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -169,11 +170,14 @@
     $timestamp(currentEvent?.eventTime, { format: 'short' }),
   );
 
-  const onLinkClick = (event) => {
+  const onLinkClick = (event?) => {
     expanded = !expanded;
-    event.stopPropagation();
+    event?.stopPropagation?.();
     onRowClick();
   };
+
+  const detailsId = $derived(`event-details-${event.id}-${index}`);
+
   const handleMouseEnter = () => {
     hoveredEventId = event.id;
   };
@@ -212,6 +216,20 @@
   onmouseleave={handleMouseLeave}
   onclick={onLinkClick}
 >
+  <td class="w-8 text-center">
+    <IconButton
+      icon={expanded ? 'chevron-up' : 'chevron-down'}
+      label={expanded
+        ? translate('events.collapse-details')
+        : translate('events.expand-details')}
+      aria-expanded={expanded}
+      aria-controls={expanded ? detailsId : undefined}
+      on:click={(e) => {
+        e.stopPropagation();
+        onLinkClick(e);
+      }}
+    />
+  </td>
   {#if isEventGroup(event)}
     <td class="font-mono">
       <div class="flex items-center gap-0.5">
@@ -372,10 +390,11 @@
 </tr>
 {#if expanded}
   <tr
+    id={detailsId}
     class="w-full text-sm no-underline"
     data-testid="event-summary-row-expanded"
   >
-    <td class="!p-0" colspan={$isCloud ? 5 : 4}>
+    <td class="!p-0" colspan={$isCloud ? 6 : 5}>
       <EventDetailsFull {group} event={currentEvent} />
     </td>
   </tr>

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -201,6 +201,22 @@
   });
 </script>
 
+{#snippet expandButton()}
+  <IconButton
+    icon={expanded ? 'chevron-up' : 'chevron-down'}
+    label={expanded
+      ? translate('events.collapse-details')
+      : translate('events.expand-details')}
+    aria-expanded={expanded}
+    aria-controls={expanded ? detailsId : undefined}
+    class="h-6 w-6"
+    on:click={(e) => {
+      e.stopPropagation();
+      onLinkClick(e);
+    }}
+  />
+{/snippet}
+
 <tr
   class={merge(
     'hover:cursor-pointer',
@@ -216,43 +232,35 @@
   onmouseleave={handleMouseLeave}
   onclick={onLinkClick}
 >
-  <td class="w-8 text-center">
-    <IconButton
-      icon={expanded ? 'chevron-up' : 'chevron-down'}
-      label={expanded
-        ? translate('events.collapse-details')
-        : translate('events.expand-details')}
-      aria-expanded={expanded}
-      aria-controls={expanded ? detailsId : undefined}
-      on:click={(e) => {
-        e.stopPropagation();
-        onLinkClick(e);
-      }}
-    />
-  </td>
   {#if isEventGroup(event)}
     <td class="font-mono">
-      <div class="flex items-center gap-0.5">
-        {#each event.eventList as groupEvent}
-          <Link
-            data-testid="link"
-            href={routeForEventHistoryEvent({
-              eventId: groupEvent.id,
-              namespace,
-              workflow,
-              run,
-            })}
-          >
-            {groupEvent.id}
-          </Link>
-        {/each}
+      <div class="flex items-center gap-1">
+        {@render expandButton()}
+        <div class="flex items-center gap-0.5">
+          {#each event.eventList as groupEvent}
+            <Link
+              data-testid="link"
+              href={routeForEventHistoryEvent({
+                eventId: groupEvent.id,
+                namespace,
+                workflow,
+                run,
+              })}
+            >
+              {groupEvent.id}
+            </Link>
+          {/each}
+        </div>
       </div>
     </td>
   {:else}
     <td class="font-mono">
-      <Link data-testid="link" {href}>
-        {event.id}
-      </Link>
+      <div class="flex items-center gap-1">
+        {@render expandButton()}
+        <Link data-testid="link" {href}>
+          {event.id}
+        </Link>
+      </div>
     </td>
   {/if}
   <td class="text-right md:hidden">
@@ -394,7 +402,7 @@
     class="w-full text-sm no-underline"
     data-testid="event-summary-row-expanded"
   >
-    <td class="!p-0" colspan={$isCloud ? 6 : 5}>
+    <td class="!p-0" colspan={$isCloud ? 5 : 4}>
       <EventDetailsFull {group} event={currentEvent} />
     </td>
   </tr>

--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -67,6 +67,8 @@ export const Strings = {
   'event-history-load-error': 'Could not parse JSON',
   'event-classification-label': 'Event Classification',
   'row-accessible-name': 'Event {{eventType}}: {{classification}}',
+  'expand-details': 'Expand details',
+  'collapse-details': 'Collapse details',
   'event-classification': {
     unspecified: 'Unspecified',
     scheduled: 'Scheduled',


### PR DESCRIPTION
## Description & motivation 💭

In the workflow event history, each event row toggles an inline `EventDetailsFull` panel via a click handler on the `<tr>`. The only focusable elements inside the row were `<Link>` components that call `stopPropagation`, making the expand toggle unreachable by keyboard.

This PR adds a dedicated expand `<button>` (via `IconButton`) as the row's leading cell, wired to the same `onLinkClick` handler with `aria-expanded` and `aria-controls` semantics. Keyboard users now have full feature parity with mouse: Tab to the chevron button, press Enter/Space to expand/collapse `EventDetailsFull` inline without losing surrounding history context.

The `<tr onclick>` mouse path is fully preserved — this PR adds the keyboard path, it does not remove the mouse path.

**SC:** 2.1.1 Keyboard (Level A) — current verdict: **Fails → Supports**

### Screenshots (if applicable) 📸

No visual change at default state. Chevron button appears as the first cell of each event row; icon flips between `chevron-down` (collapsed) and `chevron-up` (expanded).

### Design Considerations 🎨

The 8px leading `<td>` is consistent with the existing table cell sizing. Uses the existing `IconButton` Holocene primitive — no new design tokens.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open any workflow's event history view.
2. Tab into the table — confirm the first focus stop per row is the chevron expand button.
3. Press **Enter** on a focused expand button — confirm `EventDetailsFull` renders below and focus stays on the button.
4. Press **Space** on the focused button — confirm the panel collapses and focus stays on the button.
5. Tab again — confirm the next stop is the event-ID `<Link>` inside the same row, not the next row's button.
6. Click the row body (not the button or a link) — confirm the panel still toggles via the `<tr onclick>` mouse path.
7. Click the expand button with the mouse — confirm the panel toggles exactly once (no double-fire from the `stopPropagation` logic).
8. VoiceOver smoke test: focus the button, confirm announcement is `Expand details, collapsed, button`; after Enter, confirm `Collapse details, expanded, button`.
9. axe-core on a workflow detail page: zero new violations; `aria-controls` reference resolves when expanded.

## Checklists

### Draft Checklist

- [ ] VoiceOver / NVDA smoke test
- [ ] axe-core run on workflow event history page

### Merge Checklist

- [ ] Screen reader announcement verified
- [ ] axe-core: zero new violations
- [ ] Regression: `onRowClick` still fires for both mouse-on-row and keyboard-on-button paths

### Issue(s) closed

Closes finding #6 from the 2.1.1 audit (`audit-output/issues/2.1.1-keyboard-audit.md`).

## Docs

### Any docs updates needed?

No doc changes needed.

A11y-Audit-Ref: 2.1.1-event-summary-row-expand