### PR TITLE
Fix gaps in slot cards on Worker details page

### DIFF
--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -252,7 +252,7 @@
 
   <div class="flex flex-col gap-4 xl:flex-row">
     <section
-      class="grid flex-1 grid-cols-1 gap-4 xl:self-start 2xl:grid-flow-col 2xl:grid-cols-2 2xl:grid-rows-2"
+      class="grid flex-1 grid-cols-1 gap-4 xl:self-start 2xl:grid-flow-col 2xl:grid-cols-2 2xl:grid-rows-[auto_auto]"
     >
       {@render taskSlotCard(
         translate('common.workflows-plural', { count: 1 }),
@@ -297,13 +297,12 @@
     !slots?.currentUsedSlots && !slots?.currentAvailableSlots}
   <Card class="flex flex-col gap-2">
     <h5 class="mb-2">{title}</h5>
-
     <dl class="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:grid-rows-1">
       <div>
         <dt id="slots-{title}" class="mb-1 h-6 text-sm text-secondary">
           {translate('workers.slots-used')}
         </dt>
-        <dd class="mb-2">
+        <dd>
           <p class="truncate font-mono text-lg text-secondary">
             <span class="text-2xl font-semibold text-brand">
               {#if noSlotsConfigured}
@@ -334,7 +333,6 @@
           {/if}
         </dd>
       </div>
-
       <div>
         <dt class="mb-1 flex h-6 items-center text-sm text-secondary">
           {translate('workers.tasks-processed')}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="1417" height="530" alt="Screenshot 2026-06-22 at 12 07 34 PM" src="https://github.com/user-attachments/assets/109d2893-4ea1-450e-9222-cd2fd649ad74" />|<img width="1425" height="514" alt="Screenshot 2026-06-22 at 12 06 59 PM" src="https://github.com/user-attachments/assets/43ab59f8-0b7e-40bd-a11b-85c4cdd5058c" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
