### PR TITLE
COM-191 - prefill CloudFormation template params in Launch Stack link

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -75,7 +75,7 @@
     if (lambdaArn) {
       params.push(`param_LambdaFunctionARNs=${encodeURIComponent(lambdaArn)}`);
     }
-    return `https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?${params.join('&')}`;
+    return `https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?${params.join('&')}`;
   });
 
   let showRoleHelp = $state(false);

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -62,11 +62,21 @@
 
   const resolvedCfnTemplate = $derived(cfnTemplateProp ?? cfnTemplate);
 
-  const launchStackHref = $derived(
-    cfnTemplateUrl
-      ? `https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateURL=${encodeURIComponent(cfnTemplateUrl)}`
-      : 'https://console.aws.amazon.com/cloudformation/',
-  );
+  const launchStackHref = $derived.by(() => {
+    if (!cfnTemplateUrl) {
+      return 'https://console.aws.amazon.com/cloudformation/';
+    }
+    const params = [`templateURL=${encodeURIComponent(cfnTemplateUrl)}`];
+    if (roleExternalId) {
+      params.push(
+        `param_AssumeRoleExternalId=${encodeURIComponent(roleExternalId)}`,
+      );
+    }
+    if (lambdaArn) {
+      params.push(`param_LambdaFunctionARNs=${encodeURIComponent(lambdaArn)}`);
+    }
+    return `https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?${params.join('&')}`;
+  });
 
   let showRoleHelp = $state(false);
   let showScaling = $state(false);


### PR DESCRIPTION
## Summary

The serverless worker deployment "Launch Stack" button (CloudFormation, under the "I don't have a role yet" accordion) previously linked to a bare CloudFormation console URL and prefilled nothing. This wires the form's field values into the launch URL using AWS's `param_<ParameterName>=<value>` convention so the CloudFormation quick-create form opens with the template and parameters prefilled.

## Changes

`compute-fields.svelte`: `launchStackHref` is now a `$derived.by()` that, when `cfnTemplateUrl` is set, builds a `#/stacks/quickcreate?templateURL=...` URL and appends:

- `param_AssumeRoleExternalId` from `roleExternalId`
- `param_LambdaFunctionARNs` from `lambdaArn`

`RoleName` is left to the template default (no form field exists for it). Each `param_*` entry is omitted when its source field is empty, and the template URL plus every param value are `encodeURIComponent`-encoded. When `cfnTemplateUrl` is falsy, the existing bare-console fallback is preserved.

## Decisions worth a look

- **RoleName**: left at the template default since there is no form field for it. Easy to expose a role-name input if we want one.
- **quickcreate vs create/review**: used `#/stacks/quickcreate` for the prefilled-but-editable UX. Can pin to `#/stacks/create/review` for strict parity with the S3 export / Kinesis audit-log forms if preferred.

## Notes for the integrator (out of scope here)

End-to-end this requires cloud-ui to pass a real, publicly-hosted `cfnTemplateUrl` and repack the tarball. The local `temporal-worker-role.yaml` is download-only and currently has no `Parameters` section; the parameterized hosted template is handled separately in cloud-ui.

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm lint` clean
- [x] Verified generated href for sample inputs contains the encoded `templateURL`, `param_AssumeRoleExternalId`, and `param_LambdaFunctionARNs`, and omits empty params
