### PR TITLE
fix(auth): call /auth/logout endpoint on logout instead of client-side nav

### DIFF
--- a/src/lib/stores/auth-user.test.ts
+++ b/src/lib/stores/auth-user.test.ts
@@ -1,0 +1,59 @@
+import { get } from 'svelte/store';
+
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { authUser, logout, setAuthUser } from './auth-user';
+
+describe('auth-user store: logout', () => {
+  beforeEach(() => {
+    authUser.set({});
+    vi.restoreAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    );
+    vi.stubGlobal('location', { href: '' } as Location);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('calls the /auth/logout endpoint with credentials so cookies are cleared', async () => {
+    await logout();
+
+    expect(fetch).toHaveBeenCalledWith('/auth/logout', {
+      method: 'GET',
+      credentials: 'include',
+    });
+  });
+
+  test('clears the local auth user', async () => {
+    setAuthUser({ accessToken: 'token', name: 'Test User' });
+    expect(get(authUser).accessToken).toBe('token');
+
+    await logout();
+
+    expect(get(authUser)).toEqual({});
+  });
+
+  test('redirects to the root after logging out', async () => {
+    await logout();
+
+    expect(window.location.href).toBe('/');
+  });
+
+  test('still clears auth state and redirects when the logout request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new Error('network error')),
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    setAuthUser({ accessToken: 'token', name: 'Test User' });
+
+    await logout();
+
+    expect(get(authUser)).toEqual({});
+    expect(window.location.href).toBe('/');
+  });
+});

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -18,7 +18,7 @@
   import UserMenuMobile from '$lib/holocene/user-menu-mobile.svelte';
   import UserMenu from '$lib/holocene/user-menu.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { authUser, clearAuthUser } from '$lib/stores/auth-user';
+  import { authUser, logout } from '$lib/stores/auth-user';
   import { inProgressBatchOperation } from '$lib/stores/batch-operations';
   import { lastUsedNamespace, namespaces } from '$lib/stores/namespaces';
   import { toaster } from '$lib/stores/toaster';
@@ -30,7 +30,6 @@
     routeForArchivalWorkflows,
     routeForBatchOperations,
     routeForEventHistoryImport,
-    routeForLoginPage,
     routeForNamespaces,
     routeForNexus,
     routeForSchedules,
@@ -280,11 +279,6 @@
 
     return routeForWorkflows({ namespace });
   }
-
-  const logout = () => {
-    clearAuthUser();
-    goto(routeForLoginPage());
-  };
 
   $effect(() => {
     if (updated.current) {


### PR DESCRIPTION
## What

Logging out through the UI never hit the backend, so the refresh cookie was never cleared.

The app-layout (`src/routes/(app)/+layout.svelte`) defined a local `logout` handler that only called `clearAuthUser()` and did a client-side `goto(routeForLoginPage())`. It never called `GET /auth/logout`, so the server-side refresh cookie survived the "logout" (#3579).

A correct `logout()` already exists in `src/lib/stores/auth-user.ts` — it calls `GET /auth/logout` with `credentials: 'include'`, clears local auth state, then redirects — but the SPA never used it.

## Change

- Wire the layout's `<UserMenu>` / `<UserMenuMobile>` to the shared `logout()` from `auth-user.ts`.
- Remove the now-unused local handler and its now-unused imports (`clearAuthUser`, `routeForLoginPage`). `goto` stays (still used for namespace navigation).

## ⚠️ One behavior change to confirm

The old local handler navigated to **`/login`** (soft `goto`). The shared `logout()` does `window.location.href = '/'` (hard navigation, which also fully resets app state). So after this change, logout lands on **`/`** instead of `/login`.

I think the hard nav to `/` is preferable (guarantees a clean state post-logout, and `/` will redirect unauthenticated users to login anyway), but if you'd rather preserve the exact `/login` destination, I can adjust `logout()` to redirect there instead — just let me know.

## Tests

`src/lib/stores/auth-user.ts` had no tests; added `auth-user.test.ts` covering `logout()`:
- calls `/auth/logout` with `credentials: 'include'`
- clears the local auth user
- redirects to `/`
- still clears state + redirects when the request fails (network error path)

## Verification

- `pnpm test -- --run src/lib/stores/auth-user.test.ts` → 4/4 pass
- `pnpm exec eslint` (changed files) → clean
- `pnpm prettier --check` (changed files) → clean
- `pnpm check` (svelte-check) → 0 errors

Closes #3579