### PR TITLE
a11y(2.1.1): ZoomSvg — add keyboard pan/zoom controls so the workflow family tree is operable without a mouse

### DIFF
--- a/src/lib/holocene/icon/paths.ts
+++ b/src/lib/holocene/icon/paths.ts
@@ -91,6 +91,7 @@ import merge from './svg/merge.svelte';
 import microchip from './svg/microchip.svelte';
 import microsoft from './svg/microsoft.svelte';
 import minimize from './svg/minimize.svelte';
+import minus from './svg/minus.svelte';
 import moon from './svg/moon.svelte';
 import namespaceSwitcher from './svg/namespace-switcher.svelte';
 import namespace from './svg/namespace.svelte';
@@ -102,6 +103,7 @@ import pencil from './svg/pencil.svelte';
 import pinFilled from './svg/pin-filled.svelte';
 import pin from './svg/pin.svelte';
 import play from './svg/play.svelte';
+import plus from './svg/plus.svelte';
 import regions from './svg/regions.svelte';
 import relationship from './svg/relationship.svelte';
 import retention from './svg/retention.svelte';
@@ -249,6 +251,7 @@ export const icons = {
   microchip,
   microsoft,
   minimize,
+  minus,
   moon,
   'namespace-switcher': namespaceSwitcher,
   namespace,
@@ -256,6 +259,7 @@ export const icons = {
   'office-buildings': officeBuildings,
   overview,
   play,
+  plus,
   pause,
   pencil,
   'pin-filled': pinFilled,

--- a/src/lib/holocene/icon/svg/minus.svelte
+++ b/src/lib/holocene/icon/svg/minus.svelte
@@ -4,8 +4,5 @@
 </script>
 
 <Svg {...props}>
-  <path
-    d="M19 13H5V11H19V13Z"
-    fill="currentcolor"
-  />
+  <path d="M19 13H5V11H19V13Z" fill="currentcolor" />
 </Svg>

--- a/src/lib/holocene/icon/svg/minus.svelte
+++ b/src/lib/holocene/icon/svg/minus.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Svg from '../svg.svelte';
+  let props = $props();
+</script>
+
+<Svg {...props}>
+  <path
+    d="M19 13H5V11H19V13Z"
+    fill="currentcolor"
+  />
+</Svg>

--- a/src/lib/holocene/icon/svg/plus.svelte
+++ b/src/lib/holocene/icon/svg/plus.svelte
@@ -4,8 +4,5 @@
 </script>
 
 <Svg {...props}>
-  <path
-    d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z"
-    fill="currentcolor"
-  />
+  <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" fill="currentcolor" />
 </Svg>

--- a/src/lib/holocene/icon/svg/plus.svelte
+++ b/src/lib/holocene/icon/svg/plus.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import Svg from '../svg.svelte';
+  let props = $props();
+</script>
+
+<Svg {...props}>
+  <path
+    d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z"
+    fill="currentcolor"
+  />
+</Svg>

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -143,6 +143,8 @@
 >
   <div class="absolute right-4 top-4 z-20 flex items-center gap-2">
     <slot name="controls" />
+  </div>
+  <div class="absolute bottom-4 right-4 z-20 flex items-center gap-2">
     {#if pannable}
       <Tooltip text="Pan up" bottom>
         <Button

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -12,14 +12,16 @@
   export let pannable = true;
 
   let zoomLevel = initialZoom;
+  let panX = 0;
+  let panY = 0;
 
   let svg;
 
   $: viewBox = {
-    x: 0,
-    y: 0,
-    width,
-    height,
+    x: panX,
+    y: panY,
+    width: (width * zoomLevel) / initialZoom,
+    height: (height * zoomLevel) / initialZoom,
   };
 
   let isPanning = false;
@@ -33,19 +35,16 @@
 
   function panBy(dx: number, dy: number) {
     if (!pannable) return;
-    viewBox.x += dx * viewBox.width;
-    viewBox.y += dy * viewBox.height;
+    panX += dx * viewBox.width;
+    panY += dy * viewBox.height;
   }
 
   function zoomBy(factor: number, centerX = width / 2, centerY = height / 2) {
     if (!zoomable) return;
     const newZoomLevel = zoomLevel + factor;
     if (newZoomLevel < maxZoomIn || newZoomLevel > maxZoomOut) return;
-    const zoomRatio = newZoomLevel / zoomLevel;
-    viewBox.x = centerX - (centerX - viewBox.x) * zoomRatio;
-    viewBox.y = centerY - (centerY - viewBox.y) * zoomRatio;
-    viewBox.width *= zoomRatio;
-    viewBox.height *= zoomRatio;
+    panX += (centerX * (zoomLevel - newZoomLevel)) / initialZoom;
+    panY += (centerY * (zoomLevel - newZoomLevel)) / initialZoom;
     zoomLevel = newZoomLevel;
   }
 
@@ -57,20 +56,12 @@
     const mouseX = event.clientX - rect.left;
     const mouseY = event.clientY - rect.top;
 
-    const zoomAmount = event.deltaY * 0.001;
-    let newZoomLevel = zoomLevel + zoomAmount;
+    const newZoomLevel = zoomLevel + event.deltaY * 0.001;
 
     if (newZoomLevel < maxZoomIn || newZoomLevel > maxZoomOut) return;
 
-    const zoomRatio = newZoomLevel / zoomLevel;
-    const newWidth = viewBox.width * zoomRatio;
-    const newHeight = viewBox.height * zoomRatio;
-
-    viewBox.x = mouseX - (mouseX - viewBox.x) * zoomRatio;
-    viewBox.y = mouseY - (mouseY - viewBox.y) * zoomRatio;
-    viewBox.width = newWidth;
-    viewBox.height = newHeight;
-
+    panX += (mouseX * (zoomLevel - newZoomLevel)) / initialZoom;
+    panY += (mouseY * (zoomLevel - newZoomLevel)) / initialZoom;
     zoomLevel = newZoomLevel;
   };
 
@@ -79,8 +70,8 @@
     isPanning = true;
     startX = event.clientX;
     startY = event.clientY;
-    panOffsetX = viewBox.x;
-    panOffsetY = viewBox.y;
+    panOffsetX = panX;
+    panOffsetY = panY;
   }
 
   function handleMouseMove(event: MouseEvent) {
@@ -89,8 +80,8 @@
     const dx = (startX - event.clientX) * (viewBox.width / svg.clientWidth);
     const dy = (startY - event.clientY) * (viewBox.height / svg.clientHeight);
 
-    viewBox.x = panOffsetX + dx;
-    viewBox.y = panOffsetY + dy;
+    panX = panOffsetX + dx;
+    panY = panOffsetY + dy;
   }
 
   function handleMouseUp() {
@@ -102,10 +93,8 @@
   }
 
   function onCenter() {
-    viewBox.x = 0;
-    viewBox.y = 0;
-    viewBox.width = width;
-    viewBox.height = height;
+    panX = 0;
+    panY = 0;
     zoomLevel = initialZoom;
   }
 
@@ -141,6 +130,7 @@
   }
 </script>
 
