### PR TITLE
feat(auth): add OIDC claim-based authorization (allowedClaimKey/allowedClaimValues)

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -43,18 +43,20 @@ auth:
 
 #### Provider Settings
 
-| Field                | Type    | Description                                                     |
-| -------------------- | ------- | --------------------------------------------------------------- |
-| `label`              | string  | Display name for the provider                                   |
-| `type`               | string  | Provider type. Only `oidc` is supported                         |
-| `providerUrl`        | string  | OIDC discovery URL (e.g., `https://accounts.google.com/`)       |
-| `issuerUrl`          | string  | Optional. Set only if issuer differs from provider URL          |
-| `clientId`           | string  | OAuth2 client ID                                                |
-| `clientSecret`       | string  | OAuth2 client secret                                            |
-| `scopes`             | array   | OAuth2 scopes. Include `offline_access` to enable token refresh |
-| `callbackUrl`        | string  | OAuth2 callback URL for your deployment                         |
-| `options`            | object  | Additional URL parameters for the auth redirect                 |
-| `useIdTokenAsBearer` | boolean | Use ID token instead of access token in Authorization header    |
+| Field                | Type    | Description                                                                  |
+| -------------------- | ------- | ---------------------------------------------------------------------------- |
+| `label`              | string  | Display name for the provider                                                |
+| `type`               | string  | Provider type. Only `oidc` is supported                                      |
+| `providerUrl`        | string  | OIDC discovery URL (e.g., `https://accounts.google.com/`)                    |
+| `issuerUrl`          | string  | Optional. Set only if issuer differs from provider URL                       |
+| `clientId`           | string  | OAuth2 client ID                                                             |
+| `clientSecret`       | string  | OAuth2 client secret                                                         |
+| `scopes`             | array   | OAuth2 scopes. Include `offline_access` to enable token refresh              |
+| `callbackUrl`        | string  | OAuth2 callback URL for your deployment                                      |
+| `options`            | object  | Additional URL parameters for the auth redirect                              |
+| `useIdTokenAsBearer` | boolean | Use ID token instead of access token in Authorization header                 |
+| `allowedClaimKey`    | string  | ID token claim to check for authorization (e.g., `groups`, `roles`). See [Claim-Based Authorization](#claim-based-authorization) |
+| `allowedClaimValues` | array   | List of acceptable values for the claim. User is allowed if ANY value matches |
 
 ## Session Duration Management
 
@@ -173,6 +175,129 @@ auth:
 
 Note: Google does not support `offline_access` scope. Token refresh depends on Google's token policies.
 
+## Claim-Based Authorization
+
+By default, the Temporal UI allows **any user** who can authenticate with your OIDC provider to access the UI. This can be a security risk when the UI is externally exposed and your OIDC provider serves a large tenant (e.g., an entire Azure AD / Entra ID directory).
+
+Claim-based authorization lets you restrict UI access to users whose ID token contains specific claim values, such as a group membership or role assignment.
+
+### How It Works
+
+1. After the OIDC token exchange succeeds, the server inspects the ID token's payload
+2. It looks for the claim specified by `allowedClaimKey` (supports nested claims via dot notation)
+3. It checks if the claim value (string or array) contains any value from `allowedClaimValues`
+4. If no match is found, the login is rejected with HTTP 403 Forbidden
+
+If `allowedClaimKey` is not set, all authenticated users are allowed (backward compatible).
+
+### Examples
+
+#### Azure AD / Entra ID (groups claim)
+
+```yaml
+auth:
+  enabled: true
+  providers:
+    - label: Azure AD
+      type: oidc
+      providerUrl: https://login.microsoftonline.com/{tenant-id}/v2.0
+      clientId: your-client-id
+      clientSecret: your-client-secret
+      scopes:
+        - openid
+        - profile
+        - email
+        - offline_access
+      callbackUrl: https://temporal-ui.example.com/auth/sso/callback
+      allowedClaimKey: groups
+      allowedClaimValues:
+        - "a1b2c3d4-e5f6-..."  # Object ID of your Entra ID group
+```
+
+> **Note:** Entra ID emits group **Object IDs** (GUIDs) in the `groups` claim by default, not display names. You can configure your app registration to emit group names instead.
+
+#### Keycloak (realm roles)
+
+```yaml
+auth:
+  enabled: true
+  providers:
+    - label: Keycloak
+      type: oidc
+      providerUrl: https://keycloak.example.com/realms/myrealm
+      clientId: your-client-id
+      clientSecret: your-client-secret
+      scopes:
+        - openid
+        - profile
+        - email
+      callbackUrl: https://temporal-ui.example.com/auth/sso/callback
+      allowedClaimKey: realm_access.roles  # dot notation for nested claims
+      allowedClaimValues:
+        - temporal-admin
+        - temporal-operator
+```
+
+#### Auth0 (custom roles claim)
+
+```yaml
+auth:
+  enabled: true
+  providers:
+    - label: Auth0
+      type: oidc
+      providerUrl: https://your-tenant.auth0.com/
+      clientId: your-client-id
+      clientSecret: your-client-secret
+      scopes:
+        - openid
+        - profile
+        - email
+      callbackUrl: https://temporal-ui.example.com/auth/sso/callback
+      allowedClaimKey: https://myapp.example.com/roles  # custom namespace claim
+      allowedClaimValues:
+        - temporal-admin
+```
+
+#### AWS Cognito (cognito:groups)
+
+```yaml
+auth:
+  enabled: true
+  providers:
+    - label: Cognito
+      type: oidc
+      providerUrl: https://cognito-idp.{region}.amazonaws.com/{user-pool-id}
+      clientId: your-client-id
+      clientSecret: your-client-secret
+      scopes:
+        - openid
+        - profile
+        - email
+      callbackUrl: https://temporal-ui.example.com/auth/sso/callback
+      allowedClaimKey: "cognito:groups"  # colon-containing key (treated as literal)
+      allowedClaimValues:
+        - temporal-admins
+```
+
+### Docker / Environment Variable Configuration
+
+When using the Docker image, set these environment variables:
+
+```bash
+TEMPORAL_AUTH_ALLOWED_CLAIM_KEY=groups
+TEMPORAL_AUTH_ALLOWED_CLAIM_VALUES=myApp-Admin,myApp-Ops
+```
+
+Multiple allowed values are comma-separated.
+
+### Important Notes
+
+- **Claim check happens at login only.** If a user is removed from a group mid-session, they retain access until their session expires or they log out. Use `maxSessionDuration` to bound this window.
+- **Both `allowedClaimKey` and `allowedClaimValues` must be set together.** Setting one without the other is a configuration error.
+- **Claim matching is exact.** Values are compared as exact strings — no wildcards or regex.
+- **Config changes require a server restart.** Changes to `allowedClaimKey` and `allowedClaimValues` (like other provider settings) take effect only after restarting the UI server.
+
 ## Security Considerations
 
 ### Callback URL
@@ -234,6 +359,16 @@ Check:
 - Token hasn't expired and refresh failed
 - `maxSessionDuration` hasn't been exceeded
 - Network allows communication with the IdP for token refresh
+
+### 403 Forbidden after OIDC login
+
+This means authentication succeeded but claim-based authorization failed. Check:
+
+- The user's ID token contains the claim specified by `allowedClaimKey`
+- The claim value matches one of the `allowedClaimValues` (exact string match)
+- For Entra ID: ensure the `groups` claim is configured in your app registration's token configuration
+- For Keycloak: verify the role mapper is configured to include roles in the ID token
+- Check server logs for `[Auth] Authorization denied` messages which include the specific error
 
 ## Testing Authentication Locally
 

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -65,6 +65,13 @@ auth:
       - {{ . }}
     {{- end }}
     {{- end }}
+    allowedClaimKey: {{ env "TEMPORAL_AUTH_ALLOWED_CLAIM_KEY" | default "" }}
+    allowedClaimValues:
+    {{- if env "TEMPORAL_AUTH_ALLOWED_CLAIM_VALUES" }}
+    {{- range env "TEMPORAL_AUTH_ALLOWED_CLAIM_VALUES" | split "," }}
+      - {{ . }}
+    {{- end }}
+    {{- end }}
 codec:
   endpoint: {{ env "TEMPORAL_CODEC_ENDPOINT" | default "" }}
   passAccessToken: {{ env "TEMPORAL_CODEC_PASS_ACCESS_TOKEN" | default "false" }}

--- a/server/server/auth/auth_test.go
+++ b/server/server/auth/auth_test.go
@@ -24,6 +24,8 @@ package auth_test
 
 import (
 	_ "embed"
+	"encoding/base64"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -216,4 +218,179 @@ func TestValidateAuthHeaderExists(t *testing.T) {
 			}
 		})
 	}
