### PR TITLE
Fix EventDetailsFull overflowing history table with large payloads

### DIFF
--- a/src/lib/components/payload/payload-code-block.svelte
+++ b/src/lib/components/payload/payload-code-block.svelte
@@ -88,115 +88,123 @@
   };
 </script>
 
-<PayloadDecoder {value}>
-  {#snippet loading()}
-    <CodeBlock
-      content={stringifyWithBigInt(value)}
-      {maxHeight}
-      copyIconTitle={translate('common.copy-icon-title')}
-      copySuccessIconTitle={translate('common.copy-success-icon-title')}
-      {testId}
-      language="json"
-    />
-  {/snippet}
-  {#snippet children(results)}
-    <div class="space-y-2">
-      {#each results as result (result)}
-        {#if isExternallyStoredRawPayload(result?.decodedValue)}
-          {@const size = formatBytes(
-            result.decodedValue.externalPayloads?.[0].sizeBytes ?? 0,
-          )}
-          <CodeBlock
-            content={stringifyWithBigInt(result.decodedValue.data)}
-            {maxHeight}
-            copyIconTitle={translate('common.copy-icon-title')}
-            copySuccessIconTitle={translate('common.copy-success-icon-title')}
-            {testId}
-            language="json"
-          >
-            {#snippet headerActions()}
-              <Tooltip
-                width={192}
-                top
-                hide={!!getCodecEndpoint(page.data.settings)}
-                text="Add a codec server with a /download endpoint to download this payload."
-              >
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  leadingIcon="download"
-                  disabled={!getCodecEndpoint(page.data.settings)}
-                  loading={downloadLoading}
-                  on:click={() => downloadExternalPayload(result.originalValue)}
-                >
-                  {size}
-                </Button>
-              </Tooltip>
-            {/snippet}
-          </CodeBlock>
-          {#if downloadError}
-            <div class="flex items-start gap-2 text-danger">
-              <Icon width={16} height={16} name="exclamation-octagon" />
-              <p class="leading-4">{downloadError}</p>
-            </div>
-          {/if}
-          <p>
-            Payload downloads require a codec server with a <span
-              class="rounded-sm bg-code-block px-1 font-mono">/download</span
+<!-- w-0 + min-w-full clamps the codeblock to its container's resolved width so
+     a long unbroken payload (e.g. raw base64) wraps instead of expanding a
+     table-auto cell. Covers loading, decoded, and error states. -->
+<div class="w-0 min-w-full">
+  <PayloadDecoder {value}>
+    {#snippet loading()}
+      <CodeBlock
+        content={stringifyWithBigInt(value)}
+        {maxHeight}
+        copyIconTitle={translate('common.copy-icon-title')}
+        copySuccessIconTitle={translate('common.copy-success-icon-title')}
+        {testId}
+        language="json"
+      />
+    {/snippet}
+    {#snippet children(results)}
+      <div class="space-y-2">
+        {#each results as result (result)}
+          {#if isExternallyStoredRawPayload(result?.decodedValue)}
+            {@const size = formatBytes(
+              result.decodedValue.externalPayloads?.[0].sizeBytes ?? 0,
+            )}
+            <CodeBlock
+              content={stringifyWithBigInt(result.decodedValue.data)}
+              {maxHeight}
+              copyIconTitle={translate('common.copy-icon-title')}
+              copySuccessIconTitle={translate('common.copy-success-icon-title')}
+              {testId}
+              language="json"
             >
-            endpoint. <Link href="https://docs.temporal.io/codec-server" newTab
-              >How to set up a codec server
-            </Link>
-            <Icon class="inline" name="external-link" />
-          </p>
-        {:else if isParsedPayload(result.decodedValue)}
-          <CodeBlock
-            content={stringifyWithBigInt(result.decodedValue.data)}
-            {maxHeight}
-            copyIconTitle={translate('common.copy-icon-title')}
-            copySuccessIconTitle={translate('common.copy-success-icon-title')}
-            {testId}
-            language="json"
+              {#snippet headerActions()}
+                <Tooltip
+                  width={192}
+                  top
+                  hide={!!getCodecEndpoint(page.data.settings)}
+                  text="Add a codec server with a /download endpoint to download this payload."
+                >
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    leadingIcon="download"
+                    disabled={!getCodecEndpoint(page.data.settings)}
+                    loading={downloadLoading}
+                    on:click={() =>
+                      downloadExternalPayload(result.originalValue)}
+                  >
+                    {size}
+                  </Button>
+                </Tooltip>
+              {/snippet}
+            </CodeBlock>
+            {#if downloadError}
+              <div class="flex items-start gap-2 text-danger">
+                <Icon width={16} height={16} name="exclamation-octagon" />
+                <p class="leading-4">{downloadError}</p>
+              </div>
+            {/if}
+            <p>
+              Payload downloads require a codec server with a <span
+                class="rounded-sm bg-code-block px-1 font-mono">/download</span
+              >
+              endpoint. <Link
+                href="https://docs.temporal.io/codec-server"
+                newTab
+                >How to set up a codec server
+              </Link>
+              <Icon class="inline" name="external-link" />
+            </p>
+          {:else if isParsedPayload(result.decodedValue)}
+            <CodeBlock
+              content={stringifyWithBigInt(result.decodedValue.data)}
+              {maxHeight}
+              copyIconTitle={translate('common.copy-icon-title')}
+              copySuccessIconTitle={translate('common.copy-success-icon-title')}
+              {testId}
+              language="json"
+            />
+          {:else}
+            <CodeBlock
+              content={stringifyWithBigInt(result.decodedValue)}
+              {maxHeight}
+              copyIconTitle={translate('common.copy-icon-title')}
+              copySuccessIconTitle={translate('common.copy-success-icon-title')}
+              {testId}
+              language="json"
+            />
+          {/if}
+        {/each}
+      </div>
+    {/snippet}
+    {#snippet error({ error, retry })}
+      <CodeBlock
+        content={stringifyWithBigInt(value)}
+        {maxHeight}
+        copyIconTitle={translate('common.copy-icon-title')}
+        copySuccessIconTitle={translate('common.copy-success-icon-title')}
+        {testId}
+        language="json"
+      >
+        {#snippet headerActions()}
+          <IconButton
+            icon="retry"
+            on:click={retry}
+            label={translate('common.retry')}
           />
-        {:else}
-          <CodeBlock
-            content={stringifyWithBigInt(result.decodedValue)}
-            {maxHeight}
-            copyIconTitle={translate('common.copy-icon-title')}
-            copySuccessIconTitle={translate('common.copy-success-icon-title')}
-            {testId}
-            language="json"
-          />
-        {/if}
-      {/each}
-    </div>
-  {/snippet}
-  {#snippet error({ error, retry })}
-    <CodeBlock
-      content={stringifyWithBigInt(value)}
-      {maxHeight}
-      copyIconTitle={translate('common.copy-icon-title')}
-      copySuccessIconTitle={translate('common.copy-success-icon-title')}
-      {testId}
-      language="json"
-    >
-      {#snippet headerActions()}
-        <IconButton
-          icon="retry"
-          on:click={retry}
-          label={translate('common.retry')}
-        />
-      {/snippet}
-    </CodeBlock>
-    <div class="flex items-start gap-2 text-danger">
-      <Icon width={16} height={16} name="exclamation-octagon" />
-      <p class="leading-4">
-        {#if isNetworkError(error)}
-          {error.message} - {error.statusText}
-        {:else}
-          {stringifyWithBigInt(error)}
-        {/if}
-      </p>
-    </div>
-  {/snippet}
-</PayloadDecoder>
+        {/snippet}
+      </CodeBlock>
+      <div class="flex items-start gap-2 text-danger">
+        <Icon width={16} height={16} name="exclamation-octagon" />
+        <p class="leading-4">
+          {#if isNetworkError(error)}
+            {error.message} - {error.statusText}
+          {:else}
+            {stringifyWithBigInt(error)}
+          {/if}
+        </p>
+      </div>
+    {/snippet}
+  </PayloadDecoder>
+</div>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The `EventDetailsFull` with a large payload (e.g. in an input) was overflowing the table on the `/history` page. This is because the raw-payload loading state for the `PayloadDecoder` in the `PayloadCodeBlock` put a lineWrapping CodeMirror editor into a context with no resolved width and CodeMirror's lazy, visibility-driven measurement meant it didn't wrap until you forced a re-measure by scrolling to it.
By adding `w-0 + min-w-full` to the `PayloadCodeBlock`, the container's resolved width for a long unbroken payload wraps instead of expanding a `table-auto` cell. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="1369" height="941" alt="Screenshot 2026-06-30 at 4 20 18 PM" src="https://github.com/user-attachments/assets/659c4e41-9ecb-4f30-be45-651e5be4deb4" />|<img width="1350" height="944" alt="Screenshot 2026-06-30 at 4 19 51 PM" src="https://github.com/user-attachments/assets/1881b001-6a11-44f8-81a3-c3638df03485" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
