### PR TITLE
Fix width of ComputeBadge in VersionTableRow

### DIFF
--- a/src/lib/components/deployments/compute-badge.svelte
+++ b/src/lib/components/deployments/compute-badge.svelte
@@ -13,7 +13,7 @@
 
 {#if config}
   <div
-    class="flex min-w-24 items-center justify-center gap-2 border border-subtle px-1"
+    class="inline-flex min-w-24 items-center justify-center gap-2 border border-subtle px-1"
   >
     <Icon name={config.icon} />
     <p>{config.label}</p>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="1225" height="484" alt="Screenshot 2026-06-29 at 5 07 32 PM" src="https://github.com/user-attachments/assets/0e3e6667-8568-4d37-a269-8ee2f933dcee" />|<img width="1221" height="468" alt="Screenshot 2026-06-29 at 5 07 10 PM" src="https://github.com/user-attachments/assets/1b63d4d5-543b-41bb-bae3-42ae3b88f9cf" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
