### PR TITLE
fix(workers): reject $LATEST qualifier in Lambda ARN validation

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/shared.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { editVersionSchema } from './shared';
+
+const validLambdaArn =
+  'arn:aws:lambda:us-east-1:123456789012:function:my-function';
+const validIamRoleArn = 'arn:aws:iam::123456789012:role/my-role';
+
+const baseLambdaData = {
+  provider: 'lambda' as const,
+  lambdaArn: validLambdaArn,
+  iamRoleArn: validIamRoleArn,
+  roleExternalId: 'external-id',
+};
+
+const lambdaArnErrors = (lambdaArn: string): string[] => {
+  const result = editVersionSchema.safeParse({ ...baseLambdaData, lambdaArn });
+  if (result.success) return [];
+  return result.error.issues
+    .filter((issue) => issue.path[0] === 'lambdaArn')
+    .map((issue) => issue.message);
+};
+
+describe('editVersionSchema lambda ARN validation', () => {
+  it('accepts a valid unqualified Lambda ARN', () => {
+    expect(lambdaArnErrors(validLambdaArn)).toEqual([]);
+  });
+
+  it('accepts a Lambda ARN pinned to a numeric version', () => {
+    expect(lambdaArnErrors(`${validLambdaArn}:1`)).toEqual([]);
+  });
+
+  it('accepts a Lambda ARN referencing an alias', () => {
+    expect(lambdaArnErrors(`${validLambdaArn}:PROD`)).toEqual([]);
+  });
+
+  it('rejects a Lambda ARN with a $LATEST qualifier', () => {
+    expect(lambdaArnErrors(`${validLambdaArn}:$LATEST`)).toEqual([
+      'Lambda ARN must reference a published version or alias, not $LATEST',
+    ]);
+  });
+
+  it('rejects a malformed Lambda ARN', () => {
+    expect(lambdaArnErrors('not-an-arn')).toEqual([
+      'Invalid Lambda ARN format',
+    ]);
+  });
+
+  it('requires a Lambda ARN', () => {
+    expect(lambdaArnErrors('')).toEqual(['Lambda ARN is required']);
+  });
+});

--- a/src/lib/components/workers/serverless-worker-form/shared.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.ts
@@ -37,6 +37,13 @@ const validateProviderFields = (
         path: ['lambdaArn'],
         message: 'Invalid Lambda ARN format',
       });
+    } else if (/:\$LATEST$/.test(data.lambdaArn)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['lambdaArn'],
+        message:
+          'Lambda ARN must reference a published version or alias, not $LATEST',
+      });
     }
     if (!data.iamRoleArn) {
       ctx.addIssue({


### PR DESCRIPTION
## Description

Part of COM-211.

The serverless worker Lambda ARN validation (`serverless-worker-form/shared.ts`) accepted any function qualifier, so an ARN ending in `:$LATEST` passed validation. Worker deployment versions need a pinned function version or alias, so a `$LATEST` ARN should be rejected.

This adds a validation rule that rejects a `:$LATEST` qualifier with a clear message, and covers the schema with unit tests.

### What this does NOT cover

The other half of COM-211 (ARN / field edits not persisting) is a backend concern: worker deployment versions are currently immutable, so the edit form's changes silently no-op. Per the team discussion the direction is to make those fields mutable server-side, so there is no UI change here for that.

## Testing

- `pnpm test` (all suites pass, new `shared.test.ts` added)
- `pnpm check` (clean)
- `pnpm lint` (clean)

New tests verify:
- valid unqualified ARN, numeric version, and alias all pass
- `:$LATEST` qualifier is rejected
- malformed and empty ARNs still error as before