### PR TITLE
TS strict (4/4): enable strict mode in base tsconfig

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -104,10 +104,15 @@ async function checkStrictModeErrors() {
     const relevantErrors: Record<string, StrictError[]> = {};
     let relevantErrorCount = 0;
 
+    // svelte-check and Danger both report repo-relative POSIX paths; compare
+    // by normalized equality (substring matching both missed regressions and
+    // false-blocked unrelated files that share a path suffix).
+    const normalizePath = (p: string) => p.replace(/^\.?\//, '');
+
     for (const [filename, errors] of Object.entries(result.errorsByFile)) {
+      const normalizedFilename = normalizePath(filename);
       const isChanged = Array.from(changedFiles).some(
-        (changedFile) =>
-          changedFile.includes(filename) || filename.includes(changedFile),
+        (changedFile) => normalizePath(changedFile) === normalizedFilename,
       );
 
       if (isChanged) {
@@ -120,25 +125,23 @@ async function checkStrictModeErrors() {
       return;
     }
 
-    const percentageInPR = (
-      (relevantErrorCount / result.totalErrors) *
-      100
-    ).toFixed(1);
+    const fileCount = Object.keys(relevantErrors).length;
 
-    // Post summary warning with all errors
-    let warningMessage = `📊 **Strict Mode**: ${relevantErrorCount} error${relevantErrorCount > 1 ? 's' : ''} in ${Object.keys(relevantErrors).length} file${Object.keys(relevantErrors).length > 1 ? 's' : ''} (${percentageInPR}% of ${result.totalErrors} total)\n\n`;
+    // The codebase is strict-clean; any strict error in a changed file is a
+    // regression and must block the PR.
+    let failureMessage = `❌ **Strict Mode**: ${relevantErrorCount} TypeScript error${relevantErrorCount > 1 ? 's' : ''} in ${fileCount} changed file${fileCount > 1 ? 's' : ''}. Strict mode is enforced — please fix before merging.\n\n`;
 
     for (const [filename, errors] of Object.entries(relevantErrors)) {
-      warningMessage += `<details>\n<summary><strong>${filename}</strong> (${errors.length})</summary>\n\n`;
+      failureMessage += `<details>\n<summary><strong>${filename}</strong> (${errors.length})</summary>\n\n`;
 
       for (const error of errors) {
-        warningMessage += `- L${error.start.line}:${error.start.character}: ${error.message}\n`;
+        failureMessage += `- L${error.start.line}:${error.start.character}: ${error.message}\n`;
       }
 
-      warningMessage += '\n</details>\n\n';
+      failureMessage += '\n</details>\n\n';
     }
 
-    warn(warningMessage);
+    fail(failureMessage);
 
     // Post individual warnings for errors on lines in the diff
     for (const [filename, errors] of Object.entries(relevantErrors)) {
@@ -183,13 +186,13 @@ async function checkStrictModeErrors() {
         );
       }
 
-      // Post warnings for errors on lines that are in the diff
+      // Post inline failures for errors on lines that are in the diff
       for (const error of errors) {
         if (linesInDiff.has(error.start.line)) {
           if (DEBUG) {
-            console.log(`Posting warning for ${filename}:${error.start.line}`);
+            console.log(`Posting failure for ${filename}:${error.start.line}`);
           }
-          warn(error.message, filename, error.start.line);
+          fail(error.message, filename, error.start.line);
         }
       }
     }

--- a/scripts/count-strict-errors.ts
+++ b/scripts/count-strict-errors.ts
@@ -60,7 +60,13 @@ try {
       if (data.type === 'ERROR') {
         const error: StrictError = {
           filename: data.filename,
-          start: data.start,
+          // svelte-check's machine-verbose output uses 0-indexed LSP
+          // positions; convert to 1-indexed to match editors and GitHub
+          // inline-comment line numbers (Danger's `fail(msg, file, line)`).
+          start: {
+            line: data.start.line + 1,
+            character: data.start.character + 1,
+          },
           message: data.message.split('\n')[0], // Only first line
         };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "moduleResolution": "bundler",
-    "strict": false,
+    "strict": true,
     "module": "es2020",
     "lib": ["es2020", "es2023", "dom", "DOM.Iterable"],
     "target": "es2019",


### PR DESCRIPTION
Final of a 4-PR split (was the combined branch). Stacked on `strict/3-behavior` (#3688).

Enables and enforces strict mode now that PRs 1–3 resolve every error:
- Flip `strict: true` in `tsconfig.json`
- Switch the Danger strict-error check from **warn to fail** (`dangerfile.ts`) so any strict error in a changed file blocks the PR, with 1-indexed line numbers (`scripts/count-strict-errors.ts`)

The enforcement flip lives here, not in the base PR, so the earlier PRs can merge incrementally without prematurely blocking unrelated PRs while the ~690 errors are still being resolved across the stack.

---
**Stack (merge bottom-up):**
1. #3686 `strict/1-base` — type annotations + dead-code cleanup (zero runtime)
2. #3687 `strict/2-mechanical` — strictNullChecks null-safety guards
3. #3688 `strict/3-behavior` — runtime-affecting model/form/service changes
4. #3640 `ts-strict-mode` — flip `strict: true` + enforce in CI

Split verified: stacking all four reproduces the original combined tree byte-for-byte.