### PR TITLE
a11y(2.2.1): ui-main — warn the user before session expiry and offer an extend affordance

### DIFF
--- a/src/lib/components/session-warning-modal.svelte
+++ b/src/lib/components/session-warning-modal.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  import Button from '$lib/holocene/button.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import {
+    dismissSessionWarning,
+    sessionWarningState,
+  } from '$lib/stores/session-warning';
+  import { refreshTokens } from '$lib/utilities/auth-refresh';
+  import { logout } from '$lib/stores/auth-user';
+
+  const WARNING_SECONDS = 60;
+
+  let countdown = WARNING_SECONDS;
+  let extending = false;
+  let dialogEl: HTMLDialogElement;
+  let countdownInterval: ReturnType<typeof setInterval> | null = null;
+
+  $: isWarning = $sessionWarningState === 'warning';
+  $: isExpired = $sessionWarningState === 'expired';
+  $: open = isWarning || isExpired;
+
+  $: if (open && dialogEl) {
+    dialogEl.showModal();
+  } else if (!open && dialogEl) {
+    dialogEl.close();
+  }
+
+  $: if (isWarning) {
+    countdown = WARNING_SECONDS;
+    startCountdown();
+  } else {
+    stopCountdown();
+  }
+
+  function startCountdown() {
+    stopCountdown();
+    countdownInterval = setInterval(() => {
+      countdown -= 1;
+      if (countdown <= 0) {
+        stopCountdown();
+        sessionWarningState.set('expired');
+      }
+    }, 1000);
+  }
+
+  function stopCountdown() {
+    if (countdownInterval) {
+      clearInterval(countdownInterval);
+      countdownInterval = null;
+    }
+  }
+
+  async function handleExtend() {
+    extending = true;
+    const refreshed = await refreshTokens();
+    extending = false;
+    if (refreshed) {
+      dismissSessionWarning();
+    } else {
+      sessionWarningState.set('expired');
+    }
+  }
+
+  async function handleSignOut() {
+    await logout();
+  }
+
+  onDestroy(stopCountdown);
+</script>
+
+<dialog
+  bind:this={dialogEl}
+  role="alertdialog"
+  aria-modal="true"
+  aria-labelledby="session-warning-title"
+  aria-describedby="session-warning-body"
+  data-testid="session-warning-modal"
+  class="surface-primary z-50 w-full max-w-lg overflow-y-auto border border-secondary p-0 text-primary shadow-xl backdrop:bg-black/50"
+>
+  <div class="px-8 pb-0 pt-8 text-2xl">
+    <h2 id="session-warning-title">
+      {isExpired
+        ? translate('common.session-expired-title')
+        : translate('common.session-warning-title')}
+    </h2>
+  </div>
+  <div class="whitespace-normal p-8">
+    <p id="session-warning-body">
+      {isExpired
+        ? translate('common.session-expired-body')
+        : translate('common.session-warning-body', { seconds: countdown })}
+    </p>
+    {#if isWarning}
+      <p aria-live="polite" aria-atomic="true" class="sr-only">
+        {translate('common.session-warning-body', { seconds: countdown })}
+      </p>
+    {/if}
+  </div>
+  <div class="flex items-center justify-end gap-2 p-6">
+    {#if isExpired}
+      <Button variant="primary" on:click={handleSignOut}>
+        {translate('common.session-expired-sign-in-again')}
+      </Button>
+    {:else}
+      <Button variant="ghost" on:click={handleSignOut}>
+        {translate('common.session-warning-sign-out')}
+      </Button>
+      <Button variant="primary" loading={extending} on:click={handleExtend}>
+        {translate('common.session-warning-extend')}
+      </Button>
+    {/if}
+  </div>
+</dialog>

--- a/src/lib/components/session-warning-modal.svelte
+++ b/src/lib/components/session-warning-modal.svelte
@@ -3,12 +3,12 @@
 
   import Button from '$lib/holocene/button.svelte';
   import { translate } from '$lib/i18n/translate';
+  import { logout } from '$lib/stores/auth-user';
   import {
     dismissSessionWarning,
     sessionWarningState,
   } from '$lib/stores/session-warning';
   import { refreshTokens } from '$lib/utilities/auth-refresh';
-  import { logout } from '$lib/stores/auth-user';
 
   const WARNING_SECONDS = 60;
 

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -227,4 +227,13 @@ export const Strings = {
   'change-log': 'Change Log',
   comfortable: 'Comfortable',
   dense: 'Dense',
+  'session-warning-title': 'Your session is about to expire',
+  'session-warning-body':
+    'Your session will expire in {{seconds}} seconds. Stay signed in to keep working.',
+  'session-warning-extend': 'Stay signed in',
+  'session-warning-sign-out': 'Sign out',
+  'session-expired-title': 'Your session has expired',
+  'session-expired-body':
+    'Your session has expired. Sign in again to continue.',
+  'session-expired-sign-in-again': 'Sign in again',
 } as const;

--- a/src/lib/stores/auth-user.ts
+++ b/src/lib/stores/auth-user.ts
@@ -1,11 +1,37 @@
 import { get } from 'svelte/store';
 
 import { persistStore } from '$lib/stores/persist-store';
+import {
+  dismissSessionWarning,
+  sessionWarningState,
+} from '$lib/stores/session-warning';
 import type { User } from '$lib/types/global';
 
 export const authUser = persistStore<User>('AuthUser', {});
 
 export const getAuthUser = (): User => get(authUser);
+
+const SESSION_WARNING_LEAD_SECS = 60;
+let warningTimer: ReturnType<typeof setTimeout> | null = null;
+
+function decodeJwtExp(token: string): number | null {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+function scheduleSessionWarning(exp: number) {
+  if (warningTimer) clearTimeout(warningTimer);
+  const now = Math.floor(Date.now() / 1000);
+  const delay = (exp - now - SESSION_WARNING_LEAD_SECS) * 1000;
+  if (delay <= 0) return;
+  warningTimer = setTimeout(() => {
+    sessionWarningState.set('warning');
+  }, delay);
+}
 
 export const setAuthUser = (user: User) => {
   const { accessToken, idToken, name, email, picture } = user;
@@ -21,9 +47,17 @@ export const setAuthUser = (user: User) => {
     email,
     picture,
   });
+
+  dismissSessionWarning();
+  const exp = decodeJwtExp(accessToken);
+  if (exp) scheduleSessionWarning(exp);
 };
 
 export const clearAuthUser = () => {
+  if (warningTimer) {
+    clearTimeout(warningTimer);
+    warningTimer = null;
+  }
   authUser.set({});
 };
 

--- a/src/lib/stores/session-warning.ts
+++ b/src/lib/stores/session-warning.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+
+export type SessionWarningState = 'idle' | 'warning' | 'expired';
+
+export const sessionWarningState = writable<SessionWarningState>('idle');
+
+export const triggerSessionExpired = () => {
+  sessionWarningState.set('expired');
+};
+
+export const dismissSessionWarning = () => {
+  sessionWarningState.set('idle');
+};

--- a/src/lib/utilities/handle-error.test.ts
+++ b/src/lib/utilities/handle-error.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('$lib/stores/session-warning', () => ({
+  triggerSessionExpired: vi.fn(),
+  dismissSessionWarning: vi.fn(),
+  sessionWarningState: { subscribe: vi.fn(), set: vi.fn() },
+}));
+
+import { triggerSessionExpired } from '$lib/stores/session-warning';
+
 import { handleError } from './handle-error';
 import { routeForLoginPage } from './route-for';
 
@@ -20,26 +28,28 @@ describe('handleError', () => {
     vi.clearAllMocks();
   });
 
-  it('should redirect if it is an unauthorized error with status', () => {
+  it('should trigger session expired if it is an unauthorized error with status', () => {
     const error = {
       status: 401,
       statusText: 'Unauthorized',
       response: null as unknown as Response,
     };
 
-    expect(() => handleError(error)).toThrowError();
-    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+    handleError(error);
+    expect(triggerSessionExpired).toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
-  it('should redirect if it is an unauthorized error with statusCode', () => {
+  it('should trigger session expired if it is an unauthorized error with statusCode', () => {
     const error = {
       statusCode: 401,
       statusText: 'Unauthorized',
       response: null as unknown as Response,
     };
 
-    expect(() => handleError(error)).toThrowError();
-    expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+    handleError(error);
+    expect(triggerSessionExpired).toHaveBeenCalled();
+    expect(window.location.assign).not.toHaveBeenCalled();
   });
 
   it('should redirect if it is a forbidden error with status', () => {

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -1,6 +1,7 @@
 import { BROWSER } from 'esm-env';
 
 import { networkError } from '$lib/stores/error';
+import { triggerSessionExpired } from '$lib/stores/session-warning';
 import { toaster } from '$lib/stores/toaster';
 import type { NetworkError } from '$lib/types/global';
 
@@ -34,7 +35,8 @@ export const handleError = (
   }
 
   if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    triggerSessionExpired();
+    return;
   }
 
   if (isForbidden(error) && isBrowser) {
@@ -58,7 +60,7 @@ export const handleUnauthorizedOrForbiddenError = (
   isBrowser = BROWSER,
 ): void => {
   if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    triggerSessionExpired();
     return;
   }
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -6,6 +6,7 @@
 
   import BottomNavigation from '$lib/components/bottom-nav.svelte';
   import DataEncoderSettings from '$lib/components/data-encoder-settings.svelte';
+  import SessionWarningModal from '$lib/components/session-warning-modal.svelte';
   import NamespacePicker from '$lib/components/namespace-picker.svelte';
   import SideNavigation from '$lib/components/side-nav.svelte';
   import SkipNavigation from '$lib/components/skip-nav.svelte';
@@ -304,6 +305,7 @@
 
 <DarkMode />
 <SkipNavigation />
+<SessionWarningModal />
 
 <div class="flex h-dvh w-screen flex-row">
   <Toaster

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -6,8 +6,8 @@
 
   import BottomNavigation from '$lib/components/bottom-nav.svelte';
   import DataEncoderSettings from '$lib/components/data-encoder-settings.svelte';
-  import SessionWarningModal from '$lib/components/session-warning-modal.svelte';
   import NamespacePicker from '$lib/components/namespace-picker.svelte';
+  import SessionWarningModal from '$lib/components/session-warning-modal.svelte';
   import SideNavigation from '$lib/components/side-nav.svelte';
   import SkipNavigation from '$lib/components/skip-nav.svelte';
   import TopNavigation from '$lib/components/top-nav.svelte';


### PR DESCRIPTION
## Description & motivation 💭

The ui-main auth flow silently refreshes the access token on every 401. When the refresh token itself expires, `refreshTokens()` returns `false` and `handleError` hard-redirected the user to the login page via `window.location.assign()` — with no warning, no opportunity to extend, and any in-flight form state (Start Workflow, Cancel/Terminate confirmations, Schedule create/edit) destroyed.

SC 2.2.1 (Timing Adjustable, Level A) requires at least one of: turn off the limit, allow adjustment to ≥10×, or warn with ≥20s to extend. None of the three was met.

This PR implements the warn-with-extend path:

1. **JWT `exp` decoding** — `setAuthUser` now decodes the `exp` claim from the access token and schedules a warning timer 60 s before expiry. The timer is cancelled and rescheduled on every successful token refresh.
2. **Session warning store** — `sessionWarningState` (`idle | warning | expired`) is the single source of truth for the modal, avoids coupling UI to auth internals.
3. **`SessionWarningModal` component** — a `role="alertdialog"` `<dialog>` that opens on `warning` state with a live countdown (`aria-live="polite"`), a **Stay signed in** primary button (calls `refreshTokens()`; on failure shifts to `expired` state), and a **Sign out** secondary button. On `expired` state the modal shifts to "Your session has expired" with a **Sign in again** button. No auto-redirect — the user controls the navigation so form state in the background remains intact.
4. **`handleError` no longer hard-redirects on 401** — calls `triggerSessionExpired()` instead, making the modal the single session-end decision point. 403 Forbidden still redirects.

**Files changed (6):**
- `src/lib/stores/session-warning.ts` — new store (`sessionWarningState`, `triggerSessionExpired`, `dismissSessionWarning`)
- `src/lib/stores/auth-user.ts` — JWT `exp` decoding, warning timer scheduling/cancellation in `setAuthUser`/`clearAuthUser`
- `src/lib/utilities/handle-error.ts` — 401 path calls `triggerSessionExpired()` instead of `window.location.assign()`
- `src/lib/components/session-warning-modal.svelte` — new `alertdialog` modal
- `src/lib/i18n/locales/en/common.ts` — 7 new i18n keys
- `src/routes/(app)/+layout.svelte` — mounts `SessionWarningModal`

**SC 2.2.1 Timing Adjustable (Level A) — current verdict: Fails → Supports**

### Screenshots (if applicable) 📸

New modal appears 60 s before access-token expiry with a countdown, Stay signed in, and Sign out. If no action is taken the countdown reaches zero and the modal shifts to the expired state.

### Design Considerations 🎨

Copy for modal title, body, and button labels is a placeholder — needs designer review before merge, especially the countdown phrasing which affects screen-reader announcement cadence. i18n keys are in `common.ts` so copy can be updated without a code change.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Configure the Go server with a short refresh-token TTL (e.g., 5 min). Log in. Confirm the session-warning modal appears 60 s before the access token expires.
2. Confirm the modal is announced as `alertdialog` by VoiceOver/NVDA. Confirm the countdown is announced via `aria-live="polite"`.
3. Click **Stay signed in** inside the warning window. Confirm the modal closes and re-arms for the next expiry.
4. Click **Stay signed in** more than 10 times across multiple cycles. Confirm each extension succeeds.
5. Let the countdown reach zero with no action. Confirm the modal shifts to "Your session has expired" — no auto-redirect before user clicks.
6. Open Start Workflow, fill fields, let the session expire. Confirm form fields remain visible behind the modal so values can be copied before re-authenticating.
7. **Active-user regression**: continuous API activity keeps the warning from appearing (silent refresh keeps `exp` > 60 s ahead).
8. Confirm `handleError` no longer issues `window.location.assign` on 401.
9. Keyboard-only: Tab cycles between the two buttons; focus is trapped inside the modal.
10. axe-core on a page with the modal open: zero new violations.

## Checklists

### Draft Checklist

- [ ] **Blocked on design review** — modal copy (title, body, button labels) needs designer sign-off before merge
- [ ] **Backend coordination** — confirm refresh-token TTL with auth team; if TTL < 5 min, discuss whether 60 s lead is appropriate
- [ ] VoiceOver + NVDA smoke test on modal
- [ ] Short-TTL integration test

### Merge Checklist

- [ ] Design copy approved
- [ ] Auth team has confirmed refresh-token TTL
- [ ] Screen reader announcement verified (countdown `aria-live` cadence)
- [ ] axe-core: zero new violations
- [ ] Active-user regression: warning never fires under normal load

### Issue(s) closed

Closes finding from `audit-output/issues/2.2.1-timing-adjustable-verification.md` Section 3.

## Docs

### Any docs updates needed?

No doc changes needed.

A11y-Audit-Ref: 2.2.1-ui-main-session-timeout-warning