### PR TITLE
a11y(2.4.3): group-details-row — remove redundant outer focus stop wrapping the inner close button

### DIFF
--- a/src/lib/components/lines-and-dots/svg/group-details-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/group-details-row.svelte
@@ -62,7 +62,7 @@
   };
 </script>
 
-<g role="button" tabindex="0" class="relative z-50">
+<g class="relative z-50">
   <foreignObject {x} {y} {width} height={contentHeight}>
     <div bind:offsetHeight class="flex flex-col">
       <div


### PR DESCRIPTION
## Description

Fixes WCAG 2.2 SC 2.4.3 (Focus Order) in `src/lib/components/lines-and-dots/svg/group-details-row.svelte`.

The outer `<g role="button" tabindex="0">` at line 65 created two consecutive Tab stops for one logical control: the outer `<g>` (no `on:click` or `on:keydown` bound — pressing Enter/Space did nothing) followed by the inner native `<Button>` which is the actual close action. Keyboard users had to Tab through a phantom "button" stop that announced a role but performed no action, then Tab again to reach the real Close button.

**Fix (Option A):** remove `role="button"` and `tabindex="0"` from the outer `<g>`. The `<g>` becomes a plain SVG grouping element. The inner `<Button>` remains the single focusable stop with its `on:click={() => setActiveGroup(group)}` close handler intact.

Side effect: also resolves the 4.1.2 unnamed-role concern on this element — removing `role="button"` eliminates the unnamed interactive role that axe-core would flag.

The sibling `<g role="button">` wrappers in `workflow-row.svelte`, `history-graph-row-visual.svelte`, and `timeline-graph-row.svelte` are intentional activation surfaces (they need accessible names, tracked under `1.4.1-timeline-graph-status.md`) and are not touched here.

## Screenshots

_No visual change. The expanded-group panel renders identically; only the Tab stop count in the panel changes from two to one._

## Design

N/A.

## Testing

- [ ] Navigate to a workflow event-history timeline. Expand an event group. Tab into the expanded panel — confirm the first (and only) focus stop is the Close button, with no phantom stop before it.
- [ ] Press Enter on the focused Close button — confirm the panel collapses.
- [ ] Screen reader (VoiceOver / NVDA): confirm only one "Close, button" announcement per panel open; no preceding phantom "button" announcement.
- [ ] Regression: confirm expanding and collapsing groups via the outer row (`workflow-row.svelte`) still works — that file is untouched.
- [ ] axe-core on the workflow event-history page with a group expanded: `button-name` / `aria-allowed-attr` warnings on `group-details-row` `<g>` should be gone.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have read the [contributor guidelines](https://github.com/temporalio/ui/blob/main/CONTRIBUTING.md)

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.4.3-group-details-row-redundant-focus