### PR TITLE
Pass through source prop for News Feed Widget

### DIFF
--- a/src/lib/components/news-feed/news-feed-widget.svelte
+++ b/src/lib/components/news-feed/news-feed-widget.svelte
@@ -3,11 +3,13 @@
   import NavigationButton from '$lib/holocene/navigation/navigation-button.svelte';
   import { translate } from '$lib/i18n/translate';
   import { createNewsFeedStore } from '$lib/stores/news-feed';
+  import type { NewsFeedSource } from '$lib/types/news-feed';
 
   import NewsFeedModal from './news-feed-modal.svelte';
 
   interface Props {
     clusterId: string;
+    source?: NewsFeedSource;
     class?: string;
     previewTheme?: 'dark' | 'light';
     variant?: 'button' | 'navigation';
@@ -15,12 +17,13 @@
 
   let {
     clusterId,
+    source = 'web-ui',
     class: className = '',
     previewTheme,
     variant = 'button',
   }: Props = $props();
 
-  const newsFeed = $derived(createNewsFeedStore({ clusterId }));
+  const newsFeed = $derived(createNewsFeedStore({ clusterId, source }));
   let open = $state(false);
 
   $effect(() => {

--- a/src/lib/components/news-feed/news-feed-widget.svelte
+++ b/src/lib/components/news-feed/news-feed-widget.svelte
@@ -9,7 +9,7 @@
 
   interface Props {
     clusterId: string;
-    source?: NewsFeedSource;
+    source: NewsFeedSource;
     class?: string;
     previewTheme?: 'dark' | 'light';
     variant?: 'button' | 'navigation';
@@ -17,7 +17,7 @@
 
   let {
     clusterId,
-    source = 'web-ui',
+    source,
     class: className = '',
     previewTheme,
     variant = 'button',

--- a/src/lib/services/news-feed-service.test.ts
+++ b/src/lib/services/news-feed-service.test.ts
@@ -34,6 +34,7 @@ describe('fetchNewsFeed', () => {
       clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
       now: () => 1780442153000,
       request,
+      source: 'web-ui',
       storage: createStorage(),
     });
 
@@ -56,6 +57,7 @@ describe('fetchNewsFeed', () => {
       clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
       now: () => 1780442153000,
       request,
+      source: 'web-ui',
       storage: createStorage(),
     });
 

--- a/src/lib/services/news-feed-service.ts
+++ b/src/lib/services/news-feed-service.ts
@@ -69,10 +69,10 @@ export const MOCK_NEWS_FEED_RESPONSE = {
 
 export type FetchNewsFeedOptions = {
   clusterId: string;
+  source: NewsFeedSource;
   cache?: RequestCache;
   now?: () => number;
   request?: typeof fetch;
-  source?: NewsFeedSource;
   storage?: NewsFeedStorage;
 };
 
@@ -90,7 +90,7 @@ export const fetchNewsFeed = async ({
   cache,
   now = Date.now,
   request = fetch,
-  source = 'web-ui',
+  source,
   storage = newsFeedStorage,
 }: FetchNewsFeedOptions): Promise<NewsFeedCache> => {
   if (!clusterId) {

--- a/src/lib/stores/news-feed.test.ts
+++ b/src/lib/stores/news-feed.test.ts
@@ -41,6 +41,7 @@ describe('createNewsFeedStore', () => {
       clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
       now: () => currentTime,
       request,
+      source: 'web-ui',
       storage,
     });
 
@@ -74,6 +75,23 @@ describe('createNewsFeedStore', () => {
     newsFeed.destroy();
   });
 
+  it('requests the feed with the cloud UI source', async () => {
+    const request = vi.fn().mockResolvedValue(response());
+    const newsFeed = createNewsFeedStore({
+      clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
+      request,
+      source: 'cloud-ui',
+      storage: createStorage(),
+    });
+
+    await newsFeed.refresh();
+
+    const url = new URL(request.mock.calls[0][0]);
+    expect(url.searchParams.get('source')).toBe('cloud-ui');
+
+    newsFeed.destroy();
+  });
+
   it('does not update storage when already marked seen', () => {
     const storage = createStorage();
     const cache = {
@@ -91,6 +109,7 @@ describe('createNewsFeedStore', () => {
     const setItem = vi.spyOn(storage, 'setItem');
     const newsFeed = createNewsFeedStore({
       clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
+      source: 'web-ui',
       storage,
     });
 

--- a/src/lib/stores/news-feed.ts
+++ b/src/lib/stores/news-feed.ts
@@ -3,7 +3,7 @@ import { get, writable } from 'svelte/store';
 import { BROWSER } from 'esm-env';
 
 import { fetchNewsFeed } from '$lib/services/news-feed-service';
-import type { NewsFeedState } from '$lib/types/news-feed';
+import type { NewsFeedSource, NewsFeedState } from '$lib/types/news-feed';
 import {
   getAutoFetchEnabled,
   getDisplayableNewsFeedItems,
@@ -23,6 +23,7 @@ import {
 
 type CreateNewsFeedStoreOptions = {
   clusterId: string;
+  source?: NewsFeedSource;
   request?: typeof fetch;
   now?: () => number;
   storage?: NewsFeedStorage;
@@ -59,6 +60,7 @@ const createInitialState = (
 
 export const createNewsFeedStore = ({
   clusterId,
+  source = 'web-ui',
   now = Date.now,
   request = fetch,
   storage = newsFeedStorage,
@@ -84,6 +86,7 @@ export const createNewsFeedStore = ({
       const feedCache = await fetchNewsFeed({
         cache,
         clusterId,
+        source,
         now,
         request,
         storage,

--- a/src/lib/stores/news-feed.ts
+++ b/src/lib/stores/news-feed.ts
@@ -23,7 +23,7 @@ import {
 
 type CreateNewsFeedStoreOptions = {
   clusterId: string;
-  source?: NewsFeedSource;
+  source: NewsFeedSource;
   request?: typeof fetch;
   now?: () => number;
   storage?: NewsFeedStorage;
@@ -60,7 +60,7 @@ const createInitialState = (
 
 export const createNewsFeedStore = ({
   clusterId,
-  source = 'web-ui',
+  source,
   now = Date.now,
   request = fetch,
   storage = newsFeedStorage,

--- a/src/lib/types/news-feed.ts
+++ b/src/lib/types/news-feed.ts
@@ -19,7 +19,7 @@ export type NewsFeedCache = {
   serverTime: string;
 };
 
-export type NewsFeedSource = 'web-ui';
+export type NewsFeedSource = 'web-ui' | 'cloud-ui';
 
 export type NewsFeedState = {
   autoFetchEnabled: boolean;

--- a/src/lib/utilities/news-feed.test.ts
+++ b/src/lib/utilities/news-feed.test.ts
@@ -58,6 +58,18 @@ describe('news feed utilities', () => {
     expect(url.searchParams.get('source')).toBe('web-ui');
   });
 
+  it('builds the feed request URL with the cloud UI source', () => {
+    const url = new URL(
+      buildNewsFeedUrl({
+        clientId: 'd104aa3a-da5f-4a19-948c-7c6144f962d3',
+        clusterId: '75d9c0b6-577f-42d4-a049-9f6e47e97c46',
+        source: 'cloud-ui',
+      }),
+    );
+
+    expect(url.searchParams.get('source')).toBe('cloud-ui');
+  });
+
   it('persists a generated client ID when none exists', () => {
     const storage = createStorage();
     const clientId = getNewsFeedClientId({

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -385,6 +385,7 @@
       {#if showNewsFeed}
         <NewsFeedWidget
           clusterId={newsFeedClusterId}
+          source="web-ui"
           previewTheme={$useDarkMode ? 'dark' : 'light'}
         />
       {/if}
@@ -429,6 +430,7 @@
         {#if showNewsFeed}
           <NewsFeedWidget
             clusterId={newsFeedClusterId}
+            source="web-ui"
             variant="navigation"
             previewTheme="dark"
           />


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Add source prop passing for cloud.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
