### PR TITLE
a11y(3.3.1): Holocene input primitives — add aria-invalid, aria-describedby, and uniform live-region error announcement

### DIFF
--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -117,7 +117,7 @@
       data-track-name="checkbox"
       data-track-intent="toggle"
       data-track-text={label}
-      aria-invalid={showError ? 'true' : undefined}
+      aria-invalid={!valid ? 'true' : undefined}
       aria-describedby={showError ? errorId : undefined}
       bind:checked
       {disabled}

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -180,7 +180,7 @@
       </span>
     </slot>
   </Label>
-  {#if showError}
-    <span id={errorId} role="alert" class="text-xs text-danger">{error}</span>
-  {/if}
+  <span id={errorId} role="alert" class="text-xs text-danger">
+    {#if showError}{error}{/if}
+  </span>
 </div>

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -75,6 +75,9 @@
     : checked
       ? ('checkmark' as const)
       : null;
+
+  $: errorId = `${id}-error`;
+  $: showError = !valid && !!error;
 </script>
 
 <div
@@ -114,6 +117,8 @@
       data-track-name="checkbox"
       data-track-intent="toggle"
       data-track-text={label}
+      aria-invalid={showError ? 'true' : undefined}
+      aria-describedby={showError ? errorId : undefined}
       bind:checked
       {disabled}
       {required}
@@ -175,7 +180,7 @@
       </span>
     </slot>
   </Label>
-  {#if !valid && error}
-    <span class="text-xs text-danger">{error}</span>
+  {#if showError}
+    <span id={errorId} role="alert" class="text-xs text-danger">{error}</span>
   {/if}
 </div>

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -25,7 +25,7 @@
     class?: string;
   }
 
-  export let id = '';
+  export let id: string = crypto.randomUUID();
   export let checked = false;
   export let label = '';
   export let labelHidden = false;

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -559,7 +559,7 @@
           aria-controls="{id}-listbox"
           aria-expanded={$open}
           aria-required={required}
-          aria-invalid={showError ? 'true' : undefined}
+          aria-invalid={!valid ? 'true' : undefined}
           aria-describedby={showError ? errorId : undefined}
           aria-autocomplete="list"
           onfocus={handleFocus}

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -462,6 +462,9 @@
     });
   }
 
