### PR TITLE
a11y(2.5.8): pagination — grow caret buttons from 12×12 to 24×24 CSS px

### DIFF
--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -355,7 +355,7 @@
 
 <style lang="postcss">
   .arrow {
-    @apply absolute left-0 top-0 h-0 w-0;
+    @apply h-0 w-0;
 
     border-style: solid;
     border-width: 6px 12px 6px 0;
@@ -374,7 +374,7 @@
   }
 
   .caret {
-    @apply relative inline-flex items-center justify-center;
+    @apply inline-flex items-center justify-center;
 
     width: 24px;
     height: 24px;

--- a/src/lib/holocene/api-pagination.svelte
+++ b/src/lib/holocene/api-pagination.svelte
@@ -374,10 +374,10 @@
   }
 
   .caret {
-    @apply relative;
+    @apply relative inline-flex items-center justify-center;
 
-    width: 12px;
-    height: 12px;
+    width: 24px;
+    height: 24px;
   }
 
   .caret:disabled {

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -257,10 +257,10 @@
 
 <style lang="postcss">
   .caret {
-    @apply relative;
+    @apply relative inline-flex items-center justify-center;
 
-    width: 12px;
-    height: 12px;
+    width: 24px;
+    height: 24px;
   }
 
   .caret:disabled {

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -257,7 +257,7 @@
 
 <style lang="postcss">
   .caret {
-    @apply relative inline-flex items-center justify-center;
+    @apply inline-flex items-center justify-center;
 
     width: 24px;
     height: 24px;
@@ -268,7 +268,7 @@
   }
 
   .arrow {
-    @apply absolute left-0 top-0 h-0 w-0;
+    @apply h-0 w-0;
 
     border-style: solid;
     border-width: 6px 12px 6px 0;


### PR DESCRIPTION
## Description

The Previous/Next page caret buttons in `api-pagination.svelte` and `pagination.svelte` had `.caret { width: 12px; height: 12px; }` — half the WCAG 2.5.8 (Target Size Minimum, Level AA) 24×24 requirement.

**Fix:** change both dimensions to 24px and add `inline-flex items-center justify-center` so the existing CSS-triangle `<span class="arrow">` stays visually centred within the enlarged hit area. Applied identically to both files.

**Changed files:**
- `src/lib/holocene/api-pagination.svelte` — `.caret` block
- `src/lib/holocene/pagination.svelte` — `.caret` block

This fix cascades to all consumers in both `ui-main` and `cloud-ui-main` (via the `@temporalio/ui` tarball).

## Screenshots

No change to the visible arrow triangle. The transparent padding around it grows from 0 to 6 px per side.

## Design

No design changes. The arrow decoration is unchanged; only the button's interactive hit area is enlarged.

## Testing

- [ ] Open the workflows list (or any page with `<ApiPagination>`). Inspect the Previous/Next caret buttons — `getBoundingClientRect()` returns 24×24.
- [ ] Confirm the arrow triangle is visually centred within the button.
- [ ] Disabled state (first/last page): button renders at 24×24 with `opacity-50`.
- [ ] Tap-test on a touchscreen — consistent activation.
- [ ] Keyboard: Tab to a caret button, Enter/Space — navigates page.
- [ ] Visual regression: pagination cluster layout (workflows list, schedules list, identities list) — confirm the 12 px wider cluster per caret reflows without breakage.
- [ ] axe-core: no target-size violations on caret buttons.

## Checklist

- [x] No new i18n keys
- [x] No change to arrow triangle appearance
- [x] Cascades to cloud-ui-main via `@temporalio/ui` tarball

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.5.8-pagination-caret-buttons