### PR TITLE
Schedules - Timeout empty defaults

### DIFF
--- a/src/lib/components/schedule/constants.ts
+++ b/src/lib/components/schedule/constants.ts
@@ -83,5 +83,7 @@ const SECONDS_PER_YEAR = 365 * SECONDS_PER_DAY;
 export const MIN_CATCHUP_SECONDS = 10;
 export const DEFAULT_CATCHUP_WINDOW: DurationString = `${SECONDS_PER_YEAR}s`;
 export const DEFAULT_TASK_TIMEOUT: DurationString = '10s';
-export const DEFAULT_RUN_TIMEOUT: DurationString = '0s';
-export const DEFAULT_EXECUTION_TIMEOUT: DurationString = '0s';
+// Run/execution timeouts default to empty, meaning "use the server default"
+// (unlimited). An empty value is omitted from the request entirely.
+export const DEFAULT_RUN_TIMEOUT = '';
+export const DEFAULT_EXECUTION_TIMEOUT = '';

--- a/src/lib/components/schedule/schedule-form/schedule-policies-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-card.svelte
@@ -37,18 +37,16 @@
             formatDuration($form.taskTimeout) ||
             translate('schedules.zero-duration'),
         }),
-      $form.runTimeout &&
-        translate('schedules.timeout-run', {
-          duration:
-            formatDuration($form.runTimeout) ||
-            translate('schedules.zero-duration'),
-        }),
-      $form.executionTimeout &&
-        translate('schedules.timeout-execution', {
-          duration:
-            formatDuration($form.executionTimeout) ||
-            translate('schedules.zero-duration'),
-        }),
+      translate('schedules.timeout-run', {
+        duration:
+          formatDuration($form.runTimeout) ||
+          translate('schedules.zero-duration'),
+      }),
+      translate('schedules.timeout-execution', {
+        duration:
+          formatDuration($form.executionTimeout) ||
+          translate('schedules.zero-duration'),
+      }),
     ]
       .filter(Boolean)
       .join(', ') || translate('schedules.no-timeouts'),

--- a/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
@@ -20,8 +20,6 @@
 
   import {
     DEFAULT_CATCHUP_WINDOW,
-    DEFAULT_EXECUTION_TIMEOUT,
-    DEFAULT_RUN_TIMEOUT,
     DEFAULT_TASK_TIMEOUT,
     durationUnits,
     getOverlapPolicyContent,
@@ -311,7 +309,6 @@
         hintText={$errors.runTimeout?.[0] ?? ''}
         class="max-w-80"
         min={0}
-        onblur={snapToDefault('runTimeout', DEFAULT_RUN_TIMEOUT)}
       />
     {/key}
 
@@ -330,7 +327,6 @@
         hintText={$errors.executionTimeout?.[0] ?? ''}
         class="max-w-80"
         min={0}
-        onblur={snapToDefault('executionTimeout', DEFAULT_EXECUTION_TIMEOUT)}
       />
     {/key}
 

--- a/src/lib/components/schedule/schema/form.ts
+++ b/src/lib/components/schedule/schema/form.ts
@@ -6,8 +6,6 @@ import { searchAttributesSchema } from '$lib/stores/search-attributes';
 import { durationString, jsonString, structuredCalendarSchema } from './common';
 import {
   DEFAULT_CATCHUP_WINDOW,
-  DEFAULT_EXECUTION_TIMEOUT,
-  DEFAULT_RUN_TIMEOUT,
   DEFAULT_TASK_TIMEOUT,
   MIN_CATCHUP_SECONDS,
 } from '../constants';
@@ -22,6 +20,16 @@ const durationStringWithDefault = (fallback: DurationString) =>
     (input) => (input == null || input === '' ? fallback : input),
     durationString(),
   );
+
+// Run/execution timeouts may be left empty to mean "use the server default".
+// Keep an emptied input as '' rather than coercing it to 0s.
+const optionalDurationString = () =>
+  z
+    .preprocess(
+      (input) => input ?? '',
+      z.union([z.literal(''), durationString()]),
+    )
+    .default('');
 
 export const overlapPolicy = z
   .enum([
@@ -51,8 +59,8 @@ export const formSchedulePoliciesSchema = z.object({
     },
   ),
   taskTimeout: durationStringWithDefault(DEFAULT_TASK_TIMEOUT),
-  runTimeout: durationStringWithDefault(DEFAULT_RUN_TIMEOUT),
-  executionTimeout: durationStringWithDefault(DEFAULT_EXECUTION_TIMEOUT),
+  runTimeout: optionalDurationString(),
+  executionTimeout: optionalDurationString(),
   keepOriginalWorkflowId: z.boolean().optional(),
 });
 

