### PR TITLE
Migrate old column labels

### DIFF
--- a/src/lib/stores/configurable-table-columns.test.ts
+++ b/src/lib/stores/configurable-table-columns.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from 'vitest';
 import {
   addColumn,
   DEFAULT_DEPLOYMENTS_COLUMNS,
+  migrateColumnLabels,
   moveColumn,
   persistedDeploymentsTableColumns,
   persistedWorkflowTableColumns,
@@ -83,5 +84,79 @@ describe('Deployment Table Columns store', () => {
       removeColumn('Latest Version', 'default', TABLE_TYPE.DEPLOYMENTS);
       expect(get(persistedDeploymentsTableColumns)).toEqual({ default: [] });
     });
+  });
+});
+
+describe('migrateColumnLabels', () => {
+  const migrate = migrateColumnLabels({
+    'Start Time': 'Start',
+    'Close Time': 'End',
+    'Activity Type': 'Type',
+  });
+
+  test('renames columns matching the provided label map', () => {
+    const state = {
+      default: [
+        { label: 'Status' },
+        { label: 'Activity Type' },
+        { label: 'Start Time' },
+        { label: 'Close Time' },
+      ],
+    };
+
+    expect(migrate(state)).toEqual({
+      default: [
+        { label: 'Status' },
+        { label: 'Type' },
+        { label: 'Start' },
+        { label: 'End' },
+      ],
+    });
+  });
+
+  test('preserves other column properties like pinned', () => {
+    const state = {
+      default: [{ label: 'Activity Type', pinned: true }],
+    };
+
+    expect(migrate(state)).toEqual({
+      default: [{ label: 'Type', pinned: true }],
+    });
+  });
+
+  test('migrates labels across multiple namespaces', () => {
+    const state = {
+      default: [{ label: 'Start Time' }],
+      other: [{ label: 'Close Time' }],
+    };
+
+    expect(migrate(state)).toEqual({
+      default: [{ label: 'Start' }],
+      other: [{ label: 'End' }],
+    });
+  });
+
+  test('dedupes when a renamed label collides with an existing one', () => {
+    const state = {
+      default: [{ label: 'Start' }, { label: 'Start Time' }],
+    };
+
+    expect(migrate(state)).toEqual({
+      default: [{ label: 'Start' }],
+    });
+  });
+
+  test('returns the same reference when nothing needs migrating', () => {
+    const state = {
+      default: [{ label: 'Status' }, { label: 'Type' }, { label: 'Start' }],
+    };
+
+    expect(migrate(state)).toBe(state);
+  });
+
+  test('handles undefined namespace columns', () => {
+    const state = { default: undefined };
+
+    expect(migrate(state)).toEqual({ default: undefined });
   });
 });

--- a/src/lib/stores/configurable-table-columns.ts
+++ b/src/lib/stores/configurable-table-columns.ts
@@ -221,6 +221,50 @@ export const persistedActivitiesTableColumns = persistStore<State>(
   {},
 );
 
+export const migrateColumnLabels =
+  (renamedLabels: Record<string, AnyWorkflowHeaderLabel>) =>
+  (state: State): State => {
+    let didChange = false;
+
+    const migrated = Object.fromEntries(
+      Object.entries(state).map(([namespace, columns]) => {
+        if (!columns) return [namespace, columns];
+
+        const seen = new Set<AnyWorkflowHeaderLabel>();
+        const nextColumns = columns.reduce<ConfigurableTableHeader[]>(
+          (acc, column) => {
+            const label = renamedLabels[column.label];
+            if (label) didChange = true;
+            const nextLabel = label ?? column.label;
+
+            if (seen.has(nextLabel)) {
+              didChange = true;
+              return acc;
+            }
+
+            seen.add(nextLabel);
+            acc.push(label ? { ...column, label: nextLabel } : column);
+            return acc;
+          },
+          [],
+        );
+
+        return [namespace, nextColumns];
+      }),
+    );
+
+    return didChange ? migrated : state;
+  };
+
+// TODO: Remove after a few releases once we are confident that all users have migrated to the new column labels.
+persistedActivitiesTableColumns.update(
+  migrateColumnLabels({
+    'Start Time': 'Start',
+    'Close Time': 'End',
+    'Activity Type': 'Type',
+  }),
+);
+
 export const persistedDeploymentsTableColumns = persistStore<State>(
   'namespace-deployment-table-columns',
   {},


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Adds `migrateColumnLabels` util to migrate persisted column labels after the column label is changed. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
