### PR TITLE
Fix last refreshed timestamp for short format

### DIFF
--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -87,8 +87,6 @@
     return () => clearInterval(interval);
   });
 
-  const lastRefreshFormatted = $derived($timestamp(lastRefresh));
-
   const SupplierKindTooltipText: Record<string, string> = {
     Fixed: translate('workers.slot-supplier-kind-fixed'),
     ResourceBased: translate('workers.slot-supplier-kind-resource-based'),
@@ -245,7 +243,7 @@
       </p>
     {:else}
       <p>
-        {translate('workers.last-refreshed', { time: lastRefreshFormatted })}
+        {translate('workers.last-refreshed')}: {$timestamp(lastRefresh)}
       </p>
     {/if}
   </div>

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -89,7 +89,7 @@ export const Strings = {
     'Slot count is set to auto-adjust on based on CPU/memory usage.',
   'slot-supplier-kind-custom':
     'Slot count is set based on custom slot supplier implementation.',
-  'last-refreshed': 'Last refreshed: {{time}}',
+  'last-refreshed': 'Last refreshed',
   'pulling-latest-snapshot': 'Pulling latest snapshot from the server...',
   'serverless-workers': 'Serverless Workers',
   'serverless-worker': 'Serverless Worker',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

"Last Refreshed" timestamp on the Worker details page was being passed to a `translate()` function. If the "Short" timestamp format was selected the slashes were HTML-escaped by i18next.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