--- a/src/lib/components/schedule/utilities/get-form-schedule-defaults.test.ts
+++ b/src/lib/components/schedule/utilities/get-form-schedule-defaults.test.ts
@@ -138,12 +138,32 @@ describe('getFormScheduleDefaults', () => {
       expect(defaults.pauseSchedule).toBe(true);
       expect(defaults.catchupWindow).toBe('600s');
       expect(defaults.runTimeout).toBe('300s');
+      expect(defaults.executionTimeout).toBe('');
     });
 
     it('derives the end condition from limited actions', () => {
       expect(defaults.endKind).toBe('after');
       expect(defaults.endAfterOccurrences).toBe(3);
     });
+  });
+
+  it('normalizes a stored 0s run/execution timeout to empty', () => {
+    const defaults = getFormScheduleDefaults(
+      {
+        schedule: {
+          action: {
+            startWorkflow: {
+              workflowRunTimeout: '0s',
+              workflowExecutionTimeout: '0s',
+            },
+          },
+        },
+      } as unknown as DescribeFullSchedule,
+      noAttributes,
+    );
+
+    expect(defaults.runTimeout).toBe('');
+    expect(defaults.executionTimeout).toBe('');
   });
 
   it('prefills the end date with today in the schedule timezone', () => {

--- a/src/lib/components/schedule/utilities/get-form-schedule-defaults.ts
+++ b/src/lib/components/schedule/utilities/get-form-schedule-defaults.ts
@@ -7,12 +7,7 @@ import { fromScreamingEnum } from '$lib/utilities/screaming-enums';
 import { isoStringToCalendarDateStr } from './date';
 import { getFormSpecsFromDescribeFullSchedule } from './get-form-spec';
 import { getFormSpecInitialData } from './get-form-spec-initial-data';
-import {
-  DEFAULT_CATCHUP_WINDOW,
-  DEFAULT_EXECUTION_TIMEOUT,
-  DEFAULT_RUN_TIMEOUT,
-  DEFAULT_TASK_TIMEOUT,
-} from '../constants';
+import { DEFAULT_CATCHUP_WINDOW, DEFAULT_TASK_TIMEOUT } from '../constants';
 import { durationString } from '../schema/common';
 import {
   type FormScheduleSchema,
@@ -37,13 +32,25 @@ export function parseOverlapPolicy(
 
 const durationSchema = durationString();
 
-function toDurationString(
+function toDurationString<Fallback extends DurationString | ''>(
   value: unknown,
-  fallback: DurationString,
-): DurationString {
+  fallback: Fallback,
+): DurationString | Fallback {
   const parsed = durationSchema.safeParse(value);
 
   return parsed.success ? parsed.data : fallback;
+}
+
+// Run/execution timeouts have no default; leave them empty when unset. A stored
+// 0s means "unlimited", so normalize it to empty too.
+function toOptionalDurationString(value: unknown): DurationString | '' {
+  const parsed = durationSchema.safeParse(value);
+
+  if (!parsed.success || Number(parseDuration(parsed.data)) <= 0) {
+    return '';
+  }
+
+  return parsed.data;
 }
 
 function decodeSearchAttributeRows(
@@ -160,13 +167,9 @@ export function getFormScheduleDefaults(
       startWorkflow?.workflowTaskTimeout,
       DEFAULT_TASK_TIMEOUT,
     ),
-    runTimeout: toDurationString(
-      startWorkflow?.workflowRunTimeout,
-      DEFAULT_RUN_TIMEOUT,
-    ),
-    executionTimeout: toDurationString(
+    runTimeout: toOptionalDurationString(startWorkflow?.workflowRunTimeout),
+    executionTimeout: toOptionalDurationString(
       startWorkflow?.workflowExecutionTimeout,
-      DEFAULT_EXECUTION_TIMEOUT,
     ),
 
     searchAttributes: decodeSearchAttributeRows(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="3204" height="1884" alt="CleanShot 2026-07-07 at 11 23 25@2x" src="https://github.com/user-attachments/assets/a2f7f8c6-4175-4e8d-9eb5-1fbb5fe1e53b" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
