### PR TITLE
Fix size of news feed button to match others

### DIFF
--- a/src/lib/components/news-feed/news-feed-widget.svelte
+++ b/src/lib/components/news-feed/news-feed-widget.svelte
@@ -10,18 +10,11 @@
   interface Props {
     clusterId: string;
     source: NewsFeedSource;
-    class?: string;
     previewTheme?: 'dark' | 'light';
     variant?: 'button' | 'navigation';
   }
 
-  let {
-    clusterId,
-    source,
-    class: className = '',
-    previewTheme,
-    variant = 'button',
-  }: Props = $props();
+  let { clusterId, source, previewTheme, variant = 'button' }: Props = $props();
 
   const newsFeed = $derived(createNewsFeedStore({ clusterId, source }));
   let open = $state(false);
@@ -51,15 +44,15 @@
     label={translate('common.news')}
     icon={unread ? 'megaphone-unread' : 'megaphone'}
     data-testid="news-feed-trigger"
-    class={className}
   />
 {:else}
   <Button
     variant="ghost"
     leadingIcon={unread ? 'megaphone-unread' : 'megaphone'}
     aria-label={label}
-    class={className}
+    class="h-9 w-9 shrink-0 p-0"
     data-testid="news-feed-trigger"
+    size="sm"
     on:click={openNewsFeed}
   />
 {/if}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
