### PR TITLE
DurationInput updates

### DIFF
--- a/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
@@ -8,8 +8,7 @@
   import Checkbox from '$lib/holocene/checkbox.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
   import DurationInput, {
-    parseDuration,
-    type Units,
+    getFirstWholeNumberUnit,
   } from '$lib/holocene/duration-input/duration-input.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import RadioCard from '$lib/holocene/radio-input/radio-card.svelte';
@@ -108,26 +107,6 @@
   const onCancel = () => {
     isOpen = false;
   };
-
-  function getFirstWholeNumberUnit<UnitLabelT extends string>(
-    duration: string,
-    units: Units<UnitLabelT>,
-  ): UnitLabelT | undefined {
-    const secondsValue = Number(parseDuration(duration));
-
-    if (secondsValue === 0) {
-      // if 0, use last unit label
-      return units.at(-1)?.label;
-    }
-
-    for (const unit of units) {
-      if (Number.isInteger(secondsValue / unit.convert(1))) {
-        return unit.label;
-      }
-    }
-
-    return undefined;
-  }
 </script>
 
 <Drawer

--- a/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
+++ b/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
@@ -29,7 +29,9 @@
   import { getActivityPollers } from '$lib/services/pollers-service';
   import {
     fetchInitialValuesForStartActivity,
+    initialTimeoutUnit,
     startStandaloneActivity,
+    TIMEOUT_UNITS,
   } from '$lib/services/standalone-activities';
   import {
     customSearchAttributes,
@@ -318,6 +320,8 @@
         'standalone-activities.form-start-to-close-timeout-hint',
       )}
       bind:value={$form.startToCloseTimeout}
+      initialUnit={initialTimeoutUnit($form.startToCloseTimeout)}
+      units={TIMEOUT_UNITS}
     />
 
     <DurationInput
@@ -330,6 +334,8 @@
         'standalone-activities.form-schedule-to-close-timeout-hint',
       )}
       bind:value={$form.scheduleToCloseTimeout}
+      initialUnit={initialTimeoutUnit($form.scheduleToCloseTimeout)}
+      units={TIMEOUT_UNITS}
     />
 
     <DurationInput
@@ -341,6 +347,8 @@
         'standalone-activities.form-schedule-to-start-timeout-hint',
       )}
       bind:value={$form.scheduleToStartTimeout}
+      initialUnit={initialTimeoutUnit($form.scheduleToStartTimeout)}
+      units={TIMEOUT_UNITS}
     />
 
     {#if $errors.startToCloseTimeout}
@@ -409,6 +417,8 @@
           'standalone-activities.form-heartbeat-timeout-hint',
         )}
         bind:value={$form.heartbeatTimeout}
+        initialUnit={initialTimeoutUnit($form.heartbeatTimeout)}
+        units={TIMEOUT_UNITS}
       />
     </Card>
 
@@ -420,7 +430,7 @@
         id="start-standalone-activity-id-reuse-policy-select"
         bind:value={$form.idReusePolicy}
       >