+<!-- svelte-ignore a11y_no_noninteractive_tabindex a11y_no_noninteractive_element_interactions -->
 <div
   class="relative overflow-hidden"
   tabindex="0"

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -28,6 +28,27 @@
   let panOffsetX = 0;
   let panOffsetY = 0;
 
+  const PAN_STEP_RATIO = 0.1;
+  const ZOOM_STEP = 0.1;
+
+  function panBy(dx: number, dy: number) {
+    if (!pannable) return;
+    viewBox.x += dx * viewBox.width;
+    viewBox.y += dy * viewBox.height;
+  }
+
+  function zoomBy(factor: number, centerX = width / 2, centerY = height / 2) {
+    if (!zoomable) return;
+    const newZoomLevel = zoomLevel + factor;
+    if (newZoomLevel < maxZoomIn || newZoomLevel > maxZoomOut) return;
+    const zoomRatio = newZoomLevel / zoomLevel;
+    viewBox.x = centerX - (centerX - viewBox.x) * zoomRatio;
+    viewBox.y = centerY - (centerY - viewBox.y) * zoomRatio;
+    viewBox.width *= zoomRatio;
+    viewBox.height *= zoomRatio;
+    zoomLevel = newZoomLevel;
+  }
+
   const handleWheel = (event: WheelEvent) => {
     if (!zoomable) return;
     event.preventDefault();
@@ -87,22 +108,118 @@
     viewBox.height = height;
     zoomLevel = initialZoom;
   }
