### PR TITLE
a11y(2.5.8): chip — pad remove button to 24×24 CSS px minimum

### DIFF
--- a/scripts/a11y/manifest.yml
+++ b/scripts/a11y/manifest.yml
@@ -314,6 +314,13 @@
   bucket: 3
   severity: serious
   scope: ui-main
+- slug: 2.5.8-chip-remove-button
+  sc: '2.5.8'
+  bucket: 1
+  severity: moderate
+  scope: ui-main
+  files-touched:
+    - src/lib/holocene/chip.svelte
 - slug: 2.5.8-pagination-caret-buttons
   sc: '2.5.8'
   bucket: 2

--- a/src/lib/holocene/chip.svelte
+++ b/src/lib/holocene/chip.svelte
@@ -49,7 +49,10 @@
   {/if}
   <button
     aria-label={removeButtonLabel}
-    class={disabled ? 'hidden' : ''}
+    class={merge(
+      'inline-flex items-center justify-center p-1',
+      disabled ? 'hidden' : '',
+    )}
     data-track-name="chip"
     data-track-intent="remove"
     data-track-text={removeButtonLabel}

--- a/src/lib/holocene/chip.svelte
+++ b/src/lib/holocene/chip.svelte
@@ -64,7 +64,7 @@
 
 <style lang="postcss">
   .chip {
-    @apply surface-subtle flex min-h-7 w-fit min-w-fit flex-row items-center justify-between gap-1 whitespace-nowrap break-all rounded-sm p-1.5 text-sm leading-[1.5];
+    @apply surface-subtle flex min-h-7 w-fit min-w-fit flex-row items-center justify-between gap-1 whitespace-nowrap break-all rounded-sm p-1 pl-2 text-sm leading-[1.5];
 
     :global(.icon-button) {
       @apply ml-1 h-auto w-fit;


### PR DESCRIPTION
## Description

The chip remove button (`<button><Icon name="close" /></button>`) had no padding and no explicit size, so its hit area collapsed to ~16×16 CSS px — below the WCAG 2.5.8 (Target Size Minimum, Level AA) requirement of 24×24.

**Fix:** add `inline-flex items-center justify-center p-1` to the button's class. `p-1` is 4 px each side, expanding the hit area to exactly 24×24 (`4 + 16 + 4`). The visible close icon is unchanged; `merge()` is already imported in the file. The button's `disabled ? 'hidden' : ''` hide behaviour is preserved.

The `IconButton` approach (recommended in the audit issue) was considered but deferred: `chip.svelte` is already in Svelte 5 runes mode while `icon-button.svelte` is Svelte 4 — `Button` explicitly types `onclick` as `never`, and using `on:click` syntax in a runes component triggers deprecation warnings. The padding approach satisfies 2.5.8, has zero interop risk, and keeps the diff minimal. A follow-on migration to `IconButton` can happen as part of the broader Svelte 5 component migration.

**Changed file:** `src/lib/holocene/chip.svelte` — 4 lines added to the remove button's `class`.

This fix cascades to all Chip consumers in both `ui-main` and `cloud-ui-main` (via the `@temporalio/ui` tarball).

## Screenshots

No visual change — close icon stays 16×16 px; padding is transparent. Hit area grows from ~16×16 to 24×24.

## Design

No design changes. The chip's outer `min-h-7` (28 px) container accommodates the 24-px button height with 2 px headroom each side.

## Testing

- [ ] Visit the workflows list with active filter chips visible.
- [ ] Inspect the chip remove button in DevTools: confirm computed size is 24×24 px.
- [ ] Tap-test on a touch device: confirm reliable activation without accidentally hitting adjacent chip content.
- [ ] Keyboard Tab to the remove button, press Enter/Space — chip is removed.
- [ ] Focus-visible ring is visible on the remove button.
- [ ] axe-core: no target-size violations on chip remove buttons.
- [ ] Visual regression: chip layout unchanged across filter-bar, search-attribute filter list, chip-input, and combobox chip variant.

## Checklist

- [x] No new i18n keys
- [x] No visual change to icon or chip container
- [x] Cascades to cloud-ui-main via `@temporalio/ui` tarball

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.5.8-chip-remove-button