### PR TITLE
a11y(2.4.6): datepicker — replace empty label with translate('common.start')

### DIFF
--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -453,7 +453,7 @@
                 />
                 <div class="ml-6 flex flex-col gap-2">
                   <DatePicker
-                    label=""
+                    label={translate('common.start')}
                     labelHidden
                     onDateChange={onStartDateChange}
                     selected={new Date(start.date)}


### PR DESCRIPTION
## Description

The absolute-time `<DatePicker>` inside `dropdown-filter-chip.svelte` passed `label=""` with `labelHidden`, producing an empty `<label for="datepicker"></label>` at runtime. The input had no accessible name, violating WCAG 2.4.6 (Headings and Labels) and 4.1.2 (Name, Role, Value).

**Fix:** replace `label=""` with `label={translate('common.start')}`. The `labelHidden` prop stays, so the visual layout is unchanged — the label is rendered to the DOM but hidden from sighted users via CSS. `translate` and `common.start` are already present in this file (used on the sibling DatePickers in the `isTimeRange === true` branch).

**Changed file:** `src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte` — one line.

## Screenshots

No visual change — label remains visually hidden via `labelHidden`.

## Design

No design changes. Consistent with the two sibling `<DatePicker>` instances on lines 378–384 and 394–400 of the same file that already pass `label={translate('common.start')}` / `label={translate('common.end')}`.

## Testing

- [ ] Navigate to a workflows list, open a datetime search-attribute filter chip, switch to "Absolute" time mode.
- [ ] Inspect DOM: confirm `<label for="datepicker">` contains "Start", not empty.
- [ ] Screen reader (VoiceOver/NVDA): focus the DatePicker input — announces "Start, date picker" (or equivalent).
- [ ] axe-core: no "Form elements must have labels" / "Element has no name" violations on the DatePicker input.
- [ ] Visual regression: DatePicker layout unchanged; label remains visually hidden.
- [ ] Sibling DatePickers (start/end in range mode) unaffected.

## Checklist

- [x] No new i18n keys needed — reuses existing `common.start`
- [x] No visual change — `labelHidden` unchanged
- [x] `pnpm lint` and `pnpm check` pass

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.4.6-ui-main-datepicker-empty-label