### PR TITLE
Reduce news feed markdown whitespace

### DIFF
--- a/src/lib/components/news-feed/news-feed-modal.svelte
+++ b/src/lib/components/news-feed/news-feed-modal.svelte
@@ -82,6 +82,8 @@
           <h4>{item.title}</h4>
           <Markdown
             frameId="news-feed-{item.id}"
+            fill={false}
+            minHeight={0}
             overrideTheme="primary"
             {previewTheme}
             content={item.content}

--- a/src/lib/holocene/markdown-editor/preview.svelte
+++ b/src/lib/holocene/markdown-editor/preview.svelte
@@ -16,35 +16,55 @@
       | 'details'
       | ''
       | undefined;
+    fill?: boolean;
     frameId?: string;
+    minHeight?: number;
     previewTheme?: 'dark' | 'light';
   }
 
   let {
     content,
     class: className = '',
+    fill = true,
     overrideTheme = '',
     frameId = '',
+    minHeight = 100,
     previewTheme,
   }: Props = $props();
 
   let iframe: HTMLIFrameElement | null = $state(null);
   let iframeWidth = 0;
 
+  const parsePixels = (value: string | undefined) => {
+    const parsed = Number.parseFloat(value ?? '0');
+    return Number.isFinite(parsed) ? parsed : 0;
+  };
+
+  const getRenderedHeight = (iframeDocument: Document) => {
+    const { body } = iframeDocument;
+    const main = iframeDocument.querySelector('main');
+    const view = iframeDocument.defaultView;
+    const bodyStyles = view?.getComputedStyle(body);
+    const verticalBodyPadding =
+      parsePixels(bodyStyles?.paddingTop) +
+      parsePixels(bodyStyles?.paddingBottom);
+    const contentHeight = main
+      ? Math.max(main.scrollHeight, main.getBoundingClientRect().height) +
+        verticalBodyPadding
+      : body.getBoundingClientRect().height;
+
+    return Math.ceil(Math.max(contentHeight, minHeight));
+  };
+
   const resizeIframe = () => {
     if (!iframe) return;
     const iframeDocument = iframe.contentDocument;
     if (!iframeDocument) return;
 
-    const minHeight = 100;
     iframe.height = '0';
     iframe.style.height = '0px';
 
-    const height = Math.max(
-      iframeDocument.documentElement.scrollHeight,
-      iframeDocument.body.scrollHeight,
-      minHeight,
-    );
+    const height = getRenderedHeight(iframeDocument);
     iframe.height = `${height + 2}`;
     iframe.style.height = `${height + 2}px`;
   };
@@ -91,12 +111,12 @@
   );
 </script>
 
-<section class={twMerge('h-full w-full', className)}>
+<section class={twMerge(fill ? 'h-full w-full' : 'w-full', className)}>
   <iframe
     bind:this={iframe}
     onload={resizeIframe}
     title="output"
-    class="w-full"
+    class="block w-full"
     src={previewPath}
     id={frameId}
   ></iframe>


### PR DESCRIPTION
## Description & motivation

Reduce excess whitespace in the Temporal News modal by allowing Markdown previews to opt out of the full-height wrapper and 100px minimum iframe height.

This keeps the existing Markdown preview defaults intact for other consumers:

- `fill` defaults to `true`, preserving the existing `h-full w-full` wrapper behavior.
- `minHeight` defaults to `100`, preserving the old iframe height floor.
- The news feed modal opts into compact sizing with `fill={false}` and `minHeight={0}`.
- The iframe height is measured from the rendered `main` content plus body padding instead of whole-document scroll height.

### Screenshots (if applicable)

Not included.

### Design Considerations

The compact behavior is opt-in for the news feed to limit regression risk in other Markdown preview use cases.

## Testing

### How was this tested

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

Additional checks run:

- `pnpm exec eslint src/lib/holocene/markdown-editor/preview.svelte src/lib/components/news-feed/news-feed-modal.svelte`
- `pnpm run check`
- Pre-commit hooks for staged Svelte files: `eslint --fix`, `prettier --write`, `stylelint --fix`

### Steps for others to test:

1. Open the Temporal News modal with multiple news items.
2. Verify each Markdown item sits close to its content without the previous large blank area.
3. Verify longer Markdown still expands to fit its content.
4. Verify other Markdown preview surfaces retain their existing minimum preview height.

## Checklists

### Draft Checklist

N/A

### Merge Checklist

N/A

### Issue(s) closed

N/A

## Docs

### Any docs updates needed?

No docs updates needed.
