### PR TITLE
Cache new Intl.DateTimeFormat

### DIFF
--- a/src/lib/utilities/format-date.test.ts
+++ b/src/lib/utilities/format-date.test.ts
@@ -12,15 +12,17 @@ import { getLocalTime } from './timezone';
 // // force GH action runners to use en-US and 12-hour clocks starting at 0:00
 // but respect explicit hour12 option when provided
 const DateTimeFormat = Intl.DateTimeFormat;
-vi.spyOn(global.Intl, 'DateTimeFormat').mockImplementation((_, options) => {
-  const hour12 = options?.hour12 !== undefined ? options.hour12 : true;
-  const hourCycle = options?.hour12 !== undefined ? undefined : 'h11';
-  return new DateTimeFormat('en-US', {
-    ...options,
-    hour12,
-    ...(hourCycle && { hourCycle }),
+const dateTimeFormatSpy = vi
+  .spyOn(global.Intl, 'DateTimeFormat')
+  .mockImplementation((_, options) => {
+    const hour12 = options?.hour12 !== undefined ? options.hour12 : true;
+    const hourCycle = options?.hour12 !== undefined ? undefined : 'h11';
+    return new DateTimeFormat('en-US', {
+      ...options,
+      hour12,
+      ...(hourCycle && { hourCycle }),
+    });
   });
-});
 
 describe('formatDate', () => {
   const date = '2022-04-13T16:29:35.630571Z';
@@ -47,6 +49,22 @@ describe('formatDate', () => {
 
   it('should default to UTC', () => {
     expect(formatDate(date)).toEqual('Apr 13, 2022, 4:29:35.63 PM UTC');
+  });
+
+  it('should reuse formatters for matching format options', () => {
+    dateTimeFormatSpy.mockClear();
+
+    expect(formatDate(date, 'UTC', { format: 'short', hourFormat: '12' })).toBe(
+      '4/13/22, 4:29:35.63 PM UTC',
+    );
+    expect(
+      formatDate('2022-04-14T16:29:35.630571Z', 'UTC', {
+        format: 'short',
+        hourFormat: '12',
+      }),
+    ).toBe('4/14/22, 4:29:35.63 PM UTC');
+
+    expect(dateTimeFormatSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should format other timezones', () => {

--- a/src/lib/utilities/format-date.ts
+++ b/src/lib/utilities/format-date.ts
@@ -65,6 +65,32 @@ export const timestampFormats: Record<
 
 export type TimestampFormat = keyof typeof timestampFormats;
 
+const dateTimeFormatters = new Map<string, Intl.DateTimeFormat>();
+
+const getHour12Option = (hourFormat: HourFormat): boolean | undefined => {
+  if (hourFormat === 'system') return undefined;
+  return hourFormat === '12';
+};
+
+const getDateTimeFormatter = (
+  format: TimestampFormat,
+  hourFormat: HourFormat,
+  timeZone?: string,
+): Intl.DateTimeFormat => {
+  const cacheKey = `${timeZone ?? BASE_TIME_FORMAT_OPTIONS.LOCAL}|${format}|${hourFormat}`;
+  const cachedFormatter = dateTimeFormatters.get(cacheKey);
+  if (cachedFormatter) return cachedFormatter;
+
+  const hour12 = getHour12Option(hourFormat);
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    ...timestampFormats[format],
+    ...(hour12 !== undefined && { hour12 }),
+    ...(timeZone && { timeZone }),
+  });
+  dateTimeFormatters.set(cacheKey, formatter);
+  return formatter;
+};
+
 /**
  * Determines if a given date/time value represents a future moment.
  * Handles ValidTime types including strings, numbers, Dates, and Timestamp objects.
@@ -124,23 +150,12 @@ export function formatDate(
       return parsed.toISOString();
     }
 
-    const hour12 =
-      hourFormat === 'system' ? undefined : hourFormat === '12' ? true : false;
-
-    const formatOptions = {
-      ...timestampFormats[format],
-      ...(hour12 !== undefined && { hour12 }),
-    };
-
     if (timeFormat === BASE_TIME_FORMAT_OPTIONS.LOCAL) {
-      return new Intl.DateTimeFormat(undefined, formatOptions).format(parsed);
+      return getDateTimeFormatter(format, hourFormat).format(parsed);
     }
 
     const timeZone = getTimezone(timeFormat);
-    return new Intl.DateTimeFormat(undefined, {
-      ...formatOptions,
-      timeZone,
-    }).format(parsed);
+    return getDateTimeFormatter(format, hourFormat, timeZone).format(parsed);
   } catch (e) {
     console.error('Error formatting date:', e);
     return '';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
  - Cache `Intl.DateTimeFormat` instances in `formatDate`
  - Reuse formatters by timezone/local mode, timestamp format, and hour format
  - Add a regression test to verify repeated calls with the same options only construct one formatter

  ## Why

  Workflow details can call `formatDate` many times while rendering event history and timestamp-like attributes. Constructing a new `Intl.DateTimeFormat` per call is expensive and showed up prominently in profiling. Reusing formatters removes that repeated setup cost while preserving existing output and invalid timezone behavior.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
  - `pnpm test src/lib/utilities/format-date.test.ts --run`
  - `pnpm exec eslint src/lib/utilities/format-date.ts src/lib/utilities/format-date.test.ts`

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
