### PR TITLE
feat: allow multiple inputs in workflow and schedule screens

### DIFF
--- a/plugins/vite-plugin-temporal-server.ts
+++ b/plugins/vite-plugin-temporal-server.ts
@@ -88,6 +88,7 @@ export function temporalServer(): Plugin {
       temporal = await createTemporalServer({
         port,
         uiPort,
+        headless: server.config.mode === 'ui-server',
         dbFilename: persistentDB(server),
       });
 

--- a/src/lib/components/multi-payload-input-with-encoding.svelte
+++ b/src/lib/components/multi-payload-input-with-encoding.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import type { Writable } from 'svelte/store';
+
+  import type { Snippet } from 'svelte';
+
+  import Button from '$lib/holocene/button.svelte';
+  import Card from '$lib/holocene/card.svelte';
+  import IconButton from '$lib/holocene/icon-button.svelte';
+  import Input from '$lib/holocene/input/input.svelte';
+  import RadioGroup from '$lib/holocene/radio-input/radio-group.svelte';
+  import RadioInput from '$lib/holocene/radio-input/radio-input.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import type { PayloadInputEncoding } from '$lib/models/payload-encoding';
+
+  import PayloadInput from './payload-input.svelte';
+
+  interface Props {
+    inputs: string[];
+    encoding: Writable<PayloadInputEncoding>;
+    messageType: string;
+    error?: boolean;
+    label?: string;
+    editing?: boolean;
+    action?: Snippet;
+  }
+
+  let {
+    inputs = $bindable(),
+    encoding,
+    messageType = $bindable(),
+    error = $bindable(false),
+    label = translate('workflows.input'),
+    editing = true,
+    action,
+  }: Props = $props();
+
+  let nextId = inputs.length;
+  let ids = $state(inputs.map((_, i) => i));
+
+  $effect(() => {
+    if (ids.length !== inputs.length) {
+      ids = inputs.map((_, i) => ids[i] ?? nextId++);
+    }
+  });
+
+  $effect(() => {
+    if ($encoding === 'json/plain' && messageType) {
+      messageType = '';
+    }
+  });
+
+  const addInput = () => {
+    inputs = [...inputs, ''];
+    ids = [...ids, nextId++];
+  };
+
+  const removeInput = (index: number) => {
+    inputs = inputs.filter((_, i) => i !== index);
+    ids = ids.filter((_, i) => i !== index);
+  };
+</script>
+
+<div>
+  <h5 class="pb-1 text-sm font-medium">{label}</h5>
+  <Card class="flex flex-col gap-2">
+    {#each inputs as _, index (ids[index])}
+      <div class="flex items-start gap-2">
+        <div class="grow">
+          <PayloadInput
+            bind:input={inputs[index]}
+            id="input-{index}"
+            {editing}
+            clearOnDestroy={false}
+          />
+        </div>
+        {#if editing && inputs.length > 1}
+          <IconButton
+            icon="trash"
+            label={translate('workflows.remove-input')}
+            data-testid="remove-input-{index}"
+            on:click={() => removeInput(index)}
+          />
+        {/if}
+      </div>
+    {/each}
+    {#if editing}
+      <div>
+        <Button
+          variant="ghost"
+          leadingIcon="add"
+          data-testid="add-input"
+          on:click={addInput}>{translate('workflows.add-input')}</Button
+        >
+      </div>
+    {/if}
+    <div
+      class="flex items-end gap-2 {editing ? 'justify-between' : 'justify-end'}"
+    >
+      {#if editing}
+        <div class="flex w-full flex-col gap-2">
+          <RadioGroup
+            description={translate('workflows.encoding')}
+            group={encoding}
+            name="encoding"
+          >
+            <RadioInput id="json/plain" value="json/plain" label="json/plain" />
+            <RadioInput
+              id="json/protobuf"
+              value="json/protobuf"
+              label="json/protobuf"
+            />
+          </RadioGroup>
+          {#if $encoding === 'json/protobuf'}
+            <Input
+              label={translate('workflows.message-type')}
+              bind:value={messageType}
+              {error}
+              id="messageType"
+            />
+          {/if}
+        </div>
+      {/if}
+      {@render action?.()}
+    </div>
+  </Card>
+</div>

--- a/src/lib/components/multi-payload-input-with-encoding.svelte
+++ b/src/lib/components/multi-payload-input-with-encoding.svelte
@@ -21,6 +21,7 @@
     error?: boolean;
     label?: string;
     editing?: boolean;
+    loading?: boolean;
     action?: Snippet;
   }
 
@@ -31,6 +32,7 @@
     error = $bindable(false),
     label = translate('workflows.input'),
     editing = true,
+    loading = $bindable(false),
     action,
   }: Props = $props();
 
@@ -70,6 +72,7 @@
             bind:input={inputs[index]}
             id="input-{index}"
             {editing}
+            {loading}
             clearOnDestroy={false}
           />
         </div>

--- a/src/lib/components/multi-payload-input-with-encoding.svelte
+++ b/src/lib/components/multi-payload-input-with-encoding.svelte
@@ -65,7 +65,7 @@
 <div>
   <h5 class="pb-1 text-sm font-medium">{label}</h5>
   <Card class="flex flex-col gap-2">
-    {#each inputs as _, index (ids[index])}
+    {#each inputs as _, index (ids[index] ?? -index - 1)}
       <div class="flex items-start gap-2">
         <div class="grow">
           <PayloadInput

--- a/src/lib/components/multi-payload-input-with-encoding.svelte
+++ b/src/lib/components/multi-payload-input-with-encoding.svelte
@@ -75,6 +75,7 @@
         </div>
         {#if editing && inputs.length > 1}
           <IconButton
+            class="mt-7"
             icon="trash"
             label={translate('workflows.remove-input')}
             data-testid="remove-input-{index}"

--- a/src/lib/components/payload-input.svelte
+++ b/src/lib/components/payload-input.svelte
@@ -16,6 +16,7 @@
     editing?: boolean;
     placeholder?: string;
     copyable?: boolean;
+    clearOnDestroy?: boolean;
   }
 
   let {
@@ -28,6 +29,7 @@
     editing = true,
     placeholder,
     copyable = false,
+    clearOnDestroy = true,
   }: Props = $props();
 
   const isValidInput = (value: string) => {
@@ -61,7 +63,9 @@
     input = uploadInput;
   };
 
-  onDestroy(clearValues);
+  onDestroy(() => {
+    if (clearOnDestroy) clearValues();
+  });
 </script>
 
 <div class="flex flex-col gap-2">

--- a/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
@@ -224,7 +224,7 @@
     </div>
 
     <ScheduleInputPayload
-      bind:input={$form.input}
+      bind:inputs={$form.inputs}
       bind:editInput={$form.editInput}
       bind:encoding={$form.encoding}
       bind:messageType={$form.messageType}

--- a/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { get, type Writable, writable } from 'svelte/store';
 
+  import MultiPayloadInputWithEncoding from '$lib/components/multi-payload-input-with-encoding.svelte';
   import PayloadDecoder, {
     type DecodedPayloadResult,
   } from '$lib/components/payload/payload-decoder.svelte';
-  import PayloadInputWithEncoding from '$lib/components/payload-input-with-encoding.svelte';
   import Button from '$lib/holocene/button.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
@@ -15,11 +15,12 @@
   import {
     base64ParsePayloadMetadata,
     isParsedPayload,
+    type ParsedPayload,
   } from '$lib/utilities/decode-payload';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
   interface Props {
-    input: string;
+    inputs: string[];
     editInput: boolean;
     encoding?: PayloadInputEncoding;
     messageType: string;
@@ -28,7 +29,7 @@
   }
 
   let {
-    input = $bindable(),
+    inputs = $bindable(),
     editInput = $bindable(),
     encoding = $bindable('json/plain'),
     messageType = $bindable(),
@@ -45,16 +46,20 @@
     if (val !== encoding) encoding = val;
   });
 
-  let initialInput = $state('');
+  let initialInputs = $state<string[]>(['']);
   let initialEncoding = $state<PayloadInputEncoding>('json/plain');
   let initialMessageType = $state('');
-  let loading = $state(true);
 
   const setInitialInput = (result: DecodedPayloadResult): void => {
-    if (result && result[0] && isParsedPayload(result[0].decodedValue)) {
-      initialInput = stringifyWithBigInt(result[0].decodedValue.data) ?? '';
+    const decodedInputs = (result ?? [])
+      .map((entry) => entry.decodedValue)
+      .filter((value): value is ParsedPayload => isParsedPayload(value))
+      .map((value) => stringifyWithBigInt(value.data) ?? '');
 
-      input = initialInput;
+    if (decodedInputs.length) {
+      initialInputs = decodedInputs;
+      inputs = decodedInputs;
+
       let currentEncoding: PayloadInputEncoding = 'json/plain';
       let currentMessageType = '';
 
@@ -76,14 +81,12 @@
         }
       }
     }
-
-    loading = false;
   };
 
   const handleEdit = () => {
     if (editInput) {
       editInput = false;
-      input = initialInput;
+      inputs = initialInputs;
       encoding = initialEncoding;
       messageType = initialMessageType;
     } else {
@@ -95,23 +98,22 @@
 <div class="flex flex-col gap-1">
   <PayloadDecoder value={payloads} onDecode={setInitialInput}>
     {#snippet children(_decodedValue)}
-      <PayloadInputWithEncoding
-        bind:input
+      <MultiPayloadInputWithEncoding
+        bind:inputs
         encoding={encodingStore}
         bind:messageType
-        bind:loading
         editing={editInput}
-        payloadLabel="JSON Data"
-        placeholder={'{"key": "value"}'}
-        id="schedule-payload-input"
-        copyable={true}
       >
-        <div slot="action" class:hidden={!showEditActions}>
-          <Button variant="secondary" on:click={handleEdit}>
-            {editInput ? translate('common.cancel') : translate('common.edit')}
-          </Button>
-        </div>
-      </PayloadInputWithEncoding>
+        {#snippet action()}
+          <div class:hidden={!showEditActions}>
+            <Button variant="secondary" on:click={handleEdit}>
+              {editInput
+                ? translate('common.cancel')
+                : translate('common.edit')}
+            </Button>
+          </div>
+        {/snippet}
+      </MultiPayloadInputWithEncoding>
     {/snippet}
   </PayloadDecoder>
 </div>

--- a/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
@@ -49,6 +49,7 @@
   let initialInputs = $state<string[]>(['']);
   let initialEncoding = $state<PayloadInputEncoding>('json/plain');
   let initialMessageType = $state('');
+  let loading = $state(true);
 
   const setInitialInput = (result: DecodedPayloadResult): void => {
     const decodedInputs = (result ?? [])
@@ -81,6 +82,8 @@
         }
       }
     }
+
+    loading = false;
   };
 
   const handleEdit = () => {
@@ -102,6 +105,7 @@
         bind:inputs
         encoding={encodingStore}
         bind:messageType
+        bind:loading
         editing={editInput}
       >
         {#snippet action()}

--- a/src/lib/components/schedule/schema/form.ts
+++ b/src/lib/components/schedule/schema/form.ts
@@ -178,7 +178,7 @@ export const formScheduleSchema = z
     workflowType: z.string().trim().min(1, 'Workflow type is required'),
     workflowId: z.string().trim().default(''),
     taskQueue: z.string().trim().min(1, 'Task queue is required'),
-    input: jsonString().optional(),
+    inputs: z.array(jsonString()).default(['']),
     editInput: z.boolean().default(false),
     encoding: z.enum(['json/plain', 'json/protobuf']).default('json/plain'),
     messageType: z.string().trim().optional(),

--- a/src/lib/components/schedule/utilities/get-form-schedule-defaults.ts
+++ b/src/lib/components/schedule/utilities/get-form-schedule-defaults.ts
@@ -137,7 +137,7 @@ export function getFormScheduleDefaults(
     workflowId: startWorkflow?.workflowId ?? '',
     taskQueue: startWorkflow?.taskQueue?.name ?? '',
 
-    input: '',
+    inputs: [''],
     // Re-encoding the input only happens when this is set; default it on for
     // new schedules and off for existing ones, whose payloads aren't decoded
     // back into the form.

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -1,7 +1,10 @@
 import { parseDuration } from '$lib/holocene/duration-input/duration-input.svelte';
 import { setSearchAttributes } from '$lib/services/workflow-service';
 import type { Payload } from '$lib/types';
-import { encodePayloads } from '$lib/utilities/encode-payload';
+import {
+  encodeMultiplePayloads,
+  encodePayloads,
+} from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
 import { isValidCronString } from './cron';
@@ -105,9 +108,9 @@ async function getScheduleActionRequest(
     describeFullSchedule?.schedule.action?.startWorkflow ?? {};
 
   const [payloads, header] = await Promise.all([
-    scheduleForm.editInput && scheduleForm.input
-      ? encodePayloads({
-          input: scheduleForm.input,
+    scheduleForm.editInput && scheduleForm.inputs?.some(Boolean)
+      ? encodeMultiplePayloads({
+          inputs: scheduleForm.inputs,
           encoding: scheduleForm.encoding,
           messageType: scheduleForm.messageType,
         })

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -71,6 +71,8 @@ export const Strings = {
   'back-to-workflows': 'Back to Workflows',
   'back-to-archived-workflows': 'Back to Archived Workflows',
   input: 'Input',
+  'add-input': 'Add Input',
+  'remove-input': 'Remove Input',
   result: 'Result',
   'initial-input': 'Initial Input',
   'example-input': 'Example Input',
@@ -118,7 +120,8 @@ export const Strings = {
   'signal-modal-title': 'Send a Signal',
   'signal-name-label': 'Signal name',
   'signal-payload-input-label': 'Data',
-  'signal-payload-input-label-hint': 'Single JSON payload supported.',
+  'signal-payload-input-label-hint':
+    '(only single JSON payload supported per input, add a new input if needed)',
   'update-modal-title': 'Send an Update',
   'cancel-request-sent': 'Cancel Request Sent',
   'cancel-request-sent-description':

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -6,7 +6,7 @@
   import { page } from '$app/stores';
 
   import CodecServerErrorBanner from '$lib/components/codec-server-error-banner.svelte';
-  import PayloadInputWithEncoding from '$lib/components/payload-input-with-encoding.svelte';
+  import MultiPayloadInputWithEncoding from '$lib/components/multi-payload-input-with-encoding.svelte';
   import RandomUuidButton from '$lib/components/random-uuid-button.svelte';
   import AddSearchAttributes from '$lib/components/workflow/add-search-attributes.svelte';
   import Alert from '$lib/holocene/alert.svelte';
@@ -49,7 +49,7 @@
   let workflowId = '';
   let taskQueue = '';
   let workflowType = '';
-  let input = '';
+  let inputs: string[] = [''];
   let summary = '';
   let details = '';
   let encoding: Writable<PayloadInputEncoding> = writable('json/plain');
@@ -115,7 +115,7 @@
         workflowId,
         taskQueue,
         workflowType,
-        input,
+        inputs,
         summary,
         details,
         encoding: $encoding,
@@ -175,7 +175,7 @@
       workflowId,
       workflowType,
     });
-    input = initialValues.input;
+    inputs = initialValues.inputs;
     encoding.set(initialValues.encoding);
     messageType = initialValues.messageType;
     summary = initialValues.summary;
@@ -226,7 +226,7 @@
     }
   };
 
-  $: inputValid = !input || inputIsJSON(input);
+  $: inputValid = inputs.every((input) => !input || inputIsJSON(input));
 
   $: enableStart =
     !!workflowId &&
@@ -305,7 +305,7 @@
       label="Workflow Type"
       onblur={(e) => onInputChange(e, 'workflowType')}
     />
-    <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
+    <MultiPayloadInputWithEncoding bind:inputs {encoding} bind:messageType />
     {#if viewAdvancedOptions}
       <Card class="flex flex-col gap-2">
         <div>

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -54,6 +54,7 @@ import {
   type PotentiallyDecodable,
 } from '$lib/utilities/decode-payload';
 import {
+  encodeMultiplePayloads,
   encodePayloads,
   setBase64Payload,
 } from '$lib/utilities/encode-payload';
@@ -118,7 +119,7 @@ type StartWorkflowOptions = {
   workflowId: string;
   taskQueue: string;
   workflowType: string;
-  input: string;
+  inputs: string[];
   encoding: PayloadInputEncoding;
   messageType: string;
   summary: string;
@@ -670,7 +671,7 @@ export async function startWorkflow({
   workflowId,
   taskQueue,
   workflowType,
-  input,
+  inputs,
   summary,
   details,
   encoding,
@@ -687,9 +688,13 @@ export async function startWorkflow({
   let summaryPayload;
   let detailsPayload;
 
-  if (input) {
+  if (inputs.some(Boolean)) {
     try {
-      payloads = await encodePayloads({ input, encoding, messageType });
+      payloads = await encodeMultiplePayloads({
+        inputs,
+        encoding,
+        messageType,
+      });
     } catch {
       throw new Error('Could not encode input for starting workflow');
     }
@@ -762,7 +767,7 @@ export const fetchInitialValuesForStartWorkflow = async ({
   workflowType?: string;
   workflowId?: string;
 }): Promise<{
-  input: string;
+  inputs: string[];
   encoding: PayloadInputEncoding;
   messageType: string;
   searchAttributes: Record<string, string | Payload> | undefined;
@@ -773,7 +778,7 @@ export const fetchInitialValuesForStartWorkflow = async ({
     console.error(err);
   };
   const emptyValues = {
-    input: '',
+    inputs: [''],
     encoding: 'json/plain' as PayloadInputEncoding,
     messageType: '',
     searchAttributes: undefined,
@@ -813,10 +818,12 @@ export const fetchInitialValuesForStartWorkflow = async ({
     const firstEvent = await fetchInitialEvent(params);
 
     const startEvent = firstEvent as WorkflowExecutionStartedEvent;
-    const decodedInput = await decodePayloadAndParseDataToJSON(
-      startEvent.attributes.input?.payloads[0],
-      false,
-    ); // only single payloads are supported starting a workflow;
+    const inputPayloads = startEvent.attributes.input?.payloads ?? [];
+    const decodedInputs = await Promise.all(
+      inputPayloads.map((payload) =>
+        decodePayloadAndParseDataToJSON(payload, false),
+      ),
+    );
 
     let summary = '';
     if (workflow.summary) {
@@ -838,31 +845,29 @@ export const fetchInitialValuesForStartWorkflow = async ({
       }
     }
 
-    let input = '';
+    const inputs = decodedInputs.map((decodedInput) =>
+      decodedInput?.data ? stringifyWithBigInt(decodedInput.data) : '',
+    );
+
     let encoding: PayloadInputEncoding = 'json/plain';
     let messageType = '';
 
-    if (decodedInput) {
-      if (decodedInput.data) {
-        input = stringifyWithBigInt(decodedInput.data);
+    const firstMetadata = decodedInputs[0]?.metadata;
+    if (firstMetadata) {
+      if (
+        firstMetadata.encoding &&
+        isPayloadInputEncodingType(firstMetadata.encoding)
+      ) {
+        encoding = firstMetadata.encoding;
       }
 
-      if (decodedInput.metadata) {
-        if (
-          decodedInput.metadata.encoding &&
-          isPayloadInputEncodingType(decodedInput.metadata.encoding)
-        ) {
-          encoding = decodedInput.metadata.encoding;
-        }
-
-        if (decodedInput.metadata.messageType) {
-          messageType = decodedInput.metadata.messageType;
-        }
+      if (firstMetadata.messageType) {
+        messageType = firstMetadata.messageType;
       }
     }
 
     return {
-      input,
+      inputs: inputs.length ? inputs : [''],
       encoding,
       messageType,
       searchAttributes: workflow?.searchAttributes?.indexedFields,

--- a/src/lib/utilities/encode-payload.test.ts
+++ b/src/lib/utilities/encode-payload.test.ts
@@ -6,6 +6,7 @@ import {
 } from '$lib/utilities/parse-with-big-int';
 
 import {
+  encodeMultiplePayloads,
   encodePayloads,
   getSinglePayload,
   isBase64EncodedPayload,
@@ -121,5 +122,63 @@ describe('encodePayloads', () => {
       },
     ];
     expect(payload).toEqual(expectedEncodedPayload);
+  });
+});
+
+describe('encodeMultiplePayloads', () => {
+  it('should produce the same single-element output as encodePayloads for one input', async () => {
+    const input = stringifyWithBigInt('cats');
+    const single = await encodePayloads({ input, encoding: 'json/plain' });
+    const multiple = await encodeMultiplePayloads({
+      inputs: [input],
+      encoding: 'json/plain',
+    });
+    expect(multiple).toEqual(single);
+  });
+
+  it('should encode each input as a separate payload', async () => {
+    const payloads = await encodeMultiplePayloads({
+      inputs: [stringifyWithBigInt('cats'), stringifyWithBigInt('dogs')],
+      encoding: 'json/plain',
+    });
+    expect(payloads).toEqual([
+      {
+        data: 'ImNhdHMi',
+        metadata: { encoding: 'anNvbi9wbGFpbg==' },
+      },
+      {
+        data: 'ImRvZ3Mi',
+        metadata: { encoding: 'anNvbi9wbGFpbg==' },
+      },
+    ]);
+  });
+
+  it('should skip empty inputs', async () => {
+    const payloads = await encodeMultiplePayloads({
+      inputs: ['', stringifyWithBigInt('cats'), ''],
+      encoding: 'json/plain',
+    });
+    expect(payloads).toEqual([
+      {
+        data: 'ImNhdHMi',
+        metadata: { encoding: 'anNvbi9wbGFpbg==' },
+      },
+    ]);
+  });
+
+  it('should return null when all inputs are empty', async () => {
+    const payloads = await encodeMultiplePayloads({
+      inputs: ['', ''],
+      encoding: 'json/plain',
+    });
+    expect(payloads).toBeNull();
+  });
+
+  it('should return null when given no inputs', async () => {
+    const payloads = await encodeMultiplePayloads({
+      inputs: [],
+      encoding: 'json/plain',
+    });
+    expect(payloads).toBeNull();
   });
 });

--- a/src/lib/utilities/encode-payload.ts
+++ b/src/lib/utilities/encode-payload.ts
@@ -89,3 +89,40 @@ export const encodePayloads = async ({
   }
   return payloads;
 };
+
+type EncodeMultiplePayloads = {
+  inputs: string[];
+  encoding: PayloadInputEncoding;
+  messageType?: string;
+  encodeWithCodec?: boolean;
+};
+
+export const encodeMultiplePayloads = async ({
+  inputs,
+  encoding,
+  messageType = '',
+  encodeWithCodec = true,
+}: EncodeMultiplePayloads): Promise<Payload[]> => {
+  const nonEmptyInputs = inputs.filter((input) => Boolean(input));
+  if (!nonEmptyInputs.length) return null;
+
+  let payloads: Payload[] = nonEmptyInputs.map((input) => {
+    const parsedInput = parseWithBigInt(input);
+    return isBase64EncodedPayload(parsedInput)
+      ? parsedInput
+      : (setBase64Payload(
+          parsedInput,
+          encoding,
+          messageType,
+        ) as unknown as Payload);
+  });
+
+  const endpoint = get(dataEncoder).endpoint;
+  if (endpoint && encodeWithCodec) {
+    const awaitData = await encodePayloadsWithCodec({
+      payloads: { payloads },
+    });
+    payloads = (awaitData?.payloads as Payload[]) ?? null;
+  }
+  return payloads;
+};

--- a/tests/e2e/schedules.spec.ts
+++ b/tests/e2e/schedules.spec.ts
@@ -31,10 +31,7 @@ test.describe('Schedules Page', () => {
     await page.getByTestId('schedule-type-input').fill('test-type-e2e');
     await page.getByTestId('schedule-workflow-id-input').fill('e2e-1234');
     await page.getByTestId('schedule-task-queue-input').fill('default');
-    await page
-      .locator('#schedule-payload-input')
-      .getByRole('textbox')
-      .fill('"abc"');
+    await page.locator('#input-0').getByRole('textbox').fill('"abc"');
     await page.getByTestId('spec-type-0-button').click();
     await page.getByRole('option', { name: 'Interval' }).click();
     await page.getByLabel('Time Interval').fill('90');

--- a/tests/integration/schedule-edit.spec.ts
+++ b/tests/integration/schedule-edit.spec.ts
@@ -197,9 +197,7 @@ test.describe('Schedules List with schedules', () => {
 
     await page.goto(scheduleEditUrl);
 
-    const payloadInput = page
-      .locator('#schedule-payload-input')
-      .getByRole('textbox');
+    const payloadInput = page.locator('#input-0').getByRole('textbox');
     await expect(payloadInput).toContainText('"message"');
 
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
@@ -217,9 +215,7 @@ test.describe('Schedules List with schedules', () => {
 
     await page.goto(scheduleEditUrl);
 
-    const payloadInput = page
-      .locator('#schedule-payload-input')
-      .getByRole('textbox');
+    const payloadInput = page.locator('#input-0').getByRole('textbox');
     await expect(payloadInput).toContainText('"hello"');
     await expect(page.getByText('Input must be valid JSON')).toBeHidden();
 

--- a/tests/integration/schedules-create.spec.ts
+++ b/tests/integration/schedules-create.spec.ts
@@ -41,6 +41,54 @@ test.describe('Creates Schedule Successfully', () => {
     await expect(page.getByTestId('loading')).toBeVisible();
   });
 
+  test.describe('Multiple Inputs', () => {
+    test('adds and removes input rows', async ({ page }) => {
+      await expect(page.getByTestId('add-input')).toBeVisible();
+      await expect(page.getByTestId('remove-input-0')).toBeHidden();
+
+      await page.getByTestId('add-input').click();
+      await expect(page.getByTestId('remove-input-0')).toBeVisible();
+      await expect(page.getByTestId('remove-input-1')).toBeVisible();
+
+      await page.getByTestId('remove-input-1').click();
+      await expect(page.getByTestId('remove-input-0')).toBeHidden();
+    });
+
+    test('does not duplicate editors after add -> remove -> add', async ({
+      page,
+    }) => {
+      const editors = page.locator('[id^="input-"] .cm-content');
+
+      await expect(editors).toHaveCount(1);
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+
+      await page.getByTestId('remove-input-1').click();
+      await expect(editors).toHaveCount(1);
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+    });
+
+    test('removing the first input keeps the correct remaining content', async ({
+      page,
+    }) => {
+      const editors = page.locator('[id^="input-"] .cm-content');
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+
+      await editors.nth(0).fill('"first"');
+      await editors.nth(1).fill('"second"');
+
+      await page.getByTestId('remove-input-0').click();
+
+      await expect(editors).toHaveCount(1);
+      await expect(editors.nth(0)).toHaveText('"second"');
+    });
+  });
+
   test('fills out schedule with custom search attributes and submits', async ({
     page,
   }) => {

--- a/tests/integration/start-a-workflow.spec.ts
+++ b/tests/integration/start-a-workflow.spec.ts
@@ -57,6 +57,67 @@ test.describe('Start a Workflow', () => {
     });
   });
 
+  test.describe('Multiple Inputs', () => {
+    test.beforeEach(async ({ page }) => {
+      await mockSettingsApi(page, { StartWorkflowDisabled: false });
+      await mockSearchAttributesApi(page);
+      await page.goto(startWorkflowUrl);
+    });
+
+    test('shows a single input with no remove button by default', async ({
+      page,
+    }) => {
+      await expect(page.getByTestId('add-input')).toBeVisible();
+      await expect(page.getByTestId('remove-input-0')).toBeHidden();
+    });
+
+    test('adds and removes input rows', async ({ page }) => {
+      await page.getByTestId('add-input').click();
+
+      await expect(page.getByTestId('remove-input-0')).toBeVisible();
+      await expect(page.getByTestId('remove-input-1')).toBeVisible();
+
+      await page.getByTestId('remove-input-1').click();
+
+      await expect(page.getByTestId('remove-input-0')).toBeHidden();
+      await expect(page.getByTestId('remove-input-1')).toBeHidden();
+    });
+
+    test('does not duplicate editors after add -> remove -> add', async ({
+      page,
+    }) => {
+      const editors = page.locator('.cm-content');
+
+      await expect(editors).toHaveCount(1);
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+
+      await page.getByTestId('remove-input-1').click();
+      await expect(editors).toHaveCount(1);
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+    });
+
+    test('removing the first input keeps the correct remaining content', async ({
+      page,
+    }) => {
+      const editors = page.locator('.cm-content');
+
+      await page.getByTestId('add-input').click();
+      await expect(editors).toHaveCount(2);
+
+      await editors.nth(0).fill('"first"');
+      await editors.nth(1).fill('"second"');
+
+      await page.getByTestId('remove-input-0').click();
+
+      await expect(editors).toHaveCount(1);
+      await expect(editors.nth(0)).toHaveText('"second"');
+    });
+  });
+
   test.describe('Custom Search Attributes', () => {
     test.beforeEach(async ({ page }) => {
       await mockSettingsApi(page, { StartWorkflowDisabled: false });


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The UI was not handling multiple workflow inputs properly, causing silent failures in the "Start Workflow Like This One" experience.

Due to the lack of proper handling for all workflow inputs, users could inadvertently start a workflow with missing inputs, breaking execution expectations downstream.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->
<img width="959" height="1001" alt="image" src="https://github.com/user-attachments/assets/e4a9a3af-6e50-40b8-91f9-093979e0b11f" />
<img width="736" height="955" alt="image" src="https://github.com/user-attachments/assets/82499d9f-4988-489f-9ae9-2b7bb9a8ee7d" />
<img width="1409" height="560" alt="image" src="https://github.com/user-attachments/assets/75888922-2763-4100-9d68-4b9daf74b348" />
<img width="725" height="951" alt="image" src="https://github.com/user-attachments/assets/fd00e72e-03b5-4326-9304-bc2b2b7fa558" />



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->
- Start a new workflow with more than one input, check if inputs are been sent.
- Open an workflow with more than 1 input, check if all inputs are visible.
- Click on the 'Start Workflow Like This One' button, check if all inputs are visible.


### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] E2E tests modified
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
#3335

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