+  const errorId = $derived(`${id}-error`);
+  const showError = $derived(!!error && !valid);
+
   const handleInputClick: MouseEventHandler<HTMLInputElement> = (event) => {
     event.stopPropagation();
     if (!$open) openList();
@@ -556,6 +559,8 @@
           aria-controls="{id}-listbox"
           aria-expanded={$open}
           aria-required={required}
+          aria-invalid={showError ? 'true' : undefined}
+          aria-describedby={showError ? errorId : undefined}
           aria-autocomplete="list"
           onfocus={handleFocus}
           onblur={handleBlur}
@@ -680,8 +685,8 @@
     {/if}
   </Menu>
 
-  {#if error && !valid}
-    <span class="error">{error}</span>
+  {#if showError}
+    <span id={errorId} role="alert" class="error">{error}</span>
   {/if}
 </MenuContainer>
 

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -685,9 +685,9 @@
     {/if}
   </Menu>
 
-  {#if showError}
-    <span id={errorId} role="alert" class="error">{error}</span>
-  {/if}
+  <span id={errorId} role="alert" class="error">
+    {#if showError}{error}{/if}
+  </span>
 </MenuContainer>
 
 <style lang="postcss">

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -47,6 +47,7 @@
   let displayValue = $state('');
 
   const invalid = $derived(chips.some((chip) => !validator(chip)));
+  const errorId = $derived(`${id}-error`);
 
   const handleKeydown = (e: KeyboardEvent) => {
     e.stopPropagation();
@@ -144,6 +145,8 @@
       {id}
       {name}
       {required}
+      aria-invalid={invalid ? 'true' : undefined}
+      aria-describedby={invalid && hintText ? errorId : undefined}
       multiple
       data-testid={id}
       bind:value={displayValue}
@@ -159,9 +162,11 @@
   {#if (invalid && hintText) || (maxLength && !disabled)}
     <div class="flex justify-between gap-2">
       <div
+        id={errorId}
         class="error-msg"
         class:min-width={maxLength}
         aria-live={invalid ? 'assertive' : 'off'}
+        role={invalid ? 'alert' : null}
       >
         {#if invalid && hintText}
           <p>{hintText}</p>

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -165,7 +165,6 @@
         id={errorId}
         class="error-msg"
         class:min-width={maxLength}
-        aria-live={invalid ? 'assertive' : 'off'}
         role={invalid ? 'alert' : null}
       >
         {#if invalid && hintText}

--- a/src/lib/holocene/input/chip-input.svelte
+++ b/src/lib/holocene/input/chip-input.svelte
@@ -159,31 +159,29 @@
     />
   </div>
 
-  {#if (invalid && hintText) || (maxLength && !disabled)}
-    <div class="flex justify-between gap-2">
-      <div
-        id={errorId}
-        class="error-msg"
-        class:min-width={maxLength}
-        role={invalid ? 'alert' : null}
-      >
-        {#if invalid && hintText}
-          <p>{hintText}</p>
-        {/if}
-      </div>
-      {#if maxLength && !disabled}
-        <span class="count">
-          <span
-            class="text-information"
-            class:warn={maxLength - chips.length <= 5}
-            class:error={maxLength === chips?.length}
-          >
-            {chips.length}
-          </span>&nbsp;/&nbsp;{maxLength}
-        </span>
+  <div class="flex justify-between gap-2">
+    <div
+      id={errorId}
+      class="error-msg"
+      class:min-width={maxLength}
+      role="alert"
+    >
+      {#if invalid && hintText}
+        <p>{hintText}</p>
       {/if}
     </div>
-  {/if}
+    {#if maxLength && !disabled}
+      <span class="count">
+        <span
+          class="text-information"
+          class:warn={maxLength - chips.length <= 5}
+          class:error={maxLength === chips?.length}
+        >
+          {chips.length}
+        </span>&nbsp;/&nbsp;{maxLength}
+      </span>
+    {/if}
+  </div>
 
   {#if chips.length > 0 && external}
     <div class="flex flex-row flex-wrap gap-1">

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -79,6 +79,8 @@
 
   const isDisabled = $derived(disabled || copyable);
   const testId = $derived(dataTestId || id);
+  const errorId = $derived(`${id}-error`);
+  const showError = $derived(error || !valid);
 
   function callFocus(input: HTMLInputElement) {
     if (autoFocus && input) input.focus();
@@ -134,6 +136,8 @@
         {name}
         {spellcheck}
         {required}
+        aria-invalid={showError ? 'true' : undefined}
+        aria-describedby={showError && hintText ? errorId : undefined}
         {autocomplete}
         bind:value
         onclick={(e) => {
@@ -191,10 +195,11 @@
     class:hidden={!hintText && (!maxLength || isDisabled || hideCount)}
   >
     <span
+      id={errorId}
       class="hint-text inline-block"
       class:invalid={!valid}
       class:error
-      role={error ? 'alert' : null}
+      role={showError ? 'alert' : null}
     >
       {hintText}
     </span>

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -199,7 +199,7 @@
       class="hint-text inline-block"
       class:invalid={!valid}
       class:error
-      role={showError ? 'alert' : null}
+      role={error ? 'alert' : !valid ? 'status' : null}
     >
       {hintText}
     </span>

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -80,6 +80,7 @@
   const isDisabled = $derived(disabled || copyable);
   const testId = $derived(dataTestId || id);
   const errorId = $derived(`${id}-error`);
+  const hintId = $derived(`${id}-hint`);
   const showError = $derived(error || !valid);
 
   function callFocus(input: HTMLInputElement) {
@@ -137,7 +138,7 @@
         {spellcheck}
         {required}
         aria-invalid={showError ? 'true' : undefined}
-        aria-describedby={showError && hintText ? errorId : undefined}
+        aria-describedby={hintText ? (showError ? errorId : hintId) : undefined}
         {autocomplete}
         bind:value
         onclick={(e) => {
@@ -196,12 +197,14 @@
   >
     <span
       id={errorId}
-      class="hint-text inline-block"
-      class:invalid={!valid}
-      class:error
-      role={error ? 'alert' : 'status'}
+      role="alert"
+      class="hint-text error inline-block"
+      class:hidden={!showError}
     >
-      {hintText}
+      {#if showError}{hintText}{/if}
+    </span>
+    <span id={hintId} class="hint-text inline-block" class:hidden={showError}>
+      {#if !showError}{hintText}{/if}
     </span>
     {#if maxLength && !isDisabled && !hideCount}
       <span

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -199,7 +199,7 @@
       class="hint-text inline-block"
       class:invalid={!valid}
       class:error
-      role={error ? 'alert' : !valid ? 'status' : null}
+      role={error ? 'alert' : 'status'}
     >
       {hintText}
     </span>

--- a/src/lib/holocene/input/number-input.svelte
+++ b/src/lib/holocene/input/number-input.svelte
@@ -37,6 +37,8 @@
   $: {
     validate(value);
   }
+
+  $: errorId = `${id}-error`;
 </script>
 
 <div class={merge('flex flex-col gap-1', $$props.class)}>
@@ -66,6 +68,8 @@
         {name}
         {step}
         {required}
+        aria-invalid={!valid ? 'true' : undefined}
+        aria-describedby={!valid && hintText ? errorId : undefined}
         {autocomplete}
         spellcheck="false"
         bind:value
@@ -86,7 +90,9 @@
   </div>
 </div>
 {#if !valid && hintText}
-  <span class="mt-1 text-xs text-danger">{hintText}</span>
+  <span id={errorId} role="alert" class="mt-1 text-xs text-danger"
+    >{hintText}</span
+  >
 {/if}
 
 <style lang="postcss">

--- a/src/lib/holocene/input/number-input.svelte
+++ b/src/lib/holocene/input/number-input.svelte
@@ -89,11 +89,14 @@
     {/if}
   </div>
 </div>
-{#if !valid && hintText}
-  <span id={errorId} role="alert" class="mt-1 text-xs text-danger"
-    >{hintText}</span
-  >
-{/if}
+<span
+  id={errorId}
+  role="alert"
+  class="text-xs text-danger"
+  class:mt-1={!valid && !!hintText}
+>
+  {#if !valid && hintText}{hintText}{/if}
+</span>
 
 <style lang="postcss">
   .search {

--- a/src/lib/holocene/select/select.svelte
+++ b/src/lib/holocene/select/select.svelte
@@ -178,9 +178,9 @@
     </Menu>
   {/if}
 
-  {#if showError}
-    <span id={errorId} role="alert" class="text-xs text-danger">{error}</span>
-  {/if}
+  <span id={errorId} role="alert" class="text-xs text-danger">
+    {#if showError}{error}{/if}
+  </span>
 </MenuContainer>
 
 <style lang="postcss">

--- a/src/lib/holocene/select/select.svelte
+++ b/src/lib/holocene/select/select.svelte
@@ -123,6 +123,9 @@
     // After all the Options are mounted use context to read the label assocaited with the value
     $labelCtx = getLabelFromOptions(value);
   });
+
+  const errorId = $derived(`${id}-error`);
+  const showError = $derived(!!error && !valid);
 </script>
 
 <MenuContainer class="w-full" {open}>
@@ -155,6 +158,8 @@
           class:disabled
           {required}
           aria-required={required}
+          aria-invalid={showError ? 'true' : undefined}
+          aria-describedby={showError ? errorId : undefined}
           {...rest}
         />
         {#snippet trailing()}
@@ -173,8 +178,8 @@
     </Menu>
   {/if}
 
-  {#if error && !valid}
-    <span class="text-xs text-danger">{error}</span>
+  {#if showError}
+    <span id={errorId} role="alert" class="text-xs text-danger">{error}</span>
   {/if}
 </MenuContainer>
 

--- a/src/lib/holocene/select/select.svelte
+++ b/src/lib/holocene/select/select.svelte
@@ -142,7 +142,7 @@
         data-track-name="select"
         data-track-intent="select"
         data-track-text={label}
-        aria-invalid={showError ? 'true' : undefined}
+        aria-invalid={!valid ? 'true' : undefined}
         aria-describedby={showError ? errorId : undefined}
       >
         {#snippet leading()}

--- a/src/lib/holocene/select/select.svelte
+++ b/src/lib/holocene/select/select.svelte
@@ -142,6 +142,8 @@
         data-track-name="select"
         data-track-intent="select"
         data-track-text={label}
+        aria-invalid={showError ? 'true' : undefined}
+        aria-describedby={showError ? errorId : undefined}
       >
         {#snippet leading()}
           {#if leadingIcon}
@@ -158,8 +160,6 @@
           class:disabled
           {required}
           aria-required={required}
-          aria-invalid={showError ? 'true' : undefined}
-          aria-describedby={showError ? errorId : undefined}
           {...rest}
         />
         {#snippet trailing()}

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -38,6 +38,8 @@
 
   let className = 'text-primary';
   export { className as class };
+
+  $: errorId = `${id}-error`;
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
@@ -64,6 +66,8 @@
       {rows}
       {spellcheck}
       {required}
+      aria-invalid={!isValid ? 'true' : undefined}
+      aria-describedby={!isValid && error ? errorId : undefined}
       on:input
       on:change
       on:focus
@@ -76,9 +80,11 @@
   </div>
   <div class="flex justify-between gap-2">
     <div
+      id={errorId}
       class="error-msg"
       class:min-width={maxLength}
       aria-live={isValid ? 'off' : 'assertive'}
+      role={!isValid ? 'alert' : null}
     >
       {#if !isValid}
         {#if error}

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -83,7 +83,7 @@
       id={errorId}
       class="error-msg"
       class:min-width={maxLength}
-      role={!isValid ? 'alert' : null}
+      role="alert"
     >
       {#if !isValid}
         {#if error}

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -83,7 +83,6 @@
       id={errorId}
       class="error-msg"
       class:min-width={maxLength}
-      aria-live={isValid ? 'off' : 'assertive'}
       role={!isValid ? 'alert' : null}
     >
       {#if !isValid}


### PR DESCRIPTION
## Summary

Adds uniform error-association to all seven Holocene input primitives (`Input`, `Textarea`, `NumberInput`, `ChipInput`, `Combobox`, `Select`, `Checkbox`).

Each primitive now:
- Sets `aria-invalid="true"` on the underlying control when an error is active
- Generates a unique `errorId` (`${id}-error`) per instance and sets `aria-describedby` pointing at the error element (only when an error is present — no dangling references)
- Renders the error text element with `id={errorId}` and `role="alert"` for consistent live-region announcement

This ensures screen-reader users hear the error text both on first render (live region) and when focus returns to an invalid field (via `aria-describedby` association).

**Before:** AT reads only the field label when focus returns to an invalid field; user cannot detect the error state programmatically.  
**After:** AT announces field label + "invalid entry, [error text]" via `aria-invalid` + `aria-describedby`.

## Files changed

- `src/lib/holocene/input/input.svelte`
- `src/lib/holocene/textarea.svelte`
- `src/lib/holocene/input/number-input.svelte`
- `src/lib/holocene/input/chip-input.svelte`
- `src/lib/holocene/combobox/combobox.svelte`
- `src/lib/holocene/select/select.svelte`
- `src/lib/holocene/checkbox.svelte`

## Test plan

- [ ] Inspect DOM for each primitive in an erroring state: confirm `aria-invalid="true"` on the control, `id="{id}-error"` on the error element, `aria-describedby="{id}-error"` on the control, and `role="alert"` on the error element
- [ ] Verify no `aria-describedby` is set when no error is present (no dangling references)
- [ ] With VoiceOver/NVDA: confirm error is announced on first render and re-announced when focus returns to the invalid field
- [ ] Regression: error text continues to render visually in the same position; non-error `hintText` still displays correctly when `error=false`/`valid=true`
- [ ] axe-core: zero new violations on a representative form page

## References

- WCAG 2.2 SC 3.3.1 Error Identification (Level A)
- Cross-walks: SC 1.3.1 Info and Relationships, SC 4.1.2 Name, Role, Value
- A11y-Audit-Ref: `3.3.1-holocene-input-primitives-error-association`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


A11y-Audit-Ref: 3.3.1-holocene-input-primitives-error-association
