### PR TITLE
Improve Search Attribute deletion messaging

### DIFF
--- a/src/lib/components/search-attributes-form/search-attribute-row.svelte
+++ b/src/lib/components/search-attributes-form/search-attribute-row.svelte
@@ -46,6 +46,8 @@
     submitting || (disableTypeForExisting && isExisting),
   );
 
+  const showButton = $derived(!isExisting || isDeletable);
+
   const hasError = $derived(!!error);
 
   const handleNameInput: FormEventHandler<HTMLInputElement> = (e) => {
@@ -53,7 +55,7 @@
   };
 </script>
 
-<div class="grid grid-cols-[1fr,200px,auto] items-center gap-3">
+<div class="grid grid-cols-[1fr,200px,2rem] items-center gap-3">
   <Input
     id={`attribute-name-${index}`}
     value={name}
@@ -66,21 +68,23 @@
     oninput={handleNameInput}
   />
 
-  <Select
-    id={`attribute-type-${index}`}
-    value={type}
-    label={translate('search-attributes.type-label', {
-      index: index + 1,
-    })}
-    labelHidden
-    disabled={isTypeDisabled}
-    placeholder={translate('search-attributes.select-type-placeholder')}
-    onChange={onTypeChange}
-  >
-    {#each supportedTypes as type (`${type.label}:${type.value}`)}
-      <Option value={type.value}>{type.label}</Option>
-    {/each}
-  </Select>
+  <div class:col-span-2={!showButton}>
+    <Select
+      id={`attribute-type-${index}`}
+      value={type}
+      label={translate('search-attributes.type-label', {
+        index: index + 1,
+      })}
+      labelHidden
+      disabled={isTypeDisabled}
+      placeholder={translate('search-attributes.select-type-placeholder')}
+      onChange={onTypeChange}
+    >
+      {#each supportedTypes as type (`${type.label}:${type.value}`)}
+        <Option value={type.value}>{type.label}</Option>
+      {/each}
+    </Select>
+  </div>
 
   {#if !isExisting}
     <Button

--- a/src/lib/components/search-attributes-form/search-attribute-row.svelte
+++ b/src/lib/components/search-attributes-form/search-attribute-row.svelte
@@ -5,6 +5,7 @@
   import Input from '$lib/holocene/input/input.svelte';
   import Option from '$lib/holocene/select/option.svelte';
   import Select from '$lib/holocene/select/select.svelte';
+  import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
 
   import type { SearchAttributeTypeOption } from './types';
@@ -18,6 +19,8 @@
     error?: string;
     disableTypeForExisting?: boolean;
     isDeletable?: boolean;
+    isExisting?: boolean;
+    isCloud?: boolean;
     onRemove: () => void;
     onNameChange: (value: string) => void;
     onTypeChange: (value: string) => void;
@@ -32,16 +35,16 @@
     error,
     disableTypeForExisting = false,
     isDeletable = true,
+    isCloud = false,
+    isExisting = false,
     onRemove,
     onNameChange,
     onTypeChange,
   }: Props = $props();
 
   const isTypeDisabled = $derived(
-    submitting || (disableTypeForExisting && !isDeletable),
+    submitting || (disableTypeForExisting && isExisting),
   );
-
-  const isDeleteDisabled = $derived(submitting || !isDeletable);
 
   const hasError = $derived(!!error);
 
@@ -50,7 +53,7 @@
   };
 </script>
 
-<div class="grid grid-cols-[1fr,200px,auto] gap-3">
+<div class="grid grid-cols-[1fr,200px,auto] items-center gap-3">
   <Input
     id={`attribute-name-${index}`}
     value={name}
@@ -74,19 +77,35 @@
     placeholder={translate('search-attributes.select-type-placeholder')}
     onChange={onTypeChange}
   >
-    {#each supportedTypes as type}
+    {#each supportedTypes as type (`${type.label}:${type.value}`)}
       <Option value={type.value}>{type.label}</Option>
     {/each}
   </Select>
 
-  <Button
-    variant="ghost"
-    size="xs"
-    on:click={onRemove}
-    disabled={isDeleteDisabled}
-    type="button"
-    leadingIcon="trash"
-  />
+  {#if !isExisting}
+    <Button
+      variant="ghost"
+      size="xs"
+      on:click={onRemove}
+      disabled={submitting}
+      leadingIcon="close"
+      class="rounded-full"
+    />
+  {:else if isDeletable}
+    <Tooltip
+      text={translate('search-attributes.cloud-delete-tooltip')}
+      hide={!isCloud}
+      topRight
+    >
+      <Button
+        variant="ghost"
+        size="xs"
+        on:click={onRemove}
+        disabled={submitting || isCloud}
+        leadingIcon="trash"
+      />
+    </Tooltip>
+  {/if}
 </div>
 
 {#if error}

--- a/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { superForm } from 'sveltekit-superforms';
   import { zodClient } from 'sveltekit-superforms/adapters';
   import { z } from 'zod/v3';
@@ -7,6 +8,7 @@
   import TaintedBadge from '$lib/components/form/tainted-badge.svelte';
   import Button from '$lib/holocene/button.svelte';
   import Card from '$lib/holocene/card.svelte';
+  import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
 
   import type {
@@ -18,29 +20,58 @@
 
   interface Props {
     class?: string;
+    description?: Snippet;
     initialAttributes: SearchAttributeDefinition[];
     onSave: (attributes: SearchAttributeDefinition[]) => Promise<void>;
     onSuccess?: (attributes: SearchAttributeDefinition[]) => void;
     onCancel?: () => void;
     hideTainted?: boolean;
-    hideCancelButton?: boolean;
     disableTypeForExisting?: boolean;
-    getSupportedTypes: () => SearchAttributeTypeOption[];
+    isCloud?: boolean;
   }
 
   let {
     class: className = '',
+    description,
     initialAttributes,
     onSave,
     onSuccess = () => {},
     onCancel,
     hideTainted = false,
-    hideCancelButton = false,
     disableTypeForExisting = false,
-    getSupportedTypes,
+    isCloud = false,
   }: Props = $props();
 
-  const supportedTypes = $derived(getSupportedTypes());
+  const supportedTypes: SearchAttributeTypeOption[] = [
+    {
+      label: translate('search-attributes.type-keyword'),
+      value: 'Keyword',
+    },
+    {
+      label: translate('search-attributes.type-text'),
+      value: 'Text',
+    },
+    {
+      label: translate('search-attributes.type-int'),
+      value: 'Int',
+    },
+    {
+      label: translate('search-attributes.type-double'),
+      value: 'Double',
+    },
+    {
+      label: translate('search-attributes.type-bool'),
+      value: 'Bool',
+    },
+    {
+      label: translate('search-attributes.type-datetime'),
+      value: 'Datetime',
+    },
+    {
+      label: translate('search-attributes.type-keywordlist'),
+      value: 'KeywordList',
+    },
+  ];
   const defaultType = $derived(supportedTypes[0]?.value || '');
 
   // Create form schema
@@ -54,6 +85,7 @@
               .min(1, translate('search-attributes.validation-name-required')),
             type: z.enum(typeValues as [string, ...string[]]),
             isDeletable: z.boolean().optional().default(true),
+            isExisting: z.boolean().optional().default(false),
             initialName: z.string().optional().default(''),
           }),
         )
@@ -69,8 +101,9 @@
     });
   };
 
