### PR TITLE
 Fix live timeline refresh for completed event groups

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -27,11 +27,10 @@
     getWorkflowTaskFailedEvent as getBufferWftFailedEvent,
     getEventArray,
     getGroupArray,
-    onLatestGroup,
   } from '$lib/services/grouped-event-buffer';
   import { clearActives } from '$lib/stores/active-events';
   import { eventFilterSort, eventViewType } from '$lib/stores/event-view';
-  import { pauseLiveUpdates } from '$lib/stores/events';
+  import { bufferVersion, pauseLiveUpdates } from '$lib/stores/events';
   import { eventCategoryFilter, eventTypeFilter } from '$lib/stores/filters';
   import { workflowRun } from '$lib/stores/workflow-run';
   import type {
@@ -79,20 +78,27 @@
     historyCtx.resume();
     bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
     bufferEvents = getEventArray();
-
-    const unsub = onLatestGroup(() => {
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-      bufferEvents = getEventArray();
-    });
-    return () => unsub();
   });
 
   $effect(() => {
-    if (historyCtx.fetchComplete) {
-      enrichGroups(pendingActivities, pendingNexusOperations);
+    void $bufferVersion;
+
+    const fetchComplete = historyCtx.fetchComplete;
+    const activities = pendingActivities;
+    const nexusOperations = pendingNexusOperations;
+
+    let frame: number | null = requestAnimationFrame(() => {
+      frame = null;
+      if (fetchComplete) {
+        enrichGroups(activities, nexusOperations);
+      }
       bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
       bufferEvents = getEventArray();
-    }
+    });
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
   });
 
   const filteredGroups = $derived.by(() => {
@@ -116,14 +122,14 @@
     });
   });
 
