### PR TITLE
feat(nexus-operations): add loading state to standalone nexus operation details page

### DIFF
--- a/src/lib/components/standalone-nexus-operations/nexus-operation-details-loading.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operation-details-loading.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import Card from '$lib/holocene/card.svelte';
+  import Skeleton from '$lib/holocene/skeleton/index.svelte';
+
+  import { DetailList, DetailListColumn } from '../detail-list';
+</script>
+
+<div class="grid w-full grid-cols-2 gap-4 max-md:grid-cols-1">
+  <div class="flex flex-col gap-2">
+    <Skeleton class="h-5 w-10 rounded-sm" />
+    <Skeleton class="h-32 rounded-md" />
+  </div>
+  <div class="flex flex-col gap-2">
+    <Skeleton class="h-5 w-12 rounded-sm" />
+    <Skeleton class="h-32 rounded-md" />
+  </div>
+</div>
+
+<Card class="space-y-6">
+  <Skeleton class="h-5 w-52 rounded-sm" />
+
+  <div class="space-y-4">
+    <Skeleton class="h-4 w-28 rounded-sm" />
+    <DetailList
+      aria-label="nexus operation details loading"
+      rowCount={4}
+      class="gap-y-4"
+    >
+      <DetailListColumn>
+        <Skeleton class="h-4 w-28 rounded-sm" />
+        <Skeleton class="h-4 w-32 rounded-sm" />
+        <Skeleton class="h-4 w-24 rounded-sm" />
+        <Skeleton class="h-4 w-20 rounded-sm" />
+      </DetailListColumn>
+      <DetailListColumn>
+        <Skeleton class="h-4 w-36 rounded-sm" />
+        <Skeleton class="h-4 w-20 rounded-sm" />
+        <Skeleton class="h-4 w-16 rounded-sm" />
+        <Skeleton class="h-4 w-64 rounded-sm" />
+      </DetailListColumn>
+    </DetailList>
+  </div>
+
+  <div class="space-y-4">
+    <Skeleton class="h-4 w-36 rounded-sm" />
+    <DetailList
+      aria-label="nexus operation details section loading"
+      rowCount={3}
+      class="gap-y-4"
+    >
+      <DetailListColumn>
+        <Skeleton class="h-4 w-24 rounded-sm" />
+        <Skeleton class="h-4 w-28 rounded-sm" />
+        <Skeleton class="h-4 w-32 rounded-sm" />
+      </DetailListColumn>
+      <DetailListColumn>
+        <Skeleton class="h-4 w-48 rounded-sm" />
+        <Skeleton class="h-4 w-32 rounded-sm" />
+        <Skeleton class="h-4 w-24 rounded-sm" />
+      </DetailListColumn>
+    </DetailList>
+  </div>
+</Card>

--- a/src/lib/components/standalone-nexus-operations/nexus-operation-header-loading.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operation-header-loading.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import Skeleton from '$lib/holocene/skeleton/index.svelte';
+
+  import { DetailList, DetailListColumn } from '../detail-list';
+</script>
+
+<div class="space-y-2">
+  <div class="flex items-center gap-4 max-xl:w-full max-xl:flex-wrap">
+    <Skeleton class="h-5 w-20 rounded-sm" />
+    <Skeleton class="h-8 w-72 rounded-sm" />
+    <div class="ml-auto flex items-center gap-2">
+      <Skeleton class="h-7 w-36 rounded-sm" />
+      <Skeleton class="h-7 w-28 rounded-sm" />
+    </div>
+  </div>
+
+  <DetailList aria-label="nexus operation loading" rowCount={4}>
+    <DetailListColumn>
+      <Skeleton class="h-4 w-28 rounded-sm" />
+      <Skeleton class="h-4 w-36 rounded-sm" />
+      <Skeleton class="h-4 w-24 rounded-sm" />
+      <Skeleton class="h-4 w-32 rounded-sm" />
+      <Skeleton class="h-4 w-32 rounded-sm" />
+      <Skeleton class="h-4 w-20 rounded-sm" />
+      <Skeleton class="h-4 w-28 rounded-sm" />
+      <Skeleton class="h-4 w-10 rounded-sm" />
+    </DetailListColumn>
+    <DetailListColumn>
+      <Skeleton class="h-4 w-16 rounded-sm" />
+      <Skeleton class="h-4 w-64 rounded-sm" />
+      <Skeleton class="h-4 w-20 rounded-sm" />
+      <Skeleton class="h-4 w-40 rounded-sm" />
+      <Skeleton class="h-4 w-16 rounded-sm" />
+      <Skeleton class="h-4 w-32 rounded-sm" />
+      <Skeleton class="h-4 w-20 rounded-sm" />
+      <Skeleton class="h-4 w-36 rounded-sm" />
+    </DetailListColumn>
+  </DetailList>
+</div>

--- a/src/lib/layouts/standalone-nexus-operation-layout.svelte
+++ b/src/lib/layouts/standalone-nexus-operation-layout.svelte
@@ -23,6 +23,9 @@
     StandaloneNexusOperationPoller,
   } from '$lib/utilities/standalone-nexus-operation-poller.svelte';
 
