### PR TITLE
Improve re-renders for large encoded event histories

### DIFF
--- a/src/lib/components/lines-and-dots/svg/graph-widget.svelte
+++ b/src/lib/components/lines-and-dots/svg/graph-widget.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
+
   import { groupEvents } from '$lib/models/event-groups';
+  import type { EventGroups } from '$lib/models/event-groups/event-groups';
   import { fetchAllEvents } from '$lib/services/events-service';
   import { fetchWorkflow } from '$lib/services/workflow-service';
-  import type { WorkflowEvents } from '$lib/types/events';
   import type { WorkflowExecution } from '$lib/types/workflows';
 
   import TimelineGraph from './timeline-graph.svelte';
 
   interface Props {
     namespace: string;
-    workflowId: string;
-    runId?: string;
+    workflowId?: string | null;
+    runId?: string | null;
+    eventCount?: number;
     viewportHeight?: number;
     onLoad?: () => void;
     class?: string;
@@ -20,36 +23,55 @@
     namespace,
     workflowId,
     runId = '',
+    eventCount = 0,
     viewportHeight = 360,
     onLoad = () => {},
     class: className = '',
   }: Props = $props();
 
+  let snapshot = $state<{ workflow: WorkflowExecution; groups: EventGroups }>();
+
   const getWorkflowAndEventHistory = async () => {
-    const [workflow, history] = await Promise.all([
+    if (!workflowId || !runId) return;
+
+    const [{ workflow }, history] = await Promise.all([
       fetchWorkflow({ namespace, workflowId, runId }),
       fetchAllEvents({ namespace, workflowId, runId }),
     ]);
-    return { workflow: workflow.workflow, history };
+    if (!workflow) return;
+
+    const pendingActivities = workflow?.pendingActivities ?? [];
+    return {
+      workflow,
+      groups: groupEvents(history, 'ascending', pendingActivities),
+    };
   };
 
-  const createGroups = (
-    workflow: WorkflowExecution,
-    history: WorkflowEvents,
-  ) => {
-    onLoad();
-    const pendingActivities = workflow?.pendingActivities ?? [];
-    return groupEvents(history, 'ascending', pendingActivities);
-  };
+  const fetchKey = $derived(
+    `${namespace}|${workflowId}|${runId}|${eventCount}`,
+  );
+
+  $effect(() => {
+    void fetchKey;
+    let cancelled = false;
+    untrack(() => getWorkflowAndEventHistory()).then((next) => {
+      if (cancelled) return;
+      snapshot = next;
+      onLoad();
+    });
+    return () => {
+      cancelled = true;
+    };
+  });
 </script>
 
-{#await getWorkflowAndEventHistory() then { workflow, history }}
+{#if snapshot}
   <div class="cursor-pointer overflow-auto {className}">
     <TimelineGraph
       {viewportHeight}
-      {workflow}
-      groups={createGroups(workflow, history)}
+      workflow={snapshot.workflow}
+      groups={snapshot.groups}
       readOnly
     />
   </div>
-{/await}
+{/if}

--- a/src/lib/components/lines-and-dots/svg/group-details-row.svelte
+++ b/src/lib/components/lines-and-dots/svg/group-details-row.svelte
@@ -95,18 +95,17 @@
       {#if childWorkflowStartedEvent}
         <div class="surface-primary p-4">
           <div class="font-medium leading-4 text-secondary">Child Workflow</div>
-          {#key group.eventList.length}
-            <GraphWidget
-              {namespace}
-              workflowId={childWorkflowStartedEvent.attributes.workflowExecution
-                .workflowId}
-              runId={childWorkflowStartedEvent.attributes.workflowExecution
-                .runId}
-              viewportHeight={320}
-              class="surface-primary overflow-x-hidden border-t border-subtle"
-              onLoad={onDecode}
-            />
-          {/key}
+          <GraphWidget
+            {namespace}
+            workflowId={childWorkflowStartedEvent.attributes.workflowExecution
+              ?.workflowId}
+            runId={childWorkflowStartedEvent.attributes.workflowExecution
+              ?.runId}
+            eventCount={group.eventList.length}
+            viewportHeight={320}
+            class="surface-primary overflow-x-hidden border-t border-subtle"
+            onLoad={onDecode}
+          />
         </div>
       {/if}
     </div>

--- a/src/lib/components/payload/payload-summary.svelte
+++ b/src/lib/components/payload/payload-summary.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { type Snippet } from 'svelte';
+  import { type Snippet, untrack } from 'svelte';
 
   import Badge from '$lib/holocene/badge.svelte';
   import type { Payload } from '$lib/types';
   import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
+  import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   interface Props {
     value: Payload | null | undefined;
@@ -25,25 +26,27 @@
 
   let decodedValue = $state(fallback);
 
-  const decodePromise = $derived(
-    (() => {
-      const _value = value;
-      const _fallback = fallback;
-      const _prefix = prefix;
-      const _max = maxSummaryLength;
+  const decodeValue = (_value: Payload | null | undefined): Promise<string> => {
+    if (!_value) return Promise.resolve(fallback);
 
-      if (!_value) return Promise.resolve(_fallback);
+    return decodePayloadAndParseDataToJSON(_value).then((result) => {
+      if (typeof result !== 'string' || !result) return fallback;
+      if (!prefix) return result;
+      const prefixed = `${prefix} • ${result}`;
+      return prefixed.length <= maxSummaryLength
+        ? prefixed
+        : prefixed.slice(0, maxSummaryLength) + '...';
+    });
+  };
 
-      return decodePayloadAndParseDataToJSON(_value).then((result) => {
-        if (typeof result !== 'string' || !result) return _fallback;
-        if (!_prefix) return result;
-        const prefixed = `${_prefix} • ${result}`;
-        return prefixed.length <= _max
-          ? prefixed
-          : prefixed.slice(0, _max) + '...';
-      });
-    })(),
-  );
+  const valueJson = $derived(stringifyWithBigInt(value));
+  const decodePromise = $derived.by(() => {
+    void valueJson;
+    void prefix;
+    void fallback;
+    void maxSummaryLength;
+    return decodeValue(untrack(() => value));
+  });
 
   $effect(() => {
     let cancelled = false;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

1. Updates `PayloadSummary` to decode by content, not by reference. Similar to the guard for `PayloadDecoder` added in https://github.com/temporalio/ui/pull/3401 as a follow-up to https://github.com/temporalio/ui/pull/3299. A summary that's already decoded now stays decoded across polls instead of re-hitting the codec server.
2. The "Child Workflow" timeline rendered inside an expanded event card (`GraphWidget`) now refreshes in place instead of re-fetching the child's full workflow + history on every tick (caused by a $derived/{#await getWorkflowAndEventHistory()} whose dependencies were being invalidated on every parent re-render). 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

**Prerequisites / setup**

* A codec server + encoded payloads (e.g. samples-typescript/encryption). Point the UI at it via Settings → Codec Server (set the endpoint).
* A long-running parent workflow that:
  - stays running (sleeps/loops so the UI keeps long-polling)
  - spawns many child workflows
  - sets user-metadata summaries on events — this is specifically what PayloadSummary in the timeline decodes (`group.userMetadata.summary`)

1. Open the running workflow's History / timeline view.
2. Click on a timeline row for a child
   - [ ] Verify the "Child Timeline" does not flash on every tick

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->


### Issue(s) closed <!-- add issue number here -->

`DT-4192`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
