### PR TITLE
feat(nexus-operations): add loading state to standalone nexus operations list page header

### DIFF
--- a/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
@@ -10,6 +10,7 @@
   import { configurableTableColumns } from '$lib/stores/configurable-table-columns';
   import {
     nexusOperationCount,
+    nexusOperationLoading,
     nexusOperationRefresh,
   } from '$lib/stores/nexus-operations';
 
@@ -51,6 +52,9 @@
       'standalone-nexus-operations.empty-state-title',
     )}
     maxHeight="var(--panel-h)"
+    onLoadingChange={(loading) => {
+      $nexusOperationLoading = loading;
+    }}
   >
     <caption class="sr-only" slot="caption">
       {translate('standalone-nexus-operations.nexus-operations-table')}

--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -33,6 +33,7 @@
     onError?: ((error: Error | unknown) => void) | undefined;
     onFetch: () => Promise<PaginatedRequest<T>>;
     onItemsChange?: (items: T[]) => void;
+    onLoadingChange?: ((loading: boolean) => void) | undefined;
     onShiftUp?: KeyboardHandler;
     onShiftDown?: KeyboardHandler;
     onSpace?: KeyboardHandler;
@@ -53,6 +54,8 @@
   export let onError: ((error: Error) => void) | undefined = undefined;
   export let onFetch: () => Promise<PaginatedRequest<T>>;
   export let onItemsChange: ((items: T[]) => void) | undefined = undefined;
+  export let onLoadingChange: ((loading: boolean) => void) | undefined =
+    undefined;
   export let onShiftUp: KeyboardHandler = undefined;
   export let onShiftDown: KeyboardHandler = undefined;
   export let onSpace: KeyboardHandler = undefined;
@@ -183,6 +186,8 @@
         break;
     }
   }
