### PR TITLE
schedules - Update default timeouts  to match workflow defaults

### DIFF
--- a/src/lib/components/schedule/constants.ts
+++ b/src/lib/components/schedule/constants.ts
@@ -82,6 +82,6 @@ const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
 
 export const MIN_CATCHUP_SECONDS = 10;
 export const DEFAULT_CATCHUP_WINDOW: DurationString = `${SECONDS_PER_YEAR}s`;
-export const DEFAULT_TASK_TIMEOUT: DurationString = '30s';
-export const DEFAULT_RUN_TIMEOUT: DurationString = '120s';
-export const DEFAULT_EXECUTION_TIMEOUT: DurationString = '14400s';
+export const DEFAULT_TASK_TIMEOUT: DurationString = '10s';
+export const DEFAULT_RUN_TIMEOUT: DurationString = '0s';
+export const DEFAULT_EXECUTION_TIMEOUT: DurationString = '0s';

--- a/src/lib/components/schedule/utilities/get-request-body.test.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.test.ts
@@ -143,6 +143,32 @@ describe('getRequestBody', () => {
     );
   });
 
+  it('omits run and execution timeouts when zeroed (no timeout)', async () => {
+    const { startWorkflow } = (await getRequestBody(buildForm())).schedule
+      .action;
+
+    expect(startWorkflow.workflowTaskTimeout).toBe(DEFAULT_TASK_TIMEOUT);
+    expect(startWorkflow.workflowRunTimeout).toBeUndefined();
+    expect(startWorkflow.workflowExecutionTimeout).toBeUndefined();
+  });
+
+  it('clears a previously set timeout when the form value is zeroed', async () => {
+    const describeFullSchedule = {
+      schedule: {
+        action: { startWorkflow: { workflowRunTimeout: '300s' } },
+      },
+    } as unknown as DescribeFullSchedule;
+
+    const { startWorkflow } = (
+      await getRequestBody(
+        buildForm({ runTimeout: '0s' }),
+        describeFullSchedule,
+      )
+    ).schedule.action;
+
+    expect(startWorkflow.workflowRunTimeout).toBeUndefined();
+  });
+
   it('maps policy fields', async () => {
     const body = await getRequestBody(
       buildForm({ overlapPolicy: 'BufferOne', pauseOnFailure: true }),

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -1,3 +1,4 @@
+import { parseDuration } from '$lib/holocene/duration-input/duration-input.svelte';
 import { setSearchAttributes } from '$lib/services/workflow-service';
 import type { Payload } from '$lib/types';
 import { encodePayloads } from '$lib/utilities/encode-payload';
@@ -86,6 +87,16 @@ function getSchedulePoliciesRequest(
   } satisfies SchedulePoliciesRequest;
 }
 
+// Omit zero/empty workflow timeouts so the server applies its defaults
+// (execution/run: unlimited, task: 10s) rather than sending an explicit 0.
+function toWorkflowTimeout(value: string | undefined): string | undefined {
+  if (!value || Number(parseDuration(value)) <= 0) {
+    return undefined;
+  }
+
+  return value;
+}
+
 async function getScheduleActionRequest(
   scheduleForm: FormScheduleSchema,
   describeFullSchedule: DescribeFullSchedule | null = null,
@@ -120,15 +131,11 @@ async function getScheduleActionRequest(
       searchAttributes: getSearchAttributes(
         scheduleForm.workflowSearchAttributes,
       ),
-      ...(scheduleForm.taskTimeout && {
-        workflowTaskTimeout: scheduleForm.taskTimeout,
-      }),
-      ...(scheduleForm.runTimeout && {
-        workflowRunTimeout: scheduleForm.runTimeout,
-      }),
-      ...(scheduleForm.executionTimeout && {
-        workflowExecutionTimeout: scheduleForm.executionTimeout,
-      }),
+      workflowTaskTimeout: toWorkflowTimeout(scheduleForm.taskTimeout),
+      workflowRunTimeout: toWorkflowTimeout(scheduleForm.runTimeout),
+      workflowExecutionTimeout: toWorkflowTimeout(
+        scheduleForm.executionTimeout,
+      ),
       ...(header && { header }),
     },
   } satisfies ScheduleActionRequest;

--- a/src/lib/i18n/locales/en/schedules.ts
+++ b/src/lib/i18n/locales/en/schedules.ts
@@ -194,7 +194,7 @@ export const Strings = {
   'timeout-run': 'Run: {{- duration}}',
   'timeout-execution': 'Execution: {{- duration}}',
   'no-timeouts': 'No timeouts set',
-  'zero-duration': '0 seconds',
+  'zero-duration': 'No timeout',
   'catchup-window-default': '1 year',
   'interval-label': 'Time Interval',
   'cron-shortcuts': 'Cron Shortcuts',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

With the implementaiton of the schedules redesign, the default timeouts were changed. Instead, we want to keep them matching the defaults for when you create a workflow.

Update default timeouts when creating a schedule to match the default workflow timeouts

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="582" height="373" alt="Screenshot 2026-07-06 at 2 51 17 PM" src="https://github.com/user-attachments/assets/54c9c0d9-8e4b-4c2b-ab0f-2c833e91f9b2" />

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
https://temporalio.atlassian.net/browse/DT-4231

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
