### PR TITLE
refactor(nexus): replace hand-rolled standalone nexus operation types with @temporalio/proto

### DIFF
--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
@@ -33,7 +33,7 @@
   import {
     type NexusOperationIdConflictPolicy,
     type NexusOperationIdReusePolicy,
-  } from '$lib/types/nexus-operation-execution';
+  } from '$lib/types';
   import { getIdentity } from '$lib/utilities/core-context';
   import { isNetworkError } from '$lib/utilities/is-network-error';
   import { routeForStandaloneNexusOperationDetails } from '$lib/utilities/route-for';

--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/types.ts
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/types.ts
@@ -3,7 +3,7 @@ import type { SearchAttributesSchema } from '$lib/stores/search-attributes';
 import type {
   NexusOperationIdConflictPolicy,
   NexusOperationIdReusePolicy,
-} from '$lib/types/nexus-operation-execution';
+} from '$lib/types';
 
 export interface StartNexusOperationFormData {
   namespace: string;

--- a/src/lib/pages/standalone-nexus-operation-details.svelte
+++ b/src/lib/pages/standalone-nexus-operation-details.svelte
@@ -12,6 +12,7 @@
   import { translate } from '$lib/i18n/translate';
   import { toEventLinkView } from '$lib/utilities/event-link';
   import { routeForStandaloneNexusOperationsWithQuery } from '$lib/utilities/route-for';
+  import { toNexusOperationCancellationStateReadable } from '$lib/utilities/screaming-enums';
   import { nexusOperationExecution } from '$lib/utilities/standalone-nexus-operation-poller.svelte';
   import { fromSeconds } from '$lib/utilities/to-duration';
 
@@ -354,7 +355,11 @@
               'standalone-nexus-operations.cancellation-state',
             )}</DetailListLabel
           >
-          <DetailListTextValue text={info.cancellationInfo.state} />
+          <DetailListTextValue
+            text={toNexusOperationCancellationStateReadable(
+              info.cancellationInfo.state,
+            )}
+          />
           <DetailListLabel
             >{translate('standalone-nexus-operations.attempt')}</DetailListLabel
           >

--- a/src/lib/services/standalone-nexus-operations.ts
+++ b/src/lib/services/standalone-nexus-operations.ts
@@ -3,14 +3,17 @@ import {
   type PayloadInputEncoding,
 } from '$lib/models/payload-encoding';
 import { nexusOperationError } from '$lib/stores/nexus-operations';
-import type { Payload, SearchAttribute } from '$lib/types';
+import type {
+  NexusOperationIdConflictPolicy,
+  NexusOperationIdReusePolicy,
+  Payload,
+  SearchAttribute,
+  StartNexusOperationExecutionResponse,
+} from '$lib/types';
 import type {
   NexusOperationExecution,
   NexusOperationExecutionListInfo,
-  NexusOperationIdConflictPolicy,
-  NexusOperationIdReusePolicy,
-  StartNexusOperationExecutionRequest,
-  StartNexusOperationExecutionResponse,
+  StartNexusOperationRequest,
 } from '$lib/types/nexus-operation-execution';
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
 import { encodePayloads } from '$lib/utilities/encode-payload';