+
+  $: if (onLoadingChange) onLoadingChange($store.loading);
 
   let previousItems: T[] | undefined;
   $: if (onItemsChange && $store.visibleItems !== previousItems) {

--- a/src/lib/pages/standalone-nexus-operations.svelte
+++ b/src/lib/pages/standalone-nexus-operations.svelte
@@ -12,6 +12,7 @@
   import StatusCounts from '$lib/components/status-counts.svelte';
   import { timestamp } from '$lib/components/timestamp.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
+  import Skeleton from '$lib/holocene/skeleton/index.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import { fetchNexusOperationCountByStatus } from '$lib/services/nexus-operation-counts';
@@ -25,6 +26,7 @@
   import { savedQueryNavOpen } from '$lib/stores/nav-open';
   import {
     nexusOperationCount,
+    nexusOperationLoading,
     nexusOperationRefresh,
     nexusOperationsQuery,
     nexusOperationsSearchParams,
@@ -78,39 +80,46 @@
   <div class="flex flex-col justify-between gap-2 md:flex-row">
     <div class="flex flex-row flex-wrap items-start gap-2">
       <div>
-        <h1 class="flex items-center gap-2 leading-7">
-          {#if $supportsAdvancedVisibility}
-            <span data-testid="nexus-operation-count"
-              >{$nexusOperationCount.count.toLocaleString()}</span
-            >
-            <Translate
-              key="standalone-nexus-operations.nexus-operations-plural"
-              count={$nexusOperationCount.count}
-            />
-          {:else}
-            <Translate
-              key="standalone-nexus-operations.recent-nexus-operations"
-            />
-          {/if}
-        </h1>
-        <p class="mt-2 text-xs text-secondary">
-          {refreshTimeFormatted}
-        </p>
+        {#if $nexusOperationLoading}
+          <Skeleton class="h-7 w-48 rounded" />
+          <Skeleton class="mt-2 h-3 w-32 rounded" />
+        {:else}
+          <h1 class="flex items-center gap-2 leading-7">
+            {#if $supportsAdvancedVisibility}
+              <span data-testid="nexus-operation-count"
+                >{$nexusOperationCount.count.toLocaleString()}</span
+              >
+              <Translate
+                key="standalone-nexus-operations.nexus-operations-plural"
+                count={$nexusOperationCount.count}
+              />
+            {:else}
+              <Translate
+                key="standalone-nexus-operations.recent-nexus-operations"
+              />
+            {/if}
+          </h1>
+          <p class="mt-2 text-xs text-secondary">
+            {refreshTimeFormatted}
+          </p>
+        {/if}
       </div>
       {@render releaseStageBadge?.()}
-      <CountRefreshButton
-        count={$nexusOperationCount.newCount}
-        refresh={nexusOperationRefresh}
-      />
-      <StatusCounts
-        bind:refreshTime
-        countStore={nexusOperationCount}
-        refresh={nexusOperationRefresh}
-        filters={nexusOperationFilters}
-        fetchCounts={fetchNexusOperationCountByStatus}
-        getStatusAndCount={getNexusOperationStatusAndCountOfGroup}
-        data-testid="nexus-operation-status"
-      />
+      {#if !$nexusOperationLoading}
+        <CountRefreshButton
+          count={$nexusOperationCount.newCount}
+          refresh={nexusOperationRefresh}
+        />
+        <StatusCounts
+          bind:refreshTime
+          countStore={nexusOperationCount}
+          refresh={nexusOperationRefresh}
+          filters={nexusOperationFilters}
+          fetchCounts={fetchNexusOperationCountByStatus}
+          getStatusAndCount={getNexusOperationStatusAndCountOfGroup}
+          data-testid="nexus-operation-status"
+        />
+      {/if}
     </div>
     {#if headerActions}
       <div class="flex items-center gap-4">

--- a/src/lib/pages/standalone-nexus-operations.svelte
+++ b/src/lib/pages/standalone-nexus-operations.svelte
@@ -12,7 +12,6 @@
   import StatusCounts from '$lib/components/status-counts.svelte';
   import { timestamp } from '$lib/components/timestamp.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
-  import Skeleton from '$lib/holocene/skeleton/index.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import { fetchNexusOperationCountByStatus } from '$lib/services/nexus-operation-counts';
@@ -26,7 +25,6 @@
   import { savedQueryNavOpen } from '$lib/stores/nav-open';
   import {
     nexusOperationCount,
-    nexusOperationLoading,
     nexusOperationRefresh,
     nexusOperationsQuery,
     nexusOperationsSearchParams,
@@ -80,46 +78,39 @@
   <div class="flex flex-col justify-between gap-2 md:flex-row">
     <div class="flex flex-row flex-wrap items-start gap-2">
       <div>
-        {#if $nexusOperationLoading}
-          <Skeleton class="h-7 w-48 rounded" />
-          <Skeleton class="mt-2 h-3 w-32 rounded" />
-        {:else}
-          <h1 class="flex items-center gap-2 leading-7">
-            {#if $supportsAdvancedVisibility}
-              <span data-testid="nexus-operation-count"
-                >{$nexusOperationCount.count.toLocaleString()}</span
-              >
-              <Translate
-                key="standalone-nexus-operations.nexus-operations-plural"
-                count={$nexusOperationCount.count}
-              />
-            {:else}
-              <Translate
-                key="standalone-nexus-operations.recent-nexus-operations"
-              />
-            {/if}
-          </h1>
-          <p class="mt-2 text-xs text-secondary">
-            {refreshTimeFormatted}
-          </p>
-        {/if}
+        <h1 class="flex items-center gap-2 leading-7">
+          {#if $supportsAdvancedVisibility}
+            <span data-testid="nexus-operation-count"
+              >{$nexusOperationCount.count.toLocaleString()}</span
+            >
+            <Translate
+              key="standalone-nexus-operations.nexus-operations-plural"
+              count={$nexusOperationCount.count}
+            />
+          {:else}
+            <Translate
+              key="standalone-nexus-operations.recent-nexus-operations"
+            />
+          {/if}
+        </h1>
+        <p class="mt-2 text-xs text-secondary">
+          {refreshTimeFormatted}
+        </p>
       </div>
       {@render releaseStageBadge?.()}
-      {#if !$nexusOperationLoading}
-        <CountRefreshButton
-          count={$nexusOperationCount.newCount}
-          refresh={nexusOperationRefresh}
-        />
-        <StatusCounts
-          bind:refreshTime
-          countStore={nexusOperationCount}
-          refresh={nexusOperationRefresh}
-          filters={nexusOperationFilters}
-          fetchCounts={fetchNexusOperationCountByStatus}
-          getStatusAndCount={getNexusOperationStatusAndCountOfGroup}
-          data-testid="nexus-operation-status"
-        />
-      {/if}
+      <CountRefreshButton
+        count={$nexusOperationCount.newCount}
+        refresh={nexusOperationRefresh}
+      />
+      <StatusCounts
+        bind:refreshTime
+        countStore={nexusOperationCount}
+        refresh={nexusOperationRefresh}
+        filters={nexusOperationFilters}
+        fetchCounts={fetchNexusOperationCountByStatus}
+        getStatusAndCount={getNexusOperationStatusAndCountOfGroup}
+        data-testid="nexus-operation-status"
+      />
     </div>
     {#if headerActions}
       <div class="flex items-center gap-4">


### PR DESCRIPTION
## Description & motivation 💭

The standalone nexus operations list page header showed "0 Nexus Operations" and empty/missing status badges during the initial API fetch. This happened because the header rendered immediately from store defaults (count=0) while the table's internal pagination store was still loading.

This PR surfaces the table's internal `loading` state up to the page header via a new optional `onLoadingChange` callback on `api-paginated.svelte`, then uses it to drive improved loading UX in the header:

- **Count/timestamp**: Instead of swapping to skeleton bars and back (which caused layout shift), the header now keeps the previous count visible at all times. On first load this shows "0 Nexus Operations" only briefly before the real count arrives — the same behaviour as the workflows list page.
- **Status count badges**: `StatusCounts` and `CountRefreshButton` are now always mounted (matching the workflows page pattern). `StatusCounts` already has its own internal per-badge skeleton loader and a `min-h-[24px]` wrapper, so badges animate in without resizing the header.

**Changes:**
- `api-paginated.svelte`: add optional `onLoadingChange?: (loading: boolean) => void` prop (with \`\$\$Props\` type update) and a reactive statement to fire it
- `nexus-operations-summary-configurable-table.svelte`: wire `nexusOperationLoading` store via the new callback
- `standalone-nexus-operations.svelte`: remove loading guards; always render `h1`, timestamp, `CountRefreshButton`, and `StatusCounts`

### Screenshots (if applicable) 📸


https://github.com/user-attachments/assets/a10e9940-8398-469f-8674-65ebae29c649



### Design Considerations 🎨

Follows the established pattern in `workflows-with-new-search.svelte`, which renders `StatusCounts` and `CountRefreshButton` unconditionally. `StatusCounts` self-manages its badge skeleton state internally.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Navigate to a namespace's standalone Nexus Operations list page
2. Hard-refresh — the header shows the previous count without layout shift while the table loads
3. Status badges animate in via internal skeleton loaders rather than appearing abruptly after a blank gap
4. Trigger a manual refresh via `CountRefreshButton` — same stable layout during reload

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

DT-4239

## Docs

### Any docs updates needed?

No docs changes needed.