### PR TITLE
Live refresh fixes for event-history tab + WFT failures

### DIFF
--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -27,11 +27,10 @@
     getWorkflowTaskFailedEvent as getBufferWftFailedEvent,
     getEventArray,
     getGroupArray,
-    onLatestGroup,
   } from '$lib/services/grouped-event-buffer';
   import { clearActives } from '$lib/stores/active-events';
   import { eventFilterSort, eventViewType } from '$lib/stores/event-view';
-  import { pauseLiveUpdates } from '$lib/stores/events';
+  import { bufferVersion, pauseLiveUpdates } from '$lib/stores/events';
   import { eventCategoryFilter, eventTypeFilter } from '$lib/stores/filters';
   import { workflowRun } from '$lib/stores/workflow-run';
   import type {
@@ -79,20 +78,27 @@
     historyCtx.resume();
     bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
     bufferEvents = getEventArray();
-
-    const unsub = onLatestGroup(() => {
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-      bufferEvents = getEventArray();
-    });
-    return () => unsub();
   });
 
   $effect(() => {
-    if (historyCtx.fetchComplete) {
-      enrichGroups(pendingActivities, pendingNexusOperations);
+    void $bufferVersion;
+
+    const fetchComplete = historyCtx.fetchComplete;
+    const activities = pendingActivities;
+    const nexusOperations = pendingNexusOperations;
+
+    let frame: number | null = requestAnimationFrame(() => {
+      frame = null;
+      if (fetchComplete) {
+        enrichGroups(activities, nexusOperations);
+      }
       bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
       bufferEvents = getEventArray();
-    }
+    });
+
+    return () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
   });
 
   const filteredGroups = $derived.by(() => {
@@ -116,14 +122,14 @@
     });
   });
 
