### PR TITLE
schedules Restrict select-all to exclude workflow status

### DIFF
--- a/src/lib/components/schedule/schedule-view/schedule-view.svelte
+++ b/src/lib/components/schedule/schedule-view/schedule-view.svelte
@@ -61,13 +61,15 @@
   </Link>
   <div class="flex items-start justify-between gap-4">
     <h1
-      class="flex select-all flex-wrap items-center gap-2 text-3xl"
+      class="flex flex-wrap items-center gap-2 text-3xl"
       data-testid="schedule-name"
     >
       <WorkflowStatus
         status={schedule?.schedule?.state?.paused ? 'Paused' : 'Running'}
       />
-      {scheduleId}
+      <span class="select-all">
+        {scheduleId}
+      </span>
     </h1>
 
     <SplitButton


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Update schedules name select-all to just the name, exclude the status text

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
https://temporalio.atlassian.net/browse/DT-4234

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
