### PR TITLE
fix(markdown-editor): disable chromatic snapshot for preview story

### DIFF
--- a/src/lib/holocene/markdown-editor/markdown-editor.stories.svelte
+++ b/src/lib/holocene/markdown-editor/markdown-editor.stories.svelte
@@ -45,4 +45,5 @@
   <MarkdownEditor {...args} />
 </Template>
 
-<Story name="default" {play} />
+<!-- preview iframe hits the /render server route, which 404s in Chromatic's static build -->
+<Story name="default" {play} parameters={{ chromatic: { disable: true } }} />


### PR DESCRIPTION
## Problem

Chromatic started flagging the **Markdown Editor** story with:

> Resources requested by the new story could not be loaded. Snapshots may be affected.

<img width="2798" height="2156" alt="CleanShot 2026-07-06 at 09 23 00@2x" src="https://github.com/user-attachments/assets/77956c9a-cde3-4138-bce8-30eda4e033cd" />

## Root cause

The `Preview` component renders markdown in an `<iframe src="/render?content=…">`. `/render` is a SvelteKit **server** endpoint (`src/routes/(app)/render/+server.ts`) that sanitizes the markdown and returns an HTML page.

Chromatic snapshots the **static** `storybook build` output, which has no server — so `/render` returns **404** and the iframe's resource fails to load. The preview renders as an empty box.

It surfaced now because the News Feed PR (#3596) was the first edit to `preview.svelte` in a long time, so Chromatic's TurboSnap re-ran this story and reported the (previously dormant) resource warning. The resize/ResizeObserver rework in that PR is deterministic and not the cause.

## Fix

Disable the Chromatic snapshot for the story. No production code changes.

- No coverage is lost: the play function ends on the **Preview** tab, so the current Chromatic snapshot was just the empty 404 box anyway.
- The interaction test (`play`) still runs in Storybook.

If we ever want the preview *visible* in Chromatic, that requires rendering client-side via iframe `srcdoc` so it no longer depends on the server route.

## Verification

- Rebuilt Storybook; confirmed `chromatic: { disable: true }` resolves at runtime for `markdown-editor--default`.
- `pnpm lint` → 0 errors.