### PR TITLE
fix schedules: duplicate key

### DIFF
--- a/src/lib/components/schedule/schedules-list/schedule-frequency.svelte
+++ b/src/lib/components/schedule/schedules-list/schedule-frequency.svelte
@@ -20,7 +20,7 @@
 <div class={twMerge('flex flex-col', className)}>
   <div class="flex flex-col gap-2">
     <ul>
-      {#each summarizeScheduleSpec(spec) as summary (summary)}
+      {#each summarizeScheduleSpec(spec) as summary, i (i)}
         <li>{summary}</li>
       {:else}
         <li>{translate('common.none')}</li>


### PR DESCRIPTION
https://temporal-technologies.sentry.io/issues/7582886438/events/4051ee05ef41402c8e8298ff0a151bef/?project=6440988&referrer=event-or-group-header

Fix duplicate key for schedule summaries, just use the index