### PR TITLE
Fix required activity timeout inputs on Start a Standalone Activity form

### DIFF
--- a/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
+++ b/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
@@ -12,7 +12,9 @@
   import Alert from '$lib/holocene/alert.svelte';
   import Button from '$lib/holocene/button.svelte';
   import Card from '$lib/holocene/card.svelte';
-  import DurationInput from '$lib/holocene/duration-input/duration-input.svelte';
+  import DurationInput, {
+    parseDuration,
+  } from '$lib/holocene/duration-input/duration-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Label from '$lib/holocene/label.svelte';
   import Link from '$lib/holocene/link.svelte';
@@ -76,6 +78,11 @@
   let taskQueueActive = $state<boolean | null>(null);
   let advancedOptionsVisible = $state(false);
 
+  const isPositiveDuration = (value: string | undefined): boolean => {
+    const seconds = Number(parseDuration(value ?? ''));
+    return !isNaN(seconds) && seconds > 0;
+  };
+
   const schema = z
     .object({
       identity: z.string(),
@@ -106,7 +113,10 @@
       idConflictPolicy: z.string().optional(),
     })
     .superRefine((data, context) => {
-      if (!data.startToCloseTimeout && !data.scheduleToCloseTimeout) {
+      if (
+        !isPositiveDuration(data.startToCloseTimeout) &&
+        !isPositiveDuration(data.scheduleToCloseTimeout)
+      ) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['startToCloseTimeout'],
@@ -312,7 +322,7 @@
       label={translate(
         'standalone-activities.form-start-to-close-timeout-label',
       )}
-      required={!$form.scheduleToCloseTimeout}
+      required={!isPositiveDuration($form.scheduleToCloseTimeout)}
       hintText={translate(
         'standalone-activities.form-start-to-close-timeout-hint',
       )}
@@ -324,7 +334,7 @@
       label={translate(
         'standalone-activities.form-schedule-to-close-timeout-label',
       )}
-      required={!$form.startToCloseTimeout}
+      required={!isPositiveDuration($form.startToCloseTimeout)}
       hintText={translate(
         'standalone-activities.form-schedule-to-close-timeout-hint',
       )}

--- a/src/lib/holocene/duration-input/duration-input.svelte
+++ b/src/lib/holocene/duration-input/duration-input.svelte
@@ -93,10 +93,14 @@
 
   const convert = (durationValue: string, durationUnit: string) => {
     const unit = units.find((u) => u.label === durationUnit);
+    if (!unit) return;
 
-    if (unit) {
-      value = `${unit.convert(Number(durationValue))}s`;
+    if (durationValue === '' || isNaN(Number(durationValue))) {
+      value = '';
+      return;
     }
+
+    value = `${unit.convert(Number(durationValue))}s`;
   };
 
   const handleNumberInput: ChangeEventHandler<HTMLInputElement> = (e) => {

--- a/src/lib/holocene/duration-input/duration-input.svelte
+++ b/src/lib/holocene/duration-input/duration-input.svelte
@@ -95,7 +95,7 @@
     const unit = units.find((u) => u.label === durationUnit);
     if (!unit) return;
 
-    if (durationValue === '' || isNaN(Number(durationValue))) {
+    if (durationValue.trim() === '' || isNaN(Number(durationValue))) {
       value = '';
       return;
     }

--- a/tests/integration/start-standalone-activity.spec.ts
+++ b/tests/integration/start-standalone-activity.spec.ts
@@ -2,10 +2,12 @@ import { expect, test } from '@playwright/test';
 
 import { StartStandaloneActivityPage } from '~/pages/start-standalone-activity';
 import {
+  mockClusterApi,
   mockGlobalApis,
   mockNamespaceApi,
   mockSearchAttributesApi,
   mockSettingsApi,
+  mockTaskQueuesApi,
 } from '~/test-utilities/mock-apis';
 
 test.describe('Start a Standalone Activity', () => {
@@ -14,9 +16,11 @@ test.describe('Start a Standalone Activity', () => {
     await mockNamespaceApi(page);
     await mockSettingsApi(page);
     await mockSearchAttributesApi(page);
+    await mockTaskQueuesApi(page);
+    await mockClusterApi(page, { serverVersion: '1.30.0' });
   });
 
-  test.skip('Allows select form fields to be pre-filled via URL Search Parameters', async ({
+  test('Allows select form fields to be pre-filled via URL Search Parameters', async ({
     page,
   }) => {
     const startStandaloneActivityPage = new StartStandaloneActivityPage(page);
@@ -46,7 +50,7 @@ test.describe('Start a Standalone Activity', () => {
     ).toHaveValue('10');
   });
 
-  test.skip('Displays errors when select form fields are incomplete', async ({
+  test('Displays errors when select form fields are incomplete', async ({
     page,
   }) => {
     const startStandaloneActivityPage = new StartStandaloneActivityPage(page);
@@ -64,7 +68,7 @@ test.describe('Start a Standalone Activity', () => {
     await expect(startStandaloneActivityPage.timeoutError).toBeVisible();
   });
 
-  test.skip('Allows expanding more options', async ({ page }) => {
+  test('Allows expanding more options', async ({ page }) => {
     const startStandaloneActivityPage = new StartStandaloneActivityPage(page);
     await startStandaloneActivityPage.goto();
 
@@ -79,5 +83,40 @@ test.describe('Start a Standalone Activity', () => {
       startStandaloneActivityPage.addSearchAttributesCard,
     ).toBeVisible();
     await expect(startStandaloneActivityPage.addMetadataCard).toBeVisible();
+  });
+
+  test('shows the timeout error when Start to Close Timeout is zero', async ({
+    page,
+  }) => {
+    const startStandaloneActivityPage = new StartStandaloneActivityPage(page);
+    await startStandaloneActivityPage.goto();
+
+    await startStandaloneActivityPage.activityIdInput.fill('abc-123');
+    await startStandaloneActivityPage.activityTypeInput.fill('greet');
+    await startStandaloneActivityPage.taskQueueInput.fill('default');
+    await startStandaloneActivityPage.startToCloseTimeoutInput.fill('0');
+
+    await startStandaloneActivityPage.submitButton.click();
+
+    await expect(startStandaloneActivityPage.timeoutError).toBeVisible();
+  });
+
+  test('shows the timeout error after a value is added and then removed from Start to Close Timeout', async ({
+    page,
+  }) => {
+    const startStandaloneActivityPage = new StartStandaloneActivityPage(page);
+    await startStandaloneActivityPage.goto();
+
+    await startStandaloneActivityPage.activityIdInput.fill('abc-123');
+    await startStandaloneActivityPage.activityTypeInput.fill('greet');
+    await startStandaloneActivityPage.taskQueueInput.fill('default');
+
+    await startStandaloneActivityPage.startToCloseTimeoutInput.fill('30');
+    await expect(startStandaloneActivityPage.timeoutError).toBeHidden();
+
+    await startStandaloneActivityPage.startToCloseTimeoutInput.fill('');
+    await startStandaloneActivityPage.submitButton.click();
+
+    await expect(startStandaloneActivityPage.timeoutError).toBeVisible();
   });
 });


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

On the Start a Standalone Activity form, either Start to Close Timeout or Schedule to Close Timeout is required. The validation worked when both fields were left blank, but broke as soon as a value was entered and then removed:
1. The `DurationInput` converted its raw numeric field to a seconds string with `${unit.convert(Number(durationValue))}s`. When the field was cleared, Number('') evaluated to 0, so the bound value became '0s' instead of empty.
  2. The form's required-check used plain truthiness (`!data.startToCloseTimeout`). Since '0s' is a truthy string, the check passed, the form considered itself valid and it submitted.
3. The same root cause ('0s' from an emptied field) also meant a deliberately-typed 0 slipped past validation.

The `DurationInput` now yields an empty value (`value = ''`) when the raw input is empty or non-numeric, instead of coercing to '0s'. The Start a Standalone Activity form now has an `isPositiveDuration` helper check for the required prop on the Start to Close Timeout and Schedule to Close Timeout fields.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

* On the Start a Standalone Activity form > without entering a Start to Close Timeout or Schedule to Close Timeout hit submit
   - [ ] Verify the error ("Either "Start to Close Timeout" or "Schedule to Close Timeout" is required.") appears
* Enter a value for either Start to Close Timeout or Schedule to Close Timeout and then clear it and hit submit
   - [ ] Verify the error appears
* Enter "0" for either Start to Close Timeout or Schedule to Close Timeout and hit submit
   - [ ] Verify the error appears

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

`DT-4181`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
