### PR TITLE
Show single attempt in Standalone Activity details

### DIFF
--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -57,7 +57,8 @@
   {@const failed = attempt > 1 && !!lastFailure}
   {@const badgeType = failed ? 'danger' : 'default'}
 
-  <DetailListLabel>{translate('standalone-activities.attempt')}</DetailListLabel
+  <DetailListLabel class="flex items-center"
+    >{translate('standalone-activities.attempt')}</DetailListLabel
   >
   <DetailListValue>
     <Badge type={badgeType} class="flex items-center gap-2">
@@ -121,6 +122,36 @@
               : 2}
             aria-label={translate('standalone-activities.timing-and-progress')}
           >
+            {#if isClosed}
+              <DetailListLabel
+                >{translate(
+                  'standalone-activities.execution-duration',
+                )}</DetailListLabel
+              >
+              <DetailListTextValue
+                text={fromSeconds(
+                  $activityExecution.info.executionDuration ?? '',
+                )}
+              />
+              {#if $activityExecution.info.attempt !== undefined}
+                {#if $activityExecution.info.attempt > 1}
+                  {@render activityExecutionAttemptsBadge(
+                    $activityExecution.info.attempt,
+                    $activityExecution.info.retryPolicy?.maximumAttempts,
+                    $activityExecution.info.lastFailure,
+                  )}
+                {:else}
+                  <DetailListLabel
+                    >{translate(
+                      'standalone-activities.attempt',
+                    )}</DetailListLabel
+                  >
+                  <DetailListTextValue
+                    text={String($activityExecution.info.attempt)}
+                  />
+                {/if}
+              {/if}
+            {/if}
             <DetailListLabel
               >{translate(
                 'standalone-activities.schedule-time',
@@ -140,29 +171,12 @@
             {#if isClosed}
               <DetailListLabel
                 >{translate(
-                  'standalone-activities.execution-duration',
-                )}</DetailListLabel
-              >
-              <DetailListTextValue
-                text={fromSeconds(
-                  $activityExecution.info.executionDuration ?? '',
-                )}
-              />
-              <DetailListLabel
-                >{translate(
                   'standalone-activities.close-time',
                 )}</DetailListLabel
               >
               <DetailListTimestampValue
                 timestamp={$activityExecution.info.lastStartedTime}
               />
-              {#if $activityExecution.info.attempt > 1}
-                {@render activityExecutionAttemptsBadge(
-                  $activityExecution.info.attempt,
-                  $activityExecution.info.retryPolicy?.maximumAttempts,
-                  $activityExecution.info.lastFailure,
-                )}
-              {/if}
             {/if}
           </DetailList>
         </div>

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -36,7 +36,7 @@
 
   const isRetrying = $derived(
     $activityExecution?.info?.status === 'ACTIVITY_EXECUTION_STATUS_RUNNING' &&
-      $activityExecution?.info?.attempt > 1,
+      ($activityExecution?.info?.attempt ?? 0) > 1,
   );
 
   const hasCodeBlocks = $derived(
@@ -51,8 +51,8 @@
 
 {#snippet activityExecutionAttemptsBadge(
   attempt: number,
-  maximumAttempts: number | undefined,
-  lastFailure: Failure | undefined,
+  maximumAttempts: number | null,
+  lastFailure: Failure | null,
 )}
   {@const failed = attempt > 1 && !!lastFailure}
   {@const badgeType = failed ? 'danger' : 'default'}
@@ -63,7 +63,7 @@
   <DetailListValue>
     <Badge type={badgeType} class="flex items-center gap-2">
       <Icon name="retry" class={failed ? 'text-red-400' : ''} />
-      <span>{attempt} of {formatMaximumAttempts(maximumAttempts ?? null)}</span>
+      <span>{attempt} of {formatMaximumAttempts(maximumAttempts)}</span>
     </Badge>
 
     {#if maximumAttempts && !isClosed}
@@ -80,7 +80,7 @@
     outcome={$activityExecution.outcome}
   />
   <Card class="space-y-4">
-    <h4>{$activityExecution.info.activityType.name}</h4>
+    <h4>{$activityExecution.info.activityType?.name ?? ''}</h4>
     <div class={hasCodeBlocks ? 'grid grid-cols-2 gap-4' : ''}>
       <div class={hasCodeBlocks ? 'space-y-4' : 'grid grid-cols-3 gap-4'}>
         {#if !isClosed}
@@ -103,9 +103,9 @@
                 )}
               />
               {@render activityExecutionAttemptsBadge(
-                $activityExecution.info.attempt,
-                $activityExecution.info.retryPolicy?.maximumAttempts,
-                $activityExecution.info.lastFailure,
+                $activityExecution.info.attempt ?? 0,
+                $activityExecution.info.retryPolicy?.maximumAttempts ?? null,
+                $activityExecution.info.lastFailure ?? null,
               )}
             </DetailList>
           </div>
@@ -116,7 +116,7 @@
           </h5>
           <DetailList
             rowCount={isClosed
-              ? $activityExecution.info.attempt > 1
+              ? ($activityExecution.info.attempt ?? 0) > 1
                 ? 5
                 : 4
               : 2}
@@ -133,12 +133,13 @@
                   $activityExecution.info.executionDuration ?? '',
                 )}
               />
-              {#if $activityExecution.info.attempt !== undefined}
+              {#if $activityExecution.info.attempt != undefined}
                 {#if $activityExecution.info.attempt > 1}
                   {@render activityExecutionAttemptsBadge(
                     $activityExecution.info.attempt,
-                    $activityExecution.info.retryPolicy?.maximumAttempts,
-                    $activityExecution.info.lastFailure,
+                    $activityExecution.info.retryPolicy?.maximumAttempts ??
+                      null,
+                    $activityExecution.info.lastFailure ?? null,
                   )}
                 {:else}
                   <DetailListLabel
@@ -297,9 +298,9 @@
             <DetailListLinkValue
               href={routeForTaskQueue({
                 namespace,
-                queue: $activityExecution.info.taskQueue,
+                queue: $activityExecution.info.taskQueue ?? '',
               })}
-              text={$activityExecution.info.taskQueue}
+              text={$activityExecution.info.taskQueue ?? ''}
             />
 
             <DetailListLabel
@@ -308,7 +309,7 @@
               )}</DetailListLabel
             >
             <DetailListTextValue
-              text={$activityExecution.info.lastWorkerIdentity}
+              text={$activityExecution.info.lastWorkerIdentity ?? ''}
             />
           </DetailList>
         </div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="468" height="168" alt="Screenshot 2026-06-17 at 3 58 55 PM" src="https://github.com/user-attachments/assets/7573d523-57a1-4b8c-ac21-762d82539bcb" />|<img width="520" height="180" alt="Screenshot 2026-06-17 at 4 02 17 PM" src="https://github.com/user-attachments/assets/57245c3b-b00d-488c-8d72-cd0c8cac1f5b" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
