### PR TITLE
Clarify activity pause timeout behavior

### DIFF
--- a/src/lib/components/activity/activity-commands.svelte
+++ b/src/lib/components/activity/activity-commands.svelte
@@ -53,7 +53,7 @@
     width={200}
     text={activity.paused
       ? 'Resume this Activity'
-      : 'Pauses this Activity, starting before it retries or the next time it heartbeats. It won’t time out while it’s paused.'}
+      : 'Pauses this Activity before its next retry or heartbeat. Timeout deadlines continue while paused.'}
   >
     <Button
       variant="secondary"

--- a/src/lib/components/activity/activity-commands.svelte
+++ b/src/lib/components/activity/activity-commands.svelte
@@ -52,8 +52,8 @@
     bottomLeft
     width={200}
     text={activity.paused
-      ? 'Resume this Activity'
-      : 'Pauses this Activity before its next retry or heartbeat. Timeout deadlines continue while paused.'}
+      ? translate('activities.resume-tooltip')
+      : translate('activities.pause-tooltip')}
   >
     <Button
       variant="secondary"

--- a/src/lib/components/activity/activity-pause-confirmation-modal.svelte
+++ b/src/lib/components/activity/activity-pause-confirmation-modal.svelte
@@ -2,6 +2,7 @@
   import type { WorkflowExecution } from '@temporalio/client';
 
   import Input from '$lib/holocene/input/input.svelte';
+  import Link from '$lib/holocene/link.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
   import { Action } from '$lib/models/workflow-actions';
@@ -63,6 +64,14 @@
   </h3>
   <div slot="content" class="flex flex-col gap-4">
     <p>{translate('activities.pause-modal-description')}</p>
+    <p>
+      <Link
+        newTab
+        href="https://docs.temporal.io/activity-operations#important-considerations"
+      >
+        {translate('activities.pause-modal-docs-link')}
+      </Link>
+    </p>
     <Input
       id="activity-pause-reason"
       class="mt-4"

--- a/src/lib/components/activity/activity-pause-confirmation-modal.svelte
+++ b/src/lib/components/activity/activity-pause-confirmation-modal.svelte
@@ -62,16 +62,16 @@
       activityId: activity.id,
     })}
   </h3>
-  <div slot="content" class="flex flex-col gap-4">
+  <div slot="content">
     <p>{translate('activities.pause-modal-description')}</p>
-    <p>
-      <Link
-        newTab
-        href="https://docs.temporal.io/activity-operations#important-considerations"
-      >
-        {translate('activities.pause-modal-docs-link')}
-      </Link>
-    </p>
+    <Link
+      newTab
+      trailingIcon="book"
+      href="https://docs.temporal.io/activity-operations#important-considerations"
+      class="mt-1"
+    >
+      {translate('activities.pause-modal-docs-link')}
+    </Link>
     <Input
       id="activity-pause-reason"
       class="mt-4"

--- a/src/lib/i18n/locales/en/activities.ts
+++ b/src/lib/i18n/locales/en/activities.ts
@@ -2,7 +2,9 @@ export const Namespace = 'activities' as const;
 
 export const Strings = {
   'pause-modal-confirmation': 'Pause Activity {{activityId}}',
-  'pause-modal-description': 'Pause executing this Activity.',
+  'pause-modal-description':
+    'Pause stops new attempts, but Activity timeout deadlines continue. Use Update Activity Options to extend timeouts before a long pause.',
+  'pause-modal-docs-link': 'Important considerations',
   'unpause-modal-confirmation': 'Unpause Activity {{activityId}}',
   'unpause-modal-description': 'Resume executing this Activity.',
   'paused-since': 'Paused Since',

--- a/src/lib/i18n/locales/en/activities.ts
+++ b/src/lib/i18n/locales/en/activities.ts
@@ -15,4 +15,7 @@ export const Strings = {
     'Reset the execution of this Activity back to the initial attempt.',
   'reset-heartbeat-details': 'Reset Heartbeat Details (optional)',
   'reset-success': 'Activity {{activityId}} has been reset successfully.',
+  'resume-tooltip': 'Resume this Activity',
+  'pause-tooltip':
+    'Pauses this Activity before its next retry or heartbeat. Timeout deadlines continue while paused.',
 };


### PR DESCRIPTION
## What changed

- Corrects the Activity pause button tooltip so it no longer says a paused Activity cannot time out.
- Updates the pause confirmation modal to explain that timeout deadlines continue while paused.
- Adds a link from the modal to the Activity Operations important considerations docs.

## Why

The previous tooltip said, "It won’t time out while it’s paused," which conflicts with Activity Operations behavior: Pause stops new attempts, but timeout deadlines continue unless options are updated.

## Validation

- Ran `git diff --check` locally.
- Did not run full UI checks because this environment does not have `pnpm` or `corepack` installed.