### PR TITLE
Add direct SSO redirect and backend logout

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -38,6 +38,7 @@ auth:
 | Field                | Type     | Description                                                                                                                    |
 | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `enabled`            | boolean  | Enable or disable authentication                                                                                               |
+| `redirectToProvider` | boolean  | Skip the Temporal UI login page and redirect unauthenticated users directly to the configured OIDC provider                    |
 | `maxSessionDuration` | duration | Maximum session duration before forced re-login (e.g., `8h`, `24h`, `168h`). Set to `0` or omit for unlimited session duration |
 | `providers`          | array    | List of auth providers (currently only the first is used)                                                                      |
 

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "cors": "^2.8.5",
     "cssnano": "^5.1.14",
     "desm": "^1.3.1",
+    "ejs": "^6.0.1",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import-x": "^4.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       desm:
         specifier: ^1.3.1
         version: 1.3.1
+      ejs:
+        specifier: ^6.0.1
+        version: 6.0.1
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@1.21.7)
@@ -3766,6 +3769,11 @@ packages:
 
   effect@3.21.0:
     resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
+  ejs@6.0.1:
+    resolution: {integrity: sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==}
+    engines: {node: '>=0.12.18'}
+    hasBin: true
 
   electron-to-chromium@1.5.355:
     resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
@@ -11434,6 +11442,8 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
     optional: true
+
+  ejs@6.0.1: {}
 
   electron-to-chromium@1.5.355: {}
 

--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -24,6 +24,7 @@ refreshWorkflowCountsDisabled: false
 activityCommandsDisabled: false
 auth:
   enabled: false
+  redirectToProvider: false
   providers:
     - label: Auth0 oidc # for internal use; in future may expose as button text
       type: oidc # for futureproofing; only oidc is supported today

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -49,6 +49,7 @@ uiServerTLS:
   keyFile: {{ env "TEMPORAL_UI_SERVER_TLS_KEY" | default "" }}
 auth:
   enabled: {{ env "TEMPORAL_AUTH_ENABLED" | default "false" }}
+  redirectToProvider: {{ env "TEMPORAL_AUTH_REDIRECT_TO_PROVIDER" | default "false" }}
   providers:
   - label: {{ env "TEMPORAL_AUTH_LABEL" | default "sso" }}
     type: {{ env "TEMPORAL_AUTH_TYPE" | default "oidc" }}

--- a/server/config/with-auth.yaml
+++ b/server/config/with-auth.yaml
@@ -36,6 +36,7 @@ refreshWorkflowCountsDisabled: false
 # =============================================================================
 auth:
   enabled: true
+  redirectToProvider: false
   maxSessionDuration: 2m # Max time before forced re-login (0 = unlimited)
   providers:
     - label: Dummy OIDC
@@ -69,4 +70,3 @@ codec:
   includeCredentials: false
 forwardHeaders: # can be used to pass additional HTTP headers from HTTP requests to Temporal gRPC backend
   - X-Forwarded-For
