### PR TITLE
Fix SAA and WF consistency

### DIFF
--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
@@ -22,7 +22,7 @@
   const { label } = $derived(column);
   const namespace = $derived(page.params.namespace);
 
-  const filterableLabels = ['Activity ID', 'Activity Type', 'Task Queue'];
+  const filterableLabels = ['Activity ID', 'Run ID', 'Type', 'Task Queue'];
 
   const className = 'h-8 whitespace-nowrap';
   const testId = 'activities-summary-table-body-cell';
@@ -52,7 +52,17 @@
         runId: activity.runId,
       }),
     })}
-  {:else if label === 'Activity Type'}
+  {:else if label === 'Run ID'}
+    {@render renderFilterableTableCell({
+      attribute: 'RunId',
+      value: activity.runId ?? '',
+      href: routeForStandaloneActivityDetails({
+        namespace,
+        activityId: activity.activityId,
+        runId: activity.runId,
+      }),
+    })}
+  {:else if label === 'Type'}
     {@render renderFilterableTableCell({
       attribute: 'ActivityType',
       value: activity.activityType?.name ?? '',
@@ -67,13 +77,9 @@
   <td class={className} data-testid={testId}>
     {#if label === 'Status'}
       <WorkflowStatus status={toActivityStatus(activity.status)} />
-    {:else if label === 'Run ID'}
-      {activity.runId ?? ''}
-    {:else if label === 'Start Time'}
+    {:else if label === 'Start'}
       <Timestamp dateTime={activity.lastStartedTime || activity.scheduleTime} />
-    {:else if label === 'Execution Time'}
-      <Timestamp dateTime={activity.lastStartedTime} />
-    {:else if label === 'Close Time'}
+    {:else if label === 'End'}
       <Timestamp dateTime={activity.closeTime} />
     {:else if label === 'Execution Duration'}
       {#if activity.executionDuration}

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
@@ -7,9 +7,9 @@
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { ActivityExecutionInfo } from '$lib/types/activity-execution';
-  import { formatDistance } from '$lib/utilities/format-time';
   import { toActivityStatus } from '$lib/utilities/get-activity-status-and-count';
   import { routeForStandaloneActivityDetails } from '$lib/utilities/route-for';
+  import { fromSeconds } from '$lib/utilities/to-duration';
 
   import FilterableTableCell from './filterable-table-cell.svelte';
 
@@ -78,16 +78,12 @@
     {#if label === 'Status'}
       <WorkflowStatus status={toActivityStatus(activity.status)} />
     {:else if label === 'Start'}
-      <Timestamp dateTime={activity.lastStartedTime || activity.scheduleTime} />
+      <Timestamp dateTime={activity.scheduleTime} />
     {:else if label === 'End'}
       <Timestamp dateTime={activity.closeTime} />
     {:else if label === 'Execution Duration'}
       {#if activity.executionDuration}
-        {formatDistance({
-          start: activity.lastStartedTime || activity.scheduleTime,
-          end: activity.closeTime,
-          includeMillisecondsForUnderSecond: true,
-        })}
+        {fromSeconds(activity.executionDuration)}
       {/if}
     {:else if label === 'State Transitions'}
       {activity.stateTransitionCount ?? ''}

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
@@ -45,11 +45,11 @@
   {#if label === 'Activity ID'}
     {@render renderFilterableTableCell({
       attribute: 'ActivityId',
-      value: activity.activityId,
+      value: activity.activityId ?? '',
       href: routeForStandaloneActivityDetails({
         namespace,
-        activityId: activity.activityId,
-        runId: activity.runId,
+        activityId: activity.activityId ?? '',
+        runId: activity.runId ?? '',
       }),
     })}
   {:else if label === 'Run ID'}
@@ -58,8 +58,8 @@
       value: activity.runId ?? '',
       href: routeForStandaloneActivityDetails({
         namespace,
-        activityId: activity.activityId,
-        runId: activity.runId,
+        activityId: activity.activityId ?? '',
+        runId: activity.runId ?? '',
       }),
     })}
   {:else if label === 'Type'}

--- a/src/lib/components/standalone-activities/activity-header.svelte
+++ b/src/lib/components/standalone-activities/activity-header.svelte
@@ -83,9 +83,7 @@
       <DetailListTimestampValue
         timestamp={activityExecutionInfo.lastStartedTime}
       />
-      <DetailListLabel
-        >{translate('standalone-activities.close-time')}</DetailListLabel
-      >
+      <DetailListLabel>{translate('common.end')}</DetailListLabel>
       <DetailListTimestampValue
         timestamp={activityExecutionInfo.closeTime}
         fallback="-"

--- a/src/lib/components/standalone-activities/activity-header.svelte
+++ b/src/lib/components/standalone-activities/activity-header.svelte
@@ -30,7 +30,7 @@
 
   let { activityExecutionInfo, namespace, poller }: Props = $props();
 
-  const activityType = $derived(activityExecutionInfo.activityType.name);
+  const activityType = $derived(activityExecutionInfo.activityType?.name);
   const activityTypeFilterLink = $derived(
     routeForStandaloneActivitiesWithQuery(
       { namespace },
@@ -59,7 +59,7 @@
           <Copyable
             copyIconTitle={translate('common.copy-icon-title')}
             copySuccessIconTitle={translate('common.copy-success-icon-title')}
-            content={activityExecutionInfo.activityId}
+            content={activityExecutionInfo.activityId ?? ''}
             clickAllToCopy
             container-class="w-full"
             class="overflow-hidden text-ellipsis text-left"
@@ -93,7 +93,7 @@
       <DetailListLabel
         >{translate('standalone-activities.run-id')}</DetailListLabel
       >
-      <DetailListTextValue copyable text={activityExecutionInfo.runId} />
+      <DetailListTextValue copyable text={activityExecutionInfo.runId ?? ''} />
       {#if activityType}
         <DetailListLabel
           >{translate('standalone-activities.activity-type')}</DetailListLabel
@@ -101,7 +101,7 @@
         <DetailListLinkValue
           copyable
           iconName="filter"
-          text={activityType}
+          text={activityType ?? ''}
           href={activityTypeFilterLink}
         />
       {/if}
@@ -111,7 +111,7 @@
       <DetailListLinkValue
         copyable
         iconName="filter"
-        text={activityExecutionInfo.taskQueue}
+        text={activityExecutionInfo.taskQueue ?? ''}
         href={taskQueueFilterLink}
       />
     </DetailListColumn>

--- a/src/lib/components/standalone-activities/activity-header.svelte
+++ b/src/lib/components/standalone-activities/activity-header.svelte
@@ -69,19 +69,11 @@
     </div>
     <ActivityExecutionActions {activityExecutionInfo} {namespace} {poller} />
   </div>
-  <DetailList aria-label="activity execution details" rowCount={4}>
+  <DetailList aria-label="activity execution details" rowCount={3}>
     <DetailListColumn>
-      <DetailListLabel
-        >{translate('standalone-activities.scheduled-time')}</DetailListLabel
-      >
+      <DetailListLabel>{translate('common.start')}</DetailListLabel>
       <DetailListTimestampValue
         timestamp={activityExecutionInfo.scheduleTime}
-      />
-      <DetailListLabel
-        >{translate('standalone-activities.last-started-time')}</DetailListLabel
-      >
-      <DetailListTimestampValue
-        timestamp={activityExecutionInfo.lastStartedTime}
       />
       <DetailListLabel>{translate('common.end')}</DetailListLabel>
       <DetailListTimestampValue

--- a/src/lib/components/workers/no-workers-polling-alert.svelte
+++ b/src/lib/components/workers/no-workers-polling-alert.svelte
@@ -1,22 +1,21 @@
 <script lang="ts">
-  import { page } from '$app/state';
-
   import Alert from '$lib/holocene/alert.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fetchDeployment } from '$lib/services/deployments-service';
-  import { workflowRun } from '$lib/stores/workflow-run';
   import { deploymentHasComputeConfig } from '$lib/utilities/deployment-has-compute-config';
-  import { isRunningWithNoWorkers } from '$lib/utilities/is-running-with-no-workers';
   import { routeForWorkerDeployment } from '$lib/utilities/route-for';
 
-  const { workflow } = $derived($workflowRun);
-  const runningWithNoWorkers = $derived(isRunningWithNoWorkers($workflowRun));
-  const namespace = $derived(page.params.namespace);
-  const deployment = $derived(
-    workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'],
-  );
+  interface Props {
+    namespace: string;
+    taskQueue: string;
+    runningWithNoWorkers: boolean;
+    deployment?: string;
+  }
+
+  let { namespace, taskQueue, runningWithNoWorkers, deployment }: Props =
+    $props();
 
   let serverlessDeployment = $state(false);
   let deploymentChecked = $state(false);
@@ -64,7 +63,7 @@
     hidden={!runningWithNoWorkers}
   >
     {translate('workflows.workflow-error-no-workers-serverless-description', {
-      taskQueue: workflow?.taskQueue ?? '',
+      taskQueue,
       deployment,
     })}
     <Link
@@ -84,7 +83,7 @@
     hidden={!runningWithNoWorkers || !deploymentChecked}
   >
     {translate('workflows.workflow-error-no-workers-description', {
-      taskQueue: workflow?.taskQueue ?? '',
+      taskQueue,
     })}
     {translate('workflows.workers-alert-description')}
     <Link

--- a/src/lib/i18n/locales/en/standalone-activities.ts
+++ b/src/lib/i18n/locales/en/standalone-activities.ts
@@ -22,7 +22,6 @@ export const Strings = {
   'run-id': 'Run ID',
   'activity-type': 'Activity Type',
   'task-queue': 'Task Queue',
-  'close-time': 'Close Time',
   duration: 'Duration',
   'last-started-time': 'Last Started Time',
   'scheduled-time': 'Scheduled Time',

--- a/src/lib/i18n/locales/en/standalone-activities.ts
+++ b/src/lib/i18n/locales/en/standalone-activities.ts
@@ -24,7 +24,6 @@ export const Strings = {
   'task-queue': 'Task Queue',
   duration: 'Duration',
   'last-started-time': 'Last Started Time',
-  'scheduled-time': 'Scheduled Time',
   'activities-table': 'Standalone Activities Table',
   'back-to-activities': 'Back to Standalone Activities',
   'start-activity-like-this-one': 'Start Standalone Activity Like This One',

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -170,7 +170,6 @@ export const Strings = {
     'There are no compatible Workers polling the {{taskQueue}} Task Queue.',
   'dismiss-common-errors': 'Dismiss Common Errors',
   'state-transitions': 'State Transitions',
-  'start-and-close-time': 'Start & Close Time',
   relationships: 'Relationships',
   'family-node-label': 'Workflow {{id}}: {{status}}',
   parents_zero: '0 Parents',

--- a/src/lib/layouts/standalone-activity-layout.svelte
+++ b/src/lib/layouts/standalone-activity-layout.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/state';
 
   import ActivityExecutionHeader from '$lib/components/standalone-activities/activity-header.svelte';
-  import Alert from '$lib/holocene/alert.svelte';
+  import NoWorkersPollingAlert from '$lib/components/workers/no-workers-polling-alert.svelte';
   import ErrorComponent from '$lib/holocene/error.svelte';
   import Link from '$lib/holocene/link.svelte';
   import TabList from '$lib/holocene/tab/tab-list.svelte';
@@ -145,16 +145,13 @@
     </Tabs>
     {#if getPollersRequest}
       {#await getPollersRequest then response}
-        {#if !response.pollers && $activityExecution.info.status === 'ACTIVITY_EXECUTION_STATUS_RUNNING'}
-          <Alert
-            intent="error"
-            title={translate('workflows.workflow-error-no-workers-title')}
-          >
-            {translate('workflows.workflow-error-no-workers-description', {
-              taskQueue: $activityExecution.info.taskQueue,
-            })}
-          </Alert>
-        {/if}
+        <NoWorkersPollingAlert
+          {namespace}
+          taskQueue={$activityExecution.info.taskQueue}
+          runningWithNoWorkers={!response.pollers &&
+            $activityExecution.info.status ===
+              'ACTIVITY_EXECUTION_STATUS_RUNNING'}
+        />
       {/await}
     {/if}
     {@render children()}

--- a/src/lib/layouts/standalone-activity-layout.svelte
+++ b/src/lib/layouts/standalone-activity-layout.svelte
@@ -147,7 +147,7 @@
       {#await getPollersRequest then response}
         <NoWorkersPollingAlert
           {namespace}
-          taskQueue={$activityExecution.info.taskQueue}
+          taskQueue={$activityExecution.info.taskQueue ?? ''}
           runningWithNoWorkers={!response.pollers &&
             $activityExecution.info.status ===
               'ACTIVITY_EXECUTION_STATUS_RUNNING'}

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -36,6 +36,7 @@
     getWorkflowNexusLinksFromHistory,
     getWorkflowRelationships,
   } from '$lib/utilities/get-workflow-relationships';
+  import { isRunningWithNoWorkers } from '$lib/utilities/is-running-with-no-workers';
   import { pathMatches } from '$lib/utilities/path-matches';
   import {
     routeForCallStack,
@@ -64,6 +65,10 @@
   let { headerSnippet }: { headerSnippet?: Snippet } = $props();
 
   const { workflow } = $derived($workflowRun);
+  const runningWithNoWorkers = $derived(isRunningWithNoWorkers($workflowRun));
+  const workerDeployment = $derived(
+    workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'],
+  );
   const routeParameters = $derived({
     namespace,
     workflow: workflowId,
@@ -258,7 +263,12 @@
   {#if headerSnippet}
     {@render headerSnippet()}
   {/if}
-  <NoWorkersPollingAlert />
+  <NoWorkersPollingAlert
+    {namespace}
+    taskQueue={workflow?.taskQueue ?? ''}
+    {runningWithNoWorkers}
+    deployment={workerDeployment}
+  />
   <Tabs>
     <TabList label="workflow detail">
       <Tab

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -170,11 +170,7 @@
               timestamp={$activityExecution.info.lastStartedTime}
             />
             {#if isClosed}
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.close-time',
-                )}</DetailListLabel
-              >
+              <DetailListLabel>{translate('common.end')}</DetailListLabel>
               <DetailListTimestampValue
                 timestamp={$activityExecution.info.lastStartedTime}
               />

--- a/src/lib/stores/configurable-table-columns.ts
+++ b/src/lib/stores/configurable-table-columns.ts
@@ -126,10 +126,10 @@ const DEFAULT_SCHEDULES_COLUMNS: ConfigurableTableHeader[] = [
 export const ActivityHeaderLabels = [
   'Activity ID',
   'Run ID',
-  'Activity Type',
+  'Type',
   'Task Queue',
-  'Start Time',
-  'Close Time',
+  'Start',
+  'End',
   'Status',
   'Execution Duration',
   'State Transitions',
@@ -140,14 +140,14 @@ export type ActivityHeaderLabel = (typeof ActivityHeaderLabels)[number];
 export const DEFAULT_ACTIVITIES_COLUMNS: ConfigurableTableHeader[] = [
   { label: 'Status' },
   { label: 'Activity ID' },
-  { label: 'Activity Type' },
-  { label: 'Task Queue' },
-  { label: 'Start Time' },
-  { label: 'Close Time' },
+  { label: 'Run ID' },
+  { label: 'Type' },
+  { label: 'Start' },
+  { label: 'End' },
 ];
 
 const DEFAULT_AVAILABLE_ACTIVITIES_COLUMNS: ConfigurableTableHeader[] = [
-  { label: 'Run ID' },
+  { label: 'Task Queue' },
   { label: 'Execution Duration' },
   { label: 'State Transitions' },
 ];

--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -241,7 +241,6 @@ export const activitySearchAttributes: Readable<SearchAttributes> = derived(
     RunId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
     TaskQueue: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
     StartTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
-    ExecutionTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
     CloseTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
     ExecutionDuration: SEARCH_ATTRIBUTE_TYPE.INT,
     StateTransitionCount: SEARCH_ATTRIBUTE_TYPE.INT,


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The `/namespaces/{namespace}/activities` view 
* "Close Time" is now "End"
* "Start Time" is now "Start"
* "Activity Type" is now "Type"
* Hides the "Task Queue" column by default
* Added "Run ID" column by default that is filterable and contains a link
* Removed `ExecutionTime` as a filterable search attribute

The `/namespaces/{namespace}/activities{activityID}/{runID}/details` view
* "Scheduled Time" is now "Start"
* Removed "Last Started Time" from details at the top of page
* Uses the same "No workers polling" alert as the Workflow details page

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->


| Before | After |
|-|-|
|<img width="1662" height="538" alt="Screenshot 2026-06-29 at 4 32 13 PM" src="https://github.com/user-attachments/assets/67eae23c-792c-46e8-b2ad-38af1ad87f39" />|<img width="1674" height="489" alt="Screenshot 2026-06-29 at 4 26 26 PM" src="https://github.com/user-attachments/assets/e6c47e30-fdda-4e3e-a386-0c7b310dcfaa" />|
|<img width="1410" height="933" alt="Screenshot 2026-06-29 at 4 30 52 PM" src="https://github.com/user-attachments/assets/b4bc44c6-5a8e-40de-bfc8-56b1ebf8f7a6" />|<img width="1266" height="918" alt="Screenshot 2026-06-29 at 4 25 42 PM" src="https://github.com/user-attachments/assets/9d561a79-b310-469f-93af-c6c7eef0c617" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-4202`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
