### PR TITLE
feat(DT-4183): Add Tabs (Primitive)

### DIFF
--- a/src/lib/holocene/tabs-primitive/context.ts
+++ b/src/lib/holocene/tabs-primitive/context.ts
@@ -1,0 +1,29 @@
+import { createContext } from 'svelte';
+
+export interface TabsContextType<T extends string = string> {
+  getIdForTab: (tab: T) => string;
+  getPanelIdForTab: (tab: T) => string;
+  selectedTab: T;
+  tabs: T[];
+  setSelectedTab: (selectedTab: T) => void;
+}
+
+const [getCtx, setCtx] = createContext<TabsContextType>();
+
+export function getTabsContext<
+  T extends string = string,
+>(): TabsContextType<T> {
+  const ctx = getCtx();
+
+  if (!ctx) {
+    throw new Error('Tabs context not found — did you call setTabsContext?');
+  }
+
+  return ctx as TabsContextType<T>;
+}
+
+export function setTabsContext<T extends string = string>(
+  ctx: TabsContextType<T>,
+) {
+  return setCtx(ctx);
+}

--- a/src/lib/holocene/tabs-primitive/context.ts
+++ b/src/lib/holocene/tabs-primitive/context.ts
@@ -3,7 +3,7 @@ import { createContext } from 'svelte';
 export interface TabsContextType<T extends string = string> {
   selectedTab: T;
   tabs: T[];
-  getIdForTab: (tab: string) => string;
+  getButtonIdForTab: (tab: string) => string;
   getPanelIdForTab: (tab: string) => string;
   setSelectedTab: (tab: string) => void;
 }

--- a/src/lib/holocene/tabs-primitive/context.ts
+++ b/src/lib/holocene/tabs-primitive/context.ts
@@ -2,7 +2,6 @@ import { createContext } from 'svelte';
 
 export interface TabsContextType<T extends string = string> {
   getIdForTab: (tab: T) => string;
-  getPanelIdForTab: (tab: T) => string;
   selectedTab: T;
   tabs: T[];
   setSelectedTab: (selectedTab: T) => void;
@@ -19,11 +18,11 @@ export function getTabsContext<
     throw new Error('Tabs context not found — did you call setTabsContext?');
   }
 
-  return ctx as TabsContextType<T>;
+  return ctx as unknown as TabsContextType<T>;
 }
 
 export function setTabsContext<T extends string = string>(
   ctx: TabsContextType<T>,
 ) {
-  return setCtx(ctx);
+  return setCtx(ctx as unknown as TabsContextType<string>);
 }

--- a/src/lib/holocene/tabs-primitive/context.ts
+++ b/src/lib/holocene/tabs-primitive/context.ts
@@ -1,28 +1,21 @@
 import { createContext } from 'svelte';
 
 export interface TabsContextType<T extends string = string> {
-  getIdForTab: (tab: T) => string;
   selectedTab: T;
   tabs: T[];
-  setSelectedTab: (selectedTab: T) => void;
+  getIdForTab: (tab: string) => string;
+  getPanelIdForTab: (tab: string) => string;
+  setSelectedTab: (tab: string) => void;
 }
 
 const [getCtx, setCtx] = createContext<TabsContextType>();
 
