### PR TITLE
Fix TypeError in workflow JSON navigator on empty events

### DIFF
--- a/src/lib/components/workflow/workflow-json-navigator.svelte
+++ b/src/lib/components/workflow/workflow-json-navigator.svelte
@@ -18,7 +18,9 @@
   let { events = [], decode }: Props = $props();
 
   let index = $state(1);
-  let rawEvent = $derived(fromEventToRawEvent(events[index - 1]));
+  let rawEvent = $derived(
+    events[index - 1] ? fromEventToRawEvent(events[index - 1]) : {},
+  );
 
   function handleKeydown(event: KeyboardEvent) {
     switch (event.code) {


### PR DESCRIPTION
## Summary

The workflow JSON navigator crashed with `TypeError: Cannot destructure property 'name' of 'e' as it is undefined`.

The `rawEvent` `$derived` called `fromEventToRawEvent(events[index - 1])` unconditionally. With the default empty `events` array (or any out-of-range `index`), `events[index - 1]` is `undefined`, and `fromEventToRawEvent` immediately destructures `name` off it and throws. The `{#if events.length > 0}` guard in the template only gates rendering — the `$derived` still evaluates eagerly.

## Fix

Guard the derived so `fromEventToRawEvent` only runs when the event exists, falling back to `{}` (which satisfies both the `PayloadCodeBlock` value type and the `stringifyWithBigInt` branch).

## Testing

- `pnpm check` passes for the changed file.