### PR TITLE
fix(schedules): default absent second/minute/hour to 0 when editing

### DIFF
--- a/src/lib/components/schedule/utilities/get-form-spec.test.ts
+++ b/src/lib/components/schedule/utilities/get-form-spec.test.ts
@@ -27,9 +27,9 @@ describe('getFormSpecFromSpec', () => {
         calendar: {
           dayOfMonth: [{ start: 1, end: 31, step: 1 }],
           dayOfWeek: [{ start: 0, end: 6, step: 1 }],
-          hour: [],
-          minute: [],
-          second: [],
+          hour: [{ start: 0, end: 0, step: 1 }],
+          minute: [{ start: 0, end: 0, step: 1 }],
+          second: [{ start: 0, end: 0, step: 1 }],
           month: [{ start: 1, end: 12, step: 1 }],
           year: undefined,
           comment: '',

--- a/src/lib/components/schedule/utilities/get-form-spec.ts
+++ b/src/lib/components/schedule/utilities/get-form-spec.ts
@@ -26,9 +26,21 @@ export function getFormSpecFromSpec(
           calendar?.dayOfWeek ?? [{ start: 0, end: 6, step: 1 }],
           0,
         ),
-        hour: defaultMissingRangeStart(calendar.hour, 0),
-        minute: defaultMissingRangeStart(calendar.minute, 0),
-        second: defaultMissingRangeStart(calendar.second, 0),
+        // An absent second/minute/hour must default to 0, not an empty range.
+        // if we use an empty range, that tells the server to exclude everything
+        // and no future runs will occur.
+        hour: defaultMissingRangeStart(
+          calendar.hour ?? [{ start: 0, end: 0, step: 1 }],
+          0,
+        ),
+        minute: defaultMissingRangeStart(
+          calendar.minute ?? [{ start: 0, end: 0, step: 1 }],
+          0,
+        ),
+        second: defaultMissingRangeStart(
+          calendar.second ?? [{ start: 0, end: 0, step: 1 }],
+          0,
+        ),
         month: calendar.month ?? [{ start: 1, end: 12, step: 1 }],
         year: calendar.year,
         comment: calendar.comment ?? '',


### PR DESCRIPTION
## Problem
Editing a schedule whose structured calendar omits `second`/`minute`/`hour` left it with **no future runs**.

`getFormSpecFromSpec` mapped a missing time field to an empty range array. On save that serializes to an omitted field, and the server compiles an empty `second`/`minute`/`hour` range to *match nothing* — the `0` default is only filled for the deprecated string `CalendarSpec`, not a directly-supplied `StructuredCalendarSpec`.

## Fix
Fall back to a `0` range for these fields, mirroring how `dayOfMonth`/`dayOfWeek`/`month` already handle absent fields. Test updated.