+  import NexusOperationDetailsLoading from '../components/standalone-nexus-operations/nexus-operation-details-loading.svelte';
+  import NexusOperationLayoutLoading from '../components/standalone-nexus-operations/nexus-operation-header-loading.svelte';
+
   interface Props {
     namespace: string;
     operationId: string;
@@ -33,6 +36,7 @@
   let { children, namespace, operationId, runId }: Props = $props();
 
   let error = $state<Error | undefined>();
+  let loading = $state(true);
 
   const nexusOperationPollerAbortController = new AbortController();
   const poller = $derived(
@@ -43,9 +47,11 @@
       nexusOperationPollerAbortController,
       (execution) => {
         $nexusOperationExecution = execution;
+        loading = false;
       },
       (e) => {
         error = e;
+        loading = false;
       },
     ),
   );
@@ -78,53 +84,59 @@
   });
 </script>
 
-{#if $nexusOperationExecution}
-  <div class="flex flex-col gap-4">
-    <div class="flex items-center gap-2">
-      <Link
-        href={nexusOperationsHref}
-        data-testid="back-to-nexus-operations"
-        icon="chevron-left"
-      >
-        {translate('standalone-nexus-operations.back-to-nexus-operations')}
-      </Link>
-    </div>
+<div class="flex flex-col gap-4">
+  <div class="flex items-center gap-2">
+    <Link
+      href={nexusOperationsHref}
+      data-testid="back-to-nexus-operations"
+      icon="chevron-left"
+    >
+      {translate('standalone-nexus-operations.back-to-nexus-operations')}
+    </Link>
+  </div>
+
+  {#if $nexusOperationExecution}
     <NexusOperationHeader
       {namespace}
       {poller}
       nexusOperationInfo={$nexusOperationExecution.info}
     />
+  {:else if loading}
+    <NexusOperationLayoutLoading />
+  {/if}
 
-    <Tabs>
-      <TabList
-        label={translate('standalone-nexus-operations.layout-tabs-label')}
-      >
-        <Tab
-          label={translate('standalone-nexus-operations.layout-details-tab')}
-          id="nexus-operation-details-tab"
-          href={detailsRoute}
-          active={pathMatches(page.url.pathname, detailsRoute)}
-        />
-        <Tab
-          label={translate(
-            'standalone-nexus-operations.layout-search-attributes-tab',
-          )}
-          id="nexus-operation-search-attributes-tab"
-          href={searchAttributesRoute}
-          active={pathMatches(page.url.pathname, searchAttributesRoute)}
-        />
-        <Tab
-          label={translate(
-            'standalone-nexus-operations.layout-user-metadata-tab',
-          )}
-          id="nexus-operation-metadata-tab"
-          href={metadataRoute}
-          active={pathMatches(page.url.pathname, metadataRoute)}
-        />
-      </TabList>
-    </Tabs>
+  <Tabs>
+    <TabList label={translate('standalone-nexus-operations.layout-tabs-label')}>
+      <Tab
+        label={translate('standalone-nexus-operations.layout-details-tab')}
+        id="nexus-operation-details-tab"
+        href={detailsRoute}
+        active={pathMatches(page.url.pathname, detailsRoute)}
+      />
+      <Tab
+        label={translate(
+          'standalone-nexus-operations.layout-search-attributes-tab',
+        )}
+        id="nexus-operation-search-attributes-tab"
+        href={searchAttributesRoute}
+        active={pathMatches(page.url.pathname, searchAttributesRoute)}
+      />
+      <Tab
+        label={translate(
+          'standalone-nexus-operations.layout-user-metadata-tab',
+        )}
+        id="nexus-operation-metadata-tab"
+        href={metadataRoute}
+        active={pathMatches(page.url.pathname, metadataRoute)}
+      />
+    </TabList>
+  </Tabs>
+
+  {#if $nexusOperationExecution}
     {@render children()}
-  </div>
-{:else if error}
-  <ErrorComponent {error} />
-{/if}
+  {:else if loading}
+    <NexusOperationDetailsLoading />
+  {:else if error}
+    <ErrorComponent {error} />
+  {/if}
+</div>


### PR DESCRIPTION
## Description & motivation 💭

The standalone nexus operation details page showed a blank page between navigation and first API data load. This PR adds a skeleton loading UI so users see structural feedback immediately.

The loading skeleton is scoped appropriately: tabs are derived purely from route params (namespace, operationId, runId) and are always available, so they render immediately as real UI. Only the header area (which depends on the API response) and the details tab content area are skeletonized during load.

Two new skeleton components:
- `nexus-operation-header-loading.svelte` — mirrors the header area (status badge, title, action buttons, detail list)
- `nexus-operation-details-loading.svelte` — mirrors the details tab content (input/output grid + card sections)

The layout is restructured so back link and tabs are always visible, while header and content each independently transition from skeleton → real UI once data arrives. The loading state does not reappear when new updates to the standalone nexus operation are returned from the server via polling, only on initial load.

### Screenshots (if applicable) 📸


https://github.com/user-attachments/assets/bc23cbe2-55af-4e91-a520-263379150f41



### Design Considerations 🎨

None — follows the established skeleton pattern from #3643.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Navigate to a standalone nexus operation details page
2. Observe: back link and tabs render immediately; header and content area show animated skeleton during load
3. Once data loads: real header and content replace skeletons without layout shift
4. With an invalid operationId/runId: back link and tabs remain; error component renders in the content area

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

## Docs

### Any docs updates needed?

No.