### PR TITLE
a11y: run axe over Holocene stories in CI (report-only)

### DIFF
--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -1,0 +1,44 @@
+name: Storybook A11y
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, 'codefreeze-*']
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  storybook-a11y:
+    runs-on: ubuntu-latest
+    # Report-only for now: runs axe over every Holocene story and surfaces
+    # violations WITHOUT blocking merge, while the known baseline is burned down
+    # (see the PR description). Make it a hard gate by removing `continue-on-error`
+    # once the baseline is clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout and Setup Node
+        uses: ./.github/actions/setup-node
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install chromium --with-deps
+      - name: Build Storybook
+        run: pnpm stories:build
+      - name: Run axe accessibility checks over stories
+        run: |
+          pnpm dlx concurrently -k -s first -n SB,AXE \
+            "pnpm dlx http-server storybook-static -p 6006 -a 127.0.0.1 --silent" \
+            "pnpm dlx wait-on tcp:127.0.0.1:6006 && pnpm stories:test --url http://127.0.0.1:6006"


### PR DESCRIPTION
## Summary

Runs axe over every Holocene story (271) in CI, via the existing `stories:test` runner (`@storybook/addon-a11y` + axe-playwright). This catches the per-component **structural / name / contrast** band that the Svelte compiler gate ([#3682](https://github.com/temporalio/ui/pull/3682)) structurally cannot see — the biggest single coverage gain for shift-left a11y, since fixing a primitive cascades to every consumer.

**Report-only for now** (`continue-on-error: true`): the baseline isn't clean, so the job surfaces violations in the log without blocking merge. Remove `continue-on-error` to make it a hard gate once the baseline below is burned down.

### Baseline to burn down — 13 failing tests / 6 components
- **vertical-nav** (6 stories) — `aria-current`, `aria-required-parent`/`children`, `aria-disabled`
- **duration-input** (2), **deployments-compute-badge** (2), **code-block** (With Header), **markdown-editor**, **tab-button**
- Top rules: `aria-disabled` (29), `aria-required-parent`/`children` (8 — often isolated-render artifacts, i.e. a child role rendered without its required parent in the story), `aria-current` (6), `color-contrast` (2), `label`, `button-name`.

### Notes
- Uses `pnpm dlx` for the serve tooling (http-server / wait-on / concurrently) to avoid lockfile churn — vendor them as devDeps when flipping to blocking.
- Runs on every PR (~2–4 min: SB build + axe). Could move to a nightly schedule if per-PR cost is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