-        {#each activityIDReusePolicyOptions as option}
+        {#each activityIDReusePolicyOptions as option, i (i)}
           <Option value={option}
             >{fromScreamingEnum(option, 'ActivityIdReusePolicy')}</Option
           >
@@ -432,7 +442,7 @@
         id="start-standalone-activity-id-conflict-policy-select"
         bind:value={$form.idConflictPolicy}
       >
-        {#each activityIDConflictPolicyOptions as option}
+        {#each activityIDConflictPolicyOptions as option, i (i)}
           <Option value={option}
             >{fromScreamingEnum(option, 'ActivityIdConflictPolicy')}</Option
           >

--- a/src/lib/components/workflow/pending-nexus-operation/pending-nexus-operation-card.svelte
+++ b/src/lib/components/workflow/pending-nexus-operation/pending-nexus-operation-card.svelte
@@ -80,7 +80,7 @@
       {#if operation.scheduleToStartTimeout}
         {@render detail(
           translate('workflows.schedule-to-start-timeout'),
-          operation.scheduleToCloseTimeout as string,
+          operation.scheduleToStartTimeout as string,
         )}
       {/if}
       {#if operation.startToCloseTimeout}

--- a/src/lib/holocene/duration-input/duration-input.svelte
+++ b/src/lib/holocene/duration-input/duration-input.svelte
@@ -43,6 +43,47 @@
     return duration.split('s')[0] ?? '';
   };
 
+  // `0.1 / 0.001` is `100.00000000000001` in binary floating point; round to
+  // nanosecond precision to strip that noise before comparing or displaying.
+  const stripFloatNoise = (n: number): number => Math.round(n * 1e9) / 1e9;
+
+  export function getFirstWholeNumberUnit<UnitLabelT extends string>(
+    duration: string,
+    units: Units<UnitLabelT>,
+    defaultUnit?: UnitLabelT,
+  ): UnitLabelT | undefined {
+    const secondsValue = Number(parseDuration(duration));
+
+    if (secondsValue === 0) {
+      // no value: use the provided default, else the last unit label
+      return defaultUnit ?? units.at(-1)?.label;
+    }
+
+    for (const unit of units) {
+      if (Number.isInteger(stripFloatNoise(secondsValue / unit.convert(1)))) {
+        return unit.label;
+      }
+    }
+
+    return defaultUnit;
+  }
+
+  // Converts a value entered in a given unit to a seconds duration string
+  // (e.g. `60` + `minute(s)` -> `3600s`)
+  export function unitValueToDuration<UnitLabelT extends string>(
+    rawValue: string | number,
+    unitLabel: string,
+    units: Units<UnitLabelT>,
+  ): string | undefined {
+    const unit = units.find((u) => u.label === unitLabel);
+    if (!unit) return undefined;
+
+    const raw = String(rawValue ?? '').trim();
+    if (raw === '' || isNaN(Number(raw))) return '';
+
+    return `${unit.convert(Number(raw))}s`;
+  }
+
   type ExtractLabel<T> = T extends { label: infer K }[] ? K : never;
 </script>
 
@@ -109,7 +150,7 @@
     if (!Number.isFinite(seconds)) return '';
     const unitDef = units.find((u) => u.label === unitLabel);
     const factor = unitDef ? unitDef.convert(1) : 1;
-    return factor ? String(seconds / factor) : String(seconds);
+    return factor ? String(stripFloatNoise(seconds / factor)) : String(seconds);
   };
 
   // svelte-ignore state_referenced_locally
@@ -117,16 +158,9 @@
   // svelte-ignore state_referenced_locally
   let unit = $state(initialUnit);
 
-  const convert = (durationValue: string, durationUnit: string) => {
-    const unit = units.find((u) => u.label === durationUnit);
-    if (!unit || typeof durationValue !== 'string') return;
-
-    if (durationValue.trim() === '' || isNaN(Number(durationValue))) {
-      value = '';
-      return;
-    }
-
-    value = `${unit.convert(Number(durationValue))}s`;
+  const convert = (durationValue: string | number, durationUnit: string) => {
+    const result = unitValueToDuration(durationValue, durationUnit, units);
+    if (result !== undefined) value = result;
   };
 
   const handleNumberInput: ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -169,8 +203,8 @@
       bind:value={unit}
       onchange={handleUnitChange}
     >
-      {#each units as unit}
-        <option value={unit.label}>{unit.label}</option>
+      {#each units as { label }, i (i)}
+        <option value={label}>{label}</option>
       {/each}
     </select>
   </div>

--- a/src/lib/holocene/duration-input/duration-input.svelte
+++ b/src/lib/holocene/duration-input/duration-input.svelte
@@ -106,6 +106,7 @@
   interface BaseProps extends Omit<HTMLInputAttributes, 'class'> {
     value: string;
     label: string;
+    labelHidden?: boolean;
     afterLabel?: Snippet;
     id: string;
     required?: boolean;
@@ -130,6 +131,7 @@
 
   let {
     label,
+    labelHidden = false,
     afterLabel,
     id,
     hintText,
@@ -174,7 +176,7 @@
 
 <div class={twMerge('flex flex-col gap-1.5', className)}>
   <div class="flex items-center justify-start gap-2">
-    <Label class="grow-0" {required} {label} for={id} />
+    <Label class="grow-0" {required} {label} hidden={labelHidden} for={id} />
     {@render afterLabel?.()}
   </div>
   {#if hintTextAbove}

--- a/src/lib/holocene/duration-input/duration-input.test.ts
+++ b/src/lib/holocene/duration-input/duration-input.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getFirstWholeNumberUnit,
+  HOURS,
+  MILLISECONDS,
+  MINUTES,
+  SECONDS,
+  unitValueToDuration,
+} from './duration-input.svelte';
+
+// largest-first, matching how the activity/standalone forms configure units
+const hms = [HOURS, MINUTES, SECONDS];
+const hmsMs = [HOURS, MINUTES, SECONDS, MILLISECONDS];
+
+describe('getFirstWholeNumberUnit', () => {
+  it('returns the largest unit that divides evenly', () => {
+    expect(getFirstWholeNumberUnit('3600s', hms)).toBe('hour(s)');
+    expect(getFirstWholeNumberUnit('7200s', hms)).toBe('hour(s)');
+    expect(getFirstWholeNumberUnit('120s', hms)).toBe('minute(s)');
+    expect(getFirstWholeNumberUnit('90s', hms)).toBe('second(s)');
+  });
+
+  it('prefers larger units over smaller ones when both divide evenly', () => {
+    // 3600s divides evenly by hours, minutes, and seconds -> hours wins
+    expect(getFirstWholeNumberUnit('3600s', hms)).toBe('hour(s)');
+    // 60s divides evenly by minutes and seconds -> minutes wins
+    expect(getFirstWholeNumberUnit('60s', hms)).toBe('minute(s)');
+  });
+
+  it('resolves sub-second values to milliseconds when available', () => {
+    expect(getFirstWholeNumberUnit('0.5s', hmsMs)).toBe('millisecond(s)');
+    expect(getFirstWholeNumberUnit('0.25s', hmsMs)).toBe('millisecond(s)');
+  });
+
+  it('is not fooled by binary floating-point division error', () => {
+    // 0.1 / 0.001 === 100.00000000000001, which would fail a naive isInteger
+    expect(getFirstWholeNumberUnit('0.1s', hmsMs)).toBe('millisecond(s)');
+    expect(getFirstWholeNumberUnit('0.007s', hmsMs)).toBe('millisecond(s)');
+    // still rejects a genuinely fractional millisecond value
+    expect(getFirstWholeNumberUnit('0.0001s', hmsMs)).toBeUndefined();
+  });
+
+  describe('zero / empty values', () => {
+    it('returns the default unit when provided', () => {
+      expect(getFirstWholeNumberUnit('0s', hmsMs, 'second(s)')).toBe(
+        'second(s)',
+      );
+      expect(getFirstWholeNumberUnit('', hmsMs, 'second(s)')).toBe('second(s)');
+    });
+
+    it('falls back to the last unit label when no default is provided', () => {
+      expect(getFirstWholeNumberUnit('0s', hms)).toBe('second(s)');
+      expect(getFirstWholeNumberUnit('0s', [MINUTES, HOURS])).toBe('hour(s)');
+    });
+  });
+
+  describe('no unit divides evenly', () => {
+    it('returns the default unit when provided', () => {
+      expect(getFirstWholeNumberUnit('1.5s', hms, 'second(s)')).toBe(
+        'second(s)',
+      );
+    });
+
+    it('returns undefined when no default is provided', () => {
+      expect(getFirstWholeNumberUnit('1.5s', hms)).toBeUndefined();
+    });
+  });
+
+  it('ignores the default when a value resolves to a unit', () => {
+    expect(getFirstWholeNumberUnit('3600s', hms, 'second(s)')).toBe('hour(s)');
+    expect(getFirstWholeNumberUnit('120s', hms, 'second(s)')).toBe('minute(s)');
+  });
+});
+
+describe('unitValueToDuration', () => {
+  // Regression: the bound `<input type="number">` value arrives as a number
+  // after typing, so changing the unit afterwards must still convert it. The
+  // previous implementation bailed on non-string input and left the value in
+  // the old unit (e.g. entering 60 minutes was saved as "60s").
+  it('converts a numeric value in the selected unit', () => {
+    expect(unitValueToDuration(60, 'minute(s)', hmsMs)).toBe('3600s');
+    expect(unitValueToDuration(60, 'hour(s)', hmsMs)).toBe('216000s');
+    expect(unitValueToDuration(500, 'millisecond(s)', hmsMs)).toBe('0.5s');
+  });
+
+  it('converts a string value the same way', () => {
+    expect(unitValueToDuration('60', 'minute(s)', hmsMs)).toBe('3600s');
+    expect(unitValueToDuration('30', 'second(s)', hmsMs)).toBe('30s');
+  });
+
+  it('returns an empty string for empty or non-numeric input', () => {
+    expect(unitValueToDuration('', 'minute(s)', hmsMs)).toBe('');
+    expect(unitValueToDuration('   ', 'minute(s)', hmsMs)).toBe('');
+    expect(unitValueToDuration('abc', 'minute(s)', hmsMs)).toBe('');
+  });
+
+  it('returns undefined for an unknown unit so callers keep the current value', () => {
+    expect(unitValueToDuration(60, 'fortnight(s)', hmsMs)).toBeUndefined();
+  });
+});

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -12,6 +12,7 @@
   import Alert from '$lib/holocene/alert.svelte';
   import Button from '$lib/holocene/button.svelte';
   import Card from '$lib/holocene/card.svelte';
+  import DurationInput from '$lib/holocene/duration-input/duration-input.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Label from '$lib/holocene/label.svelte';
@@ -32,10 +33,6 @@
   import { toaster } from '$lib/stores/toaster';
   import { workflowsSearchParams } from '$lib/stores/workflows';
   import { getIdentity } from '$lib/utilities/core-context';
-  import {
-    formatSecondsAbbreviated,
-    fromNumberToDuration,
-  } from '$lib/utilities/format-time';
   import { pluralize } from '$lib/utilities/pluralize';
   import {
     routeForTaskQueue,
@@ -125,7 +122,7 @@
         messageType,
         searchAttributes,
         identity,
-        workflowStartDelay: fromNumberToDuration(workflowStartDelay),
+        workflowStartDelay: workflowStartDelay || undefined,
       });
       toaster.push({
         variant: 'success',
@@ -335,20 +332,15 @@
             Time to wait before dispatching the first workflow task.
           </p>
         </div>
-        <div class="flex flex-wrap items-center gap-2">
-          <Input
-            id="workflow-start-delay"
-            label={translate('workflows.workflow-start-delay')}
-            labelHidden
-            bind:value={workflowStartDelay}
-            suffix="sec"
-            class="w-36"
-            error={isNaN(Number(workflowStartDelay))}
-          />
-          <p class="text-nowrap text-secondary">
-            {formatSecondsAbbreviated(workflowStartDelay)}
-          </p>
-        </div>
+        <DurationInput
+          id="workflow-start-delay"
+          label={translate('workflows.workflow-start-delay')}
+          labelHidden
+          inputmode="numeric"
+          bind:value={workflowStartDelay}
+          min={0}
+          class="max-w-80"
+        />
       </Card>
       <Card class="flex flex-col gap-2">
         <div class="flex flex-wrap justify-between">

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -1,4 +1,13 @@
 import type { StandaloneActivityFormData } from '$lib/components/standalone-activities/start-standalone-activity-form/types';
+import {
+  type DefaultUnits,
+  getFirstWholeNumberUnit,
+  HOURS,
+  MILLISECONDS,
+  MINUTES,
+  SECONDS,
+  type Units,
+} from '$lib/holocene/duration-input/duration-input.svelte';
 import { translate } from '$lib/i18n/translate';
 import {
   isPayloadInputEncodingType,
@@ -21,6 +30,21 @@ import {
 import { routeForApi } from '$lib/utilities/route-for-api';
 
 import { setSearchAttributes } from './workflow-service';
+
+// Timeout duration inputs on the activity forms; largest-first so
+// getFirstWholeNumberUnit resolves to the coarsest whole unit, defaulting to
+// seconds when there is no value.
+export const TIMEOUT_UNITS: Units<DefaultUnits> = [
+  HOURS,
+  MINUTES,
+  SECONDS,
+  MILLISECONDS,
+];
+
+export const initialTimeoutUnit = (
+  duration: string,
+): DefaultUnits | undefined =>
+  getFirstWholeNumberUnit(duration, TIMEOUT_UNITS, SECONDS.label);
 
 export type ListActivitiesResponse = {
   executions: ActivityExecutionInfo[];


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

- Exports `getFirstWholeNumberUnit(duration, units, defaultUnit?)` from the `DurationInput` instead of the schedule drawer so it's shared. Updated it so it takes an optional default unit, falling back to the last unit otherwise.
- Exported `unitValueToDuration(rawValue, unitLabel, units)` for easier testing.
- It now accepts `string | number`. The `<input type="number">` binding delivers a number after typing, and the old typeof !== 'string' guard silently dropped the conversion when you changed the unit after typing (e.g. "60 minutes" was saved as 60s). `convert` now delegates to `unitValueToDuration`.
- Float-precision fix via `stripFloatNoise` (rounds to nanosecond precision) so sub-second values like 0.1s classify/display correctly instead of 100.00000000000001.
- Adds `labelHidden` prop (mirrors `Input/NumberInput`).
---
- Added shared timeout presets (`TIMEOUT_UNITS` and `initialTimeoutUnit`).
- Replaced the workflow-start-delay `Input` with the `DurationInput`.
- Fixed the "Schedule to Start Timeout" row displaying `scheduleToCloseTimeout` for pending Nexus operations.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
