### PR TITLE
feat(DT-4194): Render all available icons in storybook

### DIFF
--- a/src/lib/holocene/icon/icon.stories.svelte
+++ b/src/lib/holocene/icon/icon.stories.svelte
@@ -1,14 +1,13 @@
 <svelte:options runes />
 
 <script lang="ts" module>
-  import type { Meta } from '@storybook/svelte';
-  import type { ComponentProps } from 'svelte';
+  import { type Args, defineMeta } from '@storybook/addon-svelte-csf';
 
-  import { iconNames } from './';
+  import { type IconName, iconNames } from './';
 
   import Icon from './icon.svelte';
 
-  export const meta = {
+  const { Story } = defineMeta({
     title: 'Icon',
     component: Icon,
     args: {
@@ -25,15 +24,29 @@
       height: { name: 'Height', control: 'number' },
       width: { name: 'Width', control: 'number' },
     },
-  } satisfies Meta<ComponentProps<typeof Icon>>;
+  });
 </script>
 
-<script lang="ts">
-  import { Story, Template } from '@storybook/addon-svelte-csf';
-</script>
+<Story name="Default" args={{ name: 'add', height: 24, width: 24 }}>
+  {#snippet template(args: Args<typeof Story>)}
+    <Icon {...args} />
+  {/snippet}
+</Story>
 
-<Template let:args>
-  <Icon {...args} />
-</Template>
-
-<Story name="Default" args={{ name: 'add', height: 24, width: 24 }} />
+<Story name="All Icons">
+  {#snippet template()}
+    <div
+      style="display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 16px;"
+    >
+      {#each iconNames as name (name)}
+        {@const iconName = name as IconName}
+        <div
+          style="display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 16px; border: 1px solid #e5e7eb; border-radius: 8px; text-align: center;"
+        >
+          <Icon name={iconName} height={24} width={24} />
+          <span style="font-size: 12px; word-break: break-all;">{name}</span>
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</Story>

--- a/src/lib/holocene/icon/icon.stories.svelte
+++ b/src/lib/holocene/icon/icon.stories.svelte
@@ -1,7 +1,8 @@
 <svelte:options runes />
 
 <script lang="ts" module>
-  import { type Args, defineMeta } from '@storybook/addon-svelte-csf';
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import type { ComponentProps } from 'svelte';
 
   import { type IconName, iconNames } from './';
 
@@ -28,7 +29,7 @@
 </script>
 
 <Story name="Default" args={{ name: 'add', height: 24, width: 24 }}>
-  {#snippet template(args: Args<typeof Story>)}
+  {#snippet template(args: ComponentProps<typeof Icon>)}
     <Icon {...args} />
   {/snippet}
 </Story>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Make it easier to find the icon you want by rendering all the available icons in storybook on a single page

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="2972" height="2424" alt="CleanShot 2026-06-23 at 13 42 40@2x" src="https://github.com/user-attachments/assets/2647379f-087e-4205-9ef7-d901266185dc" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
