### PR TITLE
[COM-193] Lock compute provider for new deployment versions

### DIFF
--- a/src/lib/components/deployments/deployments-empty-state.svelte
+++ b/src/lib/components/deployments/deployments-empty-state.svelte
@@ -8,9 +8,14 @@
   interface Props {
     createHref: string;
     error?: string;
+    canCreateServerlessDeployment?: boolean;
   }
 
-  let { createHref, error = '' }: Props = $props();
+  let {
+    createHref,
+    error = '',
+    canCreateServerlessDeployment = true,
+  }: Props = $props();
 </script>
 
 <div class="flex flex-col items-center gap-4 py-16">
@@ -24,11 +29,13 @@
     </p>
   </div>
   <div class="flex flex-wrap items-center justify-center gap-4">
-    <CapabilityGuard capability="serverScaledDeployments">
-      <Button variant="secondary" href={createHref}>
-        {translate('deployments.create-serverless-deployment')}
-      </Button>
-    </CapabilityGuard>
+    {#if canCreateServerlessDeployment}
+      <CapabilityGuard capability="serverScaledDeployments">
+        <Button variant="secondary" href={createHref}>
+          {translate('deployments.create-serverless-deployment')}
+        </Button>
+      </CapabilityGuard>
+    {/if}
     <Button
       variant="ghost"
       href="https://docs.temporal.io/worker-deployments"

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -27,6 +27,7 @@
     error?: string;
     versions?: VersionSummary[];
     computeProviders?: readonly ComputeProviderOption[];
+    initialProvider?: ComputeProviderOption['value'];
     gcpRegions?: string[];
   }
 
@@ -36,6 +37,7 @@
     error,
     versions = [],
     computeProviders,
+    initialProvider,
     gcpRegions,
   }: Props = $props();
 
@@ -43,6 +45,7 @@
     {
       buildId: '',
       provider: getInitialComputeProvider({
+        provider: untrack(() => initialProvider),
         providers: untrack(() => computeProviders),
       }),
       lambdaArn: '',

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -20,6 +20,12 @@
   import { has } from '$lib/utilities/has';
   import { routeForWorkerDeploymentCreate } from '$lib/utilities/route-for';
 
+  interface Props {
+    canCreateServerlessDeployment?: boolean;
+  }
+
+  let { canCreateServerlessDeployment = true }: Props = $props();
+
   let error = $state('');
 
   const namespace = $derived(page.params.namespace);
@@ -102,7 +108,11 @@
       {/each}
 
       <svelte:fragment slot="empty">
-        <DeploymentsEmptyState {createHref} {error} />
+        <DeploymentsEmptyState
+          {createHref}
+          {error}
+          {canCreateServerlessDeployment}
+        />
       </svelte:fragment>
       <svelte:fragment slot="actions-end-additional">
         <Tooltip text="Configure Columns" top>

--- a/src/lib/pages/worker-deployment-version-create.svelte
+++ b/src/lib/pages/worker-deployment-version-create.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CreateVersionForm from '$lib/components/workers/serverless-worker-form/create-version-form.svelte';
   import type { ComputeProviderOption } from '$lib/components/workers/serverless-worker-form/shared';
+  import Alert from '$lib/holocene/alert.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
@@ -12,6 +13,7 @@
     validateWorkerDeploymentVersionComputeConfig,
   } from '$lib/services/deployments-service';
   import type { VersionSummary } from '$lib/types/deployments';
+  import { lockComputeProvider } from '$lib/utilities/lock-compute-provider';
   import { routeForWorkerDeployment } from '$lib/utilities/route-for';
 
   interface Props {
@@ -32,12 +34,20 @@
 
   let error = $state<string | undefined>();
   let versions = $state<VersionSummary[]>();
+  let lockedProvider = $state<ReturnType<typeof lockComputeProvider>>();
+  let loading = $state(true);
+  let loadError = $state(false);
 
   const backHref = $derived(
     routeForWorkerDeployment({ namespace, deployment }),
   );
 
   $effect(() => {
+    loading = true;
+    loadError = false;
+    versions = undefined;
+    lockedProvider = undefined;
+
     const controller = new AbortController();
     fetchDeployment(
       { namespace, deploymentName: deployment },
@@ -48,11 +58,21 @@
     )
       .then((response) => {
         if (controller.signal.aborted) return;
-        versions = response?.workerDeploymentInfo?.versionSummaries ?? [];
+        const info = response?.workerDeploymentInfo;
+        if (!info) {
+          loadError = true;
+          return;
+        }
+        versions = info.versionSummaries ?? [];
+        lockedProvider = lockComputeProvider(info, computeProviders);
+        loadError = versions.length > 0 && !lockedProvider;
       })
       .catch(() => {
         if (controller.signal.aborted) return;
-        versions = [];
+        loadError = true;
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) loading = false;
       });
     return () => controller.abort();
   });