-export function getTabsContext<
-  T extends string = string,
->(): TabsContextType<T> {
-  const ctx = getCtx();
-
-  if (!ctx) {
-    throw new Error('Tabs context not found — did you call setTabsContext?');
-  }
-
-  return ctx as unknown as TabsContextType<T>;
+export function getTabsContext<T extends string>(): TabsContextType<T> {
+  return getCtx() as TabsContextType<T>;
 }
 
-export function setTabsContext<T extends string = string>(
+export function setTabsContext<T extends string>(
   ctx: TabsContextType<T>,
-) {
-  return setCtx(ctx as unknown as TabsContextType<string>);
+): void {
+  setCtx(ctx);
 }

--- a/src/lib/holocene/tabs-primitive/tab-button-list.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-button-list.svelte
@@ -10,7 +10,7 @@
   type Orientation = 'horizontal' | 'vertical';
   type Activation = 'automatic' | 'manual';
 
-  type TabButtonProps = HTMLAttributes<HTMLElement>;
+  type TabButtonProps = HTMLAttributes<HTMLElement> & { class?: string };
   type GetTabButtonProps = (overrides?: TabButtonProps) => TabButtonProps;
 
   interface Props extends Omit<

--- a/src/lib/holocene/tabs-primitive/tab-button-list.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-button-list.svelte
@@ -21,11 +21,11 @@
     orientation?: Orientation;
     activation?: Activation;
     /**
-     * Renders each tab. Spread the first arg (the prop-getter) onto a
-     * `<button>` or `<a>` element — selection is wired through the composed
-     * `onclick`, which only fires on Enter/Space when the element is natively
-     * interactive. Non-interactive elements (e.g. `div`/`span`) receive the
-     * correct ARIA roles but will not activate via the keyboard.
+     * Renders each tab. Spread the first arg (the prop-getter) onto the
+     * element of your choice. A `<button>` or `<a>` is recommended for native
+     * semantics, but non-interactive elements (e.g. `div`/`span`) are also
+     * supported: the prop-getter applies the correct ARIA roles and roving
+     * tabindex, and wires Enter/Space keyboard activation for them.
      */
     tabButtonSnippet: Snippet<
       [
@@ -54,7 +54,13 @@
     isSelected: boolean,
     overrides: TabButtonProps = {},
   ): TabButtonProps {
-    const { class: className, onclick, onfocus, ...rest } = overrides;
+    const {
+      class: className,
+      onclick,
+      onfocus,
+      onkeydown,
+      ...rest
+    } = overrides;
     return {
       ...rest,
       id: context.getButtonIdForTab(tab),
@@ -63,7 +69,41 @@
       'aria-controls': context.getPanelIdForTab(tab),
       tabindex: tab === activeTab ? 0 : -1,
       class: className,
-      onclick: composeEventHandlers(onclick, () => context.setSelectedTab(tab)),
+      onkeydown: composeEventHandlers(
+        onkeydown,
+        (e: KeyboardEvent & { currentTarget: HTMLElement }) => {
+          const element = e.currentTarget;
+
+          if (
+            element instanceof HTMLAnchorElement ||
+            element instanceof HTMLButtonElement
+          ) {
+            // if <a> or <button> let click handler handle
+            return;
+          }
+
+          if (isDisabled(element)) {
+            return;
+          }
+
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            context.setSelectedTab(tab);
+          }
+        },
+      ),
+      onclick: composeEventHandlers(
+        onclick,
+        (e: MouseEvent & { currentTarget: HTMLElement }) => {
+          const element = e.currentTarget;
+
+          if (isDisabled(element)) {
+            return;
+          }
+
+          context.setSelectedTab(tab);
+        },
+      ),
       onfocus: composeEventHandlers(onfocus, () => (focusedTab = tab)),
     };
   }

--- a/src/lib/holocene/tabs-primitive/tab-button-list.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-button-list.svelte
@@ -20,6 +20,13 @@
     'aria-label': string;
     orientation?: Orientation;
     activation?: Activation;
+    /**
+     * Renders each tab. Spread the first arg (the prop-getter) onto a
+     * `<button>` or `<a>` element — selection is wired through the composed
+     * `onclick`, which only fires on Enter/Space when the element is natively
+     * interactive. Non-interactive elements (e.g. `div`/`span`) receive the
+     * correct ARIA roles but will not activate via the keyboard.
+     */
     tabButtonSnippet: Snippet<
       [
         GetTabButtonProps,

--- a/src/lib/holocene/tabs-primitive/tab-button-list.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-button-list.svelte
@@ -1,0 +1,145 @@
+<script lang="ts" generics="T extends string">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  import type { Snippet } from 'svelte';
+
+  import { composeEventHandlers } from '$lib/utilities/event-handlers';
+
+  import { getTabsContext } from './context';
+
+  type Orientation = 'horizontal' | 'vertical';
+  type Activation = 'automatic' | 'manual';
+
+  type TabButtonProps = HTMLAttributes<HTMLElement>;
+  type GetTabButtonProps = (overrides?: TabButtonProps) => TabButtonProps;
+
+  interface Props extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'role' | 'children' | 'aria-orientation' | 'onkeydown' | 'onfocusout'
+  > {
+    'aria-label': string;
+    orientation?: Orientation;
+    activation?: Activation;
+    tabButtonSnippet: Snippet<
+      [
+        GetTabButtonProps,
+        { tab: T; isSelected: boolean; setSelectedTab: (tab: T) => void },
+      ]
+    >;
+  }
+
+  const {
+    tabButtonSnippet,
+    orientation = 'horizontal',
+    activation = 'automatic',
+    ...props
+  }: Props = $props();
+
+  const context = getTabsContext<T>();
+
+  let listEl = $state<HTMLDivElement>();
+  let focusedTab = $state<T>();
+
+  const activeTab = $derived(focusedTab ?? context.selectedTab);
+
+  function getTabButtonProps(
+    tab: T,
+    isSelected: boolean,
+    overrides: TabButtonProps = {},
+  ): TabButtonProps {
+    const { class: className, onclick, onfocus, ...rest } = overrides;
+    return {
+      ...rest,
+      id: context.getIdForTab(tab),
+      role: 'tab',
+      'aria-selected': isSelected,
+      'aria-controls': context.getPanelIdForTab(tab),
+      tabindex: tab === activeTab ? 0 : -1,
+      class: className,
+      onclick: composeEventHandlers(onclick, () => context.setSelectedTab(tab)),
+      onfocus: composeEventHandlers(onfocus, () => (focusedTab = tab)),
+    };
+  }
+
+  function tabElements(): HTMLElement[] {
+    return Array.from(
+      listEl?.querySelectorAll<HTMLElement>('[role="tab"]') ?? [],
+    );
+  }
+
+  function isDisabled(element: HTMLElement): boolean {
+    return (
+      element.hasAttribute('disabled') ||
+      element.getAttribute('aria-disabled') === 'true'
+    );
+  }
+
+  function onkeydown(event: KeyboardEvent) {
+    const elements = tabElements();
+    const count = elements.length;
+    if (count === 0) return;
+
+    const nextKey = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+    const prevKey = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+
+    let from = elements.findIndex(
+      (element) => element === document.activeElement,
+    );
+    let step: number;
+    switch (event.key) {
+      case nextKey:
+        step = 1;
+        break;
+      case prevKey:
+        step = -1;
+        break;
+      case 'Home':
+        from = -1;
+        step = 1;
+        break;
+      case 'End':
+        from = count;
+        step = -1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+
+    let next = from;
+    for (let i = 0; i < count; i += 1) {
+      next = (next + step + count) % count;
+      if (!isDisabled(elements[next])) break;
+    }
+    if (isDisabled(elements[next])) return;
+
+    elements[next].focus();
+    if (activation === 'automatic') {
+      context.setSelectedTab(context.tabs[next]);
+    }
+  }
+
+  function onfocusout(event: FocusEvent) {
+    if (!listEl?.contains(event.relatedTarget as Node | null)) {
+      focusedTab = undefined;
+    }
+  }
+</script>
+
+<div
+  bind:this={listEl}
+  {...props}
+  role="tablist"
+  aria-orientation={orientation}
+  {onkeydown}
+  {onfocusout}
+>
+  {#each context.tabs as tab (tab)}
+    {@const isSelected = context.selectedTab === tab}
+    {@render tabButtonSnippet?.(
+      (overrides) => getTabButtonProps(tab, isSelected, overrides),
+      { tab, isSelected, setSelectedTab: context.setSelectedTab },
+    )}
+  {/each}
+</div>

--- a/src/lib/holocene/tabs-primitive/tab-button-list.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-button-list.svelte
@@ -50,7 +50,7 @@
     const { class: className, onclick, onfocus, ...rest } = overrides;
     return {
       ...rest,
-      id: context.getIdForTab(tab),
+      id: context.getButtonIdForTab(tab),
       role: 'tab',
       'aria-selected': isSelected,
       'aria-controls': context.getPanelIdForTab(tab),

--- a/src/lib/holocene/tabs-primitive/tab-panels.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-panels.svelte
@@ -30,7 +30,7 @@
       ...rest,
       id: context.getPanelIdForTab(tab),
       role: 'tabpanel',
-      'aria-labelledby': context.getIdForTab(tab),
+      'aria-labelledby': context.getButtonIdForTab(tab),
       tabindex: 0,
       hidden: !isSelected,
       class: className,

--- a/src/lib/holocene/tabs-primitive/tab-panels.svelte
+++ b/src/lib/holocene/tabs-primitive/tab-panels.svelte
@@ -1,0 +1,47 @@
+<script lang="ts" generics="T extends string">
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  import type { Snippet } from 'svelte';
+
+  import { getTabsContext } from './context';
+
+  type TabPanelProps = HTMLAttributes<HTMLElement>;
+  type GetTabPanelProps = (overrides?: TabPanelProps) => TabPanelProps;
+
+  interface Props {
+    tabPanelSnippet: Snippet<
+      [
+        GetTabPanelProps,
+        { tab: T; isSelected: boolean; setSelectedTab: (tab: T) => void },
+      ]
+    >;
+  }
+
+  const { tabPanelSnippet }: Props = $props();
+  const context = getTabsContext<T>();
+
+  function getTabPanelProps(
+    tab: T,
+    isSelected: boolean,
+    overrides: TabPanelProps = {},
+  ): TabPanelProps {
+    const { class: className, ...rest } = overrides;
+    return {
+      ...rest,
+      id: context.getPanelIdForTab(tab),
+      role: 'tabpanel',
+      'aria-labelledby': context.getIdForTab(tab),
+      tabindex: 0,
+      hidden: !isSelected,
+      class: className,
+    };
+  }
+</script>
+
+{#each context.tabs as tab (tab)}
+  {@const isSelected = context.selectedTab === tab}
+  {@render tabPanelSnippet?.(
+    (overrides) => getTabPanelProps(tab, isSelected, overrides),
+    { tab, isSelected, setSelectedTab: context.setSelectedTab },
+  )}
+{/each}

--- a/src/lib/holocene/tabs-primitive/tabs.stories.svelte
+++ b/src/lib/holocene/tabs-primitive/tabs.stories.svelte
@@ -1,0 +1,84 @@
+<svelte:options runes />
+
+<script lang="ts" module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import Tabs from '$lib/holocene/tabs-primitive/tabs.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Tabs (Primitive)',
+    component: Tabs,
+    argTypes: {
+      tabs: { table: { disable: true } },
+      selectedTab: { table: { disable: true } },
+      children: { table: { disable: true } },
+      onSelectedTabChange: { table: { disable: true } },
+    },
+  });
+</script>
+
+<script lang="ts">
+  import TabButtonList from './tab-button-list.svelte';
+  import TabPanels from './tab-panels.svelte';
+
+  const tabs = ['tab-a', 'tab-b', 'tab-c'];
+</script>
+
+{#snippet example(
+  orientation: 'horizontal' | 'vertical',
+  activation: 'automatic' | 'manual',
+)}
+  <Tabs {tabs}>
+    <TabButtonList
+      class={orientation === 'vertical' ? 'flex flex-col gap-2' : 'flex gap-2'}
+      aria-label="Example tabs"
+      {orientation}
+      {activation}
+    >
+      {#snippet tabButtonSnippet(getAttributes, { tab, isSelected })}
+        <button
+          type="button"
+          {...getAttributes({
+            class: `cursor-pointer rounded-md border px-3 py-1.5 text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+              isSelected
+                ? 'border-blue-600 bg-blue-600 text-white'
+                : 'border-slate-300 bg-white text-slate-700 hover:bg-slate-100'
+            }`,
+          })}
+        >
+          {tab}
+        </button>
+      {/snippet}
+    </TabButtonList>
+    <TabPanels>
+      {#snippet tabPanelSnippet(getAttributes, { tab })}
+        <div
+          {...getAttributes({
+            class:
+              'mt-4 rounded-md border border-slate-200 p-4 text-sm text-slate-700',
+          })}
+        >
+          {tab} content
+        </div>
+      {/snippet}
+    </TabPanels>
+  </Tabs>
+{/snippet}
+
+<Story name="Default">
+  {#snippet template()}
+    {@render example('horizontal', 'automatic')}
+  {/snippet}
+</Story>
+
+<Story name="Vertical">
+  {#snippet template()}
+    {@render example('vertical', 'automatic')}
+  {/snippet}
+</Story>
+
+<Story name="Manual Activation">
+  {#snippet template()}
+    {@render example('horizontal', 'manual')}
+  {/snippet}
+</Story>

--- a/src/lib/holocene/tabs-primitive/tabs.svelte
+++ b/src/lib/holocene/tabs-primitive/tabs.svelte
@@ -1,0 +1,46 @@
+<script lang="ts" generics="T extends string = string">
+  import { type Snippet } from 'svelte';
+
+  import { setTabsContext } from './context';
+
+  interface Props {
+    selectedTab?: T;
+    tabs: T[];
+    children: Snippet<[]>;
+    onSelectedTabChange?: (selected: T) => void;
+  }
+
+  let {
+    children,
+    tabs,
+    selectedTab = $bindable(tabs[0]),
+    onSelectedTabChange,
+  }: Props = $props();
+
+  const id = $props.id();
+
+  function setSelectedTab(selected: T) {
+    selectedTab = selected;
+    onSelectedTabChange?.(selected);
+  }
+
+  setTabsContext<T>({
+    getIdForTab(tab: T) {
+      return `${id}-tab-${tab}`;
+    },
+    getPanelIdForTab(tab: T) {
+      return `${id}-panel-${tab}`;
+    },
+    get selectedTab() {
+      return selectedTab;
+    },
+
+    get tabs() {
+      return tabs;
+    },
+
+    setSelectedTab,
+  });
+</script>
+
+{@render children?.()}

--- a/src/lib/holocene/tabs-primitive/tabs.svelte
+++ b/src/lib/holocene/tabs-primitive/tabs.svelte
@@ -19,18 +19,7 @@
 
   const id = $props.id();
 
-  function setSelectedTab(selected: T) {
-    selectedTab = selected;
-    onSelectedTabChange?.(selected);
-  }
-
   setTabsContext<T>({
-    getIdForTab(tab: T) {
-      return `${id}-tab-${tab}`;
-    },
-    getPanelIdForTab(tab: T) {
-      return `${id}-panel-${tab}`;
-    },
     get selectedTab() {
       return selectedTab;
     },
@@ -39,7 +28,18 @@
       return tabs;
     },
 
-    setSelectedTab,
+    getIdForTab(tab: string) {
+      return `${id}-tab-${tab}`;
+    },
+
+    getPanelIdForTab(tab: string) {
+      return `${id}-panel-${tab}`;
+    },
+
+    setSelectedTab(selected: string) {
+      selectedTab = selected as T;
+      onSelectedTabChange?.(selected as T);
+    },
   });
 </script>
 

--- a/src/lib/holocene/tabs-primitive/tabs.svelte
+++ b/src/lib/holocene/tabs-primitive/tabs.svelte
@@ -28,8 +28,8 @@
       return tabs;
     },
 
-    getIdForTab(tab: string) {
-      return `${id}-tab-${tab}`;
+    getButtonIdForTab(tab: string) {
+      return `${id}-button-${tab}`;
     },
 
     getPanelIdForTab(tab: string) {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Adds a primitive tabs component. Our existing tabs component has built-in styles and expectations. This makes it difficult to use in situations outside it's particular use-case. I have a design I need to implement where the tab buttons are more pill-like than they are our existing tab component: https://www.figma.com/design/tzggy7x7JIM0payi0D4Xr4/Cloud-UI-Redesign?node-id=3265-28495&m=dev In order to implement that design with proper aria roles and focus management I've created this headless component.

I recommend looking at the story example code to see how it's intended to be used. [`DT-4183-primitive-tabs-panels?expand=1`#diff-40a886e3e6](https://github.com/temporalio/ui/compare/DT-4183-primitive-tabs-panels?expand=1#diff-40a886e3e6d3eb98c7359a4cd8f557b18f2c10609a906112bea8ec6befe977ccR27-R66)

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

The styles shown in the video are irrelevant, they are just basic styles added specifically to this story. The idea is you style it yourself for your particular situation.

https://github.com/user-attachments/assets/38522c86-27e3-4b51-8a19-337e68126215

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
