### PR TITLE
fix(schedules): default emptied second/minute/hour to 0 on submit

### DIFF
--- a/src/lib/components/schedule/utilities/get-request-body.test.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.test.ts
@@ -88,6 +88,29 @@ describe('getRequestBody', () => {
     ]);
   });
 
+  it('defaults emptied second/minute/hour ranges to zero', async () => {
+    const body = await getRequestBody(
+      buildForm({
+        specs: [
+          {
+            kind: 'week',
+            calendar: {
+              dayOfWeek: [{ start: 1, end: 5 }],
+              second: [],
+              minute: [],
+              hour: [],
+            },
+          },
+        ],
+      }),
+    );
+
+    const [calendar] = body.schedule.spec.structuredCalendar;
+    expect(calendar.second).toEqual([{ start: 0, end: 0, step: 1 }]);
+    expect(calendar.minute).toEqual([{ start: 0, end: 0, step: 1 }]);
+    expect(calendar.hour).toEqual([{ start: 0, end: 0, step: 1 }]);
+  });
+
   it('anchors the start time to midnight of the timezone', async () => {
     const body = await getRequestBody(buildForm());
 

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -154,9 +154,9 @@ function toStructuredCalendar(
   const { comment, ...ranges } = calendar;
   return {
     ...ranges,
-    second: ranges.second?.length ? ranges.second : DEFAULT_TIME_RANGE,
-    minute: ranges.minute?.length ? ranges.minute : DEFAULT_TIME_RANGE,
-    hour: ranges.hour?.length ? ranges.hour : DEFAULT_TIME_RANGE,
+    second: ranges.second?.length ? ranges.second : defaultTimeRange(),
+    minute: ranges.minute?.length ? ranges.minute : defaultTimeRange(),
+    hour: ranges.hour?.length ? ranges.hour : defaultTimeRange(),
     ...(comment ? { comment } : {}),
   };
 }

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -143,11 +143,22 @@ async function getScheduleActionRequest(
 
 type SpecFormItem = FormScheduleSchema['specs'][number];
 
+const DEFAULT_TIME_RANGE = [{ start: 0, end: 0, step: 1 }];
+
+// An empty second/minute/hour range tells the server to exclude everything, so
+// the schedule gets no future runs. Default emptied fields to 0 so a cleared
+// calendar (or a spec loaded without these fields) still fires.
 function toStructuredCalendar(
   calendar: SpecFormItem['calendar'],
 ): StructuredCalendar {
   const { comment, ...ranges } = calendar;
-  return { ...ranges, ...(comment ? { comment } : {}) };
+  return {
+    ...ranges,
+    second: ranges.second?.length ? ranges.second : DEFAULT_TIME_RANGE,
+    minute: ranges.minute?.length ? ranges.minute : DEFAULT_TIME_RANGE,
+    hour: ranges.hour?.length ? ranges.hour : DEFAULT_TIME_RANGE,
+    ...(comment ? { comment } : {}),
+  };
 }
 
 function toInterval(interval: SpecFormItem['interval']): ScheduleInterval {

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -143,7 +143,7 @@ async function getScheduleActionRequest(
 
 type SpecFormItem = FormScheduleSchema['specs'][number];
 
-const DEFAULT_TIME_RANGE = [{ start: 0, end: 0, step: 1 }];
+const defaultTimeRange = () => [{ start: 0, end: 0, step: 1 }];
 
 // An empty second/minute/hour range tells the server to exclude everything, so
 // the schedule gets no future runs. Default emptied fields to 0 so a cleared


### PR DESCRIPTION
Follow-up to #3653.

## Problem
That PR fixed the edit-load path, but the same "empty range → server matches nothing → no future runs" hazard exists on **create**: the zod schema only defaults second/minute/hour when they're `undefined`, so an emptied calendar time field (e.g. a cleared picker) slips through as `[]`.

## Fix
Guard the single submit choke point (`toStructuredCalendar`) so an empty second/minute/hour range defaults to `0`. Covers create and edit. Test added.