### PR TITLE
Associate Combobox hints with form fields

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -143,27 +143,21 @@
       placeholder={translate('workers.gcp-project-placeholder')}
       required
     />
-    <div class="flex flex-col gap-1.5">
-      <Combobox
-        bind:value={gcpRegion}
-        id="gcpRegion"
-        name="gcpRegion"
-        label={translate('workers.gcp-region-label')}
-        placeholder={translate('workers.gcp-region-placeholder')}
-        options={gcpRegions}
-        noResultsText={translate('common.no-results')}
-        valid={!errors.gcpRegion?.[0]}
-        error={errors.gcpRegion?.[0]}
-        allowCustomValue
-        showChevron
-        required
-      />
-      {#if !errors.gcpRegion?.[0]}
-        <p class="text-xs text-primary">
-          {translate('workers.gcp-region-hint')}
-        </p>
-      {/if}
-    </div>
+    <Combobox
+      bind:value={gcpRegion}
+      id="gcpRegion"
+      name="gcpRegion"
+      label={translate('workers.gcp-region-label')}
+      hintText={translate('workers.gcp-region-hint')}
+      placeholder={translate('workers.gcp-region-placeholder')}
+      options={gcpRegions}
+      noResultsText={translate('common.no-results')}
+      valid={!errors.gcpRegion?.[0]}
+      error={errors.gcpRegion?.[0]}
+      allowCustomValue
+      showChevron
+      required
+    />
     <div class="flex flex-wrap items-end gap-4">
       <Input
         bind:value={gcpWorkerPool}

--- a/src/lib/holocene/combobox/combobox.stories.svelte
+++ b/src/lib/holocene/combobox/combobox.stories.svelte
@@ -19,6 +19,7 @@
       disabled: false,
       valid: true,
       error: '',
+      hintText: '',
       leadingIcon: 'search',
       labelHidden: false,
     },
@@ -30,6 +31,7 @@
       required: { name: 'Required', control: 'boolean' },
       disabled: { name: 'Disabled', control: 'boolean' },
       error: { name: 'Error', control: 'text' },
+      hintText: { name: 'Hint Text', control: 'text' },
       valid: { name: 'Valid', control: 'boolean' },
       labelHidden: { name: 'Label Hidden', control: 'boolean' },
       minSize: { name: 'Minimum Size', control: 'number' },
@@ -75,6 +77,44 @@
     const canvas = within(canvasElement);
     const combobox = canvas.getByTestId(id);
     await userEvent.type(combobox, 'English');
+  }}
+/>
+
+<Story
+  name="With Hint Text"
+  args={{
+    options: ['English', 'English (UK)', 'German', 'French', 'Japanese'],
+    hintText: 'Choose the language used for this workflow.',
+  }}
+  play={async ({ canvasElement, id }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByTestId(id);
+
+    expect(combobox).toHaveAccessibleDescription(
+      'Choose the language used for this workflow.',
+    );
+  }}
+/>
+
+<Story
+  name="Error Overrides Hint Text"
+  args={{
+    options: ['English', 'English (UK)', 'German', 'French', 'Japanese'],
+    hintText: 'Choose the language used for this workflow.',
+    error: 'Select a language.',
+    valid: false,
+  }}
+  play={async ({ canvasElement, id }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByTestId(id);
+
+    expect(combobox).toHaveAccessibleDescription('Select a language.');
+    expect(combobox).not.toHaveAccessibleDescription(
+      'Choose the language used for this workflow.',
+    );
+    expect(
+      canvas.queryByText('Choose the language used for this workflow.'),
+    ).not.toBeInTheDocument();
   }}
 />
 

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -81,6 +81,7 @@
     minSize?: number;
     maxSize?: number;
     'data-testid'?: string;
+    hintText?: string;
     error?: string;
     valid?: boolean;
     actionTooltip?: string;
@@ -161,6 +162,7 @@
     optionLabelKey = optionValueKey,
     minSize = 0,
     maxSize = 120,
+    hintText = '',
     error = '',
     valid = true,
     open = writable(false),
@@ -465,6 +467,7 @@
   }
 
   const errorId = $derived(`${id}-error`);
+  const hintId = $derived(`${id}-hint`);
   const showError = $derived(!!error && !valid);
 
   const handleInputClick: MouseEventHandler<HTMLInputElement> = (event) => {
@@ -562,7 +565,7 @@
           aria-expanded={$open}
           aria-required={required}
           aria-invalid={!valid ? 'true' : undefined}
-          aria-describedby={showError ? errorId : undefined}
+          aria-describedby={showError ? errorId : hintText ? hintId : undefined}
           aria-autocomplete="list"
           onfocus={handleFocus}
           onblur={handleBlur}
@@ -626,6 +629,19 @@
         </button>
       {/if}
     </div>
+    <div class="inline-flex" class:hidden={!hintText && !showError}>
+      <span
+        id={errorId}
+        role="alert"
+        class="hint-text error"
+        class:hidden={!showError}
+      >
+        {#if showError}{error}{/if}
+      </span>
+      <span id={hintId} class="hint-text" class:hidden={showError}>
+        {#if !showError}{hintText}{/if}
+      </span>
+    </div>
   </div>
 
   <Menu
@@ -686,15 +702,15 @@
       </ComboboxOption>
     {/if}
   </Menu>
-
-  <span id={errorId} role="alert" class="error">
-    {#if showError}{error}{/if}
-  </span>
 </MenuContainer>
 
 <style lang="postcss">
-  .error {
-    @apply text-xs text-danger;
+  .hint-text {
+    @apply text-xs text-primary;
+
+    &.error {
+      @apply text-danger;
+    }
   }
 
   .input-wrapper {


### PR DESCRIPTION
## Summary

Adds first-class hint text support to Combobox and associates hints and errors with the field using `aria-describedby`. Migrates the Cloud Run region hint to the new API.

## Test plan

- [x] Unit tests — 2,251 passed, 1 skipped
- [x] Svelte check — 0 errors
- [x] Combobox Storybook tests — 12 passed
- [x] Formatting, ESLint, and Stylelint