### PR TITLE
Update format of Execution Duration

### DIFF
--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-body-cell.svelte
@@ -7,9 +7,9 @@
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { ActivityExecutionInfo } from '$lib/types/activity-execution';
+  import { formatDurationAbbreviated } from '$lib/utilities/format-time';
   import { toActivityStatus } from '$lib/utilities/get-activity-status-and-count';
   import { routeForStandaloneActivityDetails } from '$lib/utilities/route-for';
-  import { fromSeconds } from '$lib/utilities/to-duration';
 
   import FilterableTableCell from './filterable-table-cell.svelte';
 
@@ -83,7 +83,7 @@
       <Timestamp dateTime={activity.closeTime} />
     {:else if label === 'Execution Duration'}
       {#if activity.executionDuration}
-        {fromSeconds(activity.executionDuration)}
+        {formatDurationAbbreviated(activity.executionDuration)}
       {/if}
     {:else if label === 'State Transitions'}
       {activity.stateTransitionCount ?? ''}

--- a/src/lib/components/standalone-activities/activity-header.svelte
+++ b/src/lib/components/standalone-activities/activity-header.svelte
@@ -4,10 +4,10 @@
   import { translate } from '$lib/i18n/translate';
   import { isCloud } from '$lib/stores/advanced-visibility';
   import type { ActivityExecutionInfo } from '$lib/types/activity-execution';
+  import { formatDurationAbbreviated } from '$lib/utilities/format-time';
   import { formatSDKName } from '$lib/utilities/get-sdk-version';
   import { routeForStandaloneActivitiesWithQuery } from '$lib/utilities/route-for';
   import type { StandaloneActivityPoller } from '$lib/utilities/standalone-activity-poller.svelte';
-  import { fromSeconds } from '$lib/utilities/to-duration';
 
   import {
     DetailList,
@@ -85,7 +85,7 @@
       >
       <DetailListTextValue
         text={activityExecutionInfo.executionDuration
-          ? fromSeconds(activityExecutionInfo.executionDuration)
+          ? formatDurationAbbreviated(activityExecutionInfo.executionDuration)
           : '-'}
       />
     </DetailListColumn>

--- a/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table/table-body-cell.svelte
@@ -5,7 +5,7 @@
   import WorkflowStatus from '$lib/components/workflow-status.svelte';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
   import type { NexusOperationExecutionListInfo } from '$lib/types/nexus-operation-execution';
-  import { formatDistance } from '$lib/utilities/format-time';
+  import { formatDistanceAbbreviated } from '$lib/utilities/format-time';
   import { toNexusOperationStatus } from '$lib/utilities/get-nexus-operation-status-and-count';
   import { routeForStandaloneNexusOperationDetails } from '$lib/utilities/route-for';
 
@@ -108,10 +108,10 @@
       <Timestamp dateTime={operation.closeTime} />
     {:else if label === 'Execution Duration'}
       {#if operation.executionDuration}
-        {formatDistance({
+        {formatDistanceAbbreviated({
           start: operation.scheduleTime,
           end: operation.closeTime,
-          includeMillisecondsForUnderSecond: true,
+          includeMilliseconds: true,
         })}
       {/if}
     {:else if label === 'State Transitions'}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
@@ -19,7 +19,7 @@
   } from '$lib/types/workflows';
   import { isWorkflowDelayed } from '$lib/utilities/delayed-workflows';
   import { formatBytes } from '$lib/utilities/format-bytes';
-  import { formatDistance } from '$lib/utilities/format-time';
+  import { formatDistanceAbbreviated } from '$lib/utilities/format-time';
   import { getBuildIdFromVersion } from '$lib/utilities/get-deployment-build-id';
   import {
     routeForWorkerDeployment,
@@ -227,10 +227,10 @@
         options={{ format: truncate ? 'short' : 'long' }}
       />
     {:else if label === 'Execution Duration'}
-      {formatDistance({
-        start: workflow.startTime,
-        end: workflow.endTime,
-        includeMillisecondsForUnderSecond: true,
+      {formatDistanceAbbreviated({
+        start: workflow?.startTime,
+        end: workflow?.endTime,
+        includeMilliseconds: true,
       })}
     {:else if label === 'History Length'}
       {parseInt(workflow.historyEvents, 10) > 0 ? workflow.historyEvents : ''}

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -19,6 +19,7 @@
     formatAttemptsLeft,
     formatMaximumAttempts,
   } from '$lib/utilities/format-event-attributes';
+  import { formatDurationAbbreviated } from '$lib/utilities/format-time';
   import { routeForTaskQueue } from '$lib/utilities/route-for';
   import { fromScreamingEnum } from '$lib/utilities/screaming-enums';
   import { activityExecution } from '$lib/utilities/standalone-activity-poller.svelte';
@@ -129,8 +130,8 @@
                 )}</DetailListLabel
               >
               <DetailListTextValue
-                text={fromSeconds(
-                  $activityExecution.info.executionDuration ?? '',
+                text={formatDurationAbbreviated(
+                  $activityExecution.info.executionDuration,
                 )}
               />
               {#if $activityExecution.info.attempt != undefined}

--- a/src/lib/pages/standalone-nexus-operation-details.svelte
+++ b/src/lib/pages/standalone-nexus-operation-details.svelte
@@ -11,6 +11,7 @@
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import { translate } from '$lib/i18n/translate';
   import { toEventLinkView } from '$lib/utilities/event-link';
+  import { formatDurationAbbreviated } from '$lib/utilities/format-time';
   import { routeForStandaloneNexusOperationsWithQuery } from '$lib/utilities/route-for';
   import { toNexusOperationCancellationStateReadable } from '$lib/utilities/screaming-enums';
   import { nexusOperationExecution } from '$lib/utilities/standalone-nexus-operation-poller.svelte';
@@ -111,7 +112,7 @@
         >
         <DetailListTextValue
           text={info.executionDuration
-            ? fromSeconds(info.executionDuration)
+            ? formatDurationAbbreviated(info.executionDuration)
             : '-'}
         />
         <DetailListLabel


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Uses `formatDurationAbbreviated` and `formatDistanceAbbreviated` (similar to what is currently used on the workflow details page) in other places that display `Duration` and `Execution Duration`.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
