### PR TITLE
fix describe SANO API requests to include runId parameter

### DIFF
--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
@@ -314,6 +314,7 @@
     const initialValues = await fetchInitialValuesForStartNexusOperation(
       namespace,
       operationIdParam,
+      runIdParam,
     );
 
     $form.input = initialValues.input;

--- a/src/lib/services/standalone-nexus-operations.ts
+++ b/src/lib/services/standalone-nexus-operations.ts
@@ -223,6 +223,8 @@ export const startStandaloneNexusOperation = async (
 export const getNexusOperationExecution = (
   namespace: string,
   operationId: string,
+  runId: string,
+  includeOutcome: boolean = true,
 ): Promise<NexusOperationExecution> => {
   const route = routeForApi('standalone-nexus-operation', {
     namespace,
@@ -230,8 +232,9 @@ export const getNexusOperationExecution = (
   });
 
   const params = new URLSearchParams({
+    runId,
     includeInput: 'true',
-    includeOutcome: 'true',
+    includeOutcome: String(includeOutcome),
   });
 
   return requestFromAPI(route, { params });
@@ -281,6 +284,7 @@ const extractMetadataString = async (
 export const fetchInitialValuesForStartNexusOperation = async (
   namespace: string,
   operationId: string,
+  runId: string,
 ): Promise<NexusOperationInitialValues> => {
   const emptyValues: NexusOperationInitialValues = {
     input: '',
@@ -292,7 +296,12 @@ export const fetchInitialValuesForStartNexusOperation = async (
   };
 
   try {
-    const operation = await getNexusOperationExecution(namespace, operationId);
+    const operation = await getNexusOperationExecution(
+      namespace,
+      operationId,
+      runId,
+      false,
+    );
     const { input, encoding, messageType } = await extractNexusInputValues(
       operation.input,
     );

--- a/src/lib/utilities/standalone-nexus-operation-poller.svelte.ts
+++ b/src/lib/utilities/standalone-nexus-operation-poller.svelte.ts
@@ -44,6 +44,7 @@ export class StandaloneNexusOperationPoller {
       nexusOperationExecution = await getNexusOperationExecution(
         this.namespace,
         this.operationId,
+        this.runId,
       );
     } catch (error) {
       this.onError(error);
@@ -92,6 +93,7 @@ export class StandaloneNexusOperationPoller {
     const nexusOperationExecution = await getNexusOperationExecution(
       this.namespace,
       this.operationId,
+      this.runId,
     );
     this.onUpdate(nexusOperationExecution);
   }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Include the `runId` [request parameter](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/request_response.proto#L3398) in `DescribeNexusOperationExecutionRequest` so that the run a user is actually trying to view is returned instead of the most recent run.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
