### PR TITLE
Add existing versions to worker create deployment version form

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -13,7 +13,7 @@
 
   import ComputeFields from './compute-fields.svelte';
   import ComputeProviderPicker from './compute-provider-picker.svelte';
-  import ExistingVersions from './existing-versions.svelte';
+  import RecentVersions from './recent-versions.svelte';
 
   interface Props {
     onSubmit: (data: CreateVersionFormData) => Promise<void>;
@@ -80,7 +80,7 @@
         placeholder="1.0.0"
         required
       />
-      <ExistingVersions {versions} />
+      <RecentVersions {versions} />
     </Card>
 
     <Card class="p-5">

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -7,19 +7,22 @@
   import Card from '$lib/holocene/card.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
+  import type { VersionSummary } from '$lib/types/deployments';
 
   import { type CreateVersionFormData, createVersionSchema } from './shared';
 
   import ComputeFields from './compute-fields.svelte';
   import ComputeProviderPicker from './compute-provider-picker.svelte';
+  import ExistingVersions from './existing-versions.svelte';
 
   interface Props {
     onSubmit: (data: CreateVersionFormData) => Promise<void>;
     cancelHref: string;
     error?: string;
+    versions?: VersionSummary[];
   }
 
-  let { onSubmit, cancelHref, error }: Props = $props();
+  let { onSubmit, cancelHref, error, versions = [] }: Props = $props();
 
   const superform = superForm(
     {
@@ -65,7 +68,7 @@
         {translate('workers.configuration-section')}
       </h3>
       <p class="mb-4 text-sm text-secondary">
-        {translate('workers.configuration-description')}
+        {translate('workers.version-configuration-description')}
       </p>
       <Input
         bind:value={$form.buildId}
@@ -77,6 +80,7 @@
         placeholder="1.0.0"
         required
       />
+      <ExistingVersions {versions} />
     </Card>
 
     <Card class="p-5">

--- a/src/lib/components/workers/serverless-worker-form/existing-versions.svelte
+++ b/src/lib/components/workers/serverless-worker-form/existing-versions.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import DeploymentStatus from '$lib/components/deployments/deployment-status.svelte';
+  import Timestamp from '$lib/components/timestamp.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import {
+    isVersionSummaryNew,
+    type VersionSummary,
+  } from '$lib/types/deployments';
+  import { parseVersionStatus } from '$lib/utilities/deployments';
+  import { getBuildIdFromVersion } from '$lib/utilities/get-deployment-build-id';
+
+  interface Props {
+    versions: VersionSummary[];
+  }
+
+  let { versions }: Props = $props();
+
+  const getBuildId = (version: VersionSummary): string =>
+    isVersionSummaryNew(version)
+      ? version.deploymentVersion.buildId
+      : getBuildIdFromVersion(version.version);
+
+  const getStatus = (version: VersionSummary) =>
+    parseVersionStatus(
+      isVersionSummaryNew(version) ? version.status : version.drainageStatus,
+    );
+</script>
+
+{#if versions?.length}
+  <div class="mt-4">
+    <h3 id="existing-versions-title" class="text-sm font-medium">
+      {translate('workers.existing-versions')}
+    </h3>
+    <ol class="flex flex-col" aria-labelledby="existing-versions-title">
+      {#each versions as version, index (index)}
+        {@const { status, label } = getStatus(version)}
+        <li
+          class="flex w-full items-start justify-between gap-2 border-b border-subtle py-2 last-of-type:border-b-0"
+        >
+          <div class="flex flex-wrap items-center gap-2 truncate">
+            <span class="select-all truncate font-mono text-sm"
+              >{getBuildId(version)}</span
+            >
+            <DeploymentStatus {status} {label} />
+          </div>
+          <Timestamp
+            class="shrink-0 text-sm text-secondary"
+            as="span"
+            dateTime={version.createTime}
+            options={{ relative: true }}
+          />
+        </li>
+      {/each}
+    </ol>
+  </div>
+{/if}

--- a/src/lib/components/workers/serverless-worker-form/existing-versions.svelte
+++ b/src/lib/components/workers/serverless-worker-form/existing-versions.svelte
@@ -7,6 +7,7 @@
     type VersionSummary,
   } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
+  import { getMilliseconds } from '$lib/utilities/format-time';
   import { getBuildIdFromVersion } from '$lib/utilities/get-deployment-build-id';
 
   interface Props {
@@ -14,6 +15,17 @@
   }
 
   let { versions }: Props = $props();
+
+  const MAX_VERSIONS = 5;
+  const sortedVersions = $derived(
+    [...versions].sort(
+      (a, b) => getMilliseconds(b.createTime) - getMilliseconds(a.createTime),
+    ),
+  );
+  const visibleVersions = $derived(sortedVersions.slice(0, MAX_VERSIONS));
+  const hiddenCount = $derived(
+    Math.max(sortedVersions.length - MAX_VERSIONS, 0),
+  );
 
   const getBuildId = (version: VersionSummary): string =>
     isVersionSummaryNew(version)
@@ -26,13 +38,13 @@
     );
 </script>
 
-{#if versions?.length}
+{#if visibleVersions.length}
   <div class="mt-4">
     <h3 id="existing-versions-title" class="text-sm font-medium">
       {translate('workers.existing-versions')}
     </h3>
     <ol class="flex flex-col" aria-labelledby="existing-versions-title">
-      {#each versions as version, index (index)}
+      {#each visibleVersions as version, index (index)}
         {@const { status, label } = getStatus(version)}
         <li
           class="flex w-full items-start justify-between gap-2 border-b border-subtle py-2 last-of-type:border-b-0"
@@ -52,5 +64,10 @@
         </li>
       {/each}
     </ol>
+    {#if hiddenCount > 0}
+      <span class="mt-1 text-xs text-secondary">
+        {translate('workers.existing-versions-more', { count: hiddenCount })}
+      </span>
+    {/if}
   </div>
 {/if}

--- a/src/lib/components/workers/serverless-worker-form/recent-versions.svelte
+++ b/src/lib/components/workers/serverless-worker-form/recent-versions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import DeploymentStatus from '$lib/components/deployments/deployment-status.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
+  import Button from '$lib/holocene/button.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     isVersionSummaryNew,
@@ -16,16 +17,21 @@
 
   let { versions }: Props = $props();
 
-  const MAX_VERSIONS = 5;
+  const DEFAULT_VISIBLE = 5;
+  let visibleCount = $state(DEFAULT_VISIBLE);
   const sortedVersions = $derived(
     [...versions].sort(
       (a, b) => getMilliseconds(b.createTime) - getMilliseconds(a.createTime),
     ),
   );
-  const visibleVersions = $derived(sortedVersions.slice(0, MAX_VERSIONS));
+  const visibleVersions = $derived(sortedVersions.slice(0, visibleCount));
   const hiddenCount = $derived(
-    Math.max(sortedVersions.length - MAX_VERSIONS, 0),
+    Math.max(sortedVersions.length - visibleCount, 0),
   );
+
+  const loadMore = () => {
+    visibleCount += DEFAULT_VISIBLE;
+  };
 
   const getBuildId = (version: VersionSummary): string =>
     isVersionSummaryNew(version)
@@ -40,10 +46,10 @@
 
 {#if visibleVersions.length}
   <div class="mt-4">
-    <h3 id="existing-versions-title" class="text-sm font-medium">
-      {translate('workers.existing-versions')}
+    <h3 id="recent-versions-title" class="text-sm font-medium">
+      {translate('workers.recent-versions')}
     </h3>
-    <ol class="flex flex-col" aria-labelledby="existing-versions-title">
+    <ol class="flex flex-col" aria-labelledby="recent-versions-title">
       {#each visibleVersions as version, index (index)}
         {@const { status, label } = getStatus(version)}
         <li
@@ -65,9 +71,9 @@
       {/each}
     </ol>
     {#if hiddenCount > 0}
-      <span class="mt-1 text-xs text-secondary">
-        {translate('workers.existing-versions-more', { count: hiddenCount })}
-      </span>
+      <Button variant="secondary" size="xs" on:click={loadMore}>
+        {translate('workers.recent-versions-more', { count: hiddenCount })}
+      </Button>
     {/if}
   </div>
 {/if}

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
@@ -92,7 +92,7 @@
         {translate('workers.configuration-section')}
       </h2>
       <p class="mb-4 text-sm text-secondary">
-        {translate('workers.configuration-description')}
+        {translate('workers.deployment-configuration-description')}
       </p>
       <div class="flex flex-col gap-4">
         <Input

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -269,6 +269,7 @@ export const Strings = {
   'build-id-label': 'Build ID',
   'build-id-hint': 'A unique identifier for this version of your Worker.',
   'existing-versions': 'Existing Versions',
+  'existing-versions-more': '+{{count}} more',
   'max-concurrent-activities-label': 'Max Concurrent Activities',
   'max-concurrent-activities-hint':
     'Maximum concurrent activities per worker instance.',

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -235,8 +235,9 @@ export const Strings = {
     "How Temporal connects to this Worker's compute provider",
   'worker-scaling-limits': 'Worker Scaling and Limits',
   'configuration-section': 'Configuration',
-  'configuration-description':
+  'deployment-configuration-description':
     'Name this Worker deployment and set its Build ID.',
+  'version-configuration-description': 'Set the Build ID for this version.',
   'compute-section': 'Compute',
   'compute-description': 'Choose where your workers run.',
   'scaling-section': 'Scaling and Limits',
@@ -266,8 +267,8 @@ export const Strings = {
   'create-version-rollback-failed':
     '{{message}} The version could not be cleaned up automatically — delete it manually from the deployment.',
   'build-id-label': 'Build ID',
-  'build-id-hint':
-    'A unique identifier for this version of your Worker. Edit or leave as-is.',
+  'build-id-hint': 'A unique identifier for this version of your Worker.',
+  'existing-versions': 'Existing Versions',
   'max-concurrent-activities-label': 'Max Concurrent Activities',
   'max-concurrent-activities-hint':
     'Maximum concurrent activities per worker instance.',

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -268,8 +268,8 @@ export const Strings = {
     '{{message}} The version could not be cleaned up automatically — delete it manually from the deployment.',
   'build-id-label': 'Build ID',
   'build-id-hint': 'A unique identifier for this version of your Worker.',
-  'existing-versions': 'Existing Versions',
-  'existing-versions-more': '+{{count}} more',
+  'recent-versions': 'Recent Versions',
+  'recent-versions-more': '+{{count}} more',
   'max-concurrent-activities-label': 'Max Concurrent Activities',
   'max-concurrent-activities-hint':
     'Maximum concurrent activities per worker instance.',

--- a/src/lib/pages/worker-deployment-version-create.svelte
+++ b/src/lib/pages/worker-deployment-version-create.svelte
@@ -7,8 +7,10 @@
     buildLambdaComputeConfig,
     createWorkerDeploymentVersion,
     deleteWorkerDeploymentVersion,
+    fetchDeployment,
     validateWorkerDeploymentVersionComputeConfig,
   } from '$lib/services/deployments-service';
+  import type { VersionSummary } from '$lib/types/deployments';
   import { routeForWorkerDeployment } from '$lib/utilities/route-for';
 
   interface Props {
@@ -20,10 +22,30 @@
   let { namespace, deployment, onSuccess }: Props = $props();
 
   let error = $state<string | undefined>();
+  let versions = $state<VersionSummary[]>();
 
   const backHref = $derived(
     routeForWorkerDeployment({ namespace, deployment }),
   );
+
+  $effect(() => {
+    const controller = new AbortController();
+    fetchDeployment(
+      { namespace, deploymentName: deployment },
+      fetch,
+      undefined,
+      false,
+      controller.signal,
+    )
+      .then((response) => {
+        versions = response?.workerDeploymentInfo?.versionSummaries ?? [];
+      })
+      .catch(() => {
+        if (controller.signal.aborted) return;
+        versions = [];
+      });
+    return () => controller.abort();
+  });
 </script>
 
 <div class="flex max-w-[45rem] flex-col gap-4">
@@ -35,6 +57,7 @@
   </h1>
   <CreateVersionForm
     {error}
+    {versions}
     cancelHref={backHref}
     onSubmit={async (data) => {
       error = undefined;

--- a/src/lib/pages/worker-deployment-version-create.svelte
+++ b/src/lib/pages/worker-deployment-version-create.svelte
@@ -38,6 +38,7 @@
       controller.signal,
     )
       .then((response) => {
+        if (controller.signal.aborted) return;
         versions = response?.workerDeploymentInfo?.versionSummaries ?? [];
       })
       .catch(() => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Displays a list of five+ past versions on the Create Worker Deployment Version page.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="875" height="563" alt="Screenshot 2026-06-24 at 6 11 38 PM" src="https://github.com/user-attachments/assets/382b5df8-72d8-4ad2-a310-d3f074e04d48" />|<img width="870" height="750" alt="Screenshot 2026-06-26 at 1 52 52 PM" src="https://github.com/user-attachments/assets/9443e25c-1c2a-469c-a5a1-c2c9aade4a4d" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-4113`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