+
+  function handleKeydown(event: KeyboardEvent) {
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        panBy(0, -PAN_STEP_RATIO);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        panBy(0, PAN_STEP_RATIO);
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        panBy(-PAN_STEP_RATIO, 0);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        panBy(PAN_STEP_RATIO, 0);
+        break;
+      case '+':
+      case '=':
+        event.preventDefault();
+        zoomBy(-ZOOM_STEP);
+        break;
+      case '-':
+      case '_':
+        event.preventDefault();
+        zoomBy(ZOOM_STEP);
+        break;
+    }
+  }
 </script>
 
 <div
   class="relative overflow-hidden"
+  tabindex="0"
+  role="group"
+  aria-label="Zoomable workflow graph. Use arrow keys to pan, plus and minus to zoom."
+  on:keydown={handleKeydown}
   bind:clientWidth={width}
   bind:clientHeight={height}
   style="height: min({containerHeight}px, calc(100dvh - 8rem));"
 >
   <div class="absolute right-4 top-4 z-20 flex items-center gap-2">
     <slot name="controls" />
+    {#if pannable}
+      <Tooltip text="Pan up" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="chevron-up"
+          aria-label="Pan up"
+          on:click={() => panBy(0, -PAN_STEP_RATIO)}
+        />
+      </Tooltip>
+      <Tooltip text="Pan down" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="chevron-down"
+          aria-label="Pan down"
+          on:click={() => panBy(0, PAN_STEP_RATIO)}
+        />
+      </Tooltip>
+      <Tooltip text="Pan left" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="chevron-left"
+          aria-label="Pan left"
+          on:click={() => panBy(-PAN_STEP_RATIO, 0)}
+        />
+      </Tooltip>
+      <Tooltip text="Pan right" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="chevron-right"
+          aria-label="Pan right"
+          on:click={() => panBy(PAN_STEP_RATIO, 0)}
+        />
+      </Tooltip>
+    {/if}
+    {#if zoomable}
+      <Tooltip text="Zoom in" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="plus"
+          aria-label="Zoom in"
+          disabled={zoomLevel - ZOOM_STEP < maxZoomIn}
+          on:click={() => zoomBy(-ZOOM_STEP)}
+        />
+      </Tooltip>
+      <Tooltip text="Zoom out" bottom>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="minus"
+          aria-label="Zoom out"
+          disabled={zoomLevel + ZOOM_STEP > maxZoomOut}
+          on:click={() => zoomBy(ZOOM_STEP)}
+        />
+      </Tooltip>
+    {/if}
     <Tooltip text="Center" bottom>
       <Button
         class="cursor-pointer"
         variant="secondary"
         size="sm"
         leadingIcon="target"
+        aria-label="Center"
         on:click={() => {
           onCenter();
         }}


### PR DESCRIPTION
## Description & motivation 💭

`ZoomSvg` is the pan/zoom container that hosts the workflow family tree. Pan was bound to mouse drag only; zoom was bound to the mouse wheel only. The sole keyboard-reachable control was the **Center** reset button. Keyboard users could not reposition or zoom the tree — a real barrier when the tree has multiple generations or wide sibling sets and nodes fall off-viewport.

This PR adds three things:

1. **`panBy` / `zoomBy` helpers** — shared viewport-mutation functions, reusable by both mouse and keyboard paths.
2. **Button cluster** — Pan Up / Down / Left / Right and Zoom In / Out buttons alongside the existing Center button, each gated by the existing `pannable` / `zoomable` props. Zoom buttons become `disabled` at the `maxZoomIn` / `maxZoomOut` clamp boundary.
3. **Container keyboard shortcuts** — `tabindex="0"` container with `on:keydown`; arrow keys pan and `+`/`-` zoom **only when the container is focused** (scoped to the element, never global).
4. **`plus` / `minus` icons** — added to the icon system (`src/lib/holocene/icon/svg/`), registered in `paths.ts`.

Mouse drag, wheel zoom, and the existing Center button are all unchanged.

**Closes SC 2.1.1, 2.5.1, and 2.5.7** — one fix resolves all three:

| SC | Defect | Closed? |
|---|---|---|
| 2.1.1 Keyboard (A) | No keyboard alternative for drag-to-pan / wheel-to-zoom | ✅ Tab-reachable buttons + container arrow-key shortcuts |
| 2.5.1 Pointer Gestures (A) | Drag-to-pan and wheel-to-zoom have no single-pointer alternative | ✅ Pan/Zoom buttons are single-tap controls |
| 2.5.7 Dragging Movements (AA) | Pan requires a drag gesture, no single-pointer alternative | ✅ Same buttons close 2.5.7 |

**Files changed (4):**
- `src/lib/holocene/zoom-svg.svelte` — all logic and template changes
- `src/lib/holocene/icon/svg/plus.svelte` — new icon
- `src/lib/holocene/icon/svg/minus.svelte` — new icon
- `src/lib/holocene/icon/paths.ts` — registers `plus` and `minus`

cloud-ui inherits the fix via the `@temporalio/ui` tarball repack.

**Closes matrix defect (d)** recorded at `audit-output/vpat-matrix.md:119`.

### Screenshots (if applicable) 📸

New button cluster appears at top-right of the ZoomSvg container alongside the existing Center button: Pan Up ↑, Pan Down ↓, Pan Left ←, Pan Right →, Zoom In +, Zoom Out −, Center ⊙.

### Design Considerations 🎨

Uses the existing `Button variant="secondary" size="sm"` pattern matching the Center button. No new design tokens. Button order in the cluster: pan directions first, zoom second, center last.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open a workflow with multiple child workflows in its family tree (`/namespaces/{ns}/workflows/{wf}/{run}/relationships`).
2. Tab into the ZoomSvg container. Confirm it is reachable and announced as `Zoomable workflow graph…, group`.
3. Tab through the controls cluster. Confirm Pan Up, Pan Down, Pan Left, Pan Right, Zoom In, Zoom Out, Center are each focus stops in that order.
4. Activate each **Pan** button with Enter and Space. Confirm the viewport moves ~10% in the expected direction.
5. Activate **Zoom In** repeatedly until the button becomes `disabled`. Confirm the boundary clamp is respected.
6. Activate **Zoom Out** repeatedly until `disabled`. Same check at `maxZoomOut`.
7. Focus the outer container `<div>` itself. Press Arrow keys — confirm the viewport pans. Press `+` / `-` — confirm zoom. Confirm these shortcuts only fire when the container is focused (Tab away and press arrow keys; should have no effect on the graph).
8. **Regression**: mouse drag still pans, wheel still zooms, Center still resets.
9. **Screen reader** (VoiceOver): confirm container announcement includes the `aria-label` keyboard description; confirm each button announces as `Pan up, button` etc.
10. axe-core on the relationships page: zero new violations.

## Checklists

### Draft Checklist

- [ ] Visual review of button cluster placement in the UI
- [ ] VoiceOver smoke test on container and each button
- [ ] Cross-browser: Firefox + Safari (wheel-zoom and arrow-key pan)

### Merge Checklist

- [ ] All pan directions and zoom levels tested with keyboard
- [ ] `disabled` state at clamp boundaries verified
- [ ] Mouse regression confirmed
- [ ] axe-core: zero new violations

### Issue(s) closed

Closes finding #10 from `audit-output/issues/2.1.1-keyboard-audit.md`.
Closes matrix defect (d) at `audit-output/vpat-matrix.md:119`.
Also closes 2.5.1 and 2.5.7 angles per `audit-output/issues/2.5.1-pointer-gestures-verification.md` §1.4.

## Docs

### Any docs updates needed?

No doc changes needed.

A11y-Audit-Ref: 2.1.1-zoom-svg-pan-zoom-keyboard