### PR TITLE
a11y(2.4.5): import history — add back-link to Import landing page

### DIFF
--- a/src/lib/i18n/locales/en/events.ts
+++ b/src/lib/i18n/locales/en/events.ts
@@ -57,6 +57,7 @@ export const Strings = {
   attribute: 'attribute',
   'event-group': 'Events related to {{eventName}}',
   'error-event': 'Error Event',
+  'back-to-import': 'Back to Import',
   'import-event-history': 'Import Event History',
   'import-event-history-file-upload':
     'Select an event history JSON file to upload',

--- a/src/routes/(app)/import/events/[namespace]/[workflow]/[run]/history/+layout.svelte
+++ b/src/routes/(app)/import/events/[namespace]/[workflow]/[run]/history/+layout.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
+  import Link from '$lib/holocene/link.svelte';
+  import { translate } from '$lib/i18n/translate';
   import ImportEventsView from '$lib/pages/import-events-view.svelte';
+  import { routeForEventHistoryImport } from '$lib/utilities/route-for';
 
   interface Props {
     children: Snippet;
@@ -9,6 +12,13 @@
   let { children }: Props = $props();
 </script>
 
+<Link
+  href={routeForEventHistoryImport()}
+  data-testid="back-to-import"
+  icon="chevron-left"
+>
+  {translate('events.back-to-import')}
+</Link>
 <ImportEventsView>
   {@render children()}
 </ImportEventsView>


### PR DESCRIPTION
## Description

WCAG 2.4.5 (Multiple Ways, Level AA) requires every non-process page to be reachable through at least two navigation mechanisms. The import event-history sub-routes (`/import/events/[namespace]/[workflow]/[run]/history/{compact,json,feed}`) were reachable only via the side-nav + list click — no back-link provided a one-step return path.

This PR adds a **"Back to Import"** `<Link icon="chevron-left">` at the layout level (`history/+layout.svelte`), so it appears on all three view tabs in one place. The new `events.back-to-import` i18n key is added alongside the existing import-related keys.

The two other defects cited in the audit issue (Nexus detail, Archival history) were already addressed in `main` prior to this PR.

**Changed files:**
- `src/routes/(app)/import/events/[namespace]/[workflow]/[run]/history/+layout.svelte` — add back-link above `<ImportEventsView>`
- `src/lib/i18n/locales/en/events.ts` — add `'back-to-import': 'Back to Import'`

## Screenshots

N/A — text link matching the existing chevron-left back-link pattern used across 15+ other detail pages.

## Design

Follows the established pattern from `src/lib/pages/worker-details.svelte`, `src/lib/layouts/workflow-header.svelte`, and `src/lib/components/schedule/schedule-form/form.svelte`.

## Testing

- [ ] Navigate to `/import/events`, upload a history JSON, and open any of the three view tabs (compact / json / feed).
- [ ] Confirm a "Back to Import" link appears above the view, styled identically to other back-links (chevron-left icon).
- [ ] Click the link — confirm navigation to `/import/events`.
- [ ] Keyboard: Tab to the link, press Enter — same navigation.
- [ ] Switching between the three view tabs preserves the back-link on every tab.
- [ ] axe-core: zero new violations on the history routes.

## Checklist

- [x] Tests added / updated (n/a — UI-only addition, covered by manual test plan above)
- [x] i18n key added (`events.back-to-import`)
- [ ] Storybook story added / updated (n/a — layout addition, no isolated story needed)

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.4.5-ui-main-detail-page-back-links