### PR TITLE
a11y(2.1.1): workflow-current-details — guard global r/R keydown so text inputs can receive the letter

### DIFF
--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -44,8 +44,15 @@
   });
 
   const handleKeydown = (event: KeyboardEvent) => {
+    const { target } = event;
+    if (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof HTMLElement && target.isContentEditable)
+    ) {
+      return;
+    }
     if (event.key === 'r' || event.key === 'R') {
-      event.preventDefault();
       fetchCurrentDetails();
     }
   };


### PR DESCRIPTION
## Summary

`workflow-current-details.svelte` registers a `<svelte:window>` keydown handler that matched `r`/`R` unconditionally and called `preventDefault()`, silently swallowing the character from every text input on the workflow detail page — search box, command palette, filter inputs, activity-options drawer text fields. This PR adds an `instanceof` guard so the handler bails when focus is inside a text input or contenteditable, and removes `preventDefault()` (the refetch action has no default to suppress).

One-line diff:

```diff
 const handleKeydown = (event: KeyboardEvent) => {
+  const { target } = event;
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  ) {
+    return;
+  }
   if (event.key === 'r' || event.key === 'R') {
-    event.preventDefault();
     fetchCurrentDetails();
   }
 };
```

The `r`/`R` refresh shortcut continues to fire when focus is on any non-input element. Long-term migration to a modifier-prefixed or focus-scoped shortcut is tracked separately in `2.1.4-global-keydown-shortcuts.md`.

## Test plan

- [ ] Open a workflow detail page. Press `r` with focus on the page body — confirm current-details refetches (network call fires, timestamp updates).
- [ ] Click into the workflow search box. Type `relay-worker` — confirm every `r` appears in the input.
- [ ] Open the command palette (`Cmd+K`). Type `restart` — confirm all `r` characters are captured.
- [ ] Open an activity-options drawer with a text field. Type a word containing `r` — confirm no characters are dropped.
- [ ] Confirm `Cmd/Ctrl+R` (browser refresh) still works — the handler doesn't match modified keystrokes.
- [ ] Screen reader smoke test (VoiceOver): navigate to the detail panel, press `r` — refetch fires, no AT announcement suppressed.

## References

- WCAG 2.2 SC 2.1.1 Keyboard: https://www.w3.org/WAI/WCAG22/Understanding/keyboard
- WCAG 2.2 SC 2.1.4 Character Key Shortcuts: https://www.w3.org/WAI/WCAG22/Understanding/character-key-shortcuts
- Audit finding #11 in `audit-output/issues/2.1.1-keyboard-audit.md`
- Root-cause anti-pattern + long-term remediation: `2.1.4-global-keydown-shortcuts.md`

A11y-Audit-Ref: 2.1.1-workflow-current-details-r-keydown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)