### PR TITLE
Add  TEMPORAL_NAV_COLLAPSED_BY_DEFAULT env var to start UI with collapsed navs

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -10,6 +10,7 @@ refreshInterval: 1m
 defaultNamespace: default
 showTemporalSystemNamespace: false
 feedbackUrl:
+navCollapsedByDefault: false
 disableWriteActions: false
 workflowTerminateDisabled: false
 workflowCancelDisabled: false

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -9,9 +9,9 @@ enableUi: {{ env "TEMPORAL_UI_ENABLED" | default "true" }}
 cloudUi: {{ env "TEMPORAL_CLOUD_UI" | default "false" }}
 defaultNamespace: {{ env "TEMPORAL_DEFAULT_NAMESPACE" | default "default" }}
 feedbackUrl: {{ env "TEMPORAL_FEEDBACK_URL" | default "" }}
+navCollapsedByDefault: {{ env "TEMPORAL_NAV_COLLAPSED_BY_DEFAULT" | default "false" }}
 refreshInterval: {{ env "TEMPORAL_CONFIG_REFRESH_INTERVAL" | default "0s" }}
 showTemporalSystemNamespace: {{ env "TEMPORAL_SHOW_TEMPORAL_SYSTEM_NAMESPACE" | default "false" }}
-navCollapsedByDefault: {{ env "TEMPORAL_NAV_COLLAPSED_BY_DEFAULT" | default "false" }}
 disableWriteActions: {{ env "TEMPORAL_DISABLE_WRITE_ACTIONS" | default "false" }}
 workflowTerminateDisabled: {{ env "TEMPORAL_WORKFLOW_TERMINATE_DISABLED" | default "false" }}
 workflowCancelDisabled: {{ env "TEMPORAL_WORKFLOW_CANCEL_DISABLED" | default "false" }}

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -11,6 +11,7 @@ defaultNamespace: {{ env "TEMPORAL_DEFAULT_NAMESPACE" | default "default" }}
 feedbackUrl: {{ env "TEMPORAL_FEEDBACK_URL" | default "" }}
 refreshInterval: {{ env "TEMPORAL_CONFIG_REFRESH_INTERVAL" | default "0s" }}
 showTemporalSystemNamespace: {{ env "TEMPORAL_SHOW_TEMPORAL_SYSTEM_NAMESPACE" | default "false" }}
+navCollapsedByDefault: {{ env "TEMPORAL_NAV_COLLAPSED_BY_DEFAULT" | default "false" }}
 disableWriteActions: {{ env "TEMPORAL_DISABLE_WRITE_ACTIONS" | default "false" }}
 workflowTerminateDisabled: {{ env "TEMPORAL_WORKFLOW_TERMINATE_DISABLED" | default "false" }}
 workflowCancelDisabled: {{ env "TEMPORAL_WORKFLOW_CANCEL_DISABLED" | default "false" }}

--- a/server/config/with-auth.yaml
+++ b/server/config/with-auth.yaml
@@ -9,6 +9,7 @@ refreshInterval: 1m
 defaultNamespace: default
 showTemporalSystemNamespace: false
 feedbackUrl:
+navCollapsedByDefault: false
 disableWriteActions: false
 workflowTerminateDisabled: false
 workflowCancelDisabled: false

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -61,6 +61,7 @@ type SettingsResponse struct {
 	Auth                          *Auth
 	DefaultNamespace              string
 	ShowTemporalSystemNamespace   bool
+	NavCollapsedByDefault         bool
 	FeedbackURL                   string
 	Codec                         *CodecResponse
 	Version                       string
@@ -132,6 +133,7 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 			},
 			DefaultNamespace:            cfg.DefaultNamespace,
 			ShowTemporalSystemNamespace: cfg.ShowTemporalSystemNamespace,
