### PR TITLE
a11y(2.4.3): keep toast live region announcing during a focus trap [DT-4252]

### DIFF
--- a/src/lib/holocene/toaster.svelte
+++ b/src/lib/holocene/toaster.svelte
@@ -3,6 +3,7 @@
 
   import { cva } from 'class-variance-authority';
 
+  import { portal } from '$lib/holocene/portal/portal-action';
   import {
     type Toaster as Toast,
     toaster as toasterStore,
@@ -45,8 +46,14 @@
   });
 </script>
 
-<div class={toast({ position: $position })}>
+<!-- Hoisted to <body> so it stays outside any focus-trap's inerted subtree
+(drawer/maximizable inert everything else); data-inert-skip keeps the trap's
+inertBackground walk from re-inerting it as a body-level sibling. -->
+<div class="sr-only" data-inert-skip use:portal>
   <LiveRegion messages={$announcements} data-testid="toast-live-region" />
+</div>
+
+<div class={toast({ position: $position })}>
   {#each $toasts as { message, variant, id, link } (id)}
     <ToastComponent {closeButtonLabel} {variant} {id} on:dismiss={dismissToast}>
       {#if link}

--- a/src/lib/utilities/focus-trap.test.ts
+++ b/src/lib/utilities/focus-trap.test.ts
@@ -141,7 +141,6 @@ describe('focusTrap focus management (inert-based)', () => {
   it('does not inert a background sibling marked data-inert-skip (hoisted live region)', () => {
     const liveRegion = document.createElement('div');
     liveRegion.setAttribute('data-inert-skip', '');
-    liveRegion.setAttribute('aria-live', 'polite');
     const background = document.createElement('div');
     background.appendChild(document.createElement('button'));
     const trapNode = document.createElement('div');

--- a/src/lib/utilities/focus-trap.test.ts
+++ b/src/lib/utilities/focus-trap.test.ts
@@ -138,6 +138,57 @@ describe('focusTrap focus management (inert-based)', () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it('does not inert a background sibling marked data-inert-skip (hoisted live region)', () => {
+    const liveRegion = document.createElement('div');
+    liveRegion.setAttribute('data-inert-skip', '');
+    liveRegion.setAttribute('aria-live', 'polite');
+    const background = document.createElement('div');
+    background.appendChild(document.createElement('button'));
+    const trapNode = document.createElement('div');
+    trapNode.appendChild(document.createElement('button'));
+    document.body.append(background, liveRegion, trapNode);
+
+    const action = focusTrap(trapNode, true);
+    expect(background.inert).toBe(true); // ordinary background inerted
+    expect(liveRegion.inert).toBeFalsy(); // live region skipped → still announces
+
+    action.destroy();
+    expect(background.inert).toBe(false);
+  });
+
+  it('does not inert a background sibling that is itself an aria-live region', () => {
+    const liveRegion = document.createElement('div');
+    liveRegion.setAttribute('aria-live', 'assertive');
+    const trapNode = document.createElement('div');
+    trapNode.appendChild(document.createElement('button'));
+    document.body.append(liveRegion, trapNode);
+
+    const action = focusTrap(trapNode, true);
+    expect(liveRegion.inert).toBeFalsy();
+
+    action.destroy();
+  });
+
+  // Containment guard: a container that merely *contains* a live region must
+  // still be inerted (the real app shell holds form-error live regions etc.).
+  // Skipping it would leave the whole background reachable. Only the live-region
+  // root itself is spared, which is why it must be hoisted out first.
+  it('still inerts a background container that merely contains a nested live region', () => {
+    const shell = document.createElement('div');
+    const nestedLive = document.createElement('div');
+    nestedLive.setAttribute('aria-live', 'polite');
+    shell.append(document.createElement('button'), nestedLive);
+    const trapNode = document.createElement('div');
+    trapNode.appendChild(document.createElement('button'));
+    document.body.append(shell, trapNode);
+
+    const action = focusTrap(trapNode, true);
+    expect(shell.inert).toBe(true); // container inerted despite holding a live region
+
+    action.destroy();
+    expect(shell.inert).toBe(false);
+  });
+
   it('does not clear inert that was already set before activation', () => {
     const preInert = document.createElement('div');
     preInert.inert = true;

--- a/src/lib/utilities/focus-trap.ts
+++ b/src/lib/utilities/focus-trap.ts
@@ -9,6 +9,13 @@ export const getFocusableElements = (node: HTMLElement) =>
       !(element.getAttribute('tabindex') === '-1'),
   );
 
+// A live-region root that must keep announcing while a trap is active (e.g. the
+// toast region hoisted to <body>). Matched on the element itself, never on a
+// descendant — a container that merely *holds* a live region (the app shell,
+// with its form-error regions) must still be inerted, so the region has to be
+// hoisted out to a sibling of the trap for this to spare it.
+const LIVE_REGION_SELECTOR = '[data-inert-skip], [aria-live]';
+
 // Make everything outside `node`'s ancestor chain `inert` — removing it from
 // the focus order, tab sequence, pointer events, and the accessibility tree.
 // Walks up to <body>, marking the siblings at each level. Returns a function
@@ -24,7 +31,8 @@ const inertBackground = (node: HTMLElement): (() => void) => {
       if (
         sibling !== current &&
         sibling instanceof HTMLElement &&
-        !sibling.inert
+        !sibling.inert &&
+        !sibling.matches(LIVE_REGION_SELECTOR)
       ) {
         sibling.inert = true;
         inerted.push(sibling);


### PR DESCRIPTION
Follow-up to #3598, from Laura's review. The inert-based trap inerts everything outside it up to `<body>`; the toast `aria-live` region lived inside the main app container, so toasts fired while a drawer/maximizable was open were **not announced** to screen readers (still shown visually — an AT-only gap).

**Fix:** hoist the live region to `<body>` from within `Toaster` (`data-inert-skip`), and have `inertBackground` skip live-region roots — matched on the element itself, so a container merely *holding* a live region (the app shell) is still inerted and containment is preserved.

Stacked on `wcag/2.4.3-focus-trap-inert` (#3598); retarget to `main` once it merges. cloud-ui picks this up on the next tarball repack — verify both its toaster mounts then (see DT-4252).

## Testing
- 3 new unit tests in `focus-trap.test.ts`: skips `data-inert-skip` / `aria-live` roots; still inerts a container with a *nested* live region.
- `pnpm check` clean, focus-trap suite green.
- [x] NVDA/VoiceOver: toast announced with a drawer/maximized surface open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)