### PR TITLE
fix(a11y): add scope="col" to all table column headers (SC 1.3.1)

### DIFF
--- a/eslint-rules/th-has-scope.js
+++ b/eslint-rules/th-has-scope.js
@@ -1,0 +1,56 @@
+/**
+ * Local ESLint plugin: enforce that every <th> has a `scope` attribute.
+ *
+ * WCAG 2.1 SC 1.3.1 (Info and Relationships): table header cells must be
+ * programmatically associated with their data cells. This codebase is
+ * entirely column-oriented, so the correct association is `scope="col"`.
+ * The rule autofixes any bare <th> to `<th scope="col">`.
+ */
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'require a `scope` attribute on every <th> element',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      missingScope:
+        '<th> is missing a `scope` attribute (WCAG 2.1 SC 1.3.1). Add scope="col" for column headers.',
+    },
+  },
+  create(context) {
+    return {
+      SvelteElement(node) {
+        if (node.kind !== 'html') return;
+        if (!node.name || node.name.name !== 'th') return;
+
+        const attributes = node.startTag?.attributes ?? [];
+        const hasScope = attributes.some(
+          (attr) =>
+            attr.type === 'SvelteAttribute' && attr.key?.name === 'scope',
+        );
+        if (hasScope) return;
+
+        context.report({
+          node,
+          messageId: 'missingScope',
+          fix(fixer) {
+            return fixer.insertTextAfterRange(node.name.range, ' scope="col"');
+          },
+        });
+      },
+    };
+  },
+};
+
+export default {
+  meta: {
+    name: 'eslint-plugin-local',
+    version: '1.0.0',
+  },
+  rules: {
+    'th-has-scope': rule,
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,6 +8,8 @@ import pluginVitest from 'eslint-plugin-vitest';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
+import local from './eslint-rules/th-has-scope.js';
+
 const sharedGlobals = {
   ...globals.browser,
   ...globals.es2017,
@@ -123,9 +125,10 @@ export default [
         extraFileExtensions: ['.svelte'],
       },
     },
-    plugins: sharedPlugins,
+    plugins: { ...sharedPlugins, local },
     rules: {
       ...sharedRules,
+      'local/th-has-scope': 'warn',
       'svelte/require-each-key': 'warn',
       'svelte/no-reactive-reassign': 'warn',
       'svelte/no-reactive-functions': 'warn',
@@ -145,6 +148,7 @@ export default [
   {
     ignores: [
       '**/*.cjs',
+      'eslint-rules/**',
       'server/**',
       '**/error-boundary.svelte',
       '.svelte-kit/**',

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table.svelte
@@ -47,7 +47,7 @@
       {translate('standalone-activities.standalone-activities')}
     </caption>
     <TableHeaderRow slot="headers">
-      <th></th>
+      <th scope="col"></th>
       {#each columns as column}
         <TableHeaderCell {column} />
       {/each}

--- a/src/lib/holocene/skeleton/skeleton-table.stories.svelte
+++ b/src/lib/holocene/skeleton/skeleton-table.stories.svelte
@@ -30,7 +30,7 @@
   <SkeletonTable {columnWidths} {...args}>
     <svelte:fragment slot="headers">
       {#each Array(args.columns) as _, index}
-        <th>Heading {index + 1}</th>
+        <th scope="col">Heading {index + 1}</th>
       {/each}
     </svelte:fragment>
   </SkeletonTable>

--- a/src/lib/holocene/skeleton/table.svelte
+++ b/src/lib/holocene/skeleton/table.svelte
@@ -16,7 +16,7 @@
   <TableHeaderRow slot="headers" class="h-8">
     <slot name="headers">
       {#each Array.from(new Array(columns)) as _column, index}
-        <th style="width: {columnWidths[index]}%;"></th>
+        <th scope="col" style="width: {columnWidths[index]}%;"></th>
       {/each}
     </slot>
   </TableHeaderRow>

--- a/src/lib/holocene/table/table.stories.svelte
+++ b/src/lib/holocene/table/table.stories.svelte
@@ -29,7 +29,7 @@
   <Table class="w-full" updating={args.updating} data-testid={context.id}>
     <tr slot="headers">
       {#each Array(args.columns) as _, index}
-        <th>Heading {index + 1}</th>
+        <th scope="col">Heading {index + 1}</th>
       {/each}
     </tr>
     {#each Array(args.rows) as _}

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -84,13 +84,13 @@
         {translate('deployments.deployments')}
       </caption>
       <tr slot="headers">
-        <th>{translate('deployments.build-id')}</th>
-        <th>{translate('deployments.build-status')}</th>
+        <th scope="col">{translate('deployments.build-id')}</th>
+        <th scope="col">{translate('deployments.build-status')}</th>
         <CapabilityGuard capability="serverScaledDeployments">
-          <th>{translate('deployments.compute')}</th>
+          <th scope="col">{translate('deployments.compute')}</th>
         </CapabilityGuard>
-        <th>{translate('deployments.deployed')}</th>
-        <th>{translate('deployments.actions')}</th>
+        <th scope="col">{translate('deployments.deployed')}</th>
+        <th scope="col">{translate('deployments.actions')}</th>
       </tr>
       {#each visibleItems as version (version.version)}
         <VersionTableRow

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -59,7 +59,7 @@
       >
       <tr slot="headers" class="text-left">
         {#each columns as { label } (label)}
-          <th>{label}</th>
+          <th scope="col">{label}</th>
         {/each}
       </tr>
       {#each visibleItems as deployment}

--- a/src/lib/pages/nexus-endpoint.svelte
+++ b/src/lib/pages/nexus-endpoint.svelte
@@ -114,7 +114,7 @@
           >{translate('nexus.allowed-caller-namespaces')}</caption
         >
         <TableHeaderRow slot="headers">
-          <th class="w-full">{translate('common.name')}</th>
+          <th scope="col" class="w-full">{translate('common.name')}</th>
         </TableHeaderRow>
         {#each visibleItems as namespace (namespace)}
           <TableRow>

--- a/src/lib/pages/schedules.svelte
+++ b/src/lib/pages/schedules.svelte
@@ -156,7 +156,7 @@
     >
     <tr slot="headers" class="text-left">
       {#each columns as { label }}
-        <th>{label}</th>
+        <th scope="col">{label}</th>
       {/each}
     </tr>
     {#each visibleItems as schedule}

--- a/src/lib/pages/workflow-nexus-links.svelte
+++ b/src/lib/pages/workflow-nexus-links.svelte
@@ -59,10 +59,10 @@
         >{translate('workflows.workers-tab')}</caption
       >
       <TableHeaderRow slot="headers">
-        <th class="w-24">{translate('nexus.caller-event')}</th>
-        <th>{translate('nexus.caller-workflow')}</th>
-        <th>{translate('nexus.caller-namespace')}</th>
-        <th>{translate('nexus.handler-event')}</th>
+        <th scope="col" class="w-24">{translate('nexus.caller-event')}</th>
+        <th scope="col">{translate('nexus.caller-workflow')}</th>
+        <th scope="col">{translate('nexus.caller-namespace')}</th>
+        <th scope="col">{translate('nexus.handler-event')}</th>
       </TableHeaderRow>
       {#each inboundLinkEvents as event}
         {@const link = getInboundLinkForEvent(event)}
@@ -117,13 +117,13 @@
         >{translate('workflows.workers-tab')}</caption
       >
       <TableHeaderRow slot="headers">
-        <th class="w-28">{translate('nexus.source-event')}</th>
-        <th>{translate('nexus.nexus-endpoint-simple')}</th>
-        <th>{translate('nexus.nexus-service')}</th>
-        <th>{translate('nexus.nexus-operation')}</th>
-        <th>{translate('nexus.handler-namespace')}</th>
-        <th>{translate('nexus.handler-workflow')}</th>
-        <th>{translate('nexus.handler-event')}</th>
+        <th scope="col" class="w-28">{translate('nexus.source-event')}</th>
+        <th scope="col">{translate('nexus.nexus-endpoint-simple')}</th>
+        <th scope="col">{translate('nexus.nexus-service')}</th>
+        <th scope="col">{translate('nexus.nexus-operation')}</th>
+        <th scope="col">{translate('nexus.handler-namespace')}</th>
+        <th scope="col">{translate('nexus.handler-workflow')}</th>
+        <th scope="col">{translate('nexus.handler-event')}</th>
       </TableHeaderRow>
       {#each nexusGroups as group}
         {@const link = group.links?.[0]}

--- a/src/routes/(app)/namespaces/+page.svelte
+++ b/src/routes/(app)/namespaces/+page.svelte
@@ -33,7 +33,7 @@
         >{translate('common.namespaces')}</caption
       >
       <TableHeaderRow slot="headers">
-        <th>{translate('common.name')}</th>
+        <th scope="col">{translate('common.name')}</th>
       </TableHeaderRow>
       {#each visibleItems as namespace (namespace.namespaceInfo.name)}
         <TableRow>

--- a/src/routes/(app)/namespaces/[namespace]/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/+page.svelte
@@ -83,7 +83,7 @@
         )}`}</caption
       >
       <tr slot="headers">
-        <th colspan="2">
+        <th scope="col" colspan="2">
           <h3>{translate('common.details')}</h3>
         </th>
       </tr>
@@ -158,7 +158,7 @@
         >{translate('namespaces.versions')}</caption
       >
       <tr slot="headers">
-        <th colspan="2">
+        <th scope="col" colspan="2">
           <h3>{translate('namespaces.versions')}</h3>
         </th>
       </tr>
@@ -181,7 +181,7 @@
       >
 
       <tr slot="headers">
-        <th colspan="2">
+        <th scope="col" colspan="2">
           <h3>
             {translate('namespaces.client-actions')}
           </h3>
@@ -264,8 +264,8 @@
         >{translate('events.attribute-group.search-attributes')}</caption
       >
       <TableHeaderRow slot="headers">
-        <th>{translate('common.key')}</th>
-        <th>{translate('common.type')}</th>
+        <th scope="col">{translate('common.key')}</th>
+        <th scope="col">{translate('common.type')}</th>
       </TableHeaderRow>
       {#each Object.entries($searchAttributes) as [key, type]}
         <TableRow>

--- a/src/routes/(app)/nexus/+page.svelte
+++ b/src/routes/(app)/nexus/+page.svelte
@@ -30,9 +30,9 @@
   {/snippet}
   {#snippet headers()}
     <TableHeaderRow>
-      <th>Name</th>
-      <th>Last Updated</th>
-      <th>Created On</th>
+      <th scope="col">Name</th>
+      <th scope="col">Last Updated</th>
+      <th scope="col">Created On</th>
     </TableHeaderRow>
   {/snippet}
   {#snippet columns(endpoint)}


### PR DESCRIPTION
## Description & motivation 💭

Every `<th>` in the UI was missing a `scope` attribute, so screen readers couldn't associate header cells with their data cells — a violation of **WCAG 2.1 SC 1.3.1 (Info and Relationships)**. Severity: **Serious**.

This codebase is entirely column-oriented (body cells are always `<td>`; no row-header tables), so the fix is uniform: `scope="col"` on every `<th>`.

- Added `scope="col"` to the 32 previously-bare `<th>` elements across workflow / standalone-activity / batch / worker tables, schedules, deployments, nexus endpoints & links, the namespaces routes, and the Holocene skeleton/stories demos (including the functional checkbox/spacer/batch-actions header cells).
- Added a local ESLint plugin `eslint-rules/th-has-scope.js` (ESLint 9 flat config, using eslint-plugin-svelte's `SvelteElement` AST) that flags any `<th>` without a `scope` attribute and autofixes to `scope="col"`. Wired into `eslint.config.js` for `**/*.svelte` at `warn` (`local/th-has-scope`), with `eslint-rules/**` added to `ignores`.

### Screenshots (if applicable) 📸

N/A — semantic/attribute-only change, no visual difference.

### Design Considerations 🎨

None.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

- `grep -rnE '<th[ >]' --include='*.svelte' src/ | grep -v 'scope=' | grep -v '<!--'` returns nothing.
- `pnpm lint` — 0 errors.
- `pnpm check` — 0 errors.
- Verified the new ESLint rule both flags a bare `<th>` and autofixes it to `<th scope="col">`.
- Playwright a11y suite (`scope-attr-valid` / `td-has-header`) not run locally — the test `webServer` couldn't start in this environment; should be exercised in CI.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Run `pnpm exec playwright test tests/accessibility/` and confirm the axe `scope-attr-valid` and `td-has-header` rules pass.
2. Add a bare `<th>` to any `.svelte` file and run `pnpm lint` — `local/th-has-scope` should warn and `--fix` should insert `scope="col"`.

## Checklists

### Draft Checklist

- [ ] Confirm Playwright a11y suite passes in CI

### Merge Checklist

### Issue(s) closed

## Docs

### Any docs updates needed?

No.
