### PR TITLE
a11y(4.1.2): fix nested interactive elements in Copyable component

### DIFF
--- a/src/lib/holocene/copyable/index.svelte
+++ b/src/lib/holocene/copyable/index.svelte
@@ -17,15 +17,19 @@
 </script>
 
 {#if clickAllToCopy}
-  <button
-    class="group flex items-center gap-1 break-all {$$props['container-class']}"
-    on:click={handleOnClick}
-  >
-    <slot>
-      <span class={$$props.class} class:select-all={!$$slots.default}
-        >{content}</span
-      >
-    </slot>
+  <div class="group flex items-center gap-1 {$$props['container-class']}">
+    <button
+      type="button"
+      class="break-all text-left"
+      on:click={handleOnClick}
+      aria-label={`Copy ${content}`}
+    >
+      <slot>
+        <span class={$$props.class} class:select-all={!$$slots.default}
+          >{content}</span
+        >
+      </slot>
+    </button>
     <CopyButton
       {copyIconTitle}
       {copySuccessIconTitle}
@@ -35,7 +39,7 @@
       on:click={handleOnClick}
       copied={$copied}
     />
-  </button>
+  </div>
 {:else}
   <div class="group flex items-center gap-1 {$$props['container-class']}">
     <slot>

--- a/src/lib/holocene/copyable/index.svelte
+++ b/src/lib/holocene/copyable/index.svelte
@@ -16,13 +16,13 @@
   }
 </script>
 
-{#if clickAllToCopy}
-  <div class="group flex items-center gap-1 {$$props['container-class']}">
+<div class="group flex items-center gap-1 {$$props['container-class']}">
+  {#if clickAllToCopy}
     <button
       type="button"
       class="break-all text-left"
       on:click={handleOnClick}
-      aria-label={`Copy ${content}`}
+      aria-label={$$slots.default ? undefined : `Copy ${content}`}
     >
       <slot>
         <span class={$$props.class} class:select-all={!$$slots.default}
@@ -30,31 +30,20 @@
         >
       </slot>
     </button>
-    <CopyButton
-      {copyIconTitle}
-      {copySuccessIconTitle}
-      class={visible
-        ? 'visible'
-        : 'invisible group-focus-within:visible group-hover:visible'}
-      on:click={handleOnClick}
-      copied={$copied}
-    />
-  </div>
-{:else}
-  <div class="group flex items-center gap-1 {$$props['container-class']}">
+  {:else}
     <slot>
       <span class={$$props.class} class:select-all={!$$slots.default}
         >{content}</span
       >
     </slot>
-    <CopyButton
-      {copyIconTitle}
-      {copySuccessIconTitle}
-      class={visible
-        ? 'visible'
-        : 'invisible group-focus-within:visible group-hover:visible'}
-      on:click={handleOnClick}
-      copied={$copied}
-    />
-  </div>
-{/if}
+  {/if}
+  <CopyButton
+    {copyIconTitle}
+    {copySuccessIconTitle}
+    class={visible
+      ? 'visible'
+      : 'invisible group-focus-within:visible group-hover:visible'}
+    on:click={handleOnClick}
+    copied={$copied}
+  />
+</div>


### PR DESCRIPTION
## Summary

- Replaces outer `<button>` wrapper in `clickAllToCopy` mode with a `<div class="group">`, moving the click-to-copy action into an inner `<button>` sibling of `CopyButton`
- Eliminates nested interactive elements (button inside button), which violates WCAG 2.2 SC 4.1.2 (Name, Role, Value)
- The inner button gets `aria-label={\`Copy \${content}\`}` so screen readers announce it meaningfully
- The `group` class stays on the `<div>`, so `group-hover:visible` / `group-focus-within:visible` Tailwind utilities continue to work for the `CopyButton` reveal
- No consumer changes required — the fix is entirely within the primitive

## Test plan

- [ ] Verify `clickAllToCopy` mode renders `<div>` wrapping two sibling buttons (no button-in-button)
- [ ] Tab to the inner copy button and confirm screen reader announces "Copy [content]"
- [ ] Hover over the component and confirm `CopyButton` becomes visible via `group-hover:visible`
- [ ] Focus the inner button and confirm `CopyButton` stays visible via `group-focus-within:visible`
- [ ] Click the inner button and confirm content is copied to clipboard

A11y-Audit-Ref: 4.1.2-copyable-nested-interactive

🤖 Generated with [Claude Code](https://claude.com/claude-code)