### PR TITLE
Various serverless UI updates

### DIFF
--- a/src/lib/components/deployments/compute-badge.svelte
+++ b/src/lib/components/deployments/compute-badge.svelte
@@ -12,14 +12,10 @@
 </script>
 
 {#if config}
-  <div class="flex items-center gap-1">
-    <span
-      class="surface-primary flex items-center rounded border border-subtle p-0.5"
-    >
-      <Icon name={config.icon} class="h-4 w-4" />
-    </span>
-    <span class="text-primary">{config.label}</span>
+  <div
+    class="flex min-w-24 items-center justify-center gap-2 border border-subtle px-1"
+  >
+    <Icon name={config.icon} />
+    <p>{config.label}</p>
   </div>
-{:else}
-  <span class="text-secondary">—</span>
 {/if}

--- a/src/lib/components/deployments/deployment-header.svelte
+++ b/src/lib/components/deployments/deployment-header.svelte
@@ -60,8 +60,13 @@
 
   <div class="flex w-full items-center justify-between">
     <h1>{deploymentName}</h1>
-    <div class="flex items-center gap-2">
+    <div class="flex items-center gap-4">
       <CapabilityGuard capability="serverScaledDeployments">
+        {#snippet fallback()}
+          <Button href={workflowHref}>
+            {translate('deployments.view-workflows')}
+          </Button>
+        {/snippet}
         <Button
           href={routeForWorkerDeploymentVersionCreate({
             namespace,
@@ -70,31 +75,27 @@
         >
           {translate('deployments.create-new-version')}
         </Button>
-      </CapabilityGuard>
-      <MenuContainer>
-        <MenuButton
-          controls="deployment-header-actions"
-          variant="secondary"
-          hasIndicator
-        >
-          {translate('deployments.more-actions')}
-        </MenuButton>
-        <Menu id="deployment-header-actions" position="right" usePortal>
-          <MenuItem href={workflowHref}>
-            {translate('deployments.view-workflows')}
-          </MenuItem>
-          <CapabilityGuard capability="serverScaledDeployments">
+        <MenuContainer>
+          <MenuButton
+            controls="deployment-header-actions"
+            variant="secondary"
+            hasIndicator
+          >
+            {translate('deployments.more-actions')}
+          </MenuButton>
+          <Menu id="deployment-header-actions" position="right" usePortal>
+            <MenuItem href={workflowHref}>
+              {translate('deployments.view-workflows')}
+            </MenuItem>
             <MenuItem onclick={onRampToUnversioned}>
               {translate('deployments.ramp-to-unversioned')}
             </MenuItem>
-          </CapabilityGuard>
-          <CapabilityGuard capability="serverScaledDeployments">
             <MenuItem onclick={onDeleteClick} destructive>
               {translate('deployments.delete-deployment')}
             </MenuItem>
-          </CapabilityGuard>
-        </Menu>
-      </MenuContainer>
+          </Menu>
+        </MenuContainer>
+      </CapabilityGuard>
     </div>
   </div>
 </header>

--- a/src/lib/components/deployments/deployment-status.svelte
+++ b/src/lib/components/deployments/deployment-status.svelte
@@ -33,7 +33,7 @@
 
   const deploymentStatus = cva(
     [
-      'flex items-center justify-center gap-1 px-1 min-w-24 transition-colors rounded-sm border border-subtle',
+      'flex items-center justify-center gap-1 px-1 min-w-24 transition-colors border border-subtle',
     ],
     {
       variants: {

--- a/src/lib/components/deployments/set-ramping-version-modal.svelte
+++ b/src/lib/components/deployments/set-ramping-version-modal.svelte
@@ -103,6 +103,8 @@
         <Button variant="destructive" on:click={onRemove}>
           {translate('deployments.remove-ramping')}
         </Button>
+      {:else}
+        <div></div>
       {/if}
     </svelte:fragment>
   </Modal>

--- a/src/lib/components/deployments/validate-connection-modal.svelte
+++ b/src/lib/components/deployments/validate-connection-modal.svelte
@@ -13,14 +13,21 @@
     onRetry: () => void;
   }
 
-  let { buildId, open, loading, result, onClose, onRetry }: Props = $props();
+  let {
+    buildId,
+    open = $bindable(),
+    loading,
+    result,
+    onClose,
+    onRetry,
+  }: Props = $props();
 
   const isValid = $derived(!result?.message);
 </script>
 
 <Modal
   id="validate-connection-modal-{buildId}"
-  {open}
+  bind:open
   confirmText=""
   cancelText=""
   hideCancel

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -453,7 +453,7 @@
 
 <ValidateConnectionModal
   buildId={versionBuildId}
-  open={showValidateModal}
+  bind:open={showValidateModal}
   loading={validateLoading}
   result={validateResult}
   onClose={() => (showValidateModal = false)}

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -95,7 +95,7 @@
 </p>
 
 {#if provider === 'lambda'}
-  <div class="flex items-end gap-4">
+  <div class="flex flex-wrap items-end gap-4">
     <Input
       bind:value={lambdaArn}
       id="lambdaArn"
@@ -139,7 +139,7 @@
       placeholder={translate('workers.gcp-region-placeholder')}
       required
     />
-    <div class="flex items-end gap-4">
+    <div class="flex flex-wrap items-end gap-4">
       <Input
         bind:value={gcpWorkerPool}
         id="gcpWorkerPool"
@@ -221,7 +221,7 @@
           <p class="text-sm text-secondary">
             {translate('workers.launch-stack-description')}
           </p>
-          <div class="flex items-center gap-4">
+          <div class="flex flex-wrap items-center gap-4">
             <Button
               variant="secondary"
               size="sm"
@@ -274,7 +274,7 @@
 
 <hr class="my-5 border-subtle" />
 
-<div class="flex items-start justify-between gap-4">
+<div class="flex flex-wrap items-center justify-between gap-4">
   <div>
     <div class="flex items-center gap-2">
       <h2 class="text-base font-medium">
@@ -293,9 +293,12 @@
     size="sm"
     type="button"
     disabled={provider === 'cloud-run'}
+    trailingIcon={showScaling ? 'chevron-up' : 'chevron-down'}
     on:click={() => (showScaling = !showScaling)}
   >
-    {translate('workers.customize')}
+    {showScaling
+      ? translate('workers.hide-defaults')
+      : translate('workers.show-defaults')}
   </Button>
 </div>
 {#if showScaling && provider === 'lambda'}

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import Accordion from '$lib/holocene/accordion/accordion.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import Button from '$lib/holocene/button.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
-  import Icon from '$lib/holocene/icon/icon.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Link from '$lib/holocene/link.svelte';
+  import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
+  import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
   import { translate } from '$lib/i18n/translate';
 
   import terraformTemplate from './serverless-worker-lambda.tf?raw';
@@ -194,84 +196,67 @@
       placeholder={translate('workers.external-id-placeholder')}
       required
     />
-    <button
-      type="button"
-      class="surface-primary flex w-full items-center justify-between rounded border border-subtle px-4 py-3 text-sm hover:surface-interactive-secondary"
-      onclick={() => (showRoleHelp = !showRoleHelp)}
+    <Accordion
+      icon="info"
+      title={translate('workers.no-role-prompt')}
+      bind:open={showRoleHelp}
+      class="[&_h3]:text-sm"
     >
-      <span class="flex items-center gap-2">
-        <Icon name="info" />
-        {translate('workers.no-role-prompt')}
-      </span>
-      <Icon name={showRoleHelp ? 'chevron-up' : 'chevron-down'} />
-    </button>
-    {#if showRoleHelp}
-      <div class="rounded border border-subtle">
-        <div class="flex border-b border-subtle">
-          <button
-            type="button"
-            class="px-4 py-2 text-sm {activeRoleHelpTab === 'cloudformation'
-              ? 'surface-interactive-secondary font-medium'
-              : 'text-secondary'}"
-            onclick={() => (activeRoleHelpTab = 'cloudformation')}
+      <div class="-mt-8 flex flex-col gap-3 border-t border-subtle pt-3">
+        <ToggleButtons>
+          <ToggleButton
+            active={activeRoleHelpTab === 'cloudformation'}
+            on:click={() => (activeRoleHelpTab = 'cloudformation')}
           >
             {translate('workers.cfn-tab')}
-          </button>
-          <button
-            type="button"
-            class="px-4 py-2 text-sm {activeRoleHelpTab === 'terraform'
-              ? 'surface-interactive-secondary font-medium'
-              : 'text-secondary'}"
-            onclick={() => (activeRoleHelpTab = 'terraform')}
+          </ToggleButton>
+          <ToggleButton
+            active={activeRoleHelpTab === 'terraform'}
+            on:click={() => (activeRoleHelpTab = 'terraform')}
           >
             {translate('workers.terraform-tab')}
-          </button>
-        </div>
+          </ToggleButton>
+        </ToggleButtons>
         {#if activeRoleHelpTab === 'cloudformation'}
-          <div class="flex flex-col gap-3 p-4">
-            <p class="text-sm text-secondary">
-              {translate('workers.launch-stack-description')}
-            </p>
-            <div class="flex items-center gap-4">
-              <Button
-                variant="secondary"
-                size="sm"
-                type="button"
-                href={launchStackHref}
-                target="_blank"
-                trailingIcon="external-link"
-              >
-                {translate('workers.launch-stack')}
-              </Button>
-              <button
-                type="button"
-                class="text-sm underline"
-                onclick={downloadCfnTemplate}
-              >
-                {translate('workers.download-template')}
-              </button>
-            </div>
+          <p class="text-sm text-secondary">
+            {translate('workers.launch-stack-description')}
+          </p>
+          <div class="flex items-center gap-4">
+            <Button
+              variant="secondary"
+              size="sm"
+              href={launchStackHref}
+              target="_blank"
+              trailingIcon="external-link"
+            >
+              {translate('workers.launch-stack')}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              on:click={downloadCfnTemplate}
+            >
+              {translate('workers.download-template')}
+            </Button>
           </div>
         {:else}
-          <div class="flex flex-col gap-3 p-4">
-            <p class="text-sm text-secondary">
-              {translate('workers.terraform-description-before')}<Link
-                href="https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/aws/lambda"
-                newTab>{translate('workers.terraform-iam-module-link')}</Link
-              >{translate('workers.terraform-description-after')}
-            </p>
-            <CodeBlock
-              content={terraformTemplate}
-              language="text"
-              maxHeight={300}
-              copyable
-              copyIconTitle={translate('workers.copy-snippet')}
-              copySuccessIconTitle={translate('workers.copied')}
-            />
-          </div>
+          <p class="text-sm text-secondary">
+            {translate('workers.terraform-description-before')}<Link
+              href="https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/aws/lambda"
+              newTab>{translate('workers.terraform-iam-module-link')}</Link
+            >{translate('workers.terraform-description-after')}
+          </p>
+          <CodeBlock
+            content={terraformTemplate}
+            language="text"
+            maxHeight={300}
+            copyable
+            copyIconTitle={translate('workers.copy-snippet')}
+            copySuccessIconTitle={translate('workers.copied')}
+          />
         {/if}
       </div>
-    {/if}
+    </Accordion>
   </div>
 {:else}
   <Input

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -85,7 +85,7 @@
 
 <hr class="my-5 border-subtle" />
 
-<h2 class="mb-1 text-base font-medium">
+<h2 class="text-base font-medium">
   {translate('workers.resource-section')}
 </h2>
 <p class="mb-4 text-sm text-secondary">
@@ -93,19 +93,18 @@
 </p>
 
 {#if provider === 'lambda'}
-  <div class="flex items-end gap-2">
-    <div class="flex-1">
-      <Input
-        bind:value={lambdaArn}
-        id="lambdaArn"
-        name="lambdaArn"
-        label={translate('workers.lambda-arn-label')}
-        hintText={errors.lambdaArn?.[0]}
-        error={!!errors.lambdaArn?.[0]}
-        placeholder={translate('workers.lambda-arn-placeholder')}
-        required
-      />
-    </div>
+  <div class="flex items-end gap-4">
+    <Input
+      bind:value={lambdaArn}
+      id="lambdaArn"
+      name="lambdaArn"
+      label={translate('workers.lambda-arn-label')}
+      hintText={errors.lambdaArn?.[0]}
+      error={!!errors.lambdaArn?.[0]}
+      placeholder={translate('workers.lambda-arn-placeholder')}
+      required
+      class="flex-1"
+    />
     <Button
       variant="secondary"
       type="button"
@@ -138,19 +137,18 @@
       placeholder={translate('workers.gcp-region-placeholder')}
       required
     />
-    <div class="flex items-end gap-2">
-      <div class="flex-1">
-        <Input
-          bind:value={gcpWorkerPool}
-          id="gcpWorkerPool"
-          name="gcpWorkerPool"
-          label={translate('workers.gcp-worker-pool-label')}
-          hintText={errors.gcpWorkerPool?.[0]}
-          error={!!errors.gcpWorkerPool?.[0]}
-          placeholder={translate('workers.gcp-worker-pool-placeholder')}
-          required
-        />
-      </div>
+    <div class="flex items-end gap-4">
+      <Input
+        bind:value={gcpWorkerPool}
+        id="gcpWorkerPool"
+        name="gcpWorkerPool"
+        label={translate('workers.gcp-worker-pool-label')}
+        hintText={errors.gcpWorkerPool?.[0]}
+        error={!!errors.gcpWorkerPool?.[0]}
+        placeholder={translate('workers.gcp-worker-pool-placeholder')}
+        required
+        class="flex-1"
+      />
       <Button
         variant="secondary"
         type="button"
@@ -166,7 +164,7 @@
 
 <hr class="my-5 border-subtle" />
 
-<h2 class="mb-1 text-base font-medium">
+<h2 class="text-base font-medium">
   {translate('workers.access-section')}
 </h2>
 <p class="mb-4 text-sm text-secondary">
@@ -293,7 +291,7 @@
 
 <div class="flex items-start justify-between gap-4">
   <div>
-    <div class="mb-1 flex items-center gap-2">
+    <div class="flex items-center gap-2">
       <h2 class="text-base font-medium">
         {translate('workers.scaling-lifecycle-section')}
       </h2>

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -322,7 +322,8 @@ export const Strings = {
   'terraform-iam-module-link': 'AWS IAM Role Module',
   'terraform-description-after':
     ' to create the IAM role Temporal Cloud assumes to invoke your Lambda functions.',
-  customize: 'Customize',
+  'hide-defaults': 'Hide Defaults',
+  'show-defaults': 'Show Defaults',
   'gcp-project-label': 'Project ID',
   'gcp-project-placeholder': 'my-gcp-project',
   'gcp-region-label': 'Region',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="251" height="208" alt="Screenshot 2026-06-17 at 9 37 01 AM" src="https://github.com/user-attachments/assets/6572f04d-3a2b-4a78-8064-712bfa06c11b" />|<img width="416" height="242" alt="Screenshot 2026-06-17 at 1 19 08 PM" src="https://github.com/user-attachments/assets/51a58a87-2bab-4e72-a71e-aeb28bf667a2" />|
|<img width="269" height="209" alt="Screenshot 2026-06-17 at 1 18 59 PM" src="https://github.com/user-attachments/assets/7c7dc5b3-5393-4c0a-9cb9-25b97d1dfd22" />|<img width="298" height="194" alt="Screenshot 2026-06-17 at 1 18 00 PM" src="https://github.com/user-attachments/assets/c4090b31-f84e-423b-a5d6-790323d53de4" />|
|<img width="489" height="189" alt="Screenshot 2026-06-17 at 1 37 28 PM" src="https://github.com/user-attachments/assets/9c271b28-5134-4135-a13d-ebec8d04af42" />|<img width="477" height="183" alt="Screenshot 2026-06-17 at 1 37 16 PM" src="https://github.com/user-attachments/assets/b018fba7-c20b-43a7-9258-cde95842af4e" />|
|<img width="763" height="1070" alt="Screenshot 2026-06-17 at 1 42 40 PM" src="https://github.com/user-attachments/assets/6de8af4f-e7ca-4e23-892c-7e24c2e57297" />|<img width="733" height="910" alt="Screenshot 2026-06-17 at 3 13 43 PM" src="https://github.com/user-attachments/assets/bd8f2475-bf57-4e32-a10b-1e2d5df6a935" />|
|<img width="744" height="940" alt="Screenshot 2026-06-17 at 1 42 52 PM" src="https://github.com/user-attachments/assets/b178f800-4318-4a38-9c86-8927af6b3750" />|<img width="741" height="915" alt="Screenshot 2026-06-17 at 3 14 01 PM" src="https://github.com/user-attachments/assets/0a0a560a-e8ab-4a54-b440-04181101b3e2" />|
|<img width="711" height="249" alt="Screenshot 2026-06-17 at 3 00 46 PM" src="https://github.com/user-attachments/assets/33850922-9128-4829-bd20-fe762cc051cd" />|<img width="702" height="241" alt="Screenshot 2026-06-17 at 3 00 59 PM" src="https://github.com/user-attachments/assets/b011de1a-a392-4dbe-b312-90fcacf15d06" />|
|<img width="723" height="114" alt="Screenshot 2026-06-17 at 3 04 39 PM" src="https://github.com/user-attachments/assets/3a032aa6-37ac-4787-bd91-0538cebb296f" />|<img width="727" height="128" alt="Screenshot 2026-06-17 at 3 06 08 PM" src="https://github.com/user-attachments/assets/e203d5ce-07a1-4d3f-9416-2b92e564267a" />|
|<img width="713" height="476" alt="Screenshot 2026-06-17 at 3 01 16 PM" src="https://github.com/user-attachments/assets/a3227ac7-7bc8-4a0a-9baf-dac0302723d0" />|<img width="710" height="495" alt="Screenshot 2026-06-17 at 3 06 25 PM" src="https://github.com/user-attachments/assets/b3a3a466-384a-4af0-9408-d151cc736378" />|


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

`DT-4175`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