@@ -95,7 +98,7 @@ export type StartNexusOperationFormData = {
 
 const toStartNexusOperationRequest = async (
   formData: StartNexusOperationFormData,
-): Promise<StartNexusOperationExecutionRequest> => {
+): Promise<StartNexusOperationRequest> => {
   let inputPayload: Payload | undefined = undefined;
   let summaryPayload: Payload | null = null;
   let detailsPayload: Payload | null = null;
@@ -177,7 +180,9 @@ const toStartNexusOperationRequest = async (
     ...(formData.startToCloseTimeout && {
       startToCloseTimeout: formData.startToCloseTimeout,
     }),
-    ...(formData.idReusePolicy && { idReusePolicy: formData.idReusePolicy }),
+    ...(formData.idReusePolicy && {
+      idReusePolicy: formData.idReusePolicy,
+    }),
     ...(formData.idConflictPolicy && {
       idConflictPolicy: formData.idConflictPolicy,
     }),

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,11 +18,8 @@ export type Capabilities =
     serverScaledProviderCloudRun?: boolean | null;
   };
 
-export type NamespaceCapabilities = NonNullable<
-  NonNullable<DescribeNamespaceResponse['namespaceInfo']>['capabilities']
-> & {
-  standaloneNexusOperation?: boolean | null;
-};
+export type NamespaceCapabilities =
+  DescribeNamespaceResponse['namespaceInfo']['capabilities'];
 export type GetWorkflowExecutionHistoryResponse =
   temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryResponse;
 export type GetSearchAttributesResponse =
@@ -70,7 +67,12 @@ export type DescribeWorkerRequest =
   temporal.api.workflowservice.v1.IDescribeWorkerRequest;
 export type DescribeWorkerResponse =
   temporal.api.workflowservice.v1.IDescribeWorkerResponse;
-
+export type StartNexusOperationExecutionRequest =
+  temporal.api.workflowservice.v1.IStartNexusOperationExecutionRequest;
+export type StartNexusOperationExecutionResponse =
+  temporal.api.workflowservice.v1.IStartNexusOperationExecutionResponse;
+export type DescribeNexusOperationResponse =
+  temporal.api.workflowservice.v1.IDescribeNexusOperationExecutionResponse;
 // api.history
 
 export type History = temporal.api.history.v1.IHistory;
@@ -196,10 +198,16 @@ export type NamespaceState = temporal.api.enums.v1.NamespaceState;
 export type TaskReachability = temporal.api.enums.v1.TaskReachability;
 export type PendingNexusOperationState =
   temporal.api.enums.v1.PendingNexusOperationState;
+export type NexusOperationCancellationState =
+  temporal.api.enums.v1.NexusOperationCancellationState;
 export type CallbackState = temporal.api.enums.v1.CallbackState;
 export type VersioningBehavior = temporal.api.enums.v1.VersioningBehavior;
 export type EventType = temporal.api.enums.v1.EventType;
 export type WorkerStatus = temporal.api.enums.v1.WorkerStatus;
+export type NexusOperationIdConflictPolicy =
+  keyof typeof temporal.api.enums.v1.NexusOperationIdConflictPolicy;
+export type NexusOperationIdReusePolicy =
+  keyof typeof temporal.api.enums.v1.NexusOperationIdReusePolicy;
 
 // temporal.api.enums.v1.ResetReapplyExcludeType
 export enum ResetReapplyExcludeType {

--- a/src/lib/types/nexus-operation-execution.ts
+++ b/src/lib/types/nexus-operation-execution.ts
@@ -1,38 +1,24 @@
+import { temporal } from '@temporalio/proto';
+
 import type {
-  EventLink,
-  Failure,
-  Payload,
-  SearchAttribute,
+  DescribeNexusOperationResponse,
+  NexusOperationIdConflictPolicy,
+  NexusOperationIdReusePolicy,
+  StartNexusOperationExecutionRequest,
   UserMetadata,
 } from '.';
 import type { WorkflowSearchAttributes } from './workflows';
 
 export type NexusOperationExecutionStatus =
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_UNSPECIFIED'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_RUNNING'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_COMPLETED'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_FAILED'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_CANCELED'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_TERMINATED'
-  | 'NEXUS_OPERATION_EXECUTION_STATUS_TIMED_OUT';
+  keyof typeof temporal.api.enums.v1.NexusOperationExecutionStatus;
 
-export const NEXUS_OPERATION_ID_REUSE_POLICIES = [
-  'NEXUS_OPERATION_ID_REUSE_POLICY_UNSPECIFIED',
-  'NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE',
-  'NEXUS_OPERATION_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY',
-  'NEXUS_OPERATION_ID_REUSE_POLICY_REJECT_DUPLICATE',
-] as const;
+export const NEXUS_OPERATION_ID_REUSE_POLICIES = Object.keys(
+  temporal.api.enums.v1.NexusOperationIdReusePolicy,
+) as (keyof typeof temporal.api.enums.v1.NexusOperationIdReusePolicy)[];
 
-export const NEXUS_OPERATION_ID_CONFLICT_POLICIES = [
-  'NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED',
-  'NEXUS_OPERATION_ID_CONFLICT_POLICY_FAIL',
-  'NEXUS_OPERATION_ID_CONFLICT_POLICY_USE_EXISTING',
-] as const;
-
-export type NexusOperationIdReusePolicy =
-  (typeof NEXUS_OPERATION_ID_REUSE_POLICIES)[number];
-export type NexusOperationIdConflictPolicy =
-  (typeof NEXUS_OPERATION_ID_CONFLICT_POLICIES)[number];
+export const NEXUS_OPERATION_ID_CONFLICT_POLICIES = Object.keys(
+  temporal.api.enums.v1.NexusOperationIdConflictPolicy,
+) as (keyof typeof temporal.api.enums.v1.NexusOperationIdConflictPolicy)[];
 
 export const nexusOperationIdReusePolicyOptions =
   NEXUS_OPERATION_ID_REUSE_POLICIES.filter(
@@ -43,90 +29,82 @@ export const nexusOperationIdConflictPolicyOptions =
     (policy) => policy !== 'NEXUS_OPERATION_ID_CONFLICT_POLICY_UNSPECIFIED',
   );
 
-export interface NexusOperationExecutionCancellationInfo {
+export interface NexusOperationExecutionCancellationInfo extends Omit<
+  temporal.api.nexus.v1.INexusOperationExecutionCancellationInfo,
+  'requestedTime' | 'lastAttemptCompleteTime' | 'nextAttemptScheduleTime'
+> {
   requestedTime: string;
-  state: string;
-  attempt: number;
   lastAttemptCompleteTime: string;
-  lastAttemptFailure?: Failure;
   nextAttemptScheduleTime: string;
-  blockedReason: string;
-  reason: string;
 }
 
-export interface NexusOperationExecutionInfo {
-  operationId: string;
-  runId: string;
-  endpoint: string;
-  service: string;
-  operation: string;
+export interface NexusOperationExecutionInfo extends Omit<
+  temporal.api.nexus.v1.INexusOperationExecutionInfo,
+  | 'status'
+  | 'scheduleToCloseTimeout'
+  | 'scheduleToStartTimeout'
+  | 'startToCloseTimeout'
+  | 'executionDuration'
+  | 'stateTransitionCount'
+  | 'scheduleTime'
+  | 'expirationTime'
+  | 'closeTime'
+  | 'lastAttemptCompleteTime'
+  | 'nextAttemptScheduleTime'
+  | 'searchAttributes'
+  | 'cancellationInfo'
+> {
   status: NexusOperationExecutionStatus;
-  state: string;
   scheduleToCloseTimeout: string;
   scheduleToStartTimeout: string;
   startToCloseTimeout: string;
-  attempt: number;
+  executionDuration: string;
+  stateTransitionCount: string;
   scheduleTime: string;
   expirationTime: string;
   closeTime: string;
   lastAttemptCompleteTime: string;
-  lastAttemptFailure?: Failure;
   nextAttemptScheduleTime: string;
-  executionDuration: string;
-  cancellationInfo?: NexusOperationExecutionCancellationInfo;
-  blockedReason: string;
-  requestId: string;
-  operationToken: string;
-  stateTransitionCount: string;
   searchAttributes: WorkflowSearchAttributes;
-  nexusHeader: Record<string, string>;
-  userMetadata: UserMetadata;
-  links: EventLink[];
-  identity: string;
+  cancellationInfo?: NexusOperationExecutionCancellationInfo;
 }
 
-export interface NexusOperationExecutionListInfo {
-  operationId: string;
-  runId: string;
-  endpoint: string;
-  service: string;
-  operation: string;
+export interface NexusOperationExecutionListInfo extends Omit<
+  temporal.api.nexus.v1.INexusOperationExecutionListInfo,
+  | 'status'
+  | 'scheduleTime'
+  | 'closeTime'
+  | 'stateTransitionCount'
+  | 'executionDuration'
+  | 'searchAttributes'
+> {
+  status: NexusOperationExecutionStatus;
   scheduleTime: string;
   closeTime: string;
-  status: NexusOperationExecutionStatus;
-  searchAttributes: WorkflowSearchAttributes;
   stateTransitionCount: string;
   executionDuration: string;
+  searchAttributes: WorkflowSearchAttributes;
 }
 
-export interface NexusOperationExecution {
-  runId: string;
+export interface NexusOperationExecution extends Omit<
+  DescribeNexusOperationResponse,
+  'info' | 'longPollToken'
+> {
   info: NexusOperationExecutionInfo;
-  input?: Payload;
-  result?: Payload;
-  failure?: Failure;
   longPollToken?: string;
 }
-export interface StartNexusOperationExecutionRequest {
-  namespace: string;
-  identity: string;
-  requestId: string;
-  operationId: string;
-  endpoint: string;
-  service: string;
-  operation: string;
+
+export interface StartNexusOperationRequest extends Omit<
+  StartNexusOperationExecutionRequest,
+  | 'scheduleToCloseTimeout'
+  | 'startToCloseTimeout'
+  | 'scheduleToStartTimeout'
+  | 'idReusePolicy'
+  | 'idConflictPolicy'
+> {
   scheduleToCloseTimeout?: string;
-  scheduleToStartTimeout?: string;
   startToCloseTimeout?: string;
-  input?: Payload;
+  scheduleToStartTimeout?: string;
   idReusePolicy?: NexusOperationIdReusePolicy;
   idConflictPolicy?: NexusOperationIdConflictPolicy;
-  searchAttributes?: SearchAttribute;
-  nexusHeader?: Record<string, string>;
-  userMetadata?: UserMetadata;
-}
-
-export interface StartNexusOperationExecutionResponse {
-  runId: string;
-  started: boolean;
 }

--- a/src/lib/utilities/screaming-enums.ts
+++ b/src/lib/utilities/screaming-enums.ts
@@ -3,6 +3,7 @@ import type {
   ArchivalState,
   CallbackState,
   NamespaceState,
+  NexusOperationCancellationState,
   PendingNexusOperationState,
   WorkerStatus,
   WorkflowExecutionStatus,
@@ -92,6 +93,16 @@ export const toPendingNexusOperationStateReadable = (
 ): PendingNexusOperationState => {
   if (!state) return 'Unspecified' as unknown as PendingNexusOperationState;
   return fromScreamingEnum(state, 'PendingNexusOperationState');
+};
+
+export const toNexusOperationCancellationStateReadable = (
+  state?: NexusOperationCancellationState | null,
+): string => {
+  if (!state) return 'Unspecified';
+  return fromScreamingEnum(
+    state,
+    'NexusOperationCancellationState',
+  ) as unknown as string;
 };
 
 export const toCallbackStateReadable = (


### PR DESCRIPTION
## Description & motivation 💭

Replaces the fully hand-written standalone nexus operation type definitions with interfaces that extend proto types from `@temporalio/proto`, following the same pattern already used by `activity-execution.ts`.

Previously, `NexusOperationExecutionInfo`, `NexusOperationExecutionListInfo`, `NexusOperationExecutionCancellationInfo`, and `NexusOperationExecution` were standalone interfaces that duplicated proto field names and types manually. Any new field added to the proto would be silently missing from the UI. Now they use `extends Omit<ProtoType, overridden-fields>` so all proto fields are inherited automatically, and only the fields that need UI-friendly types (timestamps as `string`, durations as `string`, enums as named string unions, search attributes as `WorkflowSearchAttributes`) are re-declared.

`StartNexusOperationExecutionRequest` omitted every one of its proto fields and redefined them all — making the `extends` redundant. It is now a plain `interface` (`StartNexusOperationRequest`) wrapping only the UI-specific overrides (timeout/policy fields as strings).

`NexusOperationIdReusePolicy`, `NexusOperationIdConflictPolicy`, and `NexusOperationCancellationState` are derived from the proto enums at runtime via `Object.keys(temporal.api.enums.v1.*)` and re-exported from `types/index.ts` so consumers import from the canonical location.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

`pnpm check` passes with the same 2 pre-existing errors (unrelated HTML nesting in `package/` components).

## Checklists

### Merge Checklist

- [x] `pnpm check` passes
- [x] `pnpm lint` passes (enforced by pre-commit hook)

### Issue(s) closed

DT-4240

## Docs

### Any docs updates needed?

No docs changes needed — purely internal type refactor.