### PR TITLE
Add danger PR comment for API version bump

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -21,6 +21,23 @@ if (totalChanges > bigPRThreshold) {
   );
 }
 
+// Remind to cut a release when the Temporal API dependency is bumped
+async function checkApiVersionBump() {
+  if (!modified.includes('server/go.mod')) {
+    return;
+  }
+
+  const diff = await danger.git.diffForFile('server/go.mod');
+  if (diff?.added.includes('go.temporal.io/api')) {
+    warn(
+      '📦 `go.temporal.io/api` was bumped in `server/go.mod`. ' +
+        'Remember to cut a new release after this merges.',
+    );
+  }
+}
+
+schedule(checkApiVersionBump());
+
 interface StrictError {
   filename: string;
   start: { line: number; character: number };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