-

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -45,8 +45,9 @@ import (
 )
 
 type Auth struct {
-	Enabled bool
-	Options []string
+	Enabled            bool
+	Options            []string
+	RedirectToProvider bool
 }
 
 type CodecResponse struct {
@@ -127,8 +128,9 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 
 		settings := &SettingsResponse{
 			Auth: &Auth{
-				Enabled: cfg.Auth.Enabled,
-				Options: options,
+				Enabled:            cfg.Auth.Enabled,
+				Options:            options,
+				RedirectToProvider: cfg.Auth.RedirectToProvider,
 			},
 			DefaultNamespace:            cfg.DefaultNamespace,
 			ShowTemporalSystemNamespace: cfg.ShowTemporalSystemNamespace,

--- a/server/server/api/handler_test.go
+++ b/server/server/api/handler_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/ui-server/v2/server/config"
+)
+
+type mockConfigProvider struct {
+	cfg *config.Config
+}
+
+func (m *mockConfigProvider) GetConfig() (*config.Config, error) {
+	return m.cfg, nil
+}
+
+func TestGetSettingsIncludesAuthRedirectToProvider(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Auth.Enabled = true
+	cfg.Auth.RedirectToProvider = true
+	cfg.Auth.Providers = []config.AuthProvider{
+		{
+			Options: map[string]interface{}{
+				"audience": "temporal",
+			},
+		},
+	}
+
+	cfgProvider, err := config.NewConfigProviderWithRefresh(&mockConfigProvider{cfg: cfg})
+	require.NoError(t, err)
+	defer cfgProvider.Close()
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = GetSettings(cfgProvider)(c)
+	require.NoError(t, err)
+
+	var settings SettingsResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &settings)
+	require.NoError(t, err)
+
+	assert.True(t, settings.Auth.Enabled)
+	assert.True(t, settings.Auth.RedirectToProvider)
+	assert.Contains(t, settings.Auth.Options, "audience")
+}

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -102,6 +102,8 @@ type (
 	Auth struct {
 		// Enabled - UI checks this first before reading your provider config
 		Enabled bool `yaml:"enabled"`
+		// RedirectToProvider - skip the UI login page and redirect unauthenticated users directly to the auth provider
+		RedirectToProvider bool `yaml:"redirectToProvider"`
 		// A list of auth providers. Currently enables only the first provider in the list.
 		Providers []AuthProvider `yaml:"providers"`
 		// MaxSessionDuration - optional maximum session duration. If set, users will be

--- a/src/lib/services/settings-service.test.ts
+++ b/src/lib/services/settings-service.test.ts
@@ -88,19 +88,17 @@ describe('fetchSettings', () => {
   });
 
   it('should map redirectToProvider auth settings', async () => {
-    const request = async () =>
-      new Response(
-        JSON.stringify({
-          Auth: {
-            Enabled: true,
-            Options: ['audience'],
-            RedirectToProvider: true,
-          },
-          Codec: {},
-        }),
-      );
+    vi.mocked(requestFromAPI).mockResolvedValue(
+      settingsResponse({
+        Auth: {
+          Enabled: true,
+          Options: ['audience'],
+          RedirectToProvider: true,
+        },
+      }),
+    );
 
-    const settings = await fetchSettings(request as typeof fetch);
+    const settings = await fetchSettings();
 
     expect(settings.auth).toEqual({
       enabled: true,
@@ -110,18 +108,16 @@ describe('fetchSettings', () => {
   });
 
   it('should default redirectToProvider to false', async () => {
-    const request = async () =>
-      new Response(
-        JSON.stringify({
-          Auth: {
-            Enabled: true,
-            Options: null,
-          },
-          Codec: {},
-        }),
-      );
+    vi.mocked(requestFromAPI).mockResolvedValue(
+      settingsResponse({
+        Auth: {
+          Enabled: true,
+          Options: null,
+        },
+      }),
+    );
 
-    const settings = await fetchSettings(request as typeof fetch);
+    const settings = await fetchSettings();
 
     expect(settings.auth.redirectToProvider).toBe(false);
   });

--- a/src/lib/services/settings-service.test.ts
+++ b/src/lib/services/settings-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCloudMatch } from './settings-service';
+import { fetchSettings, isCloudMatch } from './settings-service';
 
 describe('isCloudMatch', () => {
   it('should return true for tmprl.cloud', () => {
@@ -15,5 +15,46 @@ describe('isCloudMatch', () => {
     expect(isCloudMatch.test(undefined as unknown as string)).toBe(false);
     expect(isCloudMatch.test('xxx.xxx')).toBe(false);
     expect(isCloudMatch.test('localhost:3000')).toBe(false);
+  });
+});
+
+describe('fetchSettings', () => {
+  it('should map redirectToProvider auth settings', async () => {
+    const request = async () =>
+      new Response(
+        JSON.stringify({
+          Auth: {
+            Enabled: true,
+            Options: ['audience'],
+            RedirectToProvider: true,
+          },
+          Codec: {},
+        }),
+      );
+
+    const settings = await fetchSettings(request as typeof fetch);
+
+    expect(settings.auth).toEqual({
+      enabled: true,
+      options: ['audience'],
+      redirectToProvider: true,
+    });
+  });
+
+  it('should default redirectToProvider to false', async () => {
+    const request = async () =>
+      new Response(
+        JSON.stringify({
+          Auth: {
+            Enabled: true,
+            Options: null,
+          },
+          Codec: {},
+        }),
+      );
+
+    const settings = await fetchSettings(request as typeof fetch);
+
+    expect(settings.auth.redirectToProvider).toBe(false);
   });
 });

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -21,6 +21,7 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     auth: {
       enabled: !!settingsResponse?.Auth?.Enabled,
       options: settingsResponse?.Auth?.Options,
+      redirectToProvider: !!settingsResponse?.Auth?.RedirectToProvider,
     },
     baseUrl: getApiOrigin(),
     codec: {

--- a/src/lib/stores/auth-user.test.ts
+++ b/src/lib/stores/auth-user.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { base } from '$app/paths';
+
+import { clearAuthUser, getAuthUser, logout, setAuthUser } from './auth-user';
+
+const realLocation = window.location;
+const fakeLocation = {
+  origin: 'https://temporal.io',
+  assign: vi.fn(),
+};
+
+describe('auth-user logout', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchSpy);
+    Object.defineProperty(window, 'location', { value: fakeLocation });
+    setAuthUser({ accessToken: 'token' });
+  });
+
+  afterEach(() => {
+    clearAuthUser();
+    Object.defineProperty(window, 'location', { value: realLocation });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('should call the backend logout endpoint and clear local auth state', async () => {
+    await logout();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `http://localhost:8233${base}/auth/logout`,
+      {
+        method: 'GET',
+        credentials: 'include',
+        redirect: 'manual',
+      },
+    );
+    expect(getAuthUser()).toEqual({});
+    expect(window.location.assign).toHaveBeenCalledWith(`${base}/`);
+  });
+
+  it('should clear local auth state even when the logout request fails', async () => {
+    fetchSpy.mockRejectedValue(new Error('logout failed'));
+
+    await logout();
+
+    expect(getAuthUser()).toEqual({});
+    expect(window.location.assign).toHaveBeenCalledWith(`${base}/`);
+  });
+});

--- a/src/lib/stores/auth-user.ts
+++ b/src/lib/stores/auth-user.ts
@@ -1,7 +1,10 @@
 import { get } from 'svelte/store';
 
+import { resolve } from '$app/paths';
+
 import { persistStore } from '$lib/stores/persist-store';
 import type { User } from '$lib/types/global';
+import { getApiOrigin } from '$lib/utilities/get-api-origin';
 
 export const authUser = persistStore<User>('AuthUser', {});
 
@@ -33,9 +36,15 @@ export const clearAuthUser = () => {
  */
 export async function logout(): Promise<void> {
   try {
-    await fetch('/auth/logout', {
+    const logoutUrl = new URL(
+      resolve('/auth/logout', {}),
+      getApiOrigin() ?? window.location.origin,
+    ).toString();
+
+    await fetch(logoutUrl, {
       method: 'GET',
       credentials: 'include',
+      redirect: 'manual',
     });
 
     console.info('[Auth] Logout successful, cookies cleared');
@@ -44,5 +53,5 @@ export async function logout(): Promise<void> {
   }
 
   clearAuthUser();
-  window.location.href = '/';
+  window.location.assign(resolve('/', {}));
 }

--- a/src/lib/svelte-mocks/app/state.ts
+++ b/src/lib/svelte-mocks/app/state.ts
@@ -4,6 +4,7 @@ const settings: Settings = {
   auth: {
     enabled: false,
     options: null,
+    redirectToProvider: false,
   },
   baseUrl: 'http://localhost:3000',
   codec: {

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -15,6 +15,7 @@ const settings: Settings = {
   auth: {
     enabled: false,
     options: null,
+    redirectToProvider: false,
   },
   baseUrl: 'http://localhost:3000',
   codec: {

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -74,7 +74,8 @@ export interface NetworkError {
 export type Settings = {
   auth: {
     enabled: boolean;
-    options: string[];
+    options: string[] | null;
+    redirectToProvider: boolean;
   };
   baseUrl: string;
   codec: {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -318,7 +318,11 @@ export type Duration = google.protobuf.IDuration;
 
 // extra APIs
 export type SettingsResponse = {
-  Auth: { Enabled: boolean; Options: string[] };
+  Auth: {
+    Enabled: boolean;
+    Options: string[] | null;
+    RedirectToProvider?: boolean;
+  };
   Codec: {
     Endpoint: string;
     PassAccessToken?: boolean;

--- a/src/lib/utilities/handle-error.test.ts
+++ b/src/lib/utilities/handle-error.test.ts
@@ -1,7 +1,11 @@
+import { get } from 'svelte/store';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { page } from '$app/stores';
+
 import { handleError } from './handle-error';
-import { routeForLoginPage } from './route-for';
+import { routeForAuthenticationRedirect, routeForLoginPage } from './route-for';
 
 const realLocation = window.location.assign;
 const fakeLocation = {
@@ -16,6 +20,7 @@ describe('handleError', () => {
   });
 
   afterEach(() => {
+    get(page).data.settings.auth.redirectToProvider = false;
     Object.defineProperty(window, 'location', { value: realLocation });
     vi.clearAllMocks();
   });
@@ -29,6 +34,24 @@ describe('handleError', () => {
 
     expect(() => handleError(error)).toThrowError();
     expect(window.location.assign).toHaveBeenCalledWith(routeForLoginPage());
+  });
+
+  it('should redirect to SSO if it is unauthorized and redirectToProvider is enabled', () => {
+    get(page).data.settings.auth.redirectToProvider = true;
+    get(page).data.settings.baseUrl = 'https://t.io';
+    const error = {
+      status: 401,
+      statusText: 'Unauthorized',
+      response: null as unknown as Response,
+    };
+
+    expect(() => handleError(error)).toThrowError();
+    expect(window.location.assign).toHaveBeenCalledWith(
+      routeForAuthenticationRedirect(
+        get(page).data.settings,
+        new URL(fakeLocation.href),
+      ),
+    );
   });
 
   it('should redirect if it is an unauthorized error with statusCode', () => {

--- a/src/lib/utilities/handle-error.ts
+++ b/src/lib/utilities/handle-error.ts
@@ -1,4 +1,8 @@
+import { get } from 'svelte/store';
+
 import { BROWSER } from 'esm-env';
+
+import { page } from '$app/stores';
 
 import { networkError } from '$lib/stores/error';
 import { toaster } from '$lib/stores/toaster';
@@ -7,7 +11,7 @@ import type { NetworkError } from '$lib/types/global';
 import { has } from './has';
 import { isNetworkError } from './is-network-error';
 import type { APIErrorResponse, TemporalAPIError } from './request-from-api';
-import { routeForLoginPage } from './route-for';
+import { routeForAuthenticationRedirect, routeForLoginPage } from './route-for';
 
 interface NetworkErrorWithReport extends NetworkError {
   report?: boolean;
@@ -34,11 +38,11 @@ export const handleError = (
   }
 
   if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    window.location.assign(routeForCurrentAuthSettings());
   }
 
   if (isForbidden(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    window.location.assign(routeForCurrentAuthSettings());
   }
 
   if (isNetworkError(error)) {
@@ -58,12 +62,12 @@ export const handleUnauthorizedOrForbiddenError = (
   isBrowser = BROWSER,
 ): void => {
   if (isUnauthorized(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    window.location.assign(routeForCurrentAuthSettings());
     return;
   }
 
   if (isForbidden(error) && isBrowser) {
-    window.location.assign(routeForLoginPage());
+    window.location.assign(routeForCurrentAuthSettings());
     return;
   }
 };
@@ -97,4 +101,14 @@ const hasStatusCode = (
   }
 
   return false;
+};
+
+const routeForCurrentAuthSettings = (): string => {
+  const settings = get(page)?.data?.settings;
+  if (!settings) return routeForLoginPage();
+
+  return routeForAuthenticationRedirect(
+    settings,
+    new URL(window.location.href),
+  );
 };

--- a/src/lib/utilities/route-for-base-path.test.ts
+++ b/src/lib/utilities/route-for-base-path.test.ts
@@ -8,6 +8,7 @@ import {
   routeForArchivalEventHistory,
   routeForArchivalWorkflows,
   routeForAuthentication,
+  routeForAuthenticationRedirect,
   routeForBatchOperation,
   routeForBatchOperations,
   routeForCallStack,
@@ -194,6 +195,17 @@ describe('routeFor functions should resolve the base path exactly once', () => {
           settings: { auth: {}, baseUrl: 'https://example.com' },
           searchParams: new URLSearchParams(),
         }),
+    ],
+    [
+      'routeForAuthenticationRedirect',
+      () =>
+        routeForAuthenticationRedirect(
+          {
+            auth: { redirectToProvider: true },
+            baseUrl: 'https://example.com',
+          },
+          new URL('https://example.com/namespaces/default/workflows'),
+        ),
     ],
     ['routeForLoginPage', () => routeForLoginPage('', false)],
     ['routeForCommonErrors', () => routeForCommonErrors()],
@@ -406,6 +418,17 @@ describe('routeFor functions with prefix should resolve base + prefix correctly'
           settings: { auth: {}, baseUrl: 'https://example.com' },
           searchParams: new URLSearchParams(),
         }),
+    ],
+    [
+      'routeForAuthenticationRedirect',
+      () =>
+        routeForAuthenticationRedirect(
+          {
+            auth: { redirectToProvider: true },
+            baseUrl: 'https://example.com',
+          },
+          new URL('https://example.com/namespaces/default/workflows'),
+        ),
     ],
     ['routeForLoginPage', () => routeForLoginPage('', false)],
   ];

--- a/src/lib/utilities/route-for.test.ts
+++ b/src/lib/utilities/route-for.test.ts
@@ -19,6 +19,7 @@ import {
   isWorkflowParameters,
   routeForArchivalWorkflows,
   routeForAuthentication,
+  routeForAuthenticationRedirect,
   routeForCallStack,
   routeForEventHistory,
   routeForEventHistoryImport,
@@ -352,6 +353,43 @@ describe('routeFor SSO authentication ', () => {
 
     it('should return a URL with the correct returnUrl', () => {
       expect(routeForLoginPage('', false)).toBe(`${base}/login`);
+    });
+  });
+
+  describe('routeForAuthenticationRedirect', () => {
+    it('should return the login page when redirectToProvider is disabled', () => {
+      const settings = {
+        auth: {
+          redirectToProvider: false,
+        },
+        baseUrl: 'https://localhost',
+      };
+
+      expect(routeForAuthenticationRedirect(settings)).toBe(
+        routeForLoginPage(),
+      );
+    });
+
+    it('should return the SSO route with returnUrl when redirectToProvider is enabled', () => {
+      const settings = {
+        auth: {
+          options: ['one'],
+          redirectToProvider: true,
+        },
+        baseUrl: 'https://localhost',
+      };
+      const currentUrl = new URL(
+        'https://temporal.io/namespaces/default/workflows?one=1&two=2',
+      );
+
+      const redirectUrl = routeForAuthenticationRedirect(settings, currentUrl);
+      const parsedUrl = new URL(redirectUrl);
+
+      expect(parsedUrl.origin).toBe('https://localhost');
+      expect(parsedUrl.pathname).toBe(`${base}/auth/sso`);
+      expect(parsedUrl.searchParams.get('one')).toBe('1');
+      expect(parsedUrl.searchParams.get('two')).toBeNull();
+      expect(parsedUrl.searchParams.get('returnUrl')).toBe(currentUrl.href);
     });
   });
 

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -575,6 +575,21 @@ export const routeForLoginPage = (
   return resolve('/login', {});
 };
 
+export const routeForAuthenticationRedirect = (
+  settings: Settings,
+  currentUrl?: URL,
+): string => {
+  if (settings.auth.redirectToProvider) {
+    return routeForAuthentication({
+      settings,
+      searchParams: currentUrl?.searchParams,
+      originUrl: currentUrl?.href,
+    });
+  }
+
+  return routeForLoginPage();
+};
+
 export const routeForEventHistoryImport = (
   namespace?: string,
   view?: EventView,

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -18,7 +18,7 @@
   import UserMenuMobile from '$lib/holocene/user-menu-mobile.svelte';
   import UserMenu from '$lib/holocene/user-menu.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { authUser, clearAuthUser } from '$lib/stores/auth-user';
+  import { authUser, logout as logoutAuthUser } from '$lib/stores/auth-user';
   import { inProgressBatchOperation } from '$lib/stores/batch-operations';
   import { lastUsedNamespace, namespaces } from '$lib/stores/namespaces';
   import { toaster } from '$lib/stores/toaster';
@@ -30,7 +30,6 @@
     routeForArchivalWorkflows,
     routeForBatchOperations,
     routeForEventHistoryImport,
-    routeForLoginPage,
     routeForNamespaces,
     routeForNexus,
     routeForSchedules,
@@ -282,8 +281,7 @@
   }
 
   const logout = () => {
-    clearAuthUser();
-    goto(routeForLoginPage());
+    void logoutAuthUser();
   };
 
   $effect(() => {

--- a/src/routes/(app)/+layout.ts
+++ b/src/routes/(app)/+layout.ts
@@ -9,12 +9,13 @@ import { clearAuthUser, getAuthUser } from '$lib/stores/auth-user';
 import type { GetClusterInfoResponse, GetSystemInfoResponse } from '$lib/types';
 import type { Settings } from '$lib/types/global';
 import { isAuthorized } from '$lib/utilities/is-authorized';
-import { routeForLoginPage } from '$lib/utilities/route-for';
+import { routeForAuthenticationRedirect } from '$lib/utilities/route-for';
 
 import '../../app.css';
 
 export const load: LayoutLoad = async function ({
   fetch,
+  url,
 }): Promise<LayoutData> {
   const settings: Settings = await fetchSettings(fetch);
 
@@ -25,7 +26,7 @@ export const load: LayoutLoad = async function ({
   const user = getAuthUser();
 
   if (!isAuthorized(settings, user)) {
-    redirect(302, routeForLoginPage());
+    redirect(302, routeForAuthenticationRedirect(settings, url));
   }
 
   fetchNamespaces(settings, fetch);

--- a/src/routes/(login)/+layout.ts
+++ b/src/routes/(login)/+layout.ts
@@ -1,19 +1,31 @@
 import '../../app.css';
 
-import { error } from '@sveltejs/kit';
+import { error, redirect } from '@sveltejs/kit';
 
 import type { LayoutLoad } from './$types';
 
 import { fetchSettings } from '$lib/services/settings-service';
 import type { Settings } from '$lib/types/global';
+import { routeForAuthentication } from '$lib/utilities/route-for';
 
 export const ssr = false;
 
-export const load: LayoutLoad = async function ({ fetch }) {
+export const load: LayoutLoad = async function ({ fetch, url }) {
   const settings: Settings = await fetchSettings(fetch);
 
   if (!settings.auth.enabled) {
     error(404);
+  }
+
+  if (settings.auth.redirectToProvider) {
+    redirect(
+      302,
+      routeForAuthentication({
+        settings,
+        searchParams: url.searchParams,
+        originUrl: url.origin,
+      }),
+    );
   }
 
   return {

--- a/tests/integration/oauth-flow.spec.ts
+++ b/tests/integration/oauth-flow.spec.ts
@@ -21,7 +21,14 @@ function makeUserCookie(accessToken: string) {
   );
 }
 
-async function mockAuthApis(page: Page) {
+async function mockAuthApis(
+  page: Page,
+  authSettings: {
+    Enabled?: boolean;
+    Options?: string[] | null;
+    RedirectToProvider?: boolean;
+  } = {},
+) {
   await Promise.all([
     mockClusterApi(page),
     mockNamespacesApi(page),
@@ -29,9 +36,48 @@ async function mockAuthApis(page: Page) {
     mockNamespaceApi(page),
     mockSearchAttributesApi(page),
     mockWorkflowsCountApi(page),
-    mockSettingsApi(page, { Auth: { Enabled: true, Options: null } }),
+    mockSettingsApi(page, {
+      Auth: {
+        Enabled: true,
+        Options: null,
+        RedirectToProvider: false,
+        ...authSettings,
+      },
+    }),
   ]);
 }
+
+test('routes unauthenticated users to login by default', async ({
+  page,
+  baseURL,
+}) => {
+  await mockAuthApis(page);
+
+  await page.goto(`${baseURL}/namespaces/default/workflows`);
+
+  await expect(page).toHaveURL(/\/login\?returnUrl=/);
+  await expect(page.getByTestId('login-button')).toBeVisible();
+});
+
+test('routes unauthenticated users directly to SSO when configured', async ({
+  page,
+  baseURL,
+}) => {
+  await mockAuthApis(page, { RedirectToProvider: true });
+
+  let ssoUrl = '';
+  await page.route('**/auth/sso**', async (route) => {
+    ssoUrl = route.request().url();
+    await route.fulfill({ status: 200, body: 'sso' });
+  });
+
+  const protectedUrl = `${baseURL}/namespaces/default/workflows?query=ExecutionStatus%3D%22Running%22`;
+  await page.goto(protectedUrl);
+
+  await expect.poll(() => ssoUrl).toContain('/auth/sso');
+  const parsedUrl = new URL(ssoUrl);
+  expect(parsedUrl.searchParams.get('returnUrl')).toBe(protectedUrl);
+});
 
 test('sets Authorization Bearer header from user cookie', async ({
   page,
@@ -122,4 +168,40 @@ test('refreshes token and retries request on 401', async ({
   expect(workflowCallCount).toBe(2);
   expect(authHeaders[0]).toBe('Bearer expired-token');
   expect(authHeaders[1]).toBe('Bearer refreshed-token-456');
+});
+
+test('log out calls backend logout endpoint', async ({ page, baseURL }, {
+  project: {
+    use: { isMobile },
+  },
+}) => {
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip(isMobile, 'This test is for Desktop only');
+
+  await mockAuthApis(page);
+
+  await page.route(WORKFLOWS_API, async (route) => {
+    await route.fulfill({ json: { executions: [], nextPageToken: null } });
+  });
+
+  let logoutCalled = false;
+  await page.route('**/auth/logout**', async (route) => {
+    logoutCalled = true;
+    await route.fulfill({ status: 204, body: '' });
+  });
+
+  await page.context().addCookies([
+    {
+      name: 'user0',
+      value: makeUserCookie('test-access-token-123'),
+      domain: 'localhost',
+      path: '/',
+    },
+  ]);
+
+  await page.goto(baseURL);
+  await page.getByTestId('user-menu-trigger').click();
+  await page.getByRole('menuitem', { name: /log out/i }).click();
+
+  await expect.poll(() => logoutCalled).toBe(true);
 });

--- a/tests/test-utilities/mocks/settings.ts
+++ b/tests/test-utilities/mocks/settings.ts
@@ -8,6 +8,7 @@ const defaultSettings = {
   Auth: {
     Enabled: false,
     Options: null,
+    RedirectToProvider: false,
   },
   DefaultNamespace: '',
   ShowTemporalSystemNamespace: false,


### PR DESCRIPTION
## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR improves the OIDC authentication flow for self-hosted Temporal UI deployments.

It adds a new `auth.redirectToProvider` server configuration option that allows deployments to skip the intermediate Temporal UI `/login` page and send unauthenticated users directly to the configured OIDC provider through `/auth/sso`. This is useful for environments that want an IdP-first login flow and currently need proxy-level workarounds to bypass the "Continue to SSO" page.

It also updates UI logout behavior to call the existing `/auth/logout` backend endpoint instead of only clearing client state and navigating to `/login`. Calling the backend endpoint lets the server clear the refresh, session, and user cookies so the browser is actually logged out of the Temporal UI session.

Implementation details:

- Added `auth.redirectToProvider` to server config, Docker config, auth docs, and the `/api/v1/settings` auth response.
- Added `TEMPORAL_AUTH_REDIRECT_TO_PROVIDER` support for Docker config.
- Mapped `RedirectToProvider` into frontend settings as `settings.auth.redirectToProvider`, defaulting to `false` for compatibility with older settings responses.
- Updated unauthenticated app-route redirects to use `/auth/sso` when `redirectToProvider` is enabled.
- Updated `/login` route loading so direct visits also redirect to `/auth/sso` when the flag is enabled.
- Updated 401/403 handling to respect the same redirect setting.
- Updated the user-menu logout action to call `/auth/logout` with credentials before clearing local auth state and navigating home.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

https://github.com/user-attachments/assets/7c5c68b8-2d4b-4c2f-a08e-d2a2f5610165


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

No design review needed. The default behavior remains the existing `/login` page with the "Continue to SSO" step. The new direct provider redirect only applies when `auth.redirectToProvider` is explicitly enabled.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [x] E2E tests added
- [x] Unit tests added

Added/updated tests for:

- Server settings response includes `Auth.RedirectToProvider`.
- Frontend settings service maps `RedirectToProvider` and defaults it to `false`.
- Route helpers return `/login` by default and `/auth/sso` with `returnUrl` when direct provider redirects are enabled.
- Base-path behavior for the new auth redirect helper.
- 401/403 error handling respects `redirectToProvider`.
- UI logout calls `/auth/logout`, includes credentials, clears local auth state, and navigates home.
- Playwright OAuth flow coverage for default unauthenticated redirect, direct SSO redirect, and backend logout invocation.

Validated locally with:

```sh
pnpm test src/lib/utilities/route-for.test.ts src/lib/utilities/route-for-base-path.test.ts src/lib/services/settings-service.test.ts src/lib/utilities/handle-error.test.ts src/lib/stores/auth-user.test.ts
go test ./server/api
pnpm check
PW_MODE=integration pnpm exec playwright test tests/integration/oauth-flow.spec.ts --project "chromium desktop"
git diff --check
```

`pnpm check` reported 0 errors. Existing Svelte warnings remain.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Configure OIDC auth normally and leave `auth.redirectToProvider` unset or set to `false`.
2. Run ui with pnpm dev:with-auth
3. Visit a protected UI route while unauthenticated.
4. Confirm the UI still redirects to `/login` and shows the existing "Continue to SSO" flow.
5. Set `auth.redirectToProvider: true` or, for Docker config, `TEMPORAL_AUTH_REDIRECT_TO_PROVIDER=true`.
6. Restart the UI server and visit a protected UI route while unauthenticated.
7. Confirm the browser is redirected directly to `/auth/sso` and the original route is preserved in `returnUrl`.
8. Log in, then use the user-menu logout action.
9. Confirm the browser requests `/auth/logout`, the server clears auth cookies, and the UI navigates home.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

Ready for review.

### Merge Checklist <!-- Add todos if not ready to merge -->

- [x] CI passes

### Issue(s) closed <!-- add issue number here -->

Closes #3578
Closes #3579

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

Updated `AUTHENTICATION.md` with the new `redirectToProvider` auth setting.