+			NavCollapsedByDefault:       cfg.NavCollapsedByDefault,
 			FeedbackURL:                 cfg.FeedbackURL,
 			Codec: &CodecResponse{
 				Endpoint:            cfg.Codec.Endpoint,

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -46,6 +46,8 @@ type (
 		FeedbackURL         string `yaml:"feedbackUrl"`
 		// Show temporal-system namespace in namespace selector
 		ShowTemporalSystemNamespace bool `yaml:"showTemporalSystemNamespace"`
+		// Collapse the left navigation and saved views navigation by default
+		NavCollapsedByDefault bool `yaml:"navCollapsedByDefault"`
 		// How often to reload the config
 		RefreshInterval     time.Duration `yaml:"refreshInterval"`
 		Codec               Codec         `yaml:"codec"`

--- a/src/lib/services/settings-service.test.ts
+++ b/src/lib/services/settings-service.test.ts
@@ -1,6 +1,54 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { isCloudMatch } from './settings-service';
+import type { SettingsResponse } from '$lib/types';
+import { requestFromAPI } from '$lib/utilities/request-from-api';
+
+import { fetchSettings, isCloudMatch } from './settings-service';
+
+vi.mock('$lib/utilities/get-api-origin', () => ({
+  getApiOrigin: () => 'http://localhost:8080',
+}));
+
+vi.mock('$lib/utilities/request-from-api', () => ({
+  requestFromAPI: vi.fn(),
+}));
+
+vi.mock('$lib/utilities/route-for-api', () => ({
+  routeForApi: () => '/api/v1/settings',
+}));
+
+const settingsResponse = (
+  overrides: Partial<SettingsResponse> = {},
+): SettingsResponse => ({
+  Auth: { Enabled: false, Options: [] },
+  Codec: {
+    Endpoint: '',
+    PassAccessToken: false,
+    IncludeCredentials: false,
+  },
+  DefaultNamespace: 'default',
+  DisableWriteActions: false,
+  WorkflowTerminateDisabled: false,
+  WorkflowCancelDisabled: false,
+  WorkflowSignalDisabled: false,
+  WorkflowUpdateDisabled: false,
+  WorkflowResetDisabled: false,
+  WorkflowPauseDisabled: false,
+  BatchActionsDisabled: false,
+  StartWorkflowDisabled: false,
+  HideWorkflowQueryErrors: false,
+  RefreshWorkflowCountsDisabled: false,
+  ActivityCommandsDisabled: false,
+  ShowTemporalSystemNamespace: false,
+  NavCollapsedByDefault: false,
+  FeedbackURL: '',
+  Version: '2.51.0',
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.mocked(requestFromAPI).mockReset();
+});
 
 describe('isCloudMatch', () => {
   it('should return true for tmprl.cloud', () => {
@@ -15,5 +63,27 @@ describe('isCloudMatch', () => {
     expect(isCloudMatch.test(undefined as unknown as string)).toBe(false);
     expect(isCloudMatch.test('xxx.xxx')).toBe(false);
     expect(isCloudMatch.test('localhost:3000')).toBe(false);
+  });
+});
+
+describe('fetchSettings', () => {
+  it('maps navCollapsedByDefault from settings response', async () => {
+    vi.mocked(requestFromAPI).mockResolvedValue(
+      settingsResponse({ NavCollapsedByDefault: true }),
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings.navCollapsedByDefault).toBe(true);
+  });
+
+  it('defaults navCollapsedByDefault to false when omitted', async () => {
+    const response = settingsResponse();
+    delete (response as Partial<SettingsResponse>).NavCollapsedByDefault;
+    vi.mocked(requestFromAPI).mockResolvedValue(response);
+
+    const settings = await fetchSettings();
+
+    expect(settings.navCollapsedByDefault).toBe(false);
   });
 });

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -50,6 +50,7 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     activityCommandsDisabled: !!settingsResponse?.ActivityCommandsDisabled,
 
     showTemporalSystemNamespace: settingsResponse?.ShowTemporalSystemNamespace,
+    navCollapsedByDefault: !!settingsResponse?.NavCollapsedByDefault,
     feedbackURL: settingsResponse?.FeedbackURL,
     runtimeEnvironment: {
       get isCloud() {

--- a/src/lib/stores/nav-open.test.ts
+++ b/src/lib/stores/nav-open.test.ts
@@ -1,0 +1,65 @@
+import { get } from 'svelte/store';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loadNavStores = async () => {
+  vi.resetModules();
+  return import('./nav-open');
+};
+
+describe('nav-open stores', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults both navs to open', async () => {
+    const { navOpen, savedQueryNavOpen } = await loadNavStores();
+
+    expect(get(navOpen)).toBe(true);
+    expect(get(savedQueryNavOpen)).toBe(true);
+  });
+
+  it('collapses both navs by default without persisting a preference', async () => {
+    const { initializeNavDefaults, navOpen, savedQueryNavOpen } =
+      await loadNavStores();
+
+    initializeNavDefaults(true);
+
+    expect(get(navOpen)).toBe(false);
+    expect(get(savedQueryNavOpen)).toBe(false);
+    expect(localStorage.getItem('navOpen')).toBeNull();
+    expect(localStorage.getItem('savedQueryNavOpen')).toBeNull();
+  });
+
+  it('leaves both navs open when collapsed by default is false', async () => {
+    const { initializeNavDefaults, navOpen, savedQueryNavOpen } =
+      await loadNavStores();
+
+    initializeNavDefaults(false);
+
+    expect(get(navOpen)).toBe(true);
+    expect(get(savedQueryNavOpen)).toBe(true);
+  });
+
+  it('keeps stored preferences when collapsed by default is true', async () => {
+    localStorage.setItem('navOpen', 'true');
+    localStorage.setItem('savedQueryNavOpen', 'true');
+    const { initializeNavDefaults, navOpen, savedQueryNavOpen } =
+      await loadNavStores();
+
+    initializeNavDefaults(true);
+
+    expect(get(navOpen)).toBe(true);
+    expect(get(savedQueryNavOpen)).toBe(true);
+  });
+
+  it('persists nav changes after applying the collapsed default', async () => {
+    const { initializeNavDefaults, navOpen } = await loadNavStores();
+
+    initializeNavDefaults(true);
+    navOpen.set(true);
+
+    expect(get(navOpen)).toBe(true);
+    expect(localStorage.getItem('navOpen')).toBe('true');
+  });
+});

--- a/src/lib/stores/nav-open.ts
+++ b/src/lib/stores/nav-open.ts
@@ -2,8 +2,24 @@ import { writable } from 'svelte/store';
 
 import { persistStore } from './persist-store';
 
-export const navOpen = persistStore('navOpen', true);
+const navOpenKey = 'navOpen';
+const savedQueryNavOpenKey = 'savedQueryNavOpen';
+
+export const navOpen = persistStore(navOpenKey, true);
 
 export const namespaceSelectorOpen = writable<boolean | null>();
 
-export const savedQueryNavOpen = persistStore('savedQueryNavOpen', true);
+export const savedQueryNavOpen = persistStore(savedQueryNavOpenKey, true);
+
+let navDefaultsInitialized = false;
+
+export const initializeNavDefaults = (collapsedByDefault?: boolean) => {
+  if (navDefaultsInitialized || collapsedByDefault === undefined) return;
+
+  navDefaultsInitialized = true;
+
+  if (!collapsedByDefault) return;
+
+  navOpen.setInitialValue(false);
+  savedQueryNavOpen.setInitialValue(false);
+};

--- a/src/lib/stores/persist-store.ts
+++ b/src/lib/stores/persist-store.ts
@@ -9,22 +9,42 @@ import {
   stringifyWithBigInt,
 } from '$lib/utilities/parse-with-big-int';
 
+export type PersistedStore<T> = Pick<
+  Writable<T>,
+  'subscribe' | 'set' | 'update'
+> & {
+  hasStoredValue: () => boolean;
+  setInitialValue: (value: T) => void;
+};
+
 export function persistStore<T>(
   name: string,
   initialValue: T | (() => T),
   broadcastToAll = false,
-): Pick<Writable<T>, 'subscribe' | 'set' | 'update'> {
+): PersistedStore<T> {
   let initialStoreValue = isFunction<() => T>(initialValue)
     ? initialValue()
     : initialValue;
   let broadcaster: null | BroadcastChannel;
 
+  const getStoredValue = () => window?.localStorage?.getItem(name);
+
+  const hasStoredValue = () => {
+    if (!BROWSER) return false;
+
+    try {
+      return getStoredValue() !== null;
+    } catch {
+      return false;
+    }
+  };
+
   if (BROWSER) {
     try {
-      if (window?.localStorage?.getItem(name)) {
-        initialStoreValue = parseWithBigInt(
-          window?.localStorage?.getItem(name) ?? '',
-        );
+      const storedValue = getStoredValue();
+
+      if (storedValue !== null) {
+        initialStoreValue = parseWithBigInt(storedValue);
       }
     } catch {
       // Keep the original initialStoreValue if localStorage parsing fails
@@ -69,6 +89,11 @@ export function persistStore<T>(
           return updatedValue;
         });
       }
+    },
+    hasStoredValue,
+    setInitialValue: (value: T) => {
+      if (!BROWSER || hasStoredValue()) return;
+      set(value);
     },
   };
 }

--- a/src/lib/svelte-mocks/app/state.ts
+++ b/src/lib/svelte-mocks/app/state.ts
@@ -14,6 +14,7 @@ const settings: Settings = {
   defaultNamespace: 'default',
   disableWriteActions: false,
   showTemporalSystemNamespace: false,
+  navCollapsedByDefault: false,
   batchActionsDisabled: false,
   workflowResetDisabled: false,
   workflowPauseDisabled: false,

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -25,6 +25,7 @@ const settings: Settings = {
   defaultNamespace: 'default',
   disableWriteActions: false,
   showTemporalSystemNamespace: false,
+  navCollapsedByDefault: false,
   batchActionsDisabled: false,
   workflowResetDisabled: false,
   workflowPauseDisabled: false,

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -100,6 +100,7 @@ export type Settings = {
   batchActionsDisabled: boolean;
   activityCommandsDisabled: boolean;
   showTemporalSystemNamespace: boolean;
+  navCollapsedByDefault: boolean;
   feedbackURL: string;
   runtimeEnvironment: {
     isCloud: boolean;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -340,6 +340,7 @@ export type SettingsResponse = {
   RefreshWorkflowCountsDisabled: boolean;
   ActivityCommandsDisabled: boolean;
   ShowTemporalSystemNamespace: boolean;
+  NavCollapsedByDefault: boolean;
   FeedbackURL: string;
   Version: string;
 };

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -21,6 +21,7 @@
   import { authUser, clearAuthUser } from '$lib/stores/auth-user';
   import { inProgressBatchOperation } from '$lib/stores/batch-operations';
   import { lastUsedNamespace, namespaces } from '$lib/stores/namespaces';
+  import { initializeNavDefaults } from '$lib/stores/nav-open';
   import { toaster } from '$lib/stores/toaster';
   import { temporalVersion } from '$lib/stores/versions';
   import { type NamespaceListItem, type NavLinkItem } from '$lib/types/global';
@@ -48,6 +49,8 @@
   }
 
   let { children }: Props = $props();
+
+  initializeNavDefaults(page.data?.settings?.navCollapsedByDefault);
 
   let isCloud = $derived(page.data?.settings?.runtimeEnvironment?.isCloud);
   let activeNamespaceName = $derived(

--- a/tests/test-utilities/mocks/settings.ts
+++ b/tests/test-utilities/mocks/settings.ts
@@ -29,6 +29,7 @@ const defaultSettings = {
   HideWorkflowQueryErrors: false,
   RefreshWorkflowCountsDisabled: false,
   ActivityCommandsDisabled: false,
+  NavCollapsedByDefault: false,
 };
 
 export const mockSettingsApi = async (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Adds `TEMPORAL_NAV_COLLAPSED_BY_DEFAULT` for Docker/server config. When enabled, the left navigation and saved views navigation start collapsed by default, while preserving the existing click behavior and persisted user preferences. This is helpful for demo's that are run on startup of CLI, especially for split-screen demos. This allows for more horizontal real estate on the Web UI by default.

Existing localStorage values still win, so this acts as a first-load default rather than forcing nav state on every page load.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="844" height="907" alt="Screenshot 2026-06-22 at 9 40 18 AM" src="https://github.com/user-attachments/assets/7d6b2e2a-ee04-4ae0-ace7-a04eb36e92cc" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->
No design changes. This only changes the configurable initial state of existing nav UI.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added


Tested with:

  - `pnpm exec vitest run src/lib/stores/nav-open.test.ts src/lib/services/settings-service.test.ts`
  - `pnpm exec svelte-check --tsconfig ./tsconfig.json --tsgo --incremental`
  - `GOCACHE=/private/tmp/temporal-ui-go-build go test ./server/config ./server/api`

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->
  1. Start the UI with `TEMPORAL_NAV_COLLAPSED_BY_DEFAULT=true`.
  2. Clear localStorage for `navOpen` and `savedQueryNavOpen`.
  3. Load the app and verify the left nav starts collapsed.
  4. Open a Workflows or Standalone Activities page and verify saved views starts collapsed.
  5. Click either nav toggle and verify it expands/collapses and persists as before.
  6. Start without the env var, or with it set to `false`, and verify both navs default to expanded.


## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