+}
+
+// fakeJWT creates a fake JWT with the given claims payload for testing.
+// The header and signature are placeholders since ValidateAllowedClaims
+// only reads the payload (the token is already verified at that point).
+func fakeJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	assert.NoError(t, err)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + payloadB64 + ".fake-signature"
+}
+
+func TestValidateAllowedClaims(t *testing.T) {
+	tests := []struct {
+		name          string
+		claims        map[string]interface{}
+		claimKey      string
+		allowedValues []string
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name:          "no allowlist configured - empty key",
+			claims:        map[string]interface{}{"groups": []interface{}{"admin"}},
+			claimKey:      "",
+			allowedValues: nil,
+			wantErr:       false,
+		},
+		{
+			name:          "no allowlist configured - empty values",
+			claims:        map[string]interface{}{"groups": []interface{}{"admin"}},
+			claimKey:      "groups",
+			allowedValues: []string{},
+			wantErr:       false,
+		},
+		{
+			name:          "flat string claim - matches",
+			claims:        map[string]interface{}{"role": "admin"},
+			claimKey:      "role",
+			allowedValues: []string{"admin", "superadmin"},
+			wantErr:       false,
+		},
+		{
+			name:          "flat string claim - no match",
+			claims:        map[string]interface{}{"role": "viewer"},
+			claimKey:      "role",
+			allowedValues: []string{"admin", "superadmin"},
+			wantErr:       true,
+			errContains:   "does not have any of the required values",
+		},
+		{
+			name:          "array claim - one match",
+			claims:        map[string]interface{}{"groups": []interface{}{"readers", "myApp-Admin", "users"}},
+			claimKey:      "groups",
+			allowedValues: []string{"myApp-Admin"},
+			wantErr:       false,
+		},
+		{
+			name:          "array claim - multiple allowed, one matches",
+			claims:        map[string]interface{}{"groups": []interface{}{"readers", "ops-team"}},
+			claimKey:      "groups",
+			allowedValues: []string{"myApp-Admin", "ops-team"},
+			wantErr:       false,
+		},
+		{
+			name:          "array claim - no match",
+			claims:        map[string]interface{}{"groups": []interface{}{"readers", "users"}},
+			claimKey:      "groups",
+			allowedValues: []string{"myApp-Admin", "ops-team"},
+			wantErr:       true,
+			errContains:   "does not have any of the required values",
+		},
+		{
+			name: "nested dot-notation claim - matches",
+			claims: map[string]interface{}{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"user", "temporal-admin"},
+				},
+			},
+			claimKey:      "realm_access.roles",
+			allowedValues: []string{"temporal-admin"},
+			wantErr:       false,
+		},
+		{
+			name: "nested dot-notation claim - no match",
+			claims: map[string]interface{}{
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"user", "viewer"},
+				},
+			},
+			claimKey:      "realm_access.roles",
+			allowedValues: []string{"temporal-admin"},
+			wantErr:       true,
+			errContains:   "does not have any of the required values",
+		},
+		{
+			name: "deeply nested claim - matches",
+			claims: map[string]interface{}{
+				"resource_access": map[string]interface{}{
+					"temporal": map[string]interface{}{
+						"roles": []interface{}{"admin"},
+					},
+				},
+			},
+			claimKey:      "resource_access.temporal.roles",
+			allowedValues: []string{"admin"},
+			wantErr:       false,
+		},
+		{
+			name:          "missing claim - error",
+			claims:        map[string]interface{}{"email": "user@example.com"},
+			claimKey:      "groups",
+			allowedValues: []string{"myApp-Admin"},
+			wantErr:       true,
+			errContains:   "not found in token",
+		},
+		{
+			name: "missing nested claim - error",
+			claims: map[string]interface{}{
+				"realm_access": map[string]interface{}{
+					"other": "value",
+				},
+			},
+			claimKey:      "realm_access.roles",
+			allowedValues: []string{"admin"},
+			wantErr:       true,
+			errContains:   "not found in token",
+		},
+		{
+			name:          "colon-containing key (cognito:groups) - matches",
+			claims:        map[string]interface{}{"cognito:groups": []interface{}{"temporal-admins"}},
+			claimKey:      "cognito:groups",
+			allowedValues: []string{"temporal-admins"},
+			wantErr:       false,
+		},
+		{
+			name:          "colon-containing key (cognito:groups) - no match",
+			claims:        map[string]interface{}{"cognito:groups": []interface{}{"readers"}},
+			claimKey:      "cognito:groups",
+			allowedValues: []string{"temporal-admins"},
+			wantErr:       true,
+			errContains:   "does not have any of the required values",
+		},
+		{
+			name:          "URL-namespaced claim key with dots - literal match",
+			claims:        map[string]interface{}{"https://myapp.example.com/roles": []interface{}{"admin"}},
+			claimKey:      "https://myapp.example.com/roles",
+			allowedValues: []string{"admin"},
+			wantErr:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := fakeJWT(t, tt.claims)
+			err := auth.ValidateAllowedClaims(token, tt.claimKey, tt.allowedValues)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAllowedClaims_MalformedToken(t *testing.T) {
+	err := auth.ValidateAllowedClaims("not-a-jwt", "groups", []string{"admin"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to decode token claims")
 }

--- a/server/server/auth/oidc.go
+++ b/server/server/auth/oidc.go
@@ -26,7 +26,11 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/labstack/echo/v4"
@@ -107,4 +111,110 @@ func ExchangeCode(ctx context.Context, r *http.Request, config *oauth2.Config, p
 	}
 
 	return &user, nil
+}
+
+// ValidateAllowedClaims checks whether the raw ID token contains a claim
+// matching the configured allowlist. It returns nil if no allowlist is
+// configured or if the user has an allowed claim value. It returns an error
+// if the user lacks the required claim.
+//
+// The claimKey supports dot notation for nested claims
+// (e.g., "realm_access.roles" for Keycloak).
+//
+// Both string and array claim values are supported. For arrays, the user is
+// authorized if ANY value in the claim matches ANY value in allowedValues.
+func ValidateAllowedClaims(rawIDToken string, claimKey string, allowedValues []string) error {
+	if claimKey == "" || len(allowedValues) == 0 {
+		return nil
+	}
+
+	allClaims, err := decodeJWTPayload(rawIDToken)
+	if err != nil {
+		return fmt.Errorf("unable to decode token claims: %w", err)
+	}
+
+	claimValue, found := getNestedClaim(allClaims, claimKey)
+	if !found {
+		return fmt.Errorf("required claim %q not found in token", claimKey)
+	}
+
+	if matchesAllowedValues(claimValue, allowedValues) {
+		return nil
+	}
+
+	return fmt.Errorf("user does not have any of the required values for claim %q", claimKey)
+}
+
+// decodeJWTPayload extracts and decodes the payload from a JWT.
+// The token is assumed to be already verified.
+func decodeJWTPayload(rawToken string) (map[string]interface{}, error) {
+	parts := strings.SplitN(rawToken, ".", 3)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed JWT: expected 3 parts, got %d", len(parts))
+	}
+
+	// JWT uses base64url encoding without padding
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode JWT payload: %w", err)
+	}
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, fmt.Errorf("unable to parse JWT payload: %w", err)
+	}
+
+	return claims, nil
+}
+
+// getNestedClaim retrieves a claim value using dot notation.
+// For example, "realm_access.roles" navigates into {"realm_access": {"roles": [...]}}.
+// Keys containing colons (e.g., "cognito:groups") are treated as literal keys first.
+func getNestedClaim(claims map[string]interface{}, key string) (interface{}, bool) {
+	// First, try the key as a literal (handles keys like "cognito:groups")
+	if val, ok := claims[key]; ok {
+		return val, true
+	}
+
+	// Then try dot-notation traversal
+	parts := strings.Split(key, ".")
+	if len(parts) == 1 {
+		return nil, false
+	}
+
+	var current interface{} = claims
+	for _, part := range parts {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// matchesAllowedValues checks if a claim value (string or array) contains
+// any of the allowed values.
+func matchesAllowedValues(claimValue interface{}, allowedValues []string) bool {
+	allowed := make(map[string]bool, len(allowedValues))
+	for _, v := range allowedValues {
+		allowed[v] = true
+	}
+
+	switch v := claimValue.(type) {
+	case string:
+		return allowed[v]
+	case []interface{}:
+		for _, item := range v {
+			if s, ok := item.(string); ok && allowed[s] {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/server/server/config/auth.go
+++ b/server/server/config/auth.go
@@ -53,7 +53,7 @@ func (c *AuthProvider) validate() error {
 	}
 
 	if c.ProviderURL == "" {
-		return errors.New("auth provider url is not")
+		return errors.New("auth provider url is not set")
 	}
 
 	if c.ClientID == "" {
@@ -62,6 +62,14 @@ func (c *AuthProvider) validate() error {
 
 	if c.CallbackURL == "" {
 		return errors.New("auth callback url is not set")
+	}
+
+	if c.AllowedClaimKey != "" && len(c.AllowedClaimValues) == 0 {
+		return errors.New("auth allowedClaimValues must be set when allowedClaimKey is configured")
+	}
+
+	if c.AllowedClaimKey == "" && len(c.AllowedClaimValues) > 0 {
+		return errors.New("auth allowedClaimKey must be set when allowedClaimValues is configured")
 	}
 
 	return nil

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -131,6 +131,15 @@ type (
 		Options map[string]interface{} `yaml:"options"`
 		// UseIDTokenAsBearer - Use ID token instead of access token as Bearer in Authorization header
 		UseIDTokenAsBearer bool `yaml:"useIdTokenAsBearer"`
+		// AllowedClaimKey is the OIDC ID token claim to check for authorization.
+		// Supports dot notation for nested claims (e.g., "realm_access.roles" for Keycloak).
+		// Common values: "groups" (Entra ID/Azure AD), "roles", "cognito:groups" (AWS Cognito).
+		// If empty, no claim-based authorization is performed (all authenticated users are allowed).
+		AllowedClaimKey string `yaml:"allowedClaimKey"`
+		// AllowedClaimValues is the list of acceptable values for the claim specified by AllowedClaimKey.
+		// If the claim is an array (e.g., groups), the user is authorized if ANY value in the claim
+		// matches ANY value in this list. If the claim is a string, it must match one of these values.
+		AllowedClaimValues []string `yaml:"allowedClaimValues"`
 	}
 
 	Codec struct {

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -110,8 +110,8 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 
 	api := e.Group("/auth")
 	api.GET("/sso", authenticate(&oauthCfg, providerCfg.Options, serverCfg.CORS.AllowOrigins))
-	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
-	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration)) // compatibility with UI v1
+	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration, providerCfg))
+	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration, providerCfg)) // compatibility with UI v1
 	api.GET("/refresh", refreshTokens(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
 	api.GET("/logout", logout())
 }
@@ -154,11 +154,23 @@ func authenticate(config *oauth2.Config, options map[string]interface{}, allowed
 	}
 }
 
-func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration) func(echo.Context) error {
+func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration, providerCfg config.AuthProvider) func(echo.Context) error {
 	return func(c echo.Context) error {
 		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
 			return err
+		}
+
+		// Claim-based authorization check: verify the user has required claim values
+		if providerCfg.AllowedClaimKey != "" && user.IDToken != nil {
+			if err := auth.ValidateAllowedClaims(
+				user.IDToken.RawToken,
+				providerCfg.AllowedClaimKey,
+				providerCfg.AllowedClaimValues,
+			); err != nil {
+				log.Printf("[Auth] Authorization denied for user: %v", err)
+				return echo.NewHTTPError(http.StatusForbidden, "access denied: insufficient permissions")
+			}
 		}
 
 		err = auth.SetUser(c, user)
@@ -224,6 +236,9 @@ func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.
 		user.OAuth2Token = newTok
 
 		// Try to capture a new ID token if provided and verify it
+		// TODO: Consider re-validating allowedClaimKey/allowedClaimValues on refresh
+		// in a future iteration. Most IdPs don't update group claims on token refresh,
+		// so this would only be effective after a full re-authentication.
 		if raw, ok := newTok.Extra("id_token").(string); ok && raw != "" {
 			oidcConfig := &oidc.Config{ClientID: oauthCfg.ClientID}
 			verifier := provider.Verifier(oidcConfig)

--- a/server/server/route/auth_integration_test.go
+++ b/server/server/route/auth_integration_test.go
@@ -1,0 +1,306 @@
+package route
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/temporalio/ui-server/v2/server/config"
+)
+
+// mockOIDCServer creates a minimal OIDC provider server for integration testing.
+// It serves discovery, JWKS, and token endpoints. The token endpoint returns an
+// ID token containing the specified extraClaims in addition to standard claims.
+//
+// The server stores a nonce that will be embedded in the ID token. The test must
+// call SetNonce before triggering the callback so the token's nonce matches the
+// cookie value that ExchangeCode validates.
+type mockOIDCServer struct {
+	Server      *httptest.Server
+	PrivateKey  *rsa.PrivateKey
+	ExtraClaims map[string]interface{}
+
+	mu    sync.Mutex
+	nonce string // nonce to embed in the ID token
+}
+
+func newMockOIDCServer(t *testing.T, extraClaims map[string]interface{}) *mockOIDCServer {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	m := &mockOIDCServer{
+		PrivateKey:  privateKey,
+		ExtraClaims: extraClaims,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", m.handleDiscovery)
+	mux.HandleFunc("/jwks", m.handleJWKS)
+	mux.HandleFunc("/token", m.handleToken)
+
+	m.Server = httptest.NewServer(mux)
+	return m
+}
+
+// SetNonce sets the nonce value that will be embedded in the next ID token.
+// This must match the nonce cookie value that ExchangeCode reads.
+func (m *mockOIDCServer) SetNonce(nonce string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nonce = nonce
+}
+
+func (m *mockOIDCServer) getNonce() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nonce
+}
+
+func (m *mockOIDCServer) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"issuer":                 m.Server.URL,
+		"authorization_endpoint": m.Server.URL + "/authorize",
+		"token_endpoint":         m.Server.URL + "/token",
+		"jwks_uri":               m.Server.URL + "/jwks",
+		"userinfo_endpoint":      m.Server.URL + "/userinfo",
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+	})
+}
+
+func (m *mockOIDCServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	jwk := jose.JSONWebKey{Key: &m.PrivateKey.PublicKey, Algorithm: "RS256", Use: "sig", KeyID: "test-key-1"}
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(jwks)
+}
+
+func (m *mockOIDCServer) handleToken(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+
+	// Build the ID token with standard + extra claims
+	now := time.Now()
+	claims := map[string]interface{}{
+		"iss":            m.Server.URL,
+		"sub":            "test-user-123",
+		"aud":            "test-client",
+		"email":          "test@example.com",
+		"email_verified": true,
+		"name":           "Test User",
+		"nonce":          m.getNonce(), // must match the nonce cookie value
+		"iat":            now.Unix(),
+		"exp":            now.Add(time.Hour).Unix(),
+	}
+	for k, v := range m.ExtraClaims {
+		claims[k] = v
+	}
+
+	// Sign the token
+	signerOpts := &jose.SignerOptions{}
+	signerOpts = signerOpts.WithHeader(jose.HeaderKey("kid"), "test-key-1")
+	signer, _ := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: m.PrivateKey},
+		signerOpts,
+	)
+	rawToken, _ := josejwt.Signed(signer).Claims(claims).Serialize()
+
+	// Respond with OAuth2 token response
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"access_token": "fake-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"id_token":     rawToken,
+	})
+}
+
+// TestAuthenticateCb_ClaimAuthorization is an integration test that verifies
+// the full OIDC callback flow with claim-based authorization.
+// It starts a mock OIDC server, configures the UI server's auth callback,
+// and verifies that users are allowed or denied based on their claims.
+func TestAuthenticateCb_ClaimAuthorization(t *testing.T) {
+	tests := []struct {
+		name           string
+		extraClaims    map[string]interface{} // claims to include in the ID token
+		allowedKey     string                 // config: allowedClaimKey
+		allowedValues  []string               // config: allowedClaimValues
+		expectStatus   int                    // expected HTTP status
+		expectRedirect bool                   // whether we expect a redirect to "/"
+	}{
+		{
+			name:           "no allowlist configured - all users allowed",
+			extraClaims:    map[string]interface{}{"groups": []string{"random-group"}},
+			allowedKey:     "",
+			allowedValues:  nil,
+			expectStatus:   http.StatusSeeOther,
+			expectRedirect: true,
+		},
+		{
+			name:           "user has required group - allowed",
+			extraClaims:    map[string]interface{}{"groups": []string{"readers", "temporal-admins", "users"}},
+			allowedKey:     "groups",
+			allowedValues:  []string{"temporal-admins"},
+			expectStatus:   http.StatusSeeOther,
+			expectRedirect: true,
+		},
+		{
+			name:           "user has one of multiple allowed groups - allowed",
+			extraClaims:    map[string]interface{}{"groups": []string{"ops-team"}},
+			allowedKey:     "groups",
+			allowedValues:  []string{"temporal-admins", "ops-team"},
+			expectStatus:   http.StatusSeeOther,
+			expectRedirect: true,
+		},
+		{
+			name:          "user lacks required group - denied",
+			extraClaims:   map[string]interface{}{"groups": []string{"readers", "users"}},
+			allowedKey:    "groups",
+			allowedValues: []string{"temporal-admins"},
+			expectStatus:  http.StatusForbidden,
+		},
+		{
+			name:          "user has no groups claim at all - denied",
+			extraClaims:   map[string]interface{}{},
+			allowedKey:    "groups",
+			allowedValues: []string{"temporal-admins"},
+			expectStatus:  http.StatusForbidden,
+		},
+		{
+			name: "nested claim (Keycloak-style) - allowed",
+			extraClaims: map[string]interface{}{
+				"realm_access": map[string]interface{}{
+					"roles": []string{"user", "temporal-admin"},
+				},
+			},
+			allowedKey:     "realm_access.roles",
+			allowedValues:  []string{"temporal-admin"},
+			expectStatus:   http.StatusSeeOther,
+			expectRedirect: true,
+		},
+		{
+			name: "nested claim (Keycloak-style) - denied",
+			extraClaims: map[string]interface{}{
+				"realm_access": map[string]interface{}{
+					"roles": []string{"user", "viewer"},
+				},
+			},
+			allowedKey:    "realm_access.roles",
+			allowedValues: []string{"temporal-admin"},
+			expectStatus:  http.StatusForbidden,
+		},
+		{
+			name:           "string claim match - allowed",
+			extraClaims:    map[string]interface{}{"role": "admin"},
+			allowedKey:     "role",
+			allowedValues:  []string{"admin", "superadmin"},
+			expectStatus:   http.StatusSeeOther,
+			expectRedirect: true,
+		},
+		{
+			name:          "string claim no match - denied",
+			extraClaims:   map[string]interface{}{"role": "viewer"},
+			allowedKey:    "role",
+			allowedValues: []string{"admin", "superadmin"},
+			expectStatus:  http.StatusForbidden,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Start a mock OIDC server with the test's extra claims
+			oidcServer := newMockOIDCServer(t, tt.extraClaims)
+			defer oidcServer.Server.Close()
+
+			// Create the provider config
+			providerCfg := config.AuthProvider{
+				Label:              "test",
+				Type:               "oidc",
+				ProviderURL:        oidcServer.Server.URL,
+				ClientID:           "test-client",
+				ClientSecret:       "test-secret",
+				CallbackURL:        "http://localhost/auth/sso/callback",
+				Scopes:             []string{"openid", "profile", "email"},
+				AllowedClaimKey:    tt.allowedKey,
+				AllowedClaimValues: tt.allowedValues,
+			}
+
+			// Build the full server config
+			serverCfg := &config.Config{
+				TemporalGRPCAddress: "127.0.0.1:7233",
+				Auth: config.Auth{
+					Enabled:   true,
+					Providers: []config.AuthProvider{providerCfg},
+				},
+			}
+
+			// Create config provider
+			cfgProvider, err := config.NewConfigProviderWithRefresh(serverCfg)
+			require.NoError(t, err)
+
+			// Set up the Echo instance with auth routes
+			e := echo.New()
+			SetAuthRoutes(e, cfgProvider)
+
+			// Generate a nonce (the base64-encoded JSON struct used as cookie value).
+			// The OIDC server must embed this exact value in the ID token's nonce claim
+			// because ExchangeCode compares idToken.Nonce == cookie("nonce").Value.
+			nonceCookie, err := randNonce(
+				e.NewContext(
+					httptest.NewRequest(http.MethodGet, "/", nil),
+					httptest.NewRecorder(),
+				),
+				nil,
+			)
+			require.NoError(t, err)
+
+			// Tell the mock OIDC server what nonce to embed in the ID token
+			oidcServer.SetNonce(nonceCookie)
+
+			state, err := randString()
+			require.NoError(t, err)
+
+			// Build the callback request with code, state, and cookies
+			path := fmt.Sprintf("/auth/sso/callback?code=test-auth-code&state=%s", state)
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req.AddCookie(&http.Cookie{Name: "state", Value: state})
+			req.AddCookie(&http.Cookie{Name: "nonce", Value: nonceCookie})
+
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			// Find and execute the callback handler
+			e.Router().Find(http.MethodGet, "/auth/sso/callback", ctx)
+			err = ctx.Handler()(ctx)
+
+			if tt.expectStatus == http.StatusForbidden {
+				// Echo wraps errors as HTTPError
+				assert.Error(t, err)
+				httpErr, ok := err.(*echo.HTTPError)
+				require.True(t, ok, "expected echo.HTTPError, got %T", err)
+				assert.Equal(t, http.StatusForbidden, httpErr.Code)
+				assert.Contains(t, httpErr.Message, "access denied")
+			} else if tt.expectRedirect {
+				// Successful auth results in a redirect
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				assert.Equal(t, tt.expectStatus, rec.Code)
+				location := rec.Header().Get("Location")
+				assert.Equal(t, "/", location)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description & motivation 💭

Closes #3562

Currently, the Temporal UI allows **any user** who can authenticate with the configured OIDC provider to access the UI. This is a security gap when the UI is externally exposed and the OIDC provider serves a large tenant (e.g., an entire Azure AD / Entra ID directory).

This PR adds **claim-based authorization** — two new `AuthProvider` config fields that let operators restrict UI login to users whose ID token contains specific claim values (e.g., a group membership or role).

### New Config Fields

```yaml
auth:
  providers:
    - # ... existing fields ...
      allowedClaimKey: groups            # claim to check
      allowedClaimValues:                # allowlist of values
        - temporal-admins
```

### Docker Env Vars

```
TEMPORAL_AUTH_ALLOWED_CLAIM_KEY=groups
TEMPORAL_AUTH_ALLOWED_CLAIM_VALUES=temporal-admins,temporal-ops
```

### Key Design Decisions

- **Claim check at login only.** After `ExchangeCode` succeeds but before `SetUser`, the callback inspects the ID token payload. If the user lacks the required claim, login is rejected with 403. Most IdPs don't update group claims on token refresh, so re-checking on refresh would give false confidence. `maxSessionDuration` already bounds the window.
- **Supports nested claims via dot notation** (e.g., `realm_access.roles` for Keycloak) and literal keys containing colons (e.g., `cognito:groups` for AWS Cognito) or dots (e.g., Auth0 URL-namespaced claims).
- **Both string and array claims** are supported. For arrays, the user is authorized if ANY value matches ANY allowedValue.
- **Generic 403 response** — the HTTP body says "access denied: insufficient permissions" without leaking which claim is checked. Detailed reason is server-logged only.
- **Fully backward compatible** — if neither field is set, behavior is identical to today.

### Design Considerations 🎨

None — this is purely server-side config with no UI changes.

## Testing 🧪

- [x] Unit tests added

### How was this tested 👻

16 new unit tests in `server/server/auth/auth_test.go` covering:
- No allowlist configured (noop) — both empty key and empty values
- Flat string claims — match and no-match
- Array claims — single match, multi-allowed, no match
- Nested dot-notation — 2-level and 3-level deep
- Missing claims and missing nested paths
- Colon-containing keys (`cognito:groups`)
- URL-namespaced keys with dots (`https://myapp.example.com/roles`)
- Malformed JWT input

All existing tests pass. `go vet` clean on all modified packages.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Configure `allowedClaimKey: groups` and `allowedClaimValues: ["test-group"]` in a provider
2. Start with `pnpm dev:with-auth` (the mock OIDC server)
3. Login — if the mock token includes `groups: ["test-group"]`, access is granted; otherwise 403

## Checklists

### Merge Checklist

- [x] Code compiles (`go vet` clean)
- [x] All existing tests pass
- [x] New unit tests added (16 cases)
- [x] Documentation updated (`AUTHENTICATION.md`)
- [x] Docker config template updated (`docker.yaml`)
- [x] Config validation added (both fields must be set together)
- [x] No breaking changes

### Issue(s) closed

Closes #3562

## Docs

### Any docs updates needed?

`AUTHENTICATION.md` has been updated with:
- Provider settings reference table (2 new fields)
- New "Claim-Based Authorization" section with examples for Azure AD/Entra ID, Keycloak, Auth0, and AWS Cognito
- Docker env var documentation
- Troubleshooting entry for 403 errors after login
