### PR TITLE
Show IANA region names in schedule timezone picker (DT-4250)

### DIFF
--- a/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
@@ -12,7 +12,7 @@
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { DescribeFullSchedule } from '$lib/types/schedule';
-  import { getTimezoneOffsetRange } from '$lib/utilities/timezone';
+  import { ianaTimezoneComboboxOptions } from '$lib/utilities/timezone';
 
   import type { FormScheduleSchema } from '../schema/form';
   import { fromCalendarDateStr, toCalendarDateStr } from '../utilities/date';
@@ -26,17 +26,6 @@
   }
 
   let { form, errors, schedule = null }: Props = $props();
-
-  const timezoneComboboxOptions = $derived.by(() => {
-    const opts = [{ label: translate('common.utc'), value: 'UTC' }];
-    for (const zone of Intl.supportedValuesOf('timeZone')) {
-      opts.push({
-        label: `${zone} (${getTimezoneOffsetRange(zone)})`,
-        value: zone,
-      });
-    }
-    return opts;
-  });
 
   // svelte-ignore state_referenced_locally
   const endKindStore = fieldProxy(form, 'endKind');
@@ -198,7 +187,7 @@
         id="timezoneName"
         label={translate('schedules.timezone-label')}
         bind:value={$form.timezoneName}
-        options={timezoneComboboxOptions}
+        options={ianaTimezoneComboboxOptions}
         optionValueKey="value"
         optionLabelKey="label"
         noResultsText={translate('common.no-results')}

--- a/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
@@ -197,6 +197,7 @@
       />
 
       <Input
+        class="gap-1.5"
         id="jitter"
         label={translate('schedules.jitter')}
         type="number"

--- a/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-details-card.svelte
@@ -12,7 +12,7 @@
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { DescribeFullSchedule } from '$lib/types/schedule';
-  import { formatOffset, TimezoneOptions } from '$lib/utilities/timezone';
+  import { getTimezoneOffsetRange } from '$lib/utilities/timezone';
 
   import type { FormScheduleSchema } from '../schema/form';
   import { fromCalendarDateStr, toCalendarDateStr } from '../utilities/date';
