### PR TITLE
a11y(4.1.2): ToggleButton — expose toggled state via aria-pressed so AT users can tell which member of a group is active

### DIFF
--- a/src/lib/holocene/toggle-button/toggle-button.svelte
+++ b/src/lib/holocene/toggle-button/toggle-button.svelte
@@ -36,19 +36,21 @@
   export let base = href;
   export let active = false;
   export let variant: ComponentProps<Button>['variant'] = 'secondary';
+
+  $: pressed = href ? $page.url.pathname.includes(base) : active;
 </script>
 
 <Button
   on:click
   class={merge(
-    (href ? $page.url.pathname.includes(base) : active) &&
-      'bg-interactive-secondary-active',
+    pressed && 'bg-interactive-secondary-active',
     group && '[&:not(:last-child)]:border-r-0',
     className,
   )}
   data-track-name="toggle-button"
   {variant}
   href={href ? href + $page.url.search : null}
+  aria-pressed={pressed ? 'true' : 'false'}
   {...$$restProps}
 >
   {#if $$restProps.leadingIcon}


### PR DESCRIPTION
## Summary

- Extracts the active-state expression (`href ? $page.url.pathname.includes(base) : active`) into a reactive `pressed` variable
- Forwards it as `aria-pressed={pressed ? 'true' : 'false'}` on the underlying `Button`, placed **before** `{...$$restProps}` so consumers can still override if needed
- Eliminates WCAG 2.2 SC 4.1.2 violation: screen-reader users navigating a `ToggleButtons` group could not tell which member was selected

Consumers benefit automatically (no changes needed):
- Dark-mode menu (System / Day / Night picker)
- Timezone format toggles (Short / Medium / Long / ISO; 12h / 24h / System)
- Time-picker AM/PM toggle
- Workflow detail toolbar tab-button variants
- Cloud composites that today manually set `aria-pressed` continue to work — their explicit value wins via `$$restProps`

## Test plan

- [ ] Render a ToggleButtons group (e.g. dark-mode menu). Activate each button. Inspect DOM: active button has `aria-pressed="true"`, inactive members have `aria-pressed="false"`
- [ ] Screen-reader smoke test (NVDA / VoiceOver): confirm each button announces its name plus pressed/not-pressed state
- [ ] `bg-interactive-secondary-active` class still renders on the active member (visual unchanged)
- [ ] Anchor variant (`href`): navigate to matching route → `aria-pressed="true"`; navigate away → `aria-pressed="false"`
- [ ] Consumer override: cloud composites that set `aria-pressed` manually still render correctly (restProps wins)
- [ ] axe-core run on a page with a ToggleButtons group: zero new violations

A11y-Audit-Ref: 4.1.2-toggle-button-aria-pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)