@@ -65,85 +85,92 @@
   <h1>
     {translate('workers.create-version-title')}
   </h1>
-  <CreateVersionForm
-    {error}
-    {versions}
-    {computeProviders}
-    {gcpRegions}
-    cancelHref={backHref}
-    onSubmit={async (data) => {
-      error = undefined;
-      const computeConfig =
-        data.provider === 'cloud-run'
-          ? buildGcpCloudRunComputeConfig(
-              data.gcpProject,
-              data.gcpRegion,
-              data.gcpWorkerPool,
-              data.gcpServiceAccount,
-            )
-          : buildLambdaComputeConfig(data.lambdaArn, data.iamRoleArn, {
-              roleExternalId: data.roleExternalId,
-              scaleUpCooloffMs: data.scaleUpCooloffMs,
-              scaleUpBacklogThreshold: data.scaleUpBacklogThreshold,
-              maxWorkerLifetimeMs: data.maxWorkerLifetimeMs,
-              metricsPollIntervalMs: data.metricsPollIntervalMs,
-            });
-      await createWorkerDeploymentVersion(
-        {
-          namespace,
-          deploymentVersion: {
+  {#if loadError}
+    <Alert intent="error" title={translate('common.error-occurred')}>
+      {translate('common.unknown-error')}
+    </Alert>
+  {:else if !loading}
+    <CreateVersionForm
+      {error}
+      {versions}
+      computeProviders={lockedProvider?.providers ?? computeProviders}
+      initialProvider={lockedProvider?.provider}
+      {gcpRegions}
+      cancelHref={backHref}
+      onSubmit={async (data) => {
+        error = undefined;
+        const computeConfig =
+          data.provider === 'cloud-run'
+            ? buildGcpCloudRunComputeConfig(
+                data.gcpProject,
+                data.gcpRegion,
+                data.gcpWorkerPool,
+                data.gcpServiceAccount,
+              )
+            : buildLambdaComputeConfig(data.lambdaArn, data.iamRoleArn, {
+                roleExternalId: data.roleExternalId,
+                scaleUpCooloffMs: data.scaleUpCooloffMs,
+                scaleUpBacklogThreshold: data.scaleUpBacklogThreshold,
+                maxWorkerLifetimeMs: data.maxWorkerLifetimeMs,
+                metricsPollIntervalMs: data.metricsPollIntervalMs,
+              });
+        await createWorkerDeploymentVersion(
+          {
+            namespace,
+            deploymentVersion: {
+              deploymentName: deployment,
+              buildId: data.buildId,
+            },
+            computeConfig,
+          },
+          (err) => {
+            error =
+              err.body?.message ||
+              err.statusText ||
+              translate('workers.create-version-error');
+          },
+        );
+        if (error) return;
+
+        let validateError: string | undefined;
+        const validation = await validateWorkerDeploymentVersionComputeConfig(
+          {
+            namespace,
             deploymentName: deployment,
             buildId: data.buildId,
+            computeConfig,
           },
-          computeConfig,
-        },
-        (err) => {
-          error =
-            err.body?.message ||
-            err.statusText ||
-            translate('workers.create-version-error');
-        },
-      );
-      if (error) return;
+          (err) => {
+            if (err.status === 501) return;
+            validateError =
+              err.body?.message ||
+              err.statusText ||
+              translate('workers.create-version-error');
+          },
+        );
 
-      let validateError: string | undefined;
-      const validation = await validateWorkerDeploymentVersionComputeConfig(
-        {
-          namespace,
-          deploymentName: deployment,
-          buildId: data.buildId,
-          computeConfig,
-        },
-        (err) => {
-          if (err.status === 501) return;
-          validateError =
-            err.body?.message ||
-            err.statusText ||
-            translate('workers.create-version-error');
-        },
-      );
+        if (!validateError && (!validation || validation.valid !== false)) {
+          await onSuccess();
+          return;
+        }
 
-      if (!validateError && (!validation || validation.valid !== false)) {
-        await onSuccess();
-        return;
-      }
+        const message =
+          validation?.message ??
+          validateError ??
+          translate('workers.create-version-error');
 
-      const message =
-        validation?.message ??
-        validateError ??
-        translate('workers.create-version-error');
+        let rollbackFailed = false;
+        await deleteWorkerDeploymentVersion(
+          { namespace, deploymentName: deployment, buildId: data.buildId },
+          () => {
+            rollbackFailed = true;
+          },
+        );
 
-      let rollbackFailed = false;
-      await deleteWorkerDeploymentVersion(
-        { namespace, deploymentName: deployment, buildId: data.buildId },
-        () => {
-          rollbackFailed = true;
-        },
-      );
-
-      error = rollbackFailed
-        ? translate('workers.create-version-rollback-failed', { message })
-        : message;
-    }}
-  />
+        error = rollbackFailed
+          ? translate('workers.create-version-rollback-failed', { message })
+          : message;
+      }}
+    />
+  {/if}
 </div>

--- a/src/lib/utilities/lock-compute-provider.test.ts
+++ b/src/lib/utilities/lock-compute-provider.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkerDeploymentInfo } from '$lib/types/deployments';
+
+import { lockComputeProvider } from './lock-compute-provider';
+
+const deployment = (types: (string | undefined)[]): WorkerDeploymentInfo =>
+  ({
+    versionSummaries: types.map((type, index) => ({
+      version: `build-${index}`,
+      createTime: undefined,
+      computeConfig: {
+        scalingGroups: { default: { provider: { type } } },
+      },
+    })),
+  }) as unknown as WorkerDeploymentInfo;
+
+describe('lockComputeProvider', () => {
+  it('does not lock deployments without versions', () => {
+    expect(lockComputeProvider(deployment([]))).toBeUndefined();
+  });
+
+  it('tolerates deployment responses without version summaries', () => {
+    const info = deployment([]);
+    Object.assign(info, { versionSummaries: undefined });
+
+    expect(lockComputeProvider(info)).toBeUndefined();
+  });
+
+  it('locks all alternatives to the provider used by existing versions', () => {
+    expect(lockComputeProvider(deployment(['aws-lambda']))).toEqual({
+      provider: 'lambda',
+      providers: [{ value: 'lambda' }, { value: 'cloud-run', hidden: true }],
+    });
+  });
+
+  it('preserves metadata on the matching configured provider', () => {
+    const providers = [
+      { value: 'lambda' as const },
+      {
+        value: 'cloud-run' as const,
+        disabled: false,
+        disabledReason: 'Available',
+      },
+    ];
+
+    expect(
+      lockComputeProvider(deployment(['gcp-cloud-run']), providers),
+    ).toEqual({
+      provider: 'cloud-run',
+      providers: [{ value: 'lambda', hidden: true }, providers[1]],
+    });
+  });
+
+  it('fails closed when the existing provider is excluded by configuration', () => {
+    expect(
+      lockComputeProvider(deployment(['gcp-cloud-run']), [{ value: 'lambda' }]),
+    ).toBeUndefined();
+
+    expect(
+      lockComputeProvider(deployment(['gcp-cloud-run']), [
+        { value: 'lambda' },
+        { value: 'cloud-run', hidden: true },
+      ]),
+    ).toBeUndefined();
+
+    expect(
+      lockComputeProvider(deployment(['gcp-cloud-run']), [
+        { value: 'lambda' },
+        { value: 'cloud-run', disabled: true },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it.each([[['aws-lambda', 'gcp-cloud-run']], [['unknown']], [[undefined]]])(
+    'rejects mixed, unknown, or missing providers',
+    (types) => {
+      expect(lockComputeProvider(deployment(types))).toBeUndefined();
+    },
+  );
+
+  it('supports providerType', () => {
+    const info = deployment(['aws-lambda']);
+    const group =
+      info.versionSummaries[0].computeConfig?.scalingGroups?.default;
+    if (group) {
+      group.providerType = 'gcp-cloud-run';
+      group.provider = undefined;
+    }
+
+    expect(lockComputeProvider(info)?.provider).toBe('cloud-run');
+  });
+
+  it.each([
+    ['lambda', 'lambda'],
+    ['aws-lambda', 'lambda'],
+    ['cloud-run', 'cloud-run'],
+    ['gcp-cloud-run', 'cloud-run'],
+  ] as const)('maps the %s provider type to %s', (type, provider) => {
+    expect(lockComputeProvider(deployment([type]))?.provider).toBe(provider);
+  });
+
+  it.each([
+    'computeConfig',
+    'latestVersionSummary',
+    'currentVersionSummary',
+    'rampingVersionSummary',
+  ] as const)('resolves the provider from %s', (source) => {
+    const info = deployment(['aws-lambda']);
+    const computeConfig = {
+      scalingGroups: {
+        default: { provider: { type: 'gcp-cloud-run' } },
+      },
+    };
+
+    info.versionSummaries = info.versionSummaries.map((summary) => {
+      if ('computeConfig' in summary) summary.computeConfig = undefined;
+      return summary;
+    });
+    if (source === 'computeConfig') {
+      info.computeConfig = computeConfig;
+    } else {
+      Object.assign(info, { [source]: { computeConfig } });
+    }
+
+    expect(lockComputeProvider(info)?.provider).toBe('cloud-run');
+  });
+
+  it('fails closed when top-level and summary providers are mixed', () => {
+    const info = deployment(['aws-lambda']);
+    info.computeConfig = {
+      scalingGroups: {
+        default: { providerType: 'gcp-cloud-run' },
+      },
+    };
+
+    expect(lockComputeProvider(info)).toBeUndefined();
+  });
+});

--- a/src/lib/utilities/lock-compute-provider.ts
+++ b/src/lib/utilities/lock-compute-provider.ts
@@ -1,0 +1,86 @@
+import type {
+  ComputeProviderOption,
+  ComputeProviderValue,
+} from '$lib/components/workers/serverless-worker-form/shared';
+import type {
+  ComputeConfig,
+  WorkerDeploymentInfo,
+} from '$lib/types/deployments';
+
+export type LockedComputeProvider = {
+  provider: ComputeProviderValue;
+  providers: readonly ComputeProviderOption[];
+};
+
+const providerValue = (type?: string): ComputeProviderValue | undefined => {
+  if (type === 'aws-lambda' || type === 'lambda') return 'lambda';
+  if (type === 'gcp-cloud-run' || type === 'cloud-run') return 'cloud-run';
+};
+
+const computeConfigOf = (summary?: { computeConfig?: ComputeConfig }) =>
+  summary?.computeConfig;
+
+const providersInConfig = (
+  config: ComputeConfig,
+): ComputeProviderValue[] | undefined => {
+  const groups = Object.values(config.scalingGroups ?? {});
+  if (!groups.length) return;
+
+  const providers = groups.map((group) =>
+    providerValue(group.providerType ?? group.provider?.type),
+  );
+  if (providers.some((provider) => !provider)) return;
+  return providers as ComputeProviderValue[];
+};
+
+export const lockComputeProvider = (
+  deployment: WorkerDeploymentInfo,
+  configuredProviders?: readonly ComputeProviderOption[],
+): LockedComputeProvider | undefined => {
+  const versionSummaries = deployment.versionSummaries ?? [];
+  if (!versionSummaries.length) return;
+
+  const configs = [
+    deployment.computeConfig,
+    computeConfigOf(deployment.latestVersionSummary),
+    computeConfigOf(deployment.currentVersionSummary),
+    computeConfigOf(deployment.rampingVersionSummary),
+    ...versionSummaries.map((version) =>
+      'computeConfig' in version ? computeConfigOf(version) : undefined,
+    ),
+  ].filter((config): config is ComputeConfig => Boolean(config));
+
+  if (!configs.length) return;
+
+  const providers = configs.flatMap(
+    (config) => providersInConfig(config) ?? [],
+  );
+  if (
+    providers.length === 0 ||
+    configs.some((config) => !providersInConfig(config)) ||
+    new Set(providers).size !== 1
+  ) {
+    return;
+  }
+
+  const provider = providers[0];
+  const source = configuredProviders ?? [
+    { value: 'lambda' as const },
+    { value: 'cloud-run' as const },
+  ];
+  const configuredProvider = source.find(({ value }) => value === provider);
+  if (
+    !configuredProvider ||
+    configuredProvider.hidden ||
+    configuredProvider.disabled
+  ) {
+    return;
+  }
+
+  return {
+    provider,
+    providers: source.map((option) =>
+      option.value === provider ? option : { ...option, hidden: true },
+    ),
+  };
+};


### PR DESCRIPTION
## Summary

- Resolve the compute provider already used by an existing Worker Deployment before rendering the create-version form.
- Initialize new versions with that provider and hide every alternative so a deployment cannot move providers between versions.
- Preserve the existing configurable/default provider behavior for deployments without versions.
- Fail closed when deployment loading fails or the existing provider is missing, unknown, mixed, or excluded by configuration.
- Expose `canCreateServerlessDeployment` so consumers can hide the empty-state serverless create action when no provider is supported, while keeping the self-managed deployment link visible.

## Test plan

- [x] Focused provider-lock tests passed during implementation (25/25).
- [x] Pre-commit ESLint, Prettier, and Stylelint hooks passed for both commits.
- [x] `git diff --check` passed.
- [x] Static architect review approved both changes.
- [ ] CI checks pending. Per request, local test workers were not restarted after the final static-only adjustments.
