### PR TITLE
a11y(2.4.3): replace flex-wrap-reverse with flex-wrap on workflow history toolbar

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -150,7 +150,7 @@
 </div>
 <div class="relative">
   <div
-    class="surface-background sticky top-0 z-[11] flex flex-wrap-reverse items-center justify-between gap-2 border-b border-subtle md:top-[var(--top-nav-height)] md:pt-2 xl:gap-8"
+    class="surface-background sticky top-0 z-[11] flex flex-wrap items-center justify-between gap-2 border-b border-subtle md:top-[var(--top-nav-height)] md:pt-2 xl:gap-8"
   >
     <div class="items-bottom flex gap-4 pt-2">
       <h2>


### PR DESCRIPTION
## Description & motivation 💭

The sticky toolbar on the workflow event-history layout uses `flex-wrap-reverse`. At wide viewports (`xl:` and up) the toolbar's two clusters — heading + history tabs on the left, ToggleButtons + Download on the right — sit on one row and `-reverse` is a no-op. But when the viewport narrows enough for the toolbar to wrap onto two rows, `-reverse` flips the wrap stacking: the **second** DOM child (ToggleButtons) renders on the *upper* row while the **first** DOM child (heading + tabs) drops to the *lower* row.

Keyboard Tab order still follows DOM order — tabs first, then ToggleButtons — so a keyboard user sees focus jump *down* to the tabs and then *up* to the controls above them. That's a **SC 2.4.3 Focus Order** mismatch (it also cross-walks to 1.3.2 Meaningful Sequence) on one of the most-trafficked detail views in the product.

The fix drops `-reverse` so DOM order and visual order agree at narrow viewports. It also aligns with the structurally identical sibling `workflow-timeline-layout.svelte`, which already uses plain `flex-wrap` — the `-reverse` here appears to be copy-paste drift. Wide-viewport rendering is unchanged.

The change is one word in one class string (`src/lib/layouts/workflow-history-layout.svelte:153`):

```diff
   <div
-    class="surface-background sticky top-0 z-[11] flex flex-wrap-reverse items-center justify-between gap-2 border-b border-subtle md:top-[var(--top-nav-height)] md:pt-2 xl:gap-8"
+    class="surface-background sticky top-0 z-[11] flex flex-wrap items-center justify-between gap-2 border-b border-subtle md:top-[var(--top-nav-height)] md:pt-2 xl:gap-8"
   >
```

### Screenshots (if applicable) 📸

Before/after at a wrap-width viewport (~`md` 768px) recommended — at narrow widths the heading + tabs cluster moves to the upper row and ToggleButtons + Download to the lower row. Wide (`xl:`+) viewports are visually unchanged.

### Design Considerations 🎨

This flips the narrow-viewport visual layout (today ToggleButtons sit above the tabs). If Design wants to **keep** ToggleButtons visually on top, the alternative fix is to reorder the source — move the ToggleButtons block before the heading block and keep plain `flex-wrap`. Both shapes resolve 2.4.3. Going with the `-reverse` removal since it matches the timeline-layout sibling. **Design input welcome on which visual is preferred.**

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

_No automated test added — change is a single Tailwind class. Possible follow-up: a Playwright assertion that toolbar DOM order matches visual order at a wrap-width viewport._

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open a workflow detail page → **History** tab: `/namespaces/<ns>/workflows/<wf>/<run>/history`.
2. **Wide viewport (`xl:`, ≥1280px):** confirm the toolbar is unchanged — heading + tabs left, ToggleButtons right, single row.
3. **Narrow viewport (~`md` 768px, where the toolbar wraps):** confirm heading + tabs are now on the **upper** row and ToggleButtons + Download on the **lower** row.
4. **Keyboard tab order at narrow viewport:** Tab into the toolbar — focus should land on `All` → `Compact` → `JSON`, then proceed to the ToggleButtons (sort, event-type filter, pause, download), matching top-to-bottom visual reading order.
5. **Screen reader:** with VoiceOver (macOS Safari), walk the toolbar via the rotor — announced order should match visual order.
6. **Regression:** confirm `workflow-timeline-layout.svelte` is untouched (already correct).
7. **axe-core** on the history route at a narrow viewport: zero new violations.

## Checklists

### Draft Checklist

- [ ] Confirm with Design which narrow-viewport visual is preferred (`-reverse` removal vs. source reorder)

### Merge Checklist

- [ ] Verified no visual regression at `xl:`+ widths
- [ ] Keyboard tab order matches visual order at wrap-width viewports

### Issue(s) closed

<!-- add issue number here if one exists -->

## Docs

### Any docs updates needed?

None.

---

A11y-Audit-Ref: 2.4.3-workflow-history-toolbar-wrap
