### PR TITLE
a11y(2.4.2): ui-main — set distinct, descriptive titles on login/signin, task-queues list, and activity-workers sub-tab

### DIFF
--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -21,6 +21,7 @@ export const Strings = {
   instance_one: 'Instance',
   instance_other: 'Instances',
   'task-queue': 'Task Queue',
+  'task-queues': 'Task Queues',
   status: 'Status',
   'shutting-down': 'Shutting Down',
   sdk: 'Worker SDK',

--- a/src/routes/(app)/namespaces/[namespace]/activities/[activityId]/[runId]/workers/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/activities/[activityId]/[runId]/workers/+page.svelte
@@ -8,5 +8,8 @@
   const activityId = $derived(page.params.activityId);
 </script>
 
-<PageTitle title="Activity Execution Workers | {activityId}" url={page.url.href} />
+<PageTitle
+  title="Activity Execution Workers | {activityId}"
+  url={page.url.href}
+/>
 <ActivityExecutionWorkers {namespace} />

--- a/src/routes/(app)/namespaces/[namespace]/activities/[activityId]/[runId]/workers/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/activities/[activityId]/[runId]/workers/+page.svelte
@@ -8,5 +8,5 @@
   const activityId = $derived(page.params.activityId);
 </script>
 
-<PageTitle title="Activity Execution | {activityId}" url={page.url.href} />
+<PageTitle title="Activity Execution Workers | {activityId}" url={page.url.href} />
 <ActivityExecutionWorkers {namespace} />

--- a/src/routes/(app)/namespaces/[namespace]/task-queues/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/task-queues/+page.svelte
@@ -1,1 +1,13 @@
 <svelte:options runes />
+
+<script lang="ts">
+  import { page } from '$app/state';
+
+  import PageTitle from '$lib/components/page-title.svelte';
+  import { translate } from '$lib/i18n/translate';
+</script>
+
+<PageTitle
+  title={`${translate('workers.task-queues')} | ${page.params.namespace}`}
+  url={page.url.href}
+/>

--- a/src/routes/(login)/signin/+page.svelte
+++ b/src/routes/(login)/signin/+page.svelte
@@ -16,7 +16,7 @@
   const error = $derived(page.url.searchParams.get('error'));
 </script>
 
-<PageTitle title="Login" url={page.url.href} />
+<PageTitle title="Sign In" url={page.url.href} />
 <header class="flex h-16 w-full items-center justify-between bg-primary px-10">
   <img src={Logo} alt="" class="max-h-10" />
   <FeedbackButton />


### PR DESCRIPTION
## Description

Fixes three WCAG 2.2 SC 2.4.2 (Page Titled) defects in ui-main where routes had either identical, missing, or insufficiently descriptive page titles.

**Defect 1 — identical titles on `/login` and `/signin`**

Both routes set `<PageTitle title="Login" .../>`. A user with both tabs open cannot tell them apart. `/signin` is updated to `"Sign In"` to make the two routes distinguishable while keeping each title accurate to its flow.

**Defect 2 — `/namespaces/{ns}/task-queues` has no title**

The task-queues list page was `<svelte:options runes />` with no `<PageTitle>` and no `<svelte:head>`. The browser tab showed whichever title the previous navigation had set. Added `<PageTitle>` matching the shape used by sibling list routes (`"Task Queues | {namespace}"`). Also adds a `workers.task-queues` i18n key (the existing `workers.task-queue` was singular-only).

**Defect 3 — activity-execution workers sub-tab title missing qualifier**

`/activities/{id}/{run}/workers` set `"Activity Execution | {activityId}"` while every other sub-tab (details, metadata, search-attributes) includes a qualifier noun. Updated to `"Activity Execution Workers | {activityId}"` to be consistent and distinguishable.

## Screenshots

_Title changes appear in browser tabs and are announced by screen readers on navigation. No visual change on the page itself._

## Design

N/A.

## Testing

- [ ] Open `/login` and `/signin` in two browser tabs — confirm tab titles are visibly distinct ("Login" vs "Sign In")
- [ ] Navigate from `/namespaces/{ns}/workflows` to `/namespaces/{ns}/task-queues` — confirm tab title updates (not carried-over "Workflows | {ns}")
- [ ] Refresh `/namespaces/{ns}/task-queues` directly — confirm title is set on initial load
- [ ] Navigate to an activity execution; cycle through `/details`, `/metadata`, `/search-attributes`, `/workers` — confirm each sub-tab title is distinct and `/workers` now reads "Activity Execution Workers | {id}"
- [ ] axe-core `document-title` rule passes on each touched route

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have read the [contributor guidelines](https://github.com/temporalio/ui/blob/main/CONTRIBUTING.md)

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.4.2-ui-main-missing-and-collided-titles