### PR TITLE
fix(events): reflect pending-activity commands without reload

### DIFF
--- a/src/lib/components/lines-and-dots/event-history-legend.svelte
+++ b/src/lib/components/lines-and-dots/event-history-legend.svelte
@@ -110,6 +110,7 @@
   bottomLeft
   width={380}
   tooltipClass="!surface-primary border border-subtle"
+  usePortal
 >
   <div
     slot="content"

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -51,6 +51,48 @@ type StartingEvents = {
   Nexus: NexusOperationScheduledEvent;
 };
 
+// Computed fields live on a shared prototype (via `this`) rather than as
+// per-instance getter closures. Every group then has a single hidden class, so
+// property access in the timeline's hot loops stays monomorphic, and
+// cloneEventGroup() can shallow-copy the data fields without re-declaring the
+// accessors or invoking them.
+const eventGroupProto: ThisType<EventGroup> = {
+  get eventTime() {
+    return this.eventList[this.eventList.length - 1]?.eventTime;
+  },
+  get attributes() {
+    return this.eventList[this.eventList.length - 1]?.attributes;
+  },
+  get lastEvent() {
+    return this.eventList[this.eventList.length - 1];
+  },
+  get finalClassification() {
+    return this.eventList[this.eventList.length - 1].classification;
+  },
+  get isPending() {
+    return (
+      !!this.pendingActivity ||
+      !!this.pendingNexusOperation ||
+      (isTimerStartedEvent(this.initialEvent) && this.eventList.length === 1) ||
+      (isStartChildWorkflowExecutionInitiatedEvent(this.initialEvent) &&
+        this.eventList.length === 2)
+    );
+  },
+};
+
+/**
+ * Shallow-clone a group onto the same prototype, sharing its eventList. Copies
+ * only own data fields (the accessors live on the prototype, so they are
+ * neither copied nor invoked), giving the clone an identical shape to
+ * createGroupFor's groups and a fresh reference for reference-tracking Svelte
+ * views to re-derive from.
+ */
+export const cloneEventGroup = (group: EventGroup): EventGroup =>
+  Object.assign(
+    Object.create(Object.getPrototypeOf(group) as object),
+    group,
+  ) as EventGroup;
+
 const createGroupFor = <K extends keyof StartingEvents>(
   event: StartingEvents[K] & { userMetadata?: { summary: Payload } },
 ): EventGroup => {
@@ -65,7 +107,7 @@ const createGroupFor = <K extends keyof StartingEvents>(
   // eventList[0] is the same object as event, typed as WorkflowEvent at runtime.
   const first = eventList[0];
 
-  return {
+  return Object.assign(Object.create(eventGroupProto) as EventGroup, {
     id,
     name,
     label,
@@ -85,28 +127,7 @@ const createGroupFor = <K extends keyof StartingEvents>(
     isTerminated: eventIsTerminated(first),
     billableActions: first.billableActions ?? 0,
     links: first.links ? [...first.links] : [],
-    get eventTime() {
-      return eventList[eventList.length - 1]?.eventTime;
-    },
-    get attributes() {
-      return eventList[eventList.length - 1]?.attributes;
-    },
-    get lastEvent() {
-      return eventList[eventList.length - 1];
-    },
-    get finalClassification() {
-      return eventList[eventList.length - 1].classification;
-    },
-    get isPending() {
-      return (
-        !!this.pendingActivity ||
-        !!this.pendingNexusOperation ||
-        (isTimerStartedEvent(this.initialEvent) && eventList.length === 1) ||
-        (isStartChildWorkflowExecutionInitiatedEvent(this.initialEvent) &&
-          eventList.length === 2)
-      );
-    },
-  };
+  });
 };
 
 // Called by addToExistingGroup after pushing a new event into a group's eventList.

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -719,6 +719,43 @@ describe('enrichGroups', () => {
     expect(group.pendingActivity?.activityId).toBe('1');
   });
 
+  it('swaps in a fresh group reference when pending state changes', () => {
+    reset(10);
+    processEvent(makeActivityScheduled(1, 'MyActivity'), true);
+    const before = getGroupArray().find((g) => g.id === '1');
+
+    enrichGroups(
+      [
+        { activityId: '1', state: 'Started', activityType: 'MyActivity' },
+      ] as Parameters<typeof enrichGroups>[0],
+      [],
+    );
+
+    const after = getGroupArray().find((g) => g.id === '1');
+    // Reference-tracking views only re-derive when the object identity changes;
+    // a pause/unpause appends no history event, so the ref swap is the signal.
+    expect(after).not.toBe(before);
+    expect(after?.pendingActivity?.activityId).toBe('1');
+    // Clone keeps the prototype-backed getters and shares eventList.
+    expect(after?.isPending).toBe(true);
+    expect(after?.eventList).toBe(before?.eventList);
+  });
+
+  it('reuses the group reference when pending state is unchanged', () => {
+    reset(10);
+    processEvent(makeActivityScheduled(1, 'MyActivity'), true);
+    const pending = [
+      { activityId: '1', state: 'Started', activityType: 'MyActivity' },
+    ] as Parameters<typeof enrichGroups>[0];
+
+    enrichGroups(pending, []);
+    const first = getGroupArray().find((g) => g.id === '1');
+    enrichGroups(pending, []);
+    const second = getGroupArray().find((g) => g.id === '1');
+
+    expect(second).toBe(first);
+  });
+
   it('does not set pendingActivity on a completed activity group (3 events)', async () => {
     reset(10);
     const [s, st, c] = makeActivityGroup(1);

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -1,5 +1,6 @@
 import {
   addEventToGroup,
+  cloneEventGroup,
   createEventGroup,
   createWorkflowTaskGroup,
 } from '$lib/models/event-groups/create-event-group';
@@ -344,33 +345,42 @@ function absorbLiveGroupIntoPool(poolIdx: number, liveGroup: EventGroup): void {
   invalidateGroupArrayCaches();
 }
 
+// Returns a fresh group reference when pending metadata changed (so
+// reference-tracking Svelte views re-derive — a pause/unpause appends no
+// history event, leaving eventList and the old reference otherwise stable), or
+// the same group when nothing changed.
 function enrichGroup(
   group: EventGroup,
   byActivityId: Map<string, PendingActivity>,
   byNexusScheduledId: Map<string, PendingNexusOperation>,
-): void {
+): EventGroup {
   const initial = group.initialEvent;
 
   if (isActivityTaskScheduledEvent(initial)) {
     const pa = byActivityId.get(
       initial.activityTaskScheduledEventAttributes?.activityId ?? '',
     );
-    if (pa && !hasTerminalActivityEvent(group)) {
-      group.pendingActivity = pa;
-    } else {
-      delete group.pendingActivity;
+    const next = pa && !hasTerminalActivityEvent(group) ? pa : undefined;
+    if (group.pendingActivity === next) {
+      return group;
     }
-    return;
+    const clone = cloneEventGroup(group);
+    clone.pendingActivity = next;
+    return clone;
   }
 
   if (isNexusOperationScheduledEvent(initial)) {
     const pn = byNexusScheduledId.get(group.id);
-    if (pn && !hasTerminalNexusEvent(group)) {
-      group.pendingNexusOperation = pn;
-    } else {
-      delete group.pendingNexusOperation;
+    const next = pn && !hasTerminalNexusEvent(group) ? pn : undefined;
+    if (group.pendingNexusOperation === next) {
+      return group;
     }
+    const clone = cloneEventGroup(group);
+    clone.pendingNexusOperation = next;
+    return clone;
   }
+
+  return group;
 }
 
 function notifyLatestGroupListeners(group: EventGroup): void {
@@ -700,16 +710,27 @@ export function enrichGroups(
     pendingNexusOperations.map((p) => [String(p.scheduledEventId), p]),
   );
 
+  let changed = false;
+
   for (let i = 0; i < poolTop; i++) {
-    const { group } = groupPool[i];
-    if (!group) continue;
-    enrichGroup(group, byActivityId, byNexusScheduledId);
+    const meta = groupPool[i];
+    if (!meta.group) continue;
+    const next = enrichGroup(meta.group, byActivityId, byNexusScheduledId);
+    if (next !== meta.group) {
+      meta.group = next;
+      changed = true;
+    }
   }
 
-  for (const group of liveGroups) {
-    enrichGroup(group, byActivityId, byNexusScheduledId);
+  for (let i = 0; i < liveGroups.length; i++) {
+    const next = enrichGroup(liveGroups[i], byActivityId, byNexusScheduledId);
+    if (next !== liveGroups[i]) {
+      liveGroups[i] = next;
+      changed = true;
+    }
   }
-  invalidateGroupArrayCaches();
+
+  if (changed) invalidateGroupArrayCaches();
 }
 
 /**

--- a/tests/integration/activity-command-reflect.spec.ts
+++ b/tests/integration/activity-command-reflect.spec.ts
@@ -27,7 +27,7 @@ import {
 // "control" here.
 
 const { workflowId, runId } =
-  mockRunningWorkflow.workflowExecutionInfo.execution;
+  mockRunningWorkflow.workflowExecutionInfo!.execution!;
 
 const historyUrl = `/namespaces/default/workflows/${workflowId}/${runId}/history`;
 const pendingActivitiesUrl = `/namespaces/default/workflows/${workflowId}/${runId}/pending-activities`;

--- a/tests/integration/activity-command-reflect.spec.ts
+++ b/tests/integration/activity-command-reflect.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  mockClusterApi,
+  mockSettingsApi,
+  mockWorkflowApis,
+} from '~/test-utilities/mock-apis';
+import {
+  mockRunningWorkflow,
+  WORKFLOW_API,
+} from '~/test-utilities/mocks/workflow';
+
+// Regression coverage for: pausing a pending activity from the event view did
+// not flip the button to "Unpause" until a full page reload.
+//
+// The event-group buffer stores long-lived plain EventGroup objects. After a
+// pause command, workflow-run-layout refetches the describe and re-runs
+// enrichGroups. When a group's pending metadata changes, enrichGroups now hands
+// back a FRESH group object (grouped-event-buffer `cloneGroup`) so the
+// reference-tracking Svelte views (event-details-full / timeline
+// group-details-row) re-derive; previously it mutated `group.pendingActivity`
+// in place, leaving the reference stable, and — since pause appends no history
+// event — `eventCount` was unchanged so the buffer-backed views never updated.
+//
+// The Pending Activities tab reads $workflowRun.workflow.pendingActivities
+// straight from the store, so it has always reflected the change — it's the
+// "control" here.
+
+const { workflowId, runId } =
+  mockRunningWorkflow.workflowExecutionInfo.execution;
+
+const historyUrl = `/namespaces/default/workflows/${workflowId}/${runId}/history`;
+const pendingActivitiesUrl = `/namespaces/default/workflows/${workflowId}/${runId}/pending-activities`;
+
+// Matches both the primary (activities-deprecated) and fallback (activities) routes.
+const ACTIVITY_PAUSE_API = /\/activities(-deprecated)?\/pause/;
+
+test.describe('Activity command reflection after pause', () => {
+  test.beforeEach(async ({ page }) => {
+    // The describe response flips its pending activity's `paused` flag to true
+    // only after the pause command has been received — mirroring the server.
+    let paused = false;
+
+    await mockClusterApi(page);
+    await mockSettingsApi(page);
+    await mockWorkflowApis(page, mockRunningWorkflow);
+
+    // Registered after mockWorkflowApis so this handler wins (Playwright matches
+    // the most-recently-registered route first).
+    await page.route(WORKFLOW_API, async (route) => {
+      const workflow = structuredClone(mockRunningWorkflow);
+      const activity = workflow.pendingActivities?.[0] as
+        | { paused?: boolean }
+        | undefined;
+      if (activity) activity.paused = paused;
+      await route.fulfill({ json: workflow });
+    });
+
+    await page.route(ACTIVITY_PAUSE_API, async (route) => {
+      paused = true;
+      await route.fulfill({ json: {} });
+    });
+  });
+
+  test('control: Pending Activities tab flips to Unpause after pausing', async ({
+    page,
+  }) => {
+    await page.goto(pendingActivitiesUrl);
+
+    const pauseButton = page.getByRole('button', {
+      name: 'Pause',
+      exact: true,
+    });
+    await expect(pauseButton).toBeVisible();
+    await pauseButton.click();
+
+    const modal = page.getByTestId('activity-pause-confirmation-modal');
+    const pauseRequest = page.waitForRequest(ACTIVITY_PAUSE_API);
+    await modal.getByRole('button', { name: 'Pause', exact: true }).click();
+    await pauseRequest;
+
+    // Store-backed view — reflects the new paused state.
+    await expect(
+      page.getByRole('button', { name: 'Unpause', exact: true }),
+    ).toBeVisible();
+  });
+
+  test('event history view flips to Unpause after pausing', async ({
+    page,
+  }) => {
+    await page.goto(historyUrl);
+
+    // Expand the pending activity row to reveal the activity command buttons.
+    const activityRow = page
+      .getByTestId('pending-activity-summary-row')
+      .first();
+    await expect(activityRow).toBeVisible();
+    await activityRow.click();
+
+    const pauseButton = page.getByRole('button', {
+      name: 'Pause',
+      exact: true,
+    });
+    await expect(pauseButton).toBeVisible();
+    await pauseButton.click();
+
+    const modal = page.getByTestId('activity-pause-confirmation-modal');
+    const pauseRequest = page.waitForRequest(ACTIVITY_PAUSE_API);
+    await modal.getByRole('button', { name: 'Pause', exact: true }).click();
+    await pauseRequest;
+
+    // The buffer-backed view re-derives from the freshly-cloned group and
+    // reflects the new paused state without a reload.
+    await expect(
+      page.getByRole('button', { name: 'Unpause', exact: true }),
+    ).toBeVisible();
+  });
+});

--- a/tests/integration/activity-commands.spec.ts
+++ b/tests/integration/activity-commands.spec.ts
@@ -16,12 +16,9 @@ import {
 } from '~/test-utilities/mock-apis';
 import { mockRunningWorkflow } from '~/test-utilities/mocks/workflow';
 
-test.describe.skip('Activity Commands', () => {
-  const {
-    workflowExecutionInfo: {
-      execution: { workflowId, runId },
-    },
-  } = mockRunningWorkflow;
+test.describe('Activity Commands', () => {
+  const { workflowId, runId } =
+    mockRunningWorkflow.workflowExecutionInfo!.execution!;
   const pauseReason = 'Testing activity pause';
 
   let activityCommandsPage: ActivityCommandsPage;
@@ -108,9 +105,9 @@ test.describe.skip('Activity Commands', () => {
     await activityCommandsPage.resetConfirmButton.click();
 
     await expect(activityCommandsPage.resetModal).toBeHidden();
-    await expect(
-      page.getByText(/Activity .* has been reset successfully\./),
-    ).toBeVisible();
+    await expect(page.getByTestId('toast-live-region-polite')).toContainText(
+      /Activity .* has been reset successfully\./,
+    );
   });
 
   test('should update activity options', async ({ page }) => {
@@ -126,8 +123,8 @@ test.describe.skip('Activity Commands', () => {
     await activityCommandsPage.saveButton.click();
 
     await expect(activityCommandsPage.updateDrawer).toBeHidden();
-    await expect(
-      page.getByText(/Options for Activity .* have been updated\./),
-    ).toBeVisible();
+    await expect(page.getByTestId('toast-live-region-polite')).toContainText(
+      /Options for Activity .* have been updated\./,
+    );
   });
 });


### PR DESCRIPTION
Pausing a pending activity from the event/history view didn't reflect until a full reload: `enrichGroup` mutated pending state in place, and since pause appends no history event, the stable group reference never triggered a re-derive.

**Fix:** `enrichGroup` returns a fresh group ref when pending metadata changes. `EventGroup` accessors move to a shared prototype so `createGroupFor` and the new `cloneEventGroup` produce one V8 shape (no megamorphic slowdown in the timeline).

**Tests:** Playwright regression (verified failing without the ref swap) + unit coverage for swap-on-change / reuse-when-unchanged.

Also adds `pnpm preview:workflows` for manual verification.


https://github.com/user-attachments/assets/dba17a5f-feb4-4646-9868-933b5ef640e8


https://github.com/user-attachments/assets/0b5b7404-26f7-4746-a9c5-056e70058f0d