-  const workflowTaskFailedError = $derived(
-    historyCtx.fetchComplete
-      ? (getBufferWftFailedEvent() as
-          | WorkflowTaskFailedEvent
-          | WorkflowTaskTimedOutEvent
-          | undefined)
-      : undefined,
-  );
+  const workflowTaskFailedError = $derived.by(() => {
+    void $bufferVersion;
+    if (!historyCtx.fetchComplete) return undefined;
+    return getBufferWftFailedEvent() as
+      | WorkflowTaskFailedEvent
+      | WorkflowTaskTimedOutEvent
+      | undefined;
+  });
 
   const isNotPending = $derived(
     workflow && !workflow.isRunning && !workflow.isPaused,

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -62,18 +62,6 @@
   const reverseSort = $derived($eventFilterSort === 'descending');
 
   let bufferGroups = $state.raw<EventGroup[]>([]);
-  let groupUpdatePending = false;
-  let groupUpdateFrame: number | null = null;
-
-  function scheduleBufferGroupRefresh() {
-    if (groupUpdatePending) return;
-    groupUpdatePending = true;
-    groupUpdateFrame = requestAnimationFrame(() => {
-      groupUpdateFrame = null;
-      groupUpdatePending = false;
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-    });
-  }
 
   const filteredBufferGroups = $derived.by(() => {
     const active = $eventTypeFilter;
@@ -89,14 +77,14 @@
     ),
   );
 
-  const workflowTaskFailedError = $derived(
-    historyCtx.fetchComplete
-      ? (getBufferWftFailedEvent() as
-          | WorkflowTaskFailedEvent
-          | WorkflowTaskTimedOutEvent
-          | undefined)
-      : undefined,
-  );
+  const workflowTaskFailedError = $derived.by(() => {
+    void $bufferVersion;
+    if (!historyCtx.fetchComplete) return undefined;
+    return getBufferWftFailedEvent() as
+      | WorkflowTaskFailedEvent
+      | WorkflowTaskTimedOutEvent
+      | undefined;
+  });
 
   const isNotPending = $derived(
     Boolean(workflow && !workflow?.isRunning && !workflow?.isPaused),
@@ -126,26 +114,26 @@
   onMount(() => {
     historyCtx.resume();
     bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
+  });
+
+  $effect(() => {
+    void $bufferVersion;
+    const fetchComplete = historyCtx.fetchComplete;
+    const pendingActivities = $workflowRun.workflow?.pendingActivities ?? [];
+    const pendingNexusOperations =
+      $workflowRun.workflow?.pendingNexusOperations ?? [];
+
+    let frame: number | null = requestAnimationFrame(() => {
+      frame = null;
+      if (fetchComplete) {
+        enrichGroups(pendingActivities, pendingNexusOperations);
+      }
+      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
+    });
 
     return () => {
-      if (groupUpdateFrame !== null) cancelAnimationFrame(groupUpdateFrame);
+      if (frame !== null) cancelAnimationFrame(frame);
     };
-  });
-
-  $effect(() => {
-    const _bufferVersion = $bufferVersion;
-    scheduleBufferGroupRefresh();
-  });
-
-  $effect(() => {
-    const _bufferVersion = $bufferVersion;
-    if (historyCtx.fetchComplete) {
-      enrichGroups(
-        $workflowRun.workflow?.pendingActivities ?? [],
-        $workflowRun.workflow?.pendingNexusOperations ?? [],
-      );
-      bufferGroups = getGroupArray({ excludeWorkflowTasks: true });
-    }
   });
 
   let timeline = $state<Timeline>();

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -939,6 +939,63 @@ describe('getWorkflowTaskFailedEvent (buffer)', () => {
     expect(failed?.eventType).toBe('WorkflowTaskFailed');
     expect(failed?.id).toBe('6');
   });
+
+  it('returns a WFT failure whose group arrives entirely via the live poll', () => {
+    reset(10);
+    resetLive();
+    appendLiveEvent(makeWorkflowTaskScheduled(1));
+    appendLiveEvent(makeWorkflowTaskStarted(2, 1));
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+
+    expect(appendLiveEvent(makeWorkflowTaskFailed(3, 1))).toBe(true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
+
+  it('returns a live WFT failure appended to a WFT head already in the pool', () => {
+    reset(10);
+    resetLive();
+    processEvent(makeWorkflowTaskScheduled(1), true);
+    processEvent(makeWorkflowTaskStarted(2, 1), true);
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+
+    expect(appendLiveEvent(makeWorkflowTaskFailed(3, 1))).toBe(true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
+
+  it('clears the WFT failure when a later WFT completes via the live poll', () => {
+    reset(20);
+    resetLive();
+    processEvent(makeWorkflowTaskScheduled(1), true);
+    processEvent(makeWorkflowTaskStarted(2, 1), true);
+    processEvent(makeWorkflowTaskFailed(3, 1), true);
+    expect(getWorkflowTaskFailedEvent()?.id).toBe('3');
+
+    // Workflow recovers: a new WFT completes, delivered live.
+    appendLiveEvent(makeWorkflowTaskScheduled(4));
+    appendLiveEvent(makeWorkflowTaskStarted(5, 4));
+    appendLiveEvent(makeWorkflowTaskCompleted(6, 4));
+
+    expect(getWorkflowTaskFailedEvent()).toBeUndefined();
+  });
+
+  it('does not double-count a live WFT group once the fetch claims its head', () => {
+    reset(10);
+    resetLive();
+    // Failure lands live first, then the bidirectional fetch reaches the head.
+    appendLiveEvent(makeWorkflowTaskScheduled(1));
+    appendLiveEvent(makeWorkflowTaskFailed(3, 1));
+    processEvent(makeWorkflowTaskScheduled(1), true);
+
+    const failed = getWorkflowTaskFailedEvent();
+    expect(failed?.eventType).toBe('WorkflowTaskFailed');
+    expect(failed?.id).toBe('3');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -730,10 +730,7 @@ export function getWorkflowTaskFailedEvent(): WorkflowEvent | undefined {
   let lastFailedEvent: WorkflowEvent | undefined;
   let maxCompletedId = -1;
 
-  for (let i = 0; i < poolTop; i++) {
-    const { group } = groupPool[i];
-    if (!group || !isWorkflowTaskGroup(group)) continue;
-
+  const scanGroup = (group: EventGroup): void => {
     for (const event of group.eventList) {
       if (event.eventType === 'WorkflowTaskCompleted') {
         const id = Number(event.id);
@@ -749,6 +746,28 @@ export function getWorkflowTaskFailedEvent(): WorkflowEvent | undefined {
         }
       }
     }
+  };
+
+  for (let i = 0; i < poolTop; i++) {
+    const { group } = groupPool[i];
+    if (!group || !isWorkflowTaskGroup(group)) continue;
+    scanGroup(group);
+  }
+
+  // Live WFT groups whose head slot has not yet been claimed by the pool —
+  // covers workflow-task failures that arrive via the live poll after the
+  // initial fetch completes.
+  for (const group of liveGroups) {
+    if (!isWorkflowTaskGroup(group)) continue;
+    const headSlotIdx = parseInt(group.id) - 1;
+    if (
+      headSlotIdx >= 0 &&
+      headSlotIdx < eventToGroup.length &&
+      eventToGroup[headSlotIdx] !== 0
+    ) {
+      continue;
+    }
+    scanGroup(group);
   }
 
   if (!lastFailedEvent) return undefined;

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -246,21 +246,22 @@ function hasTerminalActivityEvent(group: EventGroup): boolean {
   );
 }
 
+function hasTerminalNexusEvent(group: EventGroup): boolean {
+  return group.eventList.some(
+    (event) =>
+      isNexusOperationCompletedEvent(event) ||
+      isNexusOperationFailedEvent(event) ||
+      isNexusOperationCanceledEvent(event) ||
+      isNexusOperationTimedOutEvent(event),
+  );
+}
+
 function clearResolvedPendingState(group: EventGroup): void {
   if (group.pendingActivity && hasTerminalActivityEvent(group)) {
     delete group.pendingActivity;
   }
 
-  if (
-    group.pendingNexusOperation &&
-    group.eventList.some(
-      (event) =>
-        isNexusOperationCompletedEvent(event) ||
-        isNexusOperationFailedEvent(event) ||
-        isNexusOperationCanceledEvent(event) ||
-        isNexusOperationTimedOutEvent(event),
-    )
-  ) {
+  if (group.pendingNexusOperation && hasTerminalNexusEvent(group)) {
     delete group.pendingNexusOperation;
   }
 }
@@ -271,6 +272,12 @@ function growArrays(newSize: number): void {
   const grown = new Int32Array(newSize);
   grown.set(eventToGroup);
   eventToGroup = grown;
+}
+
+// Grow the slot arrays so `slotIdx` is addressable, with ~25% headroom.
+function growArraysFor(slotIdx: number): void {
+  if (slotIdx < eventSlots.length) return;
+  growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
 }
 
 function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
@@ -291,9 +298,6 @@ function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
 
   eventToGroup[followerSlotIdx] = poolIdx + 1;
 
-  if (meta.group.pendingActivity && meta.group.eventList.length === 3) {
-    delete meta.group.pendingActivity;
-  }
   clearResolvedPendingState(meta.group);
 
   const followerMs = toMs(event.eventTime);
@@ -324,9 +328,7 @@ function absorbLiveGroupIntoPool(poolIdx: number, liveGroup: EventGroup): void {
 
   for (const event of liveGroup.eventList) {
     const slotIdx = parseInt(event.id) - 1;
-    if (slotIdx >= eventToGroup.length) {
-      growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-    }
+    growArraysFor(slotIdx);
     if (eventToGroup[slotIdx] !== 0) continue;
     if (group.eventList.some((existing) => existing.id === event.id)) continue;
 
@@ -363,14 +365,7 @@ function enrichGroup(
 
   if (isNexusOperationScheduledEvent(initial)) {
     const pn = byNexusScheduledId.get(group.id);
-    const isComplete = group.eventList.some(
-      (e) =>
-        isNexusOperationCompletedEvent(e) ||
-        isNexusOperationFailedEvent(e) ||
-        isNexusOperationCanceledEvent(e) ||
-        isNexusOperationTimedOutEvent(e),
-    );
-    if (pn && !isComplete) {
+    if (pn && !hasTerminalNexusEvent(group)) {
       group.pendingNexusOperation = pn;
     } else {
       delete group.pendingNexusOperation;
@@ -456,9 +451,7 @@ export function processEvent(
 ): EventGroup | null {
   const slotIdx = parseInt(raw.eventId) - 1;
 
-  if (slotIdx >= eventSlots.length) {
-    growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-  }
+  growArraysFor(slotIdx);
 
   eventSlots[slotIdx] = raw;
 
@@ -574,7 +567,6 @@ export function processEvent(
     const [liveGroup] = liveGroups.splice(liveGroupIdx, 1);
     absorbLiveGroupIntoPool(poolIdx, liveGroup);
     _liveVersion++;
-    invalidateGroupArrayCaches();
   }
 
   // Release the head slot — its data is now encoded in the EventGroup.
@@ -1012,9 +1004,7 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
         meta.group.timestamp = event.timestamp;
         addEventToGroup(meta.group, event);
         clearResolvedPendingState(meta.group);
-        if (slotIdx >= eventToGroup.length) {
-          growArrays(slotIdx + Math.ceil(slotIdx * 0.25) + 16);
-        }
+        growArraysFor(slotIdx);
         eventToGroup[slotIdx] = eventToGroup[headSlotIdx];
         const followerMs = toMs(event.eventTime);
         if (followerMs > meta.endMs) {


### PR DESCRIPTION
Stacked on top of #3689 (base: `fix-live-timeline-refresh`). These are review follow-ups from going over that PR — happy to squash or drop the cleanup commit if you'd rather keep the PR tight.

## Bug fixes (`c09662a1e`)
The timeline fix in #3689 moved refresh off `onLatestGroup` (which only fires on new group *heads*) to the `$bufferVersion` signal. Two gaps remained:

1. **Event History tab wasn't migrated.** It still refreshed via `onLatestGroup`, so a live follower/completion event (e.g. `ActivityTaskCompleted` extending an already-loaded group) never updated the table — the exact bug #3689 fixes for the timeline. Now driven by `$bufferVersion` too, with `enrichGroups` folded into a single rAF-throttled effect (both layouts), so it no longer runs synchronously on every live-poll bump after fetch completes.

2. **Workflow-task failures arriving live didn't surface the error banner.** `workflowTaskFailedError` depended only on `historyCtx.fetchComplete`, and `getWorkflowTaskFailedEvent()` scanned only the pool. Made the derived reactive to `$bufferVersion` and taught `getWorkflowTaskFailedEvent()` to scan live groups (skipping heads already claimed by the pool, mirroring `getGroupArray`'s dedup).

Adds coverage for the live WFT-failure paths: live-only groups, failures appended to a pooled head, live recovery clearing a prior failure, and no double-count once the fetch claims a live head.

## Cleanup (`eb79c4691`) — no behavior change
- Remove the dead/inconsistent `eventList.length === 3` pending-activity delete in `attachFollowerToPool`.
- Extract `hasTerminalNexusEvent` (mirroring `hasTerminalActivityEvent`); use in `clearResolvedPendingState` + `enrichGroup`.
- Drop redundant `invalidateGroupArrayCaches()` in `processEvent`'s absorb path.
- Extract `growArraysFor(slotIdx)` for all three grow sites.

## Verification
`pnpm check` 0 errors · `pnpm lint` 0 errors · full suite 2507 passing (+5 new).