-  const typeValues = getSupportedTypes().map((type) => type.value);
+  const typeValues = supportedTypes.map((type) => type.value);
 
+  // svelte-ignore state_referenced_locally
   const {
     form: formData,
     errors,
@@ -109,7 +142,7 @@
   const addAttribute = () => {
     $formData.attributes = [
       ...$formData.attributes,
-      { name: '', type: defaultType, isDeletable: true },
+      { name: '', type: defaultType, isDeletable: true, isExisting: false },
     ];
   };
 
@@ -140,9 +173,19 @@
         <h2 class="text-base font-medium">
           {translate('search-attributes.title')}
         </h2>
-        <p class="text-sm text-secondary">
-          {translate('search-attributes.description')}
-        </p>
+        {#if description}
+          {@render description()}
+        {:else}
+          <p class="text-sm text-secondary">
+            {translate('search-attributes.description')}
+            <Link
+              href="https://docs.temporal.io/search-attribute"
+              newTab
+              trailingIcon="book"
+              >{translate('search-attributes.docs-link')}</Link
+            >.
+          </p>
+        {/if}
       </div>
 
       <div class="space-y-3 pb-3">
@@ -155,7 +198,7 @@
           <div class="w-8"></div>
         </div>
 
-        {#each $formData.attributes as _, index}
+        {#each $formData.attributes as _, index (index)}
           <SearchAttributeRow
             name={$formData.attributes[index].name}
             type={$formData.attributes[index].type}
@@ -164,7 +207,9 @@
             submitting={$submitting}
             error={$errors?.attributes?.[index]?.['name']?.[0]}
             {disableTypeForExisting}
-            isDeletable={$formData.attributes[index].isDeletable ?? true}
+            {isCloud}
+            isDeletable={$formData.attributes[index].isDeletable}
+            isExisting={$formData.attributes[index].isExisting}
             onRemove={() => removeAttribute(index)}
             onNameChange={(value) => {
               $formData.attributes[index].name = value;
@@ -192,18 +237,15 @@
           <TaintedBadge show={!hideTainted} count={taintedCount} />
           {translate('search-attributes.save-button')}
         </Button>
-
-        {#if !hideCancelButton}
-          <Button
-            variant="secondary"
-            size="sm"
-            on:click={handleCancel}
-            disabled={$submitting}
-            type="button"
-          >
-            {translate('common.cancel')}
-          </Button>
-        {/if}
+        <Button
+          variant="secondary"
+          size="sm"
+          on:click={handleCancel}
+          disabled={$submitting}
+          type="button"
+        >
+          {translate('common.cancel')}
+        </Button>
       </div>
     </div>
   </form>

--- a/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
@@ -178,10 +178,7 @@
         {:else}
           <p class="text-sm text-secondary">
             {translate('search-attributes.description')}
-            <Link
-              href="https://docs.temporal.io/search-attribute"
-              newTab
-              trailingIcon="book"
+            <Link href="https://docs.temporal.io/search-attribute" newTab
               >{translate('search-attributes.docs-link')}</Link
             >.
           </p>

--- a/src/lib/components/search-attributes-form/search-attributes-form.mdx
+++ b/src/lib/components/search-attributes-form/search-attributes-form.mdx
@@ -13,6 +13,7 @@ A reusable form component for managing custom search attributes with SuperForms 
 
 - **Promise-Based Loading**: Async data loading with built-in error handling
 - **SuperForms Integration**: Built-in validation with Zod schema and dirty state tracking
+- **Custom Description**: Optional `description` snippet with a localized fallback
 - **Comprehensive Error Handling**: Form state management with proper error display
 - **i18n Support**: Full internationalization with translate() function calls
 - **Accessibility**: Full ARIA support and keyboard navigation
@@ -22,7 +23,7 @@ A reusable form component for managing custom search attributes with SuperForms 
 
 The component uses two main parts:
 
-1. **Parent Component**: Handles async data loading with `#await` pattern
+1. **Parent Component**: Handles async data loading with the `#await` pattern (skeleton, form, and error states)
 2. **Content Component**: Renders the form with SuperForms configuration
 
 ## Props Interface
@@ -32,11 +33,14 @@ The component accepts the following props:
 ```typescript
 interface Props {
   class?: string;
+  description?: Snippet;
   initialAttributesPromise: Promise<SearchAttributeDefinition[]>;
   onSave: (attributes: SearchAttributeDefinition[]) => Promise<void>;
   onSuccess?: (attributes: SearchAttributeDefinition[]) => void;
   onCancel?: () => void;
-  getSupportedTypes: () => SearchAttributeTypeOption[];
+  onRetry?: () => void;
+  hideTainted?: boolean;
+  disableTypeForExisting?: boolean;
 }
 ```
 
@@ -49,8 +53,7 @@ interface Props {
   import { page } from '$app/state';
   import SearchAttributesForm from '$lib/components/search-attributes-form/search-attributes-form.svelte';
   import { fetchSearchAttributesForNamespace } from '$lib/services/search-attributes-service';
-  import { SEARCH_ATTRIBUTE_TYPE } from '$lib/types/workflows';
-  import { translate } from '$lib/i18n/translate';
+  import type { SearchAttributeDefinition } from '$lib/components/search-attributes-form/types';
 
   const namespace = $derived(page.params.namespace);
 
@@ -59,6 +62,7 @@ interface Props {
     return Object.entries(response.customAttributes).map(([name, type]) => ({
       name,
       type,
+      isExisting: true,
     }));
   }
 
@@ -79,39 +83,6 @@ interface Props {
     // Navigate back, reset state, etc.
   }
 
-  function getSupportedTypes(): SearchAttributeTypeOption[] {
-    return [
-      {
-        label: translate('search-attributes.type-keyword'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
-      },
-      {
-        label: translate('search-attributes.type-text'),
-        value: SEARCH_ATTRIBUTE_TYPE.TEXT,
-      },
-      {
-        label: translate('search-attributes.type-int'),
-        value: SEARCH_ATTRIBUTE_TYPE.INT,
-      },
-      {
-        label: translate('search-attributes.type-double'),
-        value: SEARCH_ATTRIBUTE_TYPE.DOUBLE,
-      },
-      {
-        label: translate('search-attributes.type-bool'),
-        value: SEARCH_ATTRIBUTE_TYPE.BOOL,
-      },
-      {
-        label: translate('search-attributes.type-datetime'),
-        value: SEARCH_ATTRIBUTE_TYPE.DATETIME,
-      },
-      {
-        label: translate('search-attributes.type-keywordlist'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORDLIST,
-      },
-    ];
-  }
-
   const initialAttributesPromise = fetchAttributes();
 </script>
 
@@ -120,7 +91,6 @@ interface Props {
   onSave={handleSave}
   onSuccess={handleSuccess}
   onCancel={handleCancel}
-  {getSupportedTypes}
 />
 ```
 
@@ -133,12 +103,8 @@ interface Props {
   import SearchAttributesForm from '$lib/components/search-attributes-form/search-attributes-form.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fetchSearchAttributesForNamespace } from '$lib/services/search-attributes-service';
-  import { SEARCH_ATTRIBUTE_TYPE } from '$lib/types/workflows';
 
-  import type {
-    SearchAttributeDefinition,
-    SearchAttributeTypeOption,
-  } from '$lib/components/search-attributes-form/types';
+  import type { SearchAttributeDefinition } from '$lib/components/search-attributes-form/types';
 
   const namespace = $derived(page.params.namespace);
 
@@ -149,13 +115,11 @@ interface Props {
 
     const response = await fetchSearchAttributesForNamespace(namespace);
     const attributes = Object.entries(response.customAttributes).map(
-      ([name, type]) => ({ name, type }),
+      ([name, type]) => ({ name, type, isExisting: true }),
     );
 
     // Always return at least one empty row for the UI
-    return attributes.length > 0
-      ? attributes
-      : [{ name: '', type: getSupportedTypes()[0]?.value || '' }];
+    return attributes.length > 0 ? attributes : [{ name: '', type: '' }];
   }
 
   async function handleSave(
@@ -175,37 +139,8 @@ interface Props {
     // Add any cancel handling here (navigation, confirmation, etc.)
   }
 
-  function getSupportedTypes(): SearchAttributeTypeOption[] {
-    return [
-      {
-        label: translate('search-attributes.type-keyword'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
-      },
-      {
-        label: translate('search-attributes.type-text'),
-        value: SEARCH_ATTRIBUTE_TYPE.TEXT,
-      },
-      {
-        label: translate('search-attributes.type-int'),
-        value: SEARCH_ATTRIBUTE_TYPE.INT,
-      },
-      {
-        label: translate('search-attributes.type-double'),
-        value: SEARCH_ATTRIBUTE_TYPE.DOUBLE,
-      },
-      {
-        label: translate('search-attributes.type-bool'),
-        value: SEARCH_ATTRIBUTE_TYPE.BOOL,
-      },
-      {
-        label: translate('search-attributes.type-datetime'),
-        value: SEARCH_ATTRIBUTE_TYPE.DATETIME,
-      },
-      {
-        label: translate('search-attributes.type-keywordlist'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORDLIST,
-      },
-    ];
+  function handleRetry() {
+    // Re-run the loader / recreate the promise
   }
 
   const initialAttributesPromise = fetchAttributes();
@@ -228,7 +163,7 @@ interface Props {
     onSave={handleSave}
     onSuccess={handleSuccess}
     onCancel={handleCancel}
-    {getSupportedTypes}
+    onRetry={handleRetry}
   />
 </div>
 ```
@@ -237,14 +172,17 @@ interface Props {
 
 <Markdown>
   {`
-| Prop                    | Type                                                    | Default    | Description                             |
-| ----------------------- | ------------------------------------------------------- | ---------- | --------------------------------------- |
-| initialAttributesPromise | Promise<SearchAttributeDefinition[]>                  | Required   | Promise that resolves to initial data  |
-| onSave                  | (attributes: SearchAttributeDefinition[]) => Promise<void> | Required   | Save handler function                  |
-| onSuccess               | (attributes: SearchAttributeDefinition[]) => void     | () => {}   | Success callback after save            |
-| onCancel                | () => void                                            | () => {}   | Cancel callback                        |
-| getSupportedTypes       | () => SearchAttributeTypeOption[]                     | Required   | Function returning supported types     |
-| class                   | string                                                 | ''         | Additional CSS classes                 |
+| Prop                     | Type                                                       | Default  | Description                                                                 |
+| ------------------------ | ---------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| initialAttributesPromise | Promise<SearchAttributeDefinition[]>                       | Required | Promise that resolves to the initial attribute rows                         |
+| onSave                   | (attributes: SearchAttributeDefinition[]) => Promise<void> | Required | Save handler; throw to surface an error message                             |
+| onSuccess                | (attributes: SearchAttributeDefinition[]) => void          | undefined | Called after a successful save                                             |
+| onCancel                 | () => void                                                 | undefined | Called when the Cancel button is clicked (after the form resets)           |
+| onRetry                  | () => void                                                 | undefined | Called from the error state's retry action                                 |
+| description              | Snippet                                                    | undefined | Custom description content; falls back to the default localized description |
+| hideTainted              | boolean                                                    | false    | Hides the unsaved-changes count badge on the Save button                    |
+| disableTypeForExisting   | boolean                                                    | false    | Disables the type selector for existing (isExisting) attributes             |
+| class                    | string                                                     | ''       | Additional CSS classes                                                      |
   `}
 </Markdown>
 
@@ -254,7 +192,7 @@ The component automatically handles three states:
 
 - **Loading**: Shows skeleton loaders while the promise resolves
 - **Success**: Renders the form with loaded attributes
-- **Error**: Shows error messages with retry functionality
+- **Error**: Shows error messages with retry functionality (`onRetry`)
 
 ## Error Handling
 
@@ -271,9 +209,9 @@ The component provides comprehensive error handling through SuperForms:
 
 ## Dirty State Management
 
-The form automatically tracks unsaved changes using SuperForms `isTainted` function:
+The form automatically tracks unsaved changes using SuperForms `tainted` state:
 
-- **Visual Indicator**: Save button shows a badge when there are unsaved changes
+- **Visual Indicator**: Save button shows a badge when there are unsaved changes (unless `hideTainted` is set)
 - **Real-time Updates**: Badge updates immediately as user makes changes
 - **Form Reset**: Cancel button clears dirty state and resets to initial values
 - **Save Button State**: Disabled when no changes or while submitting
@@ -300,4 +238,3 @@ Form validation is handled by Zod schema with the following rules:
 3. **Composability**: Functions can be shared across different components
 4. **Type Safety**: Direct function signatures provide better TypeScript inference
 5. **Simplicity**: Clean API with direct function props
-6. **Tree Shaking**: Better optimization as unused functions can be eliminated

--- a/src/lib/components/search-attributes-form/search-attributes-form.stories.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form.stories.svelte
@@ -26,16 +26,19 @@
         name: 'CustomerId',
         type: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
         isDeletable: false,
+        isExisting: true,
       },
       {
         name: 'Amount',
         type: SEARCH_ATTRIBUTE_TYPE.DOUBLE,
         isDeletable: false,
+        isExisting: true,
       },
       {
         name: 'ProcessedAt',
         type: SEARCH_ATTRIBUTE_TYPE.DATETIME,
         isDeletable: false,
+        isExisting: true,
       },
     ];
   }
@@ -76,40 +79,6 @@
     action('onCancel')();
   }
 
-  // Get supported types function
-  function getSupportedTypes(): SearchAttributeTypeOption[] {
-    return [
-      {
-        label: translate('search-attributes.type-keyword'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
-      },
-      {
-        label: translate('search-attributes.type-text'),
-        value: SEARCH_ATTRIBUTE_TYPE.TEXT,
-      },
-      {
-        label: translate('search-attributes.type-int'),
-        value: SEARCH_ATTRIBUTE_TYPE.INT,
-      },
-      {
-        label: translate('search-attributes.type-double'),
-        value: SEARCH_ATTRIBUTE_TYPE.DOUBLE,
-      },
-      {
-        label: translate('search-attributes.type-bool'),
-        value: SEARCH_ATTRIBUTE_TYPE.BOOL,
-      },
-      {
-        label: translate('search-attributes.type-datetime'),
-        value: SEARCH_ATTRIBUTE_TYPE.DATETIME,
-      },
-      {
-        label: translate('search-attributes.type-keywordlist'),
-        value: SEARCH_ATTRIBUTE_TYPE.KEYWORDLIST,
-      },
-    ];
-  }
-
   export const meta = {
     title: 'Forms/SearchAttributes',
     component: SearchAttributesForm,
@@ -135,7 +104,6 @@
     onSave: handleSave,
     onSuccess: handleSuccess,
     onCancel: handleCancel,
-    getSupportedTypes,
   }}
   parameters={{
     docs: {
@@ -154,7 +122,6 @@
     onSave: handleSave,
     onSuccess: handleSuccess,
     onCancel: handleCancel,
-    getSupportedTypes,
   }}
   parameters={{
     docs: {
@@ -173,7 +140,6 @@
     onSave: handleSave,
     onSuccess: handleSuccess,
     onCancel: handleCancel,
-    getSupportedTypes,
   }}
   parameters={{
     docs: {

--- a/src/lib/components/search-attributes-form/search-attributes-form.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import FormError from '$lib/components/form/form-error.svelte';
   import { translate } from '$lib/i18n/translate';
 
@@ -9,28 +11,28 @@
 
   interface Props {
     class?: string;
+    description?: Snippet;
     initialAttributesPromise: Promise<SearchAttributeDefinition[]>;
     onSave: (attributes: SearchAttributeDefinition[]) => Promise<void>;
     onSuccess?: (attributes: SearchAttributeDefinition[]) => void;
     onCancel?: () => void;
     onRetry?: () => void;
-    getSupportedTypes: () => { label: string; value: string }[];
     hideTainted?: boolean;
-    hideCancelButton?: boolean;
     disableTypeForExisting?: boolean;
+    isCloud?: boolean;
   }
 
   let {
     class: className = '',
+    description,
     initialAttributesPromise,
     onSave,
     onSuccess,
     onCancel,
     onRetry,
-    getSupportedTypes,
     hideTainted = false,
-    hideCancelButton = false,
     disableTypeForExisting = false,
+    isCloud = false,
   }: Props = $props();
 </script>
 
@@ -39,14 +41,14 @@
 {:then initialAttributes}
   <SearchAttributesFormContent
     class={className}
+    {description}
     {initialAttributes}
     {onSave}
     {onSuccess}
     {onCancel}
-    {getSupportedTypes}
     {hideTainted}
-    {hideCancelButton}
     {disableTypeForExisting}
+    {isCloud}
   />
 {:catch error}
   <FormError

--- a/src/lib/components/search-attributes-form/types.ts
+++ b/src/lib/components/search-attributes-form/types.ts
@@ -2,6 +2,7 @@ export interface SearchAttributeDefinition {
   name?: string;
   type?: string;
   isDeletable?: boolean;
+  isExisting?: boolean;
   initialName?: string;
 }
 
@@ -18,7 +19,6 @@ export interface SearchAttributesAdapter {
   fetchAttributes(): Promise<SearchAttributeDefinition[]>;
   upsertAttributes(attributes: SearchAttributeDefinition[]): Promise<void>;
   deleteAttribute(attributeName: string): Promise<void>;
-  getSupportedTypes(): SearchAttributeTypeOption[];
   onSuccess?: (attributes: SearchAttributeDefinition[]) => Promise<void>;
   onCancel?: () => void;
 }

--- a/src/lib/i18n/locales/en/search-attributes.ts
+++ b/src/lib/i18n/locales/en/search-attributes.ts
@@ -3,13 +3,17 @@ export const Namespace = 'search-attributes' as const;
 export const Strings = {
   // Component headers and labels
   title: 'Search Attributes',
-  description: 'Define custom search attributes for workflow queries.',
+  description:
+    'Define custom search attributes for workflow queries. For more information on search attribute types, read the',
+  'docs-link': 'Search Attribute docs',
   'column-attribute': 'Attribute',
   'column-type': 'Type',
   'attribute-label': 'Attribute {{index}}',
   'type-label': 'Type for Attribute {{index}}',
   'select-type-placeholder': 'Select type',
   'custom-search-attributes': 'Custom Search Attributes',
+  'cloud-delete-tooltip':
+    'To delete a search attribute, open a Support Ticket.',
 
   // Buttons
   'add-attribute-button': 'Add New Custom Search Attribute',
@@ -39,8 +43,8 @@ export const Strings = {
   'type-int': 'Int',
   'type-double': 'Double',
   'type-bool': 'Bool',
-  'type-datetime': 'DateTime',
-  'type-keywordlist': 'KeywordList',
+  'type-datetime': 'Datetime',
+  'type-keywordlist': 'Keyword List',
 
   // Story titles
   'story-title': 'Custom Search Attributes for {{namespace}}',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

- Added an `isExisting` prop when adding a row so button to remove row is a close icon instead of a trash icon for new attributes. 
- In Cloud the trash button is disabled and shows a tooltip.
- The `getSupportedTypes` prop was removed and the content component now defines the type list internally.
- Added an optional description snippet prop with a fallback `<p>` that now includes a "Search Attribute docs" Link.
- `hideCancelButton` prop removed since it was not being used.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Default | Cloud | Cloud w/ delete enabled|
|-|-|-|
|<img width="1153" height="371" alt="Screenshot 2026-07-02 at 3 52 40 PM" src="https://github.com/user-attachments/assets/e781694e-d284-40a0-8b00-3cf80a1f513c" />|<img width="1097" height="386" alt="Screenshot 2026-07-06 at 2 57 32 PM" src="https://github.com/user-attachments/assets/124dfa36-13c8-4582-8eff-f818965a88d0" />|<img width="1152" height="387" alt="Screenshot 2026-07-02 at 3 50 41 PM" src="https://github.com/user-attachments/assets/a9ed8e88-3e84-42b6-ac36-7de8a88fd2ea" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

For an existing search attribute
  - [ ] type select should be disabled
  - [ ] if the feature flag is enabled there should be a disabled delete button
  - [ ] if the feature flag **not** enabled there should be no delete button

For a new search attbibute
  - [ ] type select should be enabled
  - [ ] there should be a close button

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-4190`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
