### PR TITLE
TS strict (1/4): type annotations, dead-code cleanup, strict-error CI infra

### DIFF
--- a/src/lib/components/codec-server-form/codec-server-form-content.svelte
+++ b/src/lib/components/codec-server-form/codec-server-form-content.svelte
@@ -133,7 +133,6 @@
 
       <!-- Info Alert -->
       <Alert intent="info" class="text-sm">
-        <Icon name="info" slot="icon" />
         {translate('codec-server.info-message')}
       </Alert>
 

--- a/src/lib/components/lines-and-dots/event-classification-filter.svelte
+++ b/src/lib/components/lines-and-dots/event-classification-filter.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { page } from '$app/state';
 
-  import MultiSelect from '$lib/holocene/select/multi-select.svelte';
+  import MultiSelect, {
+    type MultiSelectOptions,
+  } from '$lib/holocene/select/multi-select.svelte';
   import { translate } from '$lib/i18n/translate';
   import { eventClassifications } from '$lib/models/event-history/get-event-classification';
   import { eventClassificationFilter } from '$lib/stores/filters';
@@ -21,12 +23,12 @@
       : [],
   );
 
-  const onOptionClick = (_options) => {
+  const onOptionClick = (_options: MultiSelectOptions) => {
     if (_options.length === options.length) {
       _options = [];
     }
 
-    const value = _options.map((o) => o.value).join(',');
+    const value = _options.map((option) => option.value).join(',');
     updateQueryParameters({
       parameter: parameter,
       value,

--- a/src/lib/components/schedule/schedule-form/spec-type-week.svelte
+++ b/src/lib/components/schedule/schedule-form/spec-type-week.svelte
@@ -116,7 +116,7 @@
       { label: translate('schedules.recurrence-weekends'), value: 'weekends' },
       { label: translate('schedules.recurrence-custom'), value: 'custom' },
     ]}
-    onChange={selectType}
+    onChange={(value) => selectType(value as Selection['type'])}
   >
     {#snippet item({ option, checked, attrs, onSelect, onKeydown })}
       <Button

--- a/src/lib/components/search-attributes-form/search-attributes-form.stories.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form.stories.svelte
@@ -8,10 +8,7 @@
   import { translate } from '$lib/i18n/translate';
   import { SEARCH_ATTRIBUTE_TYPE } from '$lib/types/workflows';
 
-  import type {
-    SearchAttributeDefinition,
-    SearchAttributeTypeOption,
-  } from './types';
+  import type { SearchAttributeDefinition } from './types';
 
   import SearchAttributesForm from './search-attributes-form.svelte';
 

--- a/src/lib/components/workers/pollers-table/pollers-table.svelte
+++ b/src/lib/components/workers/pollers-table/pollers-table.svelte
@@ -9,7 +9,6 @@
 
   import DeploymentStatus from '$lib/components/deployments/deployment-status.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
-  import Badge from '$lib/holocene/badge.svelte';
   import EmptyState from '$lib/holocene/empty-state.svelte';
   import Link from '$lib/holocene/link.svelte';
   import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';

--- a/src/lib/components/workflow-status.stories.svelte
+++ b/src/lib/components/workflow-status.stories.svelte
@@ -11,8 +11,8 @@
     title: 'Workflow Status',
     component: WorkflowStatus,
     args: {
-      count: undefined,
-      newCount: undefined,
+      count: undefined as number | undefined,
+      newCount: undefined as number | undefined,
       big: false,
       loading: false,
       delay: 0,

--- a/src/lib/holocene/accordion/accordion-light.svelte
+++ b/src/lib/holocene/accordion/accordion-light.svelte
@@ -16,7 +16,7 @@
 
   export let id: string = crypto.randomUUID();
   export let open = false;
-  export let onToggle = undefined;
+  export let onToggle: (() => Promise<void>) | undefined = undefined;
   export let icon: IconName | undefined = undefined;
 
   const toggleAccordion = async () => {

--- a/src/lib/holocene/button-radio-group.stories.svelte
+++ b/src/lib/holocene/button-radio-group.stories.svelte
@@ -22,11 +22,17 @@
 </script>
 
 <script lang="ts">
+  import type { ComponentProps } from 'svelte';
+
   import type {
     ButtonRadioItem,
     ButtonRadioOption,
   } from '$lib/holocene/button-radio-group.svelte';
   import Button, { type ButtonStyles } from '$lib/holocene/button.svelte';
+
+  type StoryArgs = ComponentProps<
+    typeof ButtonRadioGroup<ButtonRadioOption<string>>
+  >;
 
   const options: ButtonRadioOption<string>[] = [
     { label: 'Every day', value: 'everyday' },
@@ -69,7 +75,7 @@
 {/snippet}
 
 <Story name="Default">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup {...args} {options} {value} onChange={(n) => (value = n)}>
       {#snippet item(radioItem)}
         {@render radioButton(radioItem)}
@@ -79,7 +85,7 @@
 </Story>
 
 <Story name="Small">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup {...args} {options} {value} onChange={(n) => (value = n)}>
       {#snippet item(radioItem)}
         {@render radioButton(radioItem, 'secondary', 'sm')}
@@ -89,7 +95,7 @@
 </Story>
 
 <Story name="Large">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup {...args} {options} {value} onChange={(n) => (value = n)}>
       {#snippet item(radioItem)}
         {@render radioButton(radioItem, 'secondary', 'lg')}
@@ -99,7 +105,7 @@
 </Story>
 
 <Story name="Primary">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup {...args} {options} {value} onChange={(n) => (value = n)}>
       {#snippet item(radioItem)}
         {@render radioButton(radioItem, 'primary')}
@@ -109,7 +115,7 @@
 </Story>
 
 <Story name="Ghost">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup {...args} {options} {value} onChange={(n) => (value = n)}>
       {#snippet item(radioItem)}
         {@render radioButton(radioItem, 'ghost')}
@@ -119,7 +125,7 @@
 </Story>
 
 <Story name="With Disabled Option">
-  {#snippet template(args)}
+  {#snippet template(args: StoryArgs)}
     <ButtonRadioGroup
       {...args}
       options={optionsWithDisabled}

--- a/src/lib/holocene/combobox/combobox.stories.svelte
+++ b/src/lib/holocene/combobox/combobox.stories.svelte
@@ -49,7 +49,7 @@
 </script>
 
 <script lang="ts">
-  import { action } from '@storybook/addon-actions';
+  import { action as logAction } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
   import Button from '../button.svelte';
@@ -61,7 +61,7 @@
   <Combobox
     id={context.id}
     data-testid={context.id}
-    onchange={action('change')}
+    onchange={logAction('change')}
     {...args}
   />
 </Template>
@@ -258,7 +258,7 @@
     <Combobox
       id={context.id}
       data-testid={context.id}
-      onchange={action('change')}
+      onchange={logAction('change')}
       leadingIcon="search"
       options={[
         'English',
@@ -275,14 +275,15 @@
       ]}
       {...args}
     >
-      <Button
-        on:click={() => {}}
-        slot="action"
-        variant="ghost"
-        size="xs"
-        leadingIcon="close"
-        aria-label="clear"
-      />
+      {#snippet action()}
+        <Button
+          on:click={() => {}}
+          variant="ghost"
+          size="xs"
+          leadingIcon="close"
+          aria-label="clear"
+        />
+      {/snippet}
     </Combobox>
   </div>
 </Story>

--- a/src/lib/holocene/date-picker.stories.svelte
+++ b/src/lib/holocene/date-picker.stories.svelte
@@ -51,7 +51,7 @@
   /**
    * Used for the "Focused" story to focus the input.
    */
-  const focus = async ({ canvasElement }) => {
+  const focus = (canvasElement: HTMLElement) => {
     const canvas = within(canvasElement);
     const input = canvas.getByRole('textbox');
     input.focus();
@@ -64,7 +64,10 @@
   <DatePicker {...args} onDateChange={action('date-change')} />
 </Template>
 
-<Story name="Default" play={focus} />
+<Story
+  name="Default"
+  play={async ({ canvasElement }) => focus(canvasElement)}
+/>
 
 <Story name="Disabled" args={{ disabled: true }} />
 
@@ -76,5 +79,5 @@
     selected: new Date('2012-09-19'),
     isAllowed: disallowSundays,
   }}
-  play={focus}
+  play={async ({ canvasElement }) => focus(canvasElement)}
 />

--- a/src/lib/holocene/error-boundary.svelte
+++ b/src/lib/holocene/error-boundary.svelte
@@ -8,7 +8,7 @@
 
 <svelte:boundary>
   {@render children?.()}
-  {#snippet failed(error, reset)}
+  {#snippet failed(error: unknown, reset: () => void)}
     <Error {reset} {error} />
   {/snippet}
 </svelte:boundary>

--- a/src/lib/holocene/input/chip-input.stories.svelte
+++ b/src/lib/holocene/input/chip-input.stories.svelte
@@ -21,7 +21,7 @@
       removeChipButtonLabel: 'Remove',
       labelHidden: false,
       validator: isEmail,
-      maxLength: undefined,
+      maxLength: undefined as number | undefined,
       chips: ['tobias@temporal.io'],
       scrollTo: false,
     },

--- a/src/lib/holocene/link.stories.svelte
+++ b/src/lib/holocene/link.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
 
+  import type { IconName } from './icon';
   import { iconNames } from './icon';
 
   import Link from './link.svelte';
@@ -12,7 +13,7 @@
     component: Link,
     args: {
       href: 'https://temporal.io',
-      icon: undefined,
+      icon: undefined as IconName | undefined,
       active: false,
       newTab: false,
       light: false,

--- a/src/lib/holocene/markdown-editor/markdown-editor.stories.svelte
+++ b/src/lib/holocene/markdown-editor/markdown-editor.stories.svelte
@@ -15,13 +15,20 @@
 
 <script lang="ts">
   import { Story, Template } from '@storybook/addon-svelte-csf';
+  import type { StoryContext } from '@storybook/svelte';
   import { userEvent, within } from '@storybook/test';
 
   import Editor from './editor.svelte';
   import MarkdownEditor from './markdown-editor.svelte';
   import Preview from './preview.svelte';
 
-  const play: Story['play'] = async ({ canvasElement, step }) => {
+  const play = async ({
+    canvasElement,
+    step,
+  }: {
+    canvasElement: HTMLElement;
+    step: StoryContext['step'];
+  }) => {
     const canvas = within(canvasElement);
 
     const editor = await canvas.findByRole('textbox');

--- a/src/lib/holocene/radio-input/types.ts
+++ b/src/lib/holocene/radio-input/types.ts
@@ -5,6 +5,7 @@ export interface RadioInputProps<T> extends HTMLInputAttributes {
   value: T;
   id: string;
   label: string;
+  disabled?: boolean;
   labelHidden?: boolean;
   description?: string;
   group?: Writable<T>;

--- a/src/lib/holocene/select/select.stories.svelte
+++ b/src/lib/holocene/select/select.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
 
+  import type { IconName } from '$lib/holocene/icon';
   import { iconNames } from '$lib/holocene/icon';
 
   import Option from './option.svelte';
@@ -15,7 +16,7 @@
       id: 'select',
       label: 'Select',
       placeholder: 'Select an option',
-      leadingIcon: undefined,
+      leadingIcon: undefined as IconName | undefined,
       labelHidden: false,
       disabled: false,
     },

--- a/src/lib/holocene/split-button.stories.svelte
+++ b/src/lib/holocene/split-button.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
 
+  import type { IconName } from '$lib/holocene/icon';
   import { iconNames } from '$lib/holocene/icon';
   import MenuItem from '$lib/holocene/menu/menu-item.svelte';
   import SplitButton from '$lib/holocene/split-button.svelte';
@@ -14,7 +15,7 @@
       label: 'Split Button',
       menuLabel: 'Actions',
       position: 'left',
-      icon: undefined,
+      icon: undefined as IconName | undefined,
       disabled: false,
       primaryActionDisabled: false,
       href: 'https://caniuse.com',

--- a/src/lib/holocene/tab-buttons/tab-button.stories.svelte
+++ b/src/lib/holocene/tab-buttons/tab-button.stories.svelte
@@ -1,7 +1,7 @@
 <svelte:options runes />
 
 <script lang="ts" module>
-  import type { Meta } from '@storybook/svelte';
+  import type { Meta, StoryContext } from '@storybook/svelte';
   import { expect, userEvent, within } from '@storybook/test';
 
   import { iconNames } from '$lib/holocene/icon';
@@ -35,7 +35,13 @@
     action('select')(index);
   };
 
-  const play: Story['play'] = async ({ canvasElement, step }) => {
+  const play = async ({
+    canvasElement,
+    step,
+  }: {
+    canvasElement: HTMLElement;
+    step: StoryContext['step'];
+  }) => {
     const canvas = within(canvasElement);
 
     selected.set(0);

--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -102,7 +102,8 @@
     try {
       const response = await fetchData($store.pageSize, '');
       const { nextPageToken } = response;
-      const items = response[itemsKeyname] || [];
+      const items =
+        (response as unknown as Record<string, T[]>)[itemsKeyname] || [];
       store.nextPageWithItems(nextPageToken, items);
     } catch (err) {
       error = err as Error;
@@ -118,7 +119,8 @@
         $store.indexData[$store.index].nextToken,
       );
       const { nextPageToken } = response;
-      const items = response[itemsKeyname] || [];
+      const items =
+        (response as unknown as Record<string, T[]>)[itemsKeyname] || [];
       store.nextPageWithItems(nextPageToken, items);
     } catch (error) {
       if (isError(error) && onError) {

--- a/src/lib/holocene/test-utilities.ts
+++ b/src/lib/holocene/test-utilities.ts
@@ -2,11 +2,12 @@ import type { Story } from '@storybook/addon-svelte-csf';
 import { expect, within } from '@storybook/test';
 
 type PlayFunction = Story['$$prop_def']['play'];
+type PlayFunctionContext = Parameters<NonNullable<PlayFunction>>[0];
 
 export const shouldNotBeTransparent = (
   fn: (canvas: ReturnType<typeof within>) => PlayFunction,
 ) => {
-  return ({ canvasElement }) => {
+  return ({ canvasElement }: PlayFunctionContext) => {
     const canvas = within(canvasElement);
     const element = fn(canvas);
     expect(element).not.toHaveStyle({ backgroundColor: 'rgba(0,0,0,0)' });

--- a/src/lib/holocene/textarea.stories.svelte
+++ b/src/lib/holocene/textarea.stories.svelte
@@ -19,7 +19,7 @@
       isValid: true,
       rows: 5,
       spellcheck: false,
-      maxLength: undefined,
+      maxLength: undefined as number | undefined,
       labelHidden: false,
     },
     argTypes: {

--- a/src/lib/holocene/toggle-button/toggle-button.stories.svelte
+++ b/src/lib/holocene/toggle-button/toggle-button.stories.svelte
@@ -1,7 +1,7 @@
 <svelte:options runes />
 
 <script lang="ts" module>
-  import type { Meta } from '@storybook/svelte';
+  import type { Meta, StoryContext } from '@storybook/svelte';
   import { expect, userEvent, within } from '@storybook/test';
 
   import ToggleButton from './toggle-button.svelte';
@@ -32,7 +32,13 @@
     action('select')(index);
   };
 
-  const play: Story['play'] = async ({ canvasElement, step }) => {
+  const play = async ({
+    canvasElement,
+    step,
+  }: {
+    canvasElement: HTMLElement;
+    step: StoryContext['step'];
+  }) => {
     const canvas = within(canvasElement);
     selected.set(0);
     const first = await canvas.findByTestId('toggle-button-0');

--- a/src/lib/models/event-groups/get-group-id.test.ts
+++ b/src/lib/models/event-groups/get-group-id.test.ts
@@ -6,7 +6,10 @@ import { getGroupId } from './get-group-id';
 
 import allEventTypesFixture from '$fixtures/all-event-types.json';
 
-const events = allEventTypesFixture as unknown as CommonHistoryEvent[];
+const events = allEventTypesFixture as unknown as Record<
+  string,
+  CommonHistoryEvent
+>;
 
 describe('getGroupId', () => {
   it('should get the correct ID for WorkflowExecutionCanceled events', () => {

--- a/src/lib/models/event-history/get-event-attributes.test.ts
+++ b/src/lib/models/event-history/get-event-attributes.test.ts
@@ -77,8 +77,6 @@ const historyEvent = {
   },
 } as unknown as HistoryEvent;
 
-const namespace = 'unit-tests';
-
 describe('getEventAttributes', () => {
   beforeEach(() => {
     vi.mock('$lib/utilities/decode-payload', () => {
@@ -154,7 +152,7 @@ describe('toEventHistory', () => {
 
       const [event] = events;
 
-      expect(event[property]).toBeDefined();
+      expect(event[property as keyof typeof event]).toBeDefined();
     });
   }
 });

--- a/src/lib/models/event-history/get-event-categorization.ts
+++ b/src/lib/models/event-history/get-event-categorization.ts
@@ -162,7 +162,7 @@ export const getEventCategory = (eventType: EventType): EventTypeCategory => {
 
 export const isCategoryType = (value: string): value is EventTypeCategory => {
   for (const category in CATEGORIES) {
-    if (value === CATEGORIES[category]) return true;
+    if (value === CATEGORIES[category as keyof typeof CATEGORIES]) return true;
   }
   return false;
 };

--- a/src/lib/models/event-history/to-event-history.test.ts
+++ b/src/lib/models/event-history/to-event-history.test.ts
@@ -77,8 +77,6 @@ const historyEvent = {
   },
 } as unknown as HistoryEvent;
 
-const namespace = 'unit-tests';
-
 describe('getEventAttributes', () => {
   beforeEach(() => {
     vi.mock('$lib/utilities/decode-payload', () => {
@@ -154,7 +152,7 @@ describe('toEventHistory', () => {
 
       const [event] = events;
 
-      expect(event[property]).toBeDefined();
+      expect(event[property as keyof typeof event]).toBeDefined();
     });
   }
 });
@@ -178,7 +176,7 @@ describe('fromEventToRawEvent', () => {
       const [event] = events;
       const rawEvent = fromEventToRawEvent(event);
 
-      expect(rawEvent[property]).toBeUndefined();
+      expect(rawEvent[property as keyof typeof rawEvent]).toBeUndefined();
     });
   }
 });

--- a/src/lib/svelte-mocks/app/state.ts
+++ b/src/lib/svelte-mocks/app/state.ts
@@ -36,7 +36,7 @@ const settings: Settings = {
 };
 
 export const page = {
-  error: null,
+  error: null as App.Error | null,
   params: {
     namespace: 'default',
   },

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,8 +18,9 @@ export type Capabilities =
     serverScaledProviderCloudRun?: boolean | null;
   };
 
-export type NamespaceCapabilities =
-  DescribeNamespaceResponse['namespaceInfo']['capabilities'];
+export type NamespaceCapabilities = NonNullable<
+  DescribeNamespaceResponse['namespaceInfo']
+>['capabilities'];
 export type GetWorkflowExecutionHistoryResponse =
   temporal.api.workflowservice.v1.IGetWorkflowExecutionHistoryResponse;
 export type GetSearchAttributesResponse =

--- a/src/lib/types/nexus-operation-execution.ts
+++ b/src/lib/types/nexus-operation-execution.ts
@@ -5,7 +5,6 @@ import type {
   NexusOperationIdConflictPolicy,
   NexusOperationIdReusePolicy,
   StartNexusOperationExecutionRequest,
-  UserMetadata,
 } from '.';
 import type { WorkflowSearchAttributes } from './workflows';
 

--- a/src/lib/utilities/decode-payload-test-fixtures.ts
+++ b/src/lib/utilities/decode-payload-test-fixtures.ts
@@ -1,4 +1,6 @@
-export const workflowStartedEvent = {
+import type { PotentiallyDecodable } from './decode-payload';
+
+export const workflowStartedEvent: PotentiallyDecodable = {
   type: 'workflowExecutionStartedEventAttributes',
   workflowType: {
     name: 'BackgroundCheck',
@@ -55,7 +57,7 @@ export const workflowStartedEvent = {
   },
 };
 
-export const dataConvertedWorkflowStartedEvent = {
+export const dataConvertedWorkflowStartedEvent: PotentiallyDecodable = {
   type: 'workflowExecutionStartedEventAttributes',
   workflowType: { name: 'BackgroundCheck' },
   parentWorkflowNamespace: '',
@@ -88,7 +90,7 @@ export const dataConvertedWorkflowStartedEvent = {
   },
 };
 
-export const dataConvertedFailureWorkflowStartedEvent = {
+export const dataConvertedFailureWorkflowStartedEvent: PotentiallyDecodable = {
   type: 'workflowExecutionStartedEventAttributes',
   workflowType: { name: 'BackgroundCheck' },
   parentWorkflowNamespace: '',
@@ -130,7 +132,7 @@ export const dataConvertedFailureWorkflowStartedEvent = {
   },
 };
 
-export const noRemoteDataConverterWorkflowStartedEvent = {
+export const noRemoteDataConverterWorkflowStartedEvent: PotentiallyDecodable = {
   type: 'workflowExecutionStartedEventAttributes',
   workflowType: { name: 'BackgroundCheck' },
   parentWorkflowNamespace: '',
@@ -163,7 +165,7 @@ export const noRemoteDataConverterWorkflowStartedEvent = {
   },
 };
 
-export const workflowStartedHistoryEvent = {
+export const workflowStartedHistoryEvent: PotentiallyDecodable = {
   workflowExecutionStartedEventAttributes: {
     workflowType: {
       name: 'BackgroundCheck',
@@ -222,7 +224,7 @@ export const workflowStartedHistoryEvent = {
   },
 };
 
-export const getTestPayloadEvent = () => ({
+export const getTestPayloadEvent = (): PotentiallyDecodable => ({
   type: 'workflowExecutionStartedEventAttributes',
   workflowType: {
     name: 'BackgroundCheck',
@@ -281,56 +283,57 @@ export const getTestPayloadEvent = () => ({
   prevAutoResetPoints: null,
 });
 
-export const getTestPayloadEventWithNullEncodedAttributes = () => ({
-  type: 'workflowExecutionStartedEventAttributes',
-  workflowType: {
-    name: 'BackgroundCheck',
-  },
-  parentWorkflowNamespace: '',
-  parentWorkflowExecution: null,
-  parentInitiatedEventId: '0',
-  taskQueue: {
-    name: 'background-checks-main',
-    kind: 'Normal',
-  },
-  input: {
-    payloads: [
-      {
-        metadata: {
-          encoding: 'anNvbi9wbGFpbg==',
-        },
-        data: 'InRlc3RAdGVzdC5jb20i',
-      },
-    ],
-  },
-  details: {
-    detail1: {
+export const getTestPayloadEventWithNullEncodedAttributes =
+  (): PotentiallyDecodable => ({
+    type: 'workflowExecutionStartedEventAttributes',
+    workflowType: {
+      name: 'BackgroundCheck',
+    },
+    parentWorkflowNamespace: '',
+    parentWorkflowExecution: null,
+    parentInitiatedEventId: '0',
+    taskQueue: {
+      name: 'background-checks-main',
+      kind: 'Normal',
+    },
+    input: {
       payloads: [
         {
           metadata: {
             encoding: 'anNvbi9wbGFpbg==',
           },
-          data: 'eyAidGVzdCI6ICJkZXRhaWwiIH0=',
+          data: 'InRlc3RAdGVzdC5jb20i',
         },
       ],
     },
-  },
-  encodedAttributes: null,
-  workflowExecutionTimeout: '0s',
-  workflowRunTimeout: '0s',
-  workflowTaskTimeout: '10s',
-  continuedExecutionRunId: '',
-  initiator: 'Unspecified',
-  continuedFailure: null,
-  lastCompletionResult: null,
-  originalExecutionRunId: 'b4351cb3-f54f-4ed4-be5a-b13ef429b861',
-  identity: '1@ac0cd56257aa@',
-  firstExecutionRunId: 'b4351cb3-f54f-4ed4-be5a-b13ef429b861',
-  retryPolicy: null,
-  attempt: 1,
-  workflowExecutionExpirationTime: null,
-  cronSchedule: '',
-  firstWorkflowTaskBackoff: '0s',
-  memo: null,
-  prevAutoResetPoints: null,
-});
+    details: {
+      detail1: {
+        payloads: [
+          {
+            metadata: {
+              encoding: 'anNvbi9wbGFpbg==',
+            },
+            data: 'eyAidGVzdCI6ICJkZXRhaWwiIH0=',
+          },
+        ],
+      },
+    },
+    encodedAttributes: null,
+    workflowExecutionTimeout: '0s',
+    workflowRunTimeout: '0s',
+    workflowTaskTimeout: '10s',
+    continuedExecutionRunId: '',
+    initiator: 'Unspecified',
+    continuedFailure: null,
+    lastCompletionResult: null,
+    originalExecutionRunId: 'b4351cb3-f54f-4ed4-be5a-b13ef429b861',
+    identity: '1@ac0cd56257aa@',
+    firstExecutionRunId: 'b4351cb3-f54f-4ed4-be5a-b13ef429b861',
+    retryPolicy: null,
+    attempt: 1,
+    workflowExecutionExpirationTime: null,
+    cronSchedule: '',
+    firstWorkflowTaskBackoff: '0s',
+    memo: null,
+    prevAutoResetPoints: null,
+  });

--- a/src/lib/utilities/get-activity-status-and-count.ts
+++ b/src/lib/utilities/get-activity-status-and-count.ts
@@ -1,4 +1,3 @@
-import type { Payload } from '$lib/types';
 import type { ActivityExecutionStatus } from '$lib/types/activity-execution';
 import type { CountWorkflowExecutionsResponse } from '$lib/types/workflows';
 import { parseRawPayloadToJSON } from '$lib/utilities/decode-payload';

--- a/src/lib/utilities/merge.ts
+++ b/src/lib/utilities/merge.ts
@@ -1,22 +1,22 @@
-type KeyValue = { [key: string]: string | number | boolean };
+type KeyValue = { [key: string]: unknown };
 
-export const merge = <T = KeyValue>(
+export const merge = <T extends KeyValue = KeyValue>(
   first: T = {} as T,
   second: T = {} as T,
 ): T => {
-  const result = { ...first };
+  const result: KeyValue = { ...first };
 
   for (const key of Object.keys(second)) {
     const value = result[key];
 
     if (Array.isArray(value)) {
-      result[key] = result[key].concat(second[key]);
+      result[key] = value.concat(second[key]);
     } else if (typeof value === 'object' && !Array.isArray(value)) {
-      result[key] = merge(result[key], second[key]);
+      result[key] = merge(value as KeyValue, second[key] as KeyValue);
     } else {
       result[key] = second[key];
     }
   }
 
-  return result;
+  return result as T;
 };

--- a/src/lib/utilities/namespace-capabilities.ts
+++ b/src/lib/utilities/namespace-capabilities.ts
@@ -6,7 +6,7 @@ type NamespaceCapabilityState = 'unsupported' | 'disabled' | 'enabled';
 
 export const namespaceCapabilityState = (
   capabilities: NamespaceCapabilities | undefined,
-  capabilitiy: keyof NamespaceCapabilities,
+  capabilitiy: keyof NonNullable<NamespaceCapabilities>,
 ): NamespaceCapabilityState => {
   if (!capabilities) return 'unsupported';
 

--- a/src/lib/utilities/oss-provider.test.ts
+++ b/src/lib/utilities/oss-provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('$lib/stores/auth-user', () => ({
   getAuthUser: vi.fn(),

--- a/src/lib/utilities/route-for.ts
+++ b/src/lib/utilities/route-for.ts
@@ -2,7 +2,7 @@ import { get } from 'svelte/store';
 
 import { BROWSER } from 'esm-env';
 
-import { base, resolve } from '$app/paths';
+import { resolve } from '$app/paths';
 import type { ResolvedPathname } from '$app/types';
 
 import {

--- a/utilities/oidc-server/oidc-server.d.ts
+++ b/utilities/oidc-server/oidc-server.d.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// oidc-provider ships no type declarations and there is no @types package.
+// These ambient declarations satisfy the compiler for this dev-only OIDC server.
+declare module 'oidc-provider' {
+  export interface Account {
+    [key: string]: any;
+  }
+  export interface AccountClaims {
+    [key: string]: any;
+  }
+  export type Configuration = Record<string, any>;
+  export const errors: any;
+  export default class Provider {
+    constructor(issuer: string, configuration?: Configuration);
+    [key: string]: any;
+  }
+}


### PR DESCRIPTION
First of a 4-PR split of #3640 (enable TypeScript strict mode).

**Zero runtime impact, no CI/enforcement changes.** Contains only: noImplicitAny-driven type annotations, `import type` conversions, Storybook/test typing, and dead-code removal. 36 files.

Global `strict` stays off and the Danger strict-error check stays in warn mode until the final PR — so merging this early blocks nothing. All files verified strict-clean.

---
**Stack (merge bottom-up):**
1. #3686 `strict/1-base` — type annotations + dead-code cleanup (zero runtime)
2. #3687 `strict/2-mechanical` — strictNullChecks null-safety guards
3. #3688 `strict/3-behavior` — runtime-affecting model/form/service changes
4. #3640 `ts-strict-mode` — flip `strict: true` + enforce in CI

Split verified: stacking all four reproduces the original combined tree byte-for-byte.