### PR TITLE
Bump Go 1.26.3→1.26.4 (stdlib crypto/x509, mime, net/textproto CVE fixes)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23 AS server-builder
+FROM golang:1.26.4-alpine3.23 AS server-builder
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN make build-server
 
-FROM golang:1.26.3-alpine3.23 AS dockerize-builder
+FROM golang:1.26.4-alpine3.23 AS dockerize-builder
 
 ARG DOCKERIZE_VERSION=v0.10.1
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION} && \

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/ui-server/v2
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
## Description & motivation 💭

Bumps the Go toolchain `1.26.3` → `1.26.4` in `server/Dockerfile` (both the
`server-builder` and `dockerize-builder` stages) and the `go` directive in
`server/go.mod`. No dependency changes, so `go.sum` is untouched.

This is the same kind of change as #3409 — clearing Go-toolchain CVEs flagged
against the `temporalio/ui-server` Docker image to avoid vulnerability-scanner
noise. None are exploitable in a normal Temporal UI deployment; all three fixes
land in the **standard library**, which is compiled in from the toolchain, so a
toolchain bump is the whole fix.

[Go 1.26.4](https://go.dev/doc/devel/release#go1.26.4) (released 2026-06-02)
security fixes:

- **CVE-2026-42504** — `mime`: quadratic complexity in `WordDecoder.DecodeHeader`
- **CVE-2026-42507** — `net/textproto`: input included in errors without escaping
  (log / terminal-control-byte injection)
- **CVE-2026-27145** — `crypto/x509`: quadratic hostname verification with large
  DNS SAN lists, incurred even for untrusted certificates

## Testing 🧪

### How was this tested 👻

Mechanical version-string bump only — no source or dependency changes (`go.sum`
unchanged). Relying on CI to build the server image and run the suite against the
1.26.4 toolchain.

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Build the server image and confirm it compiles under Go 1.26.4:
`docker build -f server/Dockerfile .`

## Docs

### Any docs updates needed?

No.