-  const workflowTaskFailedError = $derived(
-    historyCtx.fetchComplete
-      ? (getBufferWftFailedEvent() as
-          | WorkflowTaskFailedEvent
-          | WorkflowTaskTimedOutEvent
-          | undefined)
-      : undefined,
-  );
+  const workflowTaskFailedError = $derived.by(() => {
+    void $bufferVersion;
+    if (!historyCtx.fetchComplete) return undefined;
+    return getBufferWftFailedEvent() as
+      | WorkflowTaskFailedEvent
+      | WorkflowTaskTimedOutEvent
+      | undefined;
+  });
 
   const isNotPending = $derived(
     workflow && !workflow.isRunning && !workflow.isPaused,

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -62,18 +62,6 @@
   const reverseSort = $derived($eventFilterSort === 'descending');
 
   let bufferGroups = $state.raw<EventGroup[]>([]);
-  let groupUpdatePending = false;
-  let groupUpdateFrame: number | null = null;
-
-  function scheduleBufferGroupRefresh() {
-    if (groupUpdatePending) return;
-    groupUpdatePending = true;
-    groupUpdateFrame = requestAnimationFrame(() => {
-      groupUpdateFrame = null;
-      groupUpdatePending = false;
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-    });
-  }
 
   const filteredBufferGroups = $derived.by(() => {
     const active = $eventTypeFilter;
@@ -89,14 +77,14 @@
     ),
   );
 
-  const workflowTaskFailedError = $derived(
-    historyCtx.fetchComplete
-      ? (getBufferWftFailedEvent() as
-          | WorkflowTaskFailedEvent
-          | WorkflowTaskTimedOutEvent
-          | undefined)
-      : undefined,
-  );
+  const workflowTaskFailedError = $derived.by(() => {
+    void $bufferVersion;
+    if (!historyCtx.fetchComplete) return undefined;
+    return getBufferWftFailedEvent() as
+      | WorkflowTaskFailedEvent
+      | WorkflowTaskTimedOutEvent
+      | undefined;
+  });
 
   const isNotPending = $derived(
     Boolean(workflow && !workflow?.isRunning && !workflow?.isPaused),
@@ -126,26 +114,26 @@
   onMount(() => {
     historyCtx.resume();
     bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
+  });
+
+  $effect(() => {
+    void $bufferVersion;
+    const fetchComplete = historyCtx.fetchComplete;
+    const pendingActivities = $workflowRun.workflow?.pendingActivities ?? [];
+    const pendingNexusOperations =
+      $workflowRun.workflow?.pendingNexusOperations ?? [];
+
+    let frame: number | null = requestAnimationFrame(() => {
+      frame = null;
+      if (fetchComplete) {
+        enrichGroups(pendingActivities, pendingNexusOperations);
+      }
+      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
+    });
 
     return () => {
-      if (groupUpdateFrame !== null) cancelAnimationFrame(groupUpdateFrame);
+      if (frame !== null) cancelAnimationFrame(frame);
     };
-  });
-
-  $effect(() => {
-    const _bufferVersion = $bufferVersion;
-    scheduleBufferGroupRefresh();
-  });
-
-  $effect(() => {
-    const _bufferVersion = $bufferVersion;
-    if (historyCtx.fetchComplete) {
-      enrichGroups(
-        $workflowRun.workflow?.pendingActivities ?? [],
-        $workflowRun.workflow?.pendingNexusOperations ?? [],
-      );
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-    }
   });
 
   let timeline = $state<Timeline>();

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -24,11 +24,10 @@
     enrichGroups,
     getWorkflowTaskFailedEvent as getBufferWftFailedEvent,
     getGroupArray,
-    onLatestGroup,
   } from '$lib/services/grouped-event-buffer';
   import { clearActives } from '$lib/stores/active-events';
   import { collapseIdleTime, eventFilterSort } from '$lib/stores/event-view';
-  import { pauseLiveUpdates } from '$lib/stores/events';
+  import { bufferVersion, pauseLiveUpdates } from '$lib/stores/events';
   import { eventTypeFilter } from '$lib/stores/filters';
   import { workflowRun } from '$lib/stores/workflow-run';
   import type {
@@ -63,6 +62,18 @@
   const reverseSort = $derived($eventFilterSort === 'descending');
 
   let bufferGroups = $state.raw<EventGroup[]>([]);
+  let groupUpdatePending = false;
+  let groupUpdateFrame: number | null = null;
+
+  function scheduleBufferGroupRefresh() {
+    if (groupUpdatePending) return;
+    groupUpdatePending = true;
+    groupUpdateFrame = requestAnimationFrame(() => {
+      groupUpdateFrame = null;
+      groupUpdatePending = false;
+      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
+    });
+  }
 
   const filteredBufferGroups = $derived.by(() => {
     const active = $eventTypeFilter;
@@ -116,28 +127,18 @@
     historyCtx.resume();
     bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
 
-    // Throttle buffer → Svelte updates to at most once per animation frame.
-    // onLatestGroup fires for every new group head (~N times during load), each
-    // triggering getGroupArray() (O(N log N) sort) + a full reactive cascade;
-    // batching via rAF caps that at ≤60 updates/sec regardless of how fast the
-    // bidirectional cursors push data.
-    let groupUpdatePending = false;
-    const unsub = onLatestGroup(() => {
-      if (!groupUpdatePending) {
-        groupUpdatePending = true;
-        requestAnimationFrame(() => {
-          groupUpdatePending = false;
-          bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-        });
-      }
-    });
-
     return () => {
-      unsub();
+      if (groupUpdateFrame !== null) cancelAnimationFrame(groupUpdateFrame);
     };
   });
 
   $effect(() => {
+    const _bufferVersion = $bufferVersion;
+    scheduleBufferGroupRefresh();
+  });
+
+  $effect(() => {
+    const _bufferVersion = $bufferVersion;
     if (historyCtx.fetchComplete) {
       enrichGroups(
         $workflowRun.workflow?.pendingActivities ?? [],

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -17,6 +17,7 @@ import {
   getGroupMeta,
   getLatestEvent,
   getLatestGroup,
+  getLiveGroupCount,
   getRows,
   getVisibleGroupCount,
   getWorkflowTaskFailedEvent,
@@ -34,6 +35,9 @@ import {
   makeActivityGroup,
   makeActivityScheduled,
   makeActivityStarted,
+  makeActivityTimeoutGroup,
+  makeChildWorkflowGroup,
+  makeNexusOperationGroup,
   makeSyntheticEvents,
   makeSyntheticEventsWithWorkflowTasks,
   makeTimerGroup,
@@ -44,6 +48,7 @@ import {
   makeWorkflowTaskGroup,
   makeWorkflowTaskScheduled,
   makeWorkflowTaskStarted,
+  makeWorkflowUpdateGroup,
 } from './test-helpers/synthetic-events';
 
 // ---------------------------------------------------------------------------
@@ -751,6 +756,95 @@ describe('enrichGroups', () => {
     expect(group.pendingActivity).toBeUndefined();
   });
 
+  it('clears pendingActivity when live completion extends an existing group', async () => {
+    reset(10);
+    resetLive();
+    const [scheduled, started, completed] = makeActivityGroup(1);
+    processEvent(scheduled, true);
+    processEvent(started, true);
+
+    enrichGroups(
+      [
+        {
+          activityId: '1',
+          state: 'Started',
+          activityType: 'TestActivity',
+        },
+      ] as Parameters<typeof enrichGroups>[0],
+      [],
+    );
+
+    let [group] = await Promise.all(getRows(0, 1));
+    expect(group.pendingActivity).toBeDefined();
+    expect(group.isPending).toBe(true);
+
+    expect(appendLiveEvent(completed)).toBe(true);
+
+    [group] = await Promise.all(getRows(0, 1));
+    expect(group.eventList).toHaveLength(3);
+    expect(group.pendingActivity).toBeUndefined();
+    expect(group.isPending).toBe(false);
+  });
+
+  it('clears pendingActivity when a live timeout resolves a short activity group', async () => {
+    reset(10);
+    resetLive();
+    const [scheduled, timedOut] = makeActivityTimeoutGroup(1);
+    processEvent(scheduled, true);
+
+    enrichGroups(
+      [
+        {
+          activityId: '1',
+          state: 'Started',
+          activityType: 'TestActivity',
+        },
+      ] as Parameters<typeof enrichGroups>[0],
+      [],
+    );
+
+    let [group] = await Promise.all(getRows(0, 1));
+    expect(group.pendingActivity).toBeDefined();
+    expect(group.isPending).toBe(true);
+
+    expect(appendLiveEvent(timedOut)).toBe(true);
+
+    [group] = await Promise.all(getRows(0, 1));
+    expect(group.eventList.map((event) => event.id)).toEqual(['1', '2']);
+    expect(group.pendingActivity).toBeUndefined();
+    expect(group.isPending).toBe(false);
+  });
+
+  it('annotates live-only activity and nexus groups with pending metadata', () => {
+    reset(20);
+    resetLive();
+    appendLiveEvent(makeActivityScheduled(1, 'MyActivity'));
+    appendLiveEvent(makeNexusOperationGroup(4)[0]);
+
+    enrichGroups(
+      [
+        {
+          activityId: '1',
+          state: 'Started',
+          activityType: 'MyActivity',
+        },
+      ] as Parameters<typeof enrichGroups>[0],
+      [
+        {
+          scheduledEventId: '4',
+        },
+      ] as Parameters<typeof enrichGroups>[1],
+    );
+
+    const groups = getGroupArray();
+    expect(
+      groups.find((group) => group.id === '1')?.pendingActivity,
+    ).toBeDefined();
+    expect(
+      groups.find((group) => group.id === '4')?.pendingNexusOperation,
+    ).toBeDefined();
+  });
+
   it('ignores activities not in the pending list', async () => {
     reset(10);
     processEvent(makeActivityScheduled(1, 'MyActivity'), true);
@@ -1444,6 +1538,108 @@ describe('concurrent live poll and bidirectional fetch', () => {
     expect(unique.has('2')).toBe(true);
     expect(unique.has('3')).toBe(true);
     expect(unique.has('4')).toBe(true);
+  });
+
+  it.each([
+    ['activity', () => makeActivityGroup(2)],
+    ['timer', () => makeTimerGroup(2)],
+    ['child workflow', () => makeChildWorkflowGroup(2)],
+    ['workflow task', () => makeWorkflowTaskGroup(2)],
+    ['update', () => makeWorkflowUpdateGroup(2)],
+    ['nexus', () => makeNexusOperationGroup(2)],
+  ])(
+    'keeps live %s followers visible when bidirectional fetch later claims the head',
+    (_, buildGroup) => {
+      const group = buildGroup();
+      reset(10);
+      resetLive();
+
+      for (const ev of group) appendLiveEvent(ev);
+      expect(getGroupArray()).toHaveLength(1);
+      expect(getGroupArray()[0].eventList).toHaveLength(group.length);
+
+      processEvent(group[0], true);
+
+      const groups = getGroupArray();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].id).toBe(group[0].eventId);
+      expect(groups[0].eventList.map((event) => event.id)).toEqual(
+        group.map((event) => event.eventId),
+      );
+      expect(getLiveGroupCount()).toBe(0);
+    },
+  );
+
+  it.each([
+    ['activity', () => makeActivityGroup(2)],
+    ['timer', () => makeTimerGroup(2)],
+    ['child workflow', () => makeChildWorkflowGroup(2)],
+    ['workflow task', () => makeWorkflowTaskGroup(2)],
+    ['update', () => makeWorkflowUpdateGroup(2)],
+    ['nexus', () => makeNexusOperationGroup(2)],
+  ])(
+    'flushes live %s followers parked before the history head arrives',
+    (_, buildGroup) => {
+      const group = buildGroup();
+      reset(10);
+      resetLive();
+
+      for (const ev of group.slice(1)) appendLiveEvent(ev);
+      expect(getGroupArray()).toHaveLength(0);
+
+      processEvent(group[0], true);
+
+      const groups = getGroupArray();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].id).toBe(group[0].eventId);
+      expect(groups[0].eventList.map((event) => event.id)).toEqual(
+        group.map((event) => event.eventId),
+      );
+    },
+  );
+
+  it.each([
+    ['activity', () => makeActivityGroup(2)],
+    ['timer', () => makeTimerGroup(2)],
+    ['child workflow', () => makeChildWorkflowGroup(2)],
+    ['workflow task', () => makeWorkflowTaskGroup(2)],
+    ['update', () => makeWorkflowUpdateGroup(2)],
+    ['nexus', () => makeNexusOperationGroup(2)],
+  ])(
+    'attaches live %s followers to an existing history group head',
+    (_, buildGroup) => {
+      const group = buildGroup();
+      reset(10);
+      resetLive();
+
+      processEvent(group[0], true);
+      for (const ev of group.slice(1)) appendLiveEvent(ev);
+
+      const groups = getGroupArray();
+      expect(groups).toHaveLength(1);
+      expect(groups[0].id).toBe(group[0].eventId);
+      expect(groups[0].eventList.map((event) => event.id)).toEqual(
+        group.map((event) => event.eventId),
+      );
+    },
+  );
+
+  it('does not duplicate a far-ahead live follower when history later processes it', () => {
+    reset(5);
+    resetLive();
+    const scheduled = makeActivityScheduled(1);
+    const started = makeActivityStarted(100, 1);
+
+    processEvent(scheduled, true);
+    expect(appendLiveEvent(started)).toBe(true);
+    processEvent(started, true);
+
+    const groups = getGroupArray();
+    expect(groups).toHaveLength(1);
+    expect(groups[0].eventList.map((event) => event.id)).toEqual(['1', '100']);
+    expect(getEventArray().filter((event) => event.id === '100')).toHaveLength(
+      1,
+    );
   });
 
   it('new events from live poll remain after bidirectional fetch completes', () => {

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -939,6 +939,63 @@ describe('getWorkflowTaskFailedEvent (buffer)', () => {
     expect(failed?.eventType).toBe('WorkflowTaskFailed');
     expect(failed?.id).toBe('6');
   });
+
+  it('returns a WFT failure whose group arrives entirely via the live poll', () => {
+    reset(10);
+    resetLive();
+    appendLiveEvent(makeWorkflowTaskScheduled(1));
+    appendLiveEvent(makeWorkflowTaskStarted(2, 1));
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+
+    expect(appendLiveEvent(makeWorkflowTaskFailed(3, 1))).toBe(true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
+
+  it('returns a live WFT failure appended to a WFT head already in the pool', () => {
+    reset(10);
+    resetLive();
+    processEvent(makeWorkflowTaskScheduled(1), true);
+    processEvent(makeWorkflowTaskStarted(2, 1), true);
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+
+    expect(appendLiveEvent(makeWorkflowTaskFailed(3, 1))).toBe(true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
+
+  it('clears the WFT failure when a later WFT completes via the live poll', () => {
+    reset(20);
+    resetLive();
+    processEvent(makeWorkflowTaskScheduled(1), true);
+    processEvent(makeWorkflowTaskStarted(2, 1), true);
+    processEvent(makeWorkflowTaskFailed(3, 1), true);
+    expect(getWorkflowTaskFailedEvent()?.id).toBe('3');
+
+    // Workflow recovers: a new WFT completes, delivered live.
+    appendLiveEvent(makeWorkflowTaskScheduled(4));
+    appendLiveEvent(makeWorkflowTaskStarted(5, 4));
+    appendLiveEvent(makeWorkflowTaskCompleted(6, 4));
+
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+  });
+
+  it('does not double-count a live WFT group once the fetch claims its head', () => {
+    reset(10);
+    resetLive();
+    // Failure lands live first, then the bidirectional fetch reaches the head.
+    appendLiveEvent(makeWorkflowTaskScheduled(1));
+    appendLiveEvent(makeWorkflowTaskFailed(3, 1));
+    processEvent(makeWorkflowTaskScheduled(1), true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -246,21 +246,22 @@ function hasTerminalActivityEvent(group: EventGroup): boolean {
   );
 }
 
+function hasTerminalNexusEvent(group: EventGroup): boolean {
+  return group.eventList.some(
+    (event) =>
+      isNexusOperationCompletedEvent(event) ||
+      isNexusOperationFailedEvent(event) ||
+      isNexusOperationCanceledEvent(event) ||
+      isNexusOperationTimedOutEvent(event),
+  );
+}
+
 function clearResolvedPendingState(group: EventGroup): void {
   if (group.pendingActivity && hasTerminalActivityEvent(group)) {
     delete group.pendingActivity;
   }
 
-  if (
-    group.pendingNexusOperation &&
-    group.eventList.some(
-      (event) =>
-        isNexusOperationCompletedEvent(event) ||
-        isNexusOperationFailedEvent(event) ||
-        isNexusOperationCanceledEvent(event) ||
-        isNexusOperationTimedOutEvent(event),
-    )
-  ) {
+  if (group.pendingNexusOperation && hasTerminalNexusEvent(group)) {
     delete group.pendingNexusOperation;
   }
 }
@@ -271,6 +272,12 @@ function growArrays(newSize: number): void {
   const grown = new Int32Array(newSize);
   grown.set(eventToGroup);
   eventToGroup = grown;
+}
+
+// Grow the slot arrays so `slotIdx` is addressable, with ~25% headroom.
+function growArraysFor(slotIdx: number): void {
+  if (slotIdx < eventSlots.length) return;
+  growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
 }
 
 function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
@@ -291,9 +298,6 @@ function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
 
   eventToGroup[followerSlotIdx] = poolIdx + 1;
 
-  if (meta.group.pendingActivity && meta.group.eventList.length === 3) {
-    delete meta.group.pendingActivity;
-  }
   clearResolvedPendingState(meta.group);
 
   const followerMs = toMs(event.eventTime);
@@ -324,9 +328,7 @@ function absorbLiveGroupIntoPool(poolIdx: number, liveGroup: EventGroup): void {
 
   for (const event of liveGroup.eventList) {
     const slotIdx = parseInt(event.id) - 1;
-    if (slotIdx >= eventToGroup.length) {
-      growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-    }
+    growArraysFor(slotIdx);
     if (eventToGroup[slotIdx] !== 0) continue;
     if (group.eventList.some((existing) => existing.id === event.id)) continue;
 
@@ -363,14 +365,7 @@ function enrichGroup(
 
   if (isNexusOperationScheduledEvent(initial)) {
     const pn = byNexusScheduledId.get(group.id);
-    const isComplete = group.eventList.some(
-      (e) =>
-        isNexusOperationCompletedEvent(e) ||
-        isNexusOperationFailedEvent(e) ||
-        isNexusOperationCanceledEvent(e) ||
-        isNexusOperationTimedOutEvent(e),
-    );
-    if (pn && !isComplete) {
+    if (pn && !hasTerminalNexusEvent(group)) {
       group.pendingNexusOperation = pn;
     } else {
       delete group.pendingNexusOperation;
@@ -456,9 +451,7 @@ export function processEvent(
 ): EventGroup | null {
   const slotIdx = parseInt(raw.eventId) - 1;
 
-  if (slotIdx >= eventSlots.length) {
-    growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-  }
+  growArraysFor(slotIdx);
 
   eventSlots[slotIdx] = raw;
 
@@ -574,7 +567,6 @@ export function processEvent(
     const [liveGroup] = liveGroups.splice(liveGroupIdx, 1);
     absorbLiveGroupIntoPool(poolIdx, liveGroup);
     _liveVersion++;
-    invalidateGroupArrayCaches();
   }
 
   // Release the head slot — its data is now encoded in the EventGroup.
@@ -730,10 +722,7 @@ export function getWorkflowTaskFailedEvent(): WorkflowEvent | undefined {
   let lastFailedEvent: WorkflowEvent | undefined;
   let maxCompletedId = -1;
 
-  for (let i = 0; i < poolTop; i++) {
-    const { group } = groupPool[i];
-    if (!group || !isWorkflowTaskGroup(group)) continue;
-
+  const scanGroup = (group: EventGroup): void => {
     for (const event of group.eventList) {
       if (event.eventType === 'WorkflowTaskCompleted') {
         const id = Number(event.id);
@@ -749,6 +738,28 @@ export function getWorkflowTaskFailedEvent(): WorkflowEvent | undefined {
         }
       }
     }
+  };
+
+  for (let i = 0; i < poolTop; i++) {
+    const { group } = groupPool[i];
+    if (!group || !isWorkflowTaskGroup(group)) continue;
+    scanGroup(group);
+  }
+
+  // Live WFT groups whose head slot has not yet been claimed by the pool —
+  // covers workflow-task failures that arrive via the live poll after the
+  // initial fetch completes.
+  for (const group of liveGroups) {
+    if (!isWorkflowTaskGroup(group)) continue;
+    const headSlotIdx = parseInt(group.id) - 1;
+    if (
+      headSlotIdx >= 0 &&
+      headSlotIdx < eventToGroup.length &&
+      eventToGroup[headSlotIdx] !== 0
+    ) {
+      continue;
+    }
+    scanGroup(group);
   }
 
   if (!lastFailedEvent) return undefined;
@@ -993,9 +1004,7 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
         meta.group.timestamp = event.timestamp;
         addEventToGroup(meta.group, event);
         clearResolvedPendingState(meta.group);
-        if (slotIdx >= eventToGroup.length) {
-          growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-        }
+        growArraysFor(slotIdx);
         eventToGroup[slotIdx] = eventToGroup[headSlotIdx];
         const followerMs = toMs(event.eventTime);
         if (followerMs > meta.endMs) {

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -15,7 +15,11 @@ import type {
 } from '$lib/types/events';
 import { isWorkflowTaskFailedEventDueToReset } from '$lib/utilities/get-workflow-task-failed-event';
 import {
+  isActivityTaskCanceledEvent,
+  isActivityTaskCompletedEvent,
+  isActivityTaskFailedEvent,
   isActivityTaskScheduledEvent,
+  isActivityTaskTimedOutEvent,
   isNexusOperationCanceledEvent,
   isNexusOperationCompletedEvent,
   isNexusOperationFailedEvent,
@@ -227,6 +231,40 @@ function insertEventById(list: WorkflowEvent[], event: WorkflowEvent): void {
   list.splice(i, 0, event);
 }
 
+function invalidateGroupArrayCaches(): void {
+  _cachedGroups = null;
+  _cachedGroupsNoWFT = null;
+}
+
+function hasTerminalActivityEvent(group: EventGroup): boolean {
+  return group.eventList.some(
+    (event) =>
+      isActivityTaskCompletedEvent(event) ||
+      isActivityTaskFailedEvent(event) ||
+      isActivityTaskCanceledEvent(event) ||
+      isActivityTaskTimedOutEvent(event),
+  );
+}
+
+function clearResolvedPendingState(group: EventGroup): void {
+  if (group.pendingActivity && hasTerminalActivityEvent(group)) {
+    delete group.pendingActivity;
+  }
+
+  if (
+    group.pendingNexusOperation &&
+    group.eventList.some(
+      (event) =>
+        isNexusOperationCompletedEvent(event) ||
+        isNexusOperationFailedEvent(event) ||
+        isNexusOperationCanceledEvent(event) ||
+        isNexusOperationTimedOutEvent(event),
+    )
+  ) {
+    delete group.pendingNexusOperation;
+  }
+}
+
 function growArrays(newSize: number): void {
   if (newSize <= eventSlots.length) return;
   eventSlots.length = newSize;
@@ -256,10 +294,12 @@ function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
   if (meta.group.pendingActivity && meta.group.eventList.length === 3) {
     delete meta.group.pendingActivity;
   }
+  clearResolvedPendingState(meta.group);
 
   const followerMs = toMs(event.eventTime);
   if (followerMs > meta.endMs) meta.endMs = followerMs;
 
+  invalidateGroupArrayCaches();
   eventSlots[followerSlotIdx] = null;
 }
 
@@ -273,6 +313,67 @@ function attachFollower(headSlotIdx: number, followerSlotIdx: number): void {
       pending.push(followerSlotIdx);
     } else {
       pendingFollowers.set(headSlotIdx, [followerSlotIdx]);
+    }
+  }
+}
+
+function absorbLiveGroupIntoPool(poolIdx: number, liveGroup: EventGroup): void {
+  const meta = groupPool[poolIdx];
+  const group = meta.group;
+  if (!group) return;
+
+  for (const event of liveGroup.eventList) {
+    const slotIdx = parseInt(event.id) - 1;
+    if (slotIdx >= eventToGroup.length) {
+      growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
+    }
+    if (eventToGroup[slotIdx] !== 0) continue;
+    if (group.eventList.some((existing) => existing.id === event.id)) continue;
+
+    insertEventById(group.eventList, event);
+    group.timestamp = event.timestamp;
+    addEventToGroup(group, event);
+    eventToGroup[slotIdx] = poolIdx + 1;
+    const eventMs = toMs(event.eventTime);
+    if (eventMs > meta.endMs) meta.endMs = eventMs;
+  }
+
+  clearResolvedPendingState(group);
+  invalidateGroupArrayCaches();
+}
+
+function enrichGroup(
+  group: EventGroup,
+  byActivityId: Map<string, PendingActivity>,
+  byNexusScheduledId: Map<string, PendingNexusOperation>,
+): void {
+  const initial = group.initialEvent;
+
+  if (isActivityTaskScheduledEvent(initial)) {
+    const pa = byActivityId.get(
+      initial.activityTaskScheduledEventAttributes?.activityId ?? '',
+    );
+    if (pa && !hasTerminalActivityEvent(group)) {
+      group.pendingActivity = pa;
+    } else {
+      delete group.pendingActivity;
+    }
+    return;
+  }
+
+  if (isNexusOperationScheduledEvent(initial)) {
+    const pn = byNexusScheduledId.get(group.id);
+    const isComplete = group.eventList.some(
+      (e) =>
+        isNexusOperationCompletedEvent(e) ||
+        isNexusOperationFailedEvent(e) ||
+        isNexusOperationCanceledEvent(e) ||
+        isNexusOperationTimedOutEvent(e),
+    );
+    if (pn && !isComplete) {
+      group.pendingNexusOperation = pn;
+    } else {
+      delete group.pendingNexusOperation;
     }
   }
 }
@@ -463,9 +564,17 @@ export function processEvent(
       const followerMs = toMs(follower.eventTime);
       if (followerMs > meta.endMs) meta.endMs = followerMs;
     }
+    clearResolvedPendingState(group);
     livePendingFollowers.delete(event.id);
-    _cachedGroups = null;
-    _cachedGroupsNoWFT = null;
+    invalidateGroupArrayCaches();
+  }
+
+  const liveGroupIdx = liveGroups.findIndex((g) => g.id === event.id);
+  if (liveGroupIdx !== -1) {
+    const [liveGroup] = liveGroups.splice(liveGroupIdx, 1);
+    absorbLiveGroupIntoPool(poolIdx, liveGroup);
+    _liveVersion++;
+    invalidateGroupArrayCaches();
   }
 
   // Release the head slot — its data is now encoded in the EventGroup.
@@ -602,37 +711,13 @@ export function enrichGroups(
   for (let i = 0; i < poolTop; i++) {
     const { group } = groupPool[i];
     if (!group) continue;
-
-    const initial = group.initialEvent;
-
-    if (isActivityTaskScheduledEvent(initial)) {
-      const pa = byActivityId.get(
-        initial.activityTaskScheduledEventAttributes?.activityId ?? '',
-      );
-      if (pa && group.eventList.length < 3) {
-        group.pendingActivity = pa;
-      } else {
-        delete group.pendingActivity;
-      }
-      continue;
-    }
-
-    if (isNexusOperationScheduledEvent(initial)) {
-      const pn = byNexusScheduledId.get(group.id);
-      const isComplete = group.eventList.some(
-        (e) =>
-          isNexusOperationCompletedEvent(e) ||
-          isNexusOperationFailedEvent(e) ||
-          isNexusOperationCanceledEvent(e) ||
-          isNexusOperationTimedOutEvent(e),
-      );
-      if (pn && !isComplete) {
-        group.pendingNexusOperation = pn;
-      } else {
-        delete group.pendingNexusOperation;
-      }
-    }
+    enrichGroup(group, byActivityId, byNexusScheduledId);
   }
+
+  for (const group of liveGroups) {
+    enrichGroup(group, byActivityId, byNexusScheduledId);
+  }
+  invalidateGroupArrayCaches();
 }
 
 /**
@@ -889,9 +974,9 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
       insertEventById(existing.eventList, event);
       existing.timestamp = event.timestamp;
       addEventToGroup(existing, event);
+      clearResolvedPendingState(existing);
       _liveVersion++;
-      _cachedGroups = null;
-      _cachedGroupsNoWFT = null;
+      invalidateGroupArrayCaches();
       return true;
     }
 
@@ -907,13 +992,16 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
         insertEventById(meta.group.eventList, event);
         meta.group.timestamp = event.timestamp;
         addEventToGroup(meta.group, event);
+        clearResolvedPendingState(meta.group);
+        if (slotIdx >= eventToGroup.length) {
+          growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
+        }
         eventToGroup[slotIdx] = eventToGroup[headSlotIdx];
         const followerMs = toMs(event.eventTime);
         if (followerMs > meta.endMs) {
           meta.endMs = followerMs;
         }
-        _cachedGroups = null;
-        _cachedGroupsNoWFT = null;
+        invalidateGroupArrayCaches();
       }
       return true;
     }
@@ -950,13 +1038,13 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
       group.timestamp = follower.timestamp;
       addEventToGroup(group, follower);
     }
+    clearResolvedPendingState(group);
     livePendingFollowers.delete(event.id);
   }
 
   liveGroups.push(group);
   _liveVersion++;
-  _cachedGroups = null;
-  _cachedGroupsNoWFT = null;
+  invalidateGroupArrayCaches();
   for (const cb of liveGroupListeners) cb(group);
   for (const cb of latestGroupListeners) cb(group);
   return true;

--- a/src/lib/services/test-helpers/synthetic-events.ts
+++ b/src/lib/services/test-helpers/synthetic-events.ts
@@ -86,6 +86,21 @@ export function makeActivityCompleted(
   } as unknown as HistoryEvent;
 }
 
+export function makeActivityTimedOut(
+  eventId: number,
+  scheduledEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'ActivityTaskTimedOut'),
+    activityTaskTimedOutEventAttributes: {
+      scheduledEventId: String(scheduledEventId),
+      startedEventId: '0',
+      retryState: 'MaximumAttemptsReached',
+      failure: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
 export function makeTimerStarted(
   eventId: number,
   timerId?: string,
@@ -168,6 +183,112 @@ export function makeWorkflowTaskCompleted(
   } as unknown as HistoryEvent;
 }
 
+export function makeStartChildWorkflowInitiated(eventId: number): HistoryEvent {
+  return {
+    ...base(eventId, 'StartChildWorkflowExecutionInitiated'),
+    startChildWorkflowExecutionInitiatedEventAttributes: {
+      workflowId: `child-${eventId}`,
+      workflowType: { name: 'ChildWorkflow' },
+      taskQueue: { name: 'default', kind: 'Normal' },
+      input: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeChildWorkflowStarted(
+  eventId: number,
+  initiatedEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'ChildWorkflowExecutionStarted'),
+    childWorkflowExecutionStartedEventAttributes: {
+      initiatedEventId: String(initiatedEventId),
+      workflowExecution: {
+        workflowId: `child-${initiatedEventId}`,
+        runId: `run-${eventId}`,
+      },
+      workflowType: { name: 'ChildWorkflow' },
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeChildWorkflowCompleted(
+  eventId: number,
+  initiatedEventId: number,
+  startedEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'ChildWorkflowExecutionCompleted'),
+    childWorkflowExecutionCompletedEventAttributes: {
+      initiatedEventId: String(initiatedEventId),
+      startedEventId: String(startedEventId),
+      result: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeWorkflowUpdateAccepted(eventId: number): HistoryEvent {
+  return {
+    ...base(eventId, 'WorkflowExecutionUpdateAccepted'),
+    workflowExecutionUpdateAcceptedEventAttributes: {
+      protocolInstanceId: `update-${eventId}`,
+      acceptedRequest: null,
+      acceptedRequestSequencingEventId: String(eventId - 1),
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeWorkflowUpdateCompleted(
+  eventId: number,
+  acceptedEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'WorkflowExecutionUpdateCompleted'),
+    workflowExecutionUpdateCompletedEventAttributes: {
+      acceptedEventId: String(acceptedEventId),
+      outcome: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeNexusOperationScheduled(eventId: number): HistoryEvent {
+  return {
+    ...base(eventId, 'NexusOperationScheduled'),
+    nexusOperationScheduledEventAttributes: {
+      endpoint: 'endpoint',
+      service: 'service',
+      operation: 'operation',
+      input: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeNexusOperationStarted(
+  eventId: number,
+  scheduledEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'NexusOperationStarted'),
+    nexusOperationStartedEventAttributes: {
+      scheduledEventId: String(scheduledEventId),
+      operationId: `operation-${scheduledEventId}`,
+    },
+  } as unknown as HistoryEvent;
+}
+
+export function makeNexusOperationCompleted(
+  eventId: number,
+  scheduledEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'NexusOperationCompleted'),
+    nexusOperationCompletedEventAttributes: {
+      scheduledEventId: String(scheduledEventId),
+      result: null,
+    },
+  } as unknown as HistoryEvent;
+}
+
 // ---------------------------------------------------------------------------
 // Composite group builders (return events in ascending ID order)
 // ---------------------------------------------------------------------------
@@ -184,6 +305,15 @@ export function makeActivityGroup(
   ];
 }
 
+export function makeActivityTimeoutGroup(
+  startId: number,
+): [HistoryEvent, HistoryEvent] {
+  return [
+    makeActivityScheduled(startId),
+    makeActivityTimedOut(startId + 1, startId),
+  ];
+}
+
 /** Returns [Started, Fired] at IDs [startId, startId+1] */
 export function makeTimerGroup(startId: number): [HistoryEvent, HistoryEvent] {
   return [makeTimerStarted(startId), makeTimerFired(startId + 1, startId)];
@@ -197,6 +327,35 @@ export function makeWorkflowTaskGroup(
     makeWorkflowTaskScheduled(startId),
     makeWorkflowTaskStarted(startId + 1, startId),
     makeWorkflowTaskCompleted(startId + 2, startId),
+  ];
+}
+
+export function makeChildWorkflowGroup(
+  startId: number,
+): [HistoryEvent, HistoryEvent, HistoryEvent] {
+  return [
+    makeStartChildWorkflowInitiated(startId),
+    makeChildWorkflowStarted(startId + 1, startId),
+    makeChildWorkflowCompleted(startId + 2, startId, startId + 1),
+  ];
+}
+
+export function makeWorkflowUpdateGroup(
+  startId: number,
+): [HistoryEvent, HistoryEvent] {
+  return [
+    makeWorkflowUpdateAccepted(startId),
+    makeWorkflowUpdateCompleted(startId + 1, startId),
+  ];
+}
+
+export function makeNexusOperationGroup(
+  startId: number,
+): [HistoryEvent, HistoryEvent, HistoryEvent] {
+  return [
+    makeNexusOperationScheduled(startId),
+    makeNexusOperationStarted(startId + 1, startId),
+    makeNexusOperationCompleted(startId + 2, startId),
   ];
 }
 


### PR DESCRIPTION
 Refresh the workflow timeline on all grouped-event buffer changes so live completion events update existing rows, not just newly-created group heads. Merge live groups back into the history-backed pool when the bidirectional fetch later
 claims their head, clear stale pending activity/nexus metadata when live events resolve a group, and keep grouped-array
 caches fresh after follower mutations.
 Add coverage for history/live split ordering across activity, timer, child workflow, workflow task, update, and Nexus
 groups, including far-ahead live followers and live-only pending metadata.

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
