### PR TITLE
fix - schedules recent/upcoming runs - sort issue

### DIFF
--- a/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
+++ b/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
@@ -6,7 +6,7 @@
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { DescribeFullSchedule } from '$lib/types/schedule';
-  import { getMilliseconds } from '$lib/utilities/format-time';
+  import { getEpochMilliseconds } from '$lib/utilities/format-time';
   import { routeForWorkflow } from '$lib/utilities/route-for';
   import { toWorkflowStatusReadable } from '$lib/utilities/screaming-enums';
 
@@ -33,7 +33,9 @@
     return runs
       .filter(Boolean)
       .sort(
-        (a, b) => getMilliseconds(b.actualTime) - getMilliseconds(a.actualTime),
+        (a, b) =>
+          getEpochMilliseconds(b.actualTime) -
+          getEpochMilliseconds(a.actualTime),
       )
       .slice(0, 5);
   });

--- a/src/lib/components/schedule/schedule-view/workflow-runs-upcoming.svelte
+++ b/src/lib/components/schedule/schedule-view/workflow-runs-upcoming.svelte
@@ -4,7 +4,7 @@
   import { timestamp } from '$lib/components/timestamp.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { DescribeFullSchedule } from '$lib/types/schedule';
-  import { getMilliseconds } from '$lib/utilities/format-time';
+  import { getEpochMilliseconds } from '$lib/utilities/format-time';
 
   import WorkflowRunsEmpty from './workflow-runs-empty.svelte';
 
@@ -26,7 +26,7 @@
     const runs = schedule?.info?.futureActionTimes ?? [];
     return runs
       .filter(Boolean)
-      .sort((a, b) => getMilliseconds(a) - getMilliseconds(b))
+      .sort((a, b) => getEpochMilliseconds(a) - getEpochMilliseconds(b))
       .slice(0, 5);
   });
 </script>

--- a/src/lib/utilities/format-time.test.ts
+++ b/src/lib/utilities/format-time.test.ts
@@ -8,6 +8,7 @@ import {
   fromSecondsToDaysOrHours,
   fromSecondsToMinutesAndSeconds,
   getDuration,
+  getEpochMilliseconds,
   getTimestampDifference,
 } from './format-time';
 
@@ -315,6 +316,35 @@ describe('fromSecondsToDaysOrHours', () => {
   it('should return "33 days" for 2851200s', () => {
     const seconds = '2851200s';
     expect(fromSecondsToDaysOrHours(seconds)).toBe('33 days');
+  });
+});
+
+describe('getEpochMilliseconds', () => {
+  it('should return epoch milliseconds, not the sub-second component', () => {
+    expect(getEpochMilliseconds('2026-06-30T08:03:25.812286937Z')).toBe(
+      Date.parse('2026-06-30T08:03:25.812Z'),
+    );
+  });
+
+  it('should sort timestamps chronologically regardless of sub-second fraction', () => {
+    const times = [
+      '2026-06-30T11:05:30.793784947Z',
+      '2026-06-30T08:03:25.812286937Z',
+      '2026-06-30T13:01:01.591393007Z',
+    ];
+    const sorted = [...times].sort(
+      (a, b) => getEpochMilliseconds(a) - getEpochMilliseconds(b),
+    );
+    expect(sorted).toEqual([
+      '2026-06-30T08:03:25.812286937Z',
+      '2026-06-30T11:05:30.793784947Z',
+      '2026-06-30T13:01:01.591393007Z',
+    ]);
+  });
+
+  it('should return 0 for nullish input', () => {
+    expect(getEpochMilliseconds(undefined)).toBe(0);
+    expect(getEpochMilliseconds(null)).toBe(0);
   });
 });
 

--- a/src/lib/utilities/format-time.ts
+++ b/src/lib/utilities/format-time.ts
@@ -1,6 +1,7 @@
 import {
   differenceInDays,
   formatDuration as durationToString,
+  getMilliseconds as getSecondAsMilliseconds,
   intervalToDuration,
   parseJSON,
 } from 'date-fns';
@@ -196,6 +197,18 @@ export function formatDistanceAbbreviated({
   }
 }
 
+export function getMilliseconds(date: ValidTime | undefined | null): number {
+  if (!date) return 0;
+  if (isTimestamp(date)) {
+    date = timestampToDate(date);
+  }
+  const parsedDate = parseJSON(date);
+
+  return getSecondAsMilliseconds(parsedDate);
+}
+
+// Milliseconds since the Unix epoch, for comparing/sorting instants.
+// Unlike getMilliseconds, which returns only the 0-999 sub-second component.
 export function getEpochMilliseconds(
   date: ValidTime | undefined | null,
 ): number {

--- a/src/lib/utilities/format-time.ts
+++ b/src/lib/utilities/format-time.ts
@@ -1,7 +1,6 @@
 import {
   differenceInDays,
   formatDuration as durationToString,
-  getMilliseconds as getSecondAsMilliseconds,
   intervalToDuration,
   parseJSON,
 } from 'date-fns';
@@ -197,14 +196,16 @@ export function formatDistanceAbbreviated({
   }
 }
 
-export function getMilliseconds(date: ValidTime | undefined | null): number {
+export function getEpochMilliseconds(
+  date: ValidTime | undefined | null,
+): number {
   if (!date) return 0;
   if (isTimestamp(date)) {
     date = timestampToDate(date);
   }
   const parsedDate = parseJSON(date);
 
-  return getSecondAsMilliseconds(parsedDate);
+  return parsedDate.getTime();
 }
 
 export function fromSecondsToMinutesAndSeconds(seconds: number): string {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Sorting logic for recent runs & upcoming runs used a getMilliseconds helper function from date-fns but that getMilliseconds helper got the milliseconds portion of the date, not the full date as milliseconds which made the sort order non-sensical and caused confusion.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="816" height="360" alt="Screenshot 2026-06-30 at 8 48 43 AM" src="https://github.com/user-attachments/assets/c06a9cee-8eee-41d1-aa02-ba358d26df8d" />
<img width="574" height="360" alt="Screenshot 2026-06-30 at 8 48 37 AM" src="https://github.com/user-attachments/assets/1d720f7c-7383-416f-98ff-b16588fd91e4" />



### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here --> https://temporalio.atlassian.net/browse/DT-4207

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
