### PR TITLE
a11y(2.5.8): toast — replace bare close button with IconButton (36×36 px)

### DIFF
--- a/scripts/a11y/manifest.yml
+++ b/scripts/a11y/manifest.yml
@@ -319,6 +319,13 @@
   bucket: 2
   severity: serious
   scope: ui-main
+- slug: 2.5.8-toast-close-button
+  sc: '2.5.8'
+  bucket: 3
+  severity: moderate
+  scope: ui-main
+  files-touched:
+    - src/lib/holocene/toast.svelte
 - slug: 3.2.2-namespace-picker-on-change-navigation
   sc: '3.2.2'
   bucket: 2

--- a/src/lib/holocene/icon-button.svelte
+++ b/src/lib/holocene/icon-button.svelte
@@ -11,6 +11,7 @@
     'data-testid'?: string;
     label: string;
     variant?: 'primary' | 'secondary' | 'ghost';
+    size?: 'sm' | 'md';
     class?: string;
   }
 
@@ -19,12 +20,18 @@
   export let icon: IconName;
   export let label: string;
   export let variant: 'primary' | 'secondary' | 'ghost' = 'ghost';
+  export let size: 'sm' | 'md' = 'md';
+
+  const sizes: Record<'sm' | 'md', string> = {
+    sm: 'h-6 w-6',
+    md: 'h-9 w-9',
+  };
 </script>
 
 <Button
   {variant}
   leadingIcon={icon}
-  class={merge('h-9 w-9 shrink-0 p-0', className)}
+  class={merge('shrink-0 p-0', sizes[size], className)}
   aria-label={label}
   disableTracking={true}
   data-track-name="icon-button"

--- a/src/lib/holocene/icon-button.svelte
+++ b/src/lib/holocene/icon-button.svelte
@@ -11,7 +11,6 @@
     'data-testid'?: string;
     label: string;
     variant?: 'primary' | 'secondary' | 'ghost';
-    size?: 'sm' | 'md';
     class?: string;
   }
 
@@ -20,18 +19,12 @@
   export let icon: IconName;
   export let label: string;
   export let variant: 'primary' | 'secondary' | 'ghost' = 'ghost';
-  export let size: 'sm' | 'md' = 'md';
-
-  const sizes: Record<'sm' | 'md', string> = {
-    sm: 'h-6 w-6',
-    md: 'h-9 w-9',
-  };
 </script>
 
 <Button
   {variant}
   leadingIcon={icon}
-  class={merge('shrink-0 p-0', sizes[size], className)}
+  class={merge('h-9 w-9 shrink-0 p-0', className)}
   aria-label={label}
   disableTracking={true}
   data-track-name="icon-button"

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -60,6 +60,8 @@
     variant="ghost"
     icon="close"
     label={dismissLabel}
+    size="sm"
+    class="text-inherit"
     on:click={handleDismiss}
   />
 </div>

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -36,7 +36,8 @@
 
   $: icon = variantIcon[variant];
 
-  const handleDismiss = () => {
+  const handleDismiss = (e: Event) => {
+    e.stopPropagation();
     dispatch('dismiss', { id });
   };
 </script>
@@ -59,6 +60,6 @@
     variant="ghost"
     icon="close"
     label={dismissLabel}
-    on:click|stopPropagation={handleDismiss}
+    on:click={handleDismiss}
   />
 </div>

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -6,6 +6,7 @@
 
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
+  import IconButton from '$lib/holocene/icon-button.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { ToastVariant } from '$lib/types/holocene';
 
@@ -54,11 +55,10 @@
   <p class="text-sm">
     <slot />
   </p>
-  <button
-    type="button"
+  <IconButton
+    variant="ghost"
+    icon="close"
+    label={dismissLabel}
     on:click|stopPropagation={handleDismiss}
-    aria-label={dismissLabel}
-  >
-    <Icon name="close" />
-  </button>
+  />
 </div>

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -4,9 +4,9 @@
   import { createEventDispatcher } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
+  import Button from '$lib/holocene/button.svelte';
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
-  import IconButton from '$lib/holocene/icon-button.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { ToastVariant } from '$lib/types/holocene';
 
@@ -56,12 +56,12 @@
   <p class="text-sm">
     <slot />
   </p>
-  <IconButton
+  <Button
     variant="ghost"
-    icon="close"
-    label={dismissLabel}
-    size="sm"
-    class="text-inherit"
+    leadingIcon="close"
+    aria-label={dismissLabel}
+    class="text-inherit h-6 w-6 shrink-0 p-0"
+    disableTracking
     on:click={handleDismiss}
   />
 </div>


### PR DESCRIPTION
## Description

The toast close button was a bare `<button><Icon name="close" /></button>` with no padding or explicit size, collapsing its hit area to ~16×16 CSS px — below the WCAG 2.5.8 (Target Size Minimum, Level AA) 24×24 requirement.

**Fix:** replace with Holocene's `Button` using `leadingIcon`:

```svelte
<Button
  variant="ghost"
  leadingIcon="close"
  aria-label={dismissLabel}
  class="h-6 w-6 shrink-0 p-0 text-inherit"
  disableTracking
  on:click={handleDismiss}
/>
```

`h-6 w-6` renders at 24×24 CSS px, satisfying the criterion. `twMerge` overrides `Button`'s default text-shaped sizing (`h-10 px-4`) so the icon-only button stays square. It inherits Holocene's focus-visible ring, hover styling, and correct `aria-label` forwarding — removing the bare-button anti-pattern.

`icon-button.svelte` is **deprecated** in favor of `Button` + `leadingIcon`, so the close button uses `Button` directly rather than the wrapper.

`toast.svelte` is Svelte 4, so `on:click` on `Button` works without any interop concerns.

**Changed file:** `src/lib/holocene/toast.svelte` — import added, bare button replaced.

This fix cascades to all toast consumers in both `ui-main` and `cloud-ui-main` (via the `@temporalio/ui` tarball).

## Screenshots

No visual change — the close icon glyph stays at 16×16 px. The hit area extends evenly around it (to 24×24 total) within the existing toast padding.

## Design

No design changes. Ghost variant matches the current transparent-background close button appearance.

## Testing

- [ ] Trigger a toast (e.g. perform any action that shows a success/error toast).
- [ ] Inspect the close button: `getBoundingClientRect()` returns 24×24.
- [ ] Tap-test on a touchscreen — consistent activation.
- [ ] Tab to the close button: focus-visible ring is visible.
- [ ] Press Enter/Space on the focused button: toast is dismissed.
- [ ] Screen reader: close button announces as "Close" (or the `closeButtonLabel` value).
- [ ] axe-core: no target-size violations on toast close button.
- [ ] Stacked toasts: confirm multiple toasts render correctly with the new button size.

## Checklist

- [x] No new i18n keys — reuses existing `dismissLabel` / `common.close`
- [x] No visual change to close icon appearance
- [x] Uses `Button` + `leadingIcon` (deprecated `IconButton` avoided)
- [x] Cascades to cloud-ui-main via `@temporalio/ui` tarball

## Docs

No documentation changes required.

A11y-Audit-Ref: 2.5.8-toast-close-button