@@ -29,11 +29,10 @@
 
   const timezoneComboboxOptions = $derived.by(() => {
     const opts = [{ label: translate('common.utc'), value: 'UTC' }];
-    for (const tz of TimezoneOptions) {
-      const offsetStr = formatOffset(tz.offset);
+    for (const zone of Intl.supportedValuesOf('timeZone')) {
       opts.push({
-        label: `${tz.label} (${tz.abbr}) ${offsetStr}`,
-        value: tz.zones?.[0] ?? tz.label,
+        label: `${zone} (${getTimezoneOffsetRange(zone)})`,
+        value: zone,
       });
     }
     return opts;

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -95,7 +95,7 @@
   const { copy, copied } = copyToClipboard();
 </script>
 
-<div class={merge('group flex flex-col gap-1.5', className)}>
+<div class={merge('group flex flex-col gap-1', className)}>
   <div
     class={merge(
       'flex items-center justify-start gap-2',

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -95,7 +95,7 @@
   const { copy, copied } = copyToClipboard();
 </script>
 
-<div class={merge('group flex flex-col gap-1', className)}>
+<div class={merge('group flex flex-col gap-1.5', className)}>
   <div
     class={merge(
       'flex items-center justify-start gap-2',

--- a/src/lib/utilities/timezone.test.ts
+++ b/src/lib/utilities/timezone.test.ts
@@ -5,29 +5,29 @@ import { getTimezoneOffsetRange } from './timezone';
 describe('getTimezoneOffsetRange', () => {
   it('shows the standard/daylight pair for a DST zone', () => {
     expect(getTimezoneOffsetRange('America/New_York')).toBe(
-      'GMT-05:00/GMT-04:00',
+      'UTC-05:00/UTC-04:00',
     );
   });
 
-  it('normalizes bare GMT and pairs it with the daylight offset', () => {
-    expect(getTimezoneOffsetRange('Europe/London')).toBe('GMT+00:00/GMT+01:00');
+  it('normalizes bare UTC and pairs it with the daylight offset', () => {
+    expect(getTimezoneOffsetRange('Europe/London')).toBe('UTC+00:00/UTC+01:00');
   });
 
   it('collapses to a single offset for a non-DST zone', () => {
-    expect(getTimezoneOffsetRange('Asia/Kolkata')).toBe('GMT+05:30');
+    expect(getTimezoneOffsetRange('Asia/Kolkata')).toBe('UTC+05:30');
   });
 
   it('preserves 45-minute offsets', () => {
-    expect(getTimezoneOffsetRange('Asia/Kathmandu')).toBe('GMT+05:45');
+    expect(getTimezoneOffsetRange('Asia/Kathmandu')).toBe('UTC+05:45');
   });
 
   it('handles a 30-minute daylight shift', () => {
     expect(getTimezoneOffsetRange('Australia/Lord_Howe')).toBe(
-      'GMT+10:30/GMT+11:00',
+      'UTC+10:30/UTC+11:00',
     );
   });
 
   it('preserves negative half-hour offsets', () => {
-    expect(getTimezoneOffsetRange('Pacific/Marquesas')).toBe('GMT-09:30');
+    expect(getTimezoneOffsetRange('Pacific/Marquesas')).toBe('UTC-09:30');
   });
 });

--- a/src/lib/utilities/timezone.test.ts
+++ b/src/lib/utilities/timezone.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTimezoneOffsetRange } from './timezone';
+
+describe('getTimezoneOffsetRange', () => {
+  it('shows the standard/daylight pair for a DST zone', () => {
+    expect(getTimezoneOffsetRange('America/New_York')).toBe(
+      'GMT-05:00/GMT-04:00',
+    );
+  });
+
+  it('normalizes bare GMT and pairs it with the daylight offset', () => {
+    expect(getTimezoneOffsetRange('Europe/London')).toBe('GMT+00:00/GMT+01:00');
+  });
+
+  it('collapses to a single offset for a non-DST zone', () => {
+    expect(getTimezoneOffsetRange('Asia/Kolkata')).toBe('GMT+05:30');
+  });
+
+  it('preserves 45-minute offsets', () => {
+    expect(getTimezoneOffsetRange('Asia/Kathmandu')).toBe('GMT+05:45');
+  });
+
+  it('handles a 30-minute daylight shift', () => {
+    expect(getTimezoneOffsetRange('Australia/Lord_Howe')).toBe(
+      'GMT+10:30/GMT+11:00',
+    );
+  });
+
+  it('preserves negative half-hour offsets', () => {
+    expect(getTimezoneOffsetRange('Pacific/Marquesas')).toBe('GMT-09:30');
+  });
+});

--- a/src/lib/utilities/timezone.ts
+++ b/src/lib/utilities/timezone.ts
@@ -85,7 +85,7 @@ export const TimezoneOptions: TimeFormatOptions = Object.entries(Timezones)
   });
 
 const offsetToMinutes = (offset: string): number => {
-  const match = offset.match(/GMT([+-])(\d{2}):(\d{2})/);
+  const match = offset.match(/UTC([+-])(\d{2}):(\d{2})/);
   if (!match) return 0;
   const [, sign, hours, minutes] = match;
   return (sign === '-' ? -1 : 1) * (Number(hours) * 60 + Number(minutes));
@@ -102,7 +102,9 @@ export function getTimezoneOffsetRange(timeZone: string): string {
     const parts = formatter.formatToParts(new Date(Date.UTC(year, month, 1)));
     const value =
       parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
-    offsets.add(value === 'GMT' ? 'GMT+00:00' : value);
+    const normalized =
+      value === 'GMT' ? 'UTC+00:00' : value.replace('GMT', 'UTC');
+    offsets.add(normalized);
   }
   return [...offsets]
     .sort((a, b) => offsetToMinutes(a) - offsetToMinutes(b))

--- a/src/lib/utilities/timezone.ts
+++ b/src/lib/utilities/timezone.ts
@@ -111,6 +111,14 @@ export function getTimezoneOffsetRange(timeZone: string): string {
     .join('/');
 }
 
+export const ianaTimezoneComboboxOptions: { label: string; value: string }[] = [
+  { label: 'UTC', value: 'UTC' },
+  ...Intl.supportedValuesOf('timeZone').map((zone) => ({
+    label: `${zone} (${getTimezoneOffsetRange(zone)})`,
+    value: zone,
+  })),
+];
+
 export function getLocalTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }

--- a/src/lib/utilities/timezone.ts
+++ b/src/lib/utilities/timezone.ts
@@ -84,6 +84,31 @@ export const TimezoneOptions: TimeFormatOptions = Object.entries(Timezones)
     return 0;
   });
 
+const offsetToMinutes = (offset: string): number => {
+  const match = offset.match(/GMT([+-])(\d{2}):(\d{2})/);
+  if (!match) return 0;
+  const [, sign, hours, minutes] = match;
+  return (sign === '-' ? -1 : 1) * (Number(hours) * 60 + Number(minutes));
+};
+
+export function getTimezoneOffsetRange(timeZone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    timeZoneName: 'longOffset',
+  });
+  const year = new Date().getUTCFullYear();
+  const offsets = new Set<string>();
+  for (let month = 0; month < 12; month++) {
+    const parts = formatter.formatToParts(new Date(Date.UTC(year, month, 1)));
+    const value =
+      parts.find((part) => part.type === 'timeZoneName')?.value ?? '';
+    offsets.add(value === 'GMT' ? 'GMT+00:00' : value);
+  }
+  return [...offsets]
+    .sort((a, b) => offsetToMinutes(a) - offsetToMinutes(b))
+    .join('/');
+}
+
 export function getLocalTimezone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 }

--- a/tests/integration/schedules-create.spec.ts
+++ b/tests/integration/schedules-create.spec.ts
@@ -145,8 +145,8 @@ test.describe('Creates Schedule Successfully', () => {
 
     await page.locator('#end-date-on').check();
 
-    await page.locator('#timezoneName').fill('Japan');
-    await page.getByRole('option', { name: /Japan/ }).first().click();
+    await page.locator('#timezoneName').fill('Tokyo');
+    await page.getByRole('option', { name: /Tokyo/ }).first().click();
 
     const createRequest = page.waitForRequest(isCreateRequest);
     await page.getByTestId('create-schedule-button').click();


### PR DESCRIPTION
## What
Schedule form timezone picker now lists IANA region names (e.g. `America/New_York`) with their year offset range instead of descriptive names.

- Options built from `Intl.supportedValuesOf('timeZone')`; label + value are the region, so it's searchable by name (the combobox filters on label).
- New `getTimezoneOffsetRange` util shows the full-year offset range in UTC notation (e.g. `America/New_York (UTC-05:00/UTC-04:00)`) via `Intl` `longOffset` — DST-aware, preserves half-hour/45-min zones. Avoids the buggy `formatOffset`.

**Why this PR avoids `formatOffset`:** it only handles whole-hour offsets. The `:00` is hardcoded, so sub-hour zones render wrong (India `+05:30` → `+05:00`, Nepal `+05:45` → `+05:00`), and `Math.floor` pushes negative fractional offsets the wrong way (Marquesas `-09:30` → `-10:00`). `getTimezoneOffsetRange` uses `Intl` `longOffset`, which is accurate for all of these.

**Why a new function instead of fixing `formatOffset`:** `formatOffset`/`getUTCOffset` are shared by the nav timezone selector, workflow filters, and time-format store. Changing their output format could have far-reaching effects across those surfaces, which is out of scope for the schedules timezone selector. Fixing it repo-wide is worth a separate follow-up.

## Why
Customers see `America/New_York` on existing schedules but couldn't find it in the picker (grouped under "Eastern Standard Time" and not searchable by value).

## Test
Unit tests for `getTimezoneOffsetRange`; `pnpm check`/`lint`/`test` all pass.

<img width="2456" height="2428" alt="CleanShot 2026-07-13 at 14 47 24@2x" src="https://github.com/user-attachments/assets/2cee457d-8b15-4836-ad18-4043a3f180a7" />
