### PR TITLE
fix(events): reflect live event updates on buffer-backed views

### DIFF
--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -823,6 +823,25 @@ describe('enrichGroups', () => {
     expect(group.isPending).toBe(false);
   });
 
+  it('swaps in a fresh group reference when a live event extends a pool group', () => {
+    reset(10);
+    resetLive();
+    const [scheduled, started, completed] = makeActivityGroup(1);
+    processEvent(scheduled, true);
+    processEvent(started, true);
+
+    const before = getGroupArray().find((g) => g.id === '1');
+
+    expect(appendLiveEvent(completed)).toBe(true);
+
+    const after = getGroupArray().find((g) => g.id === '1');
+    // Reference-tracking views (event-summary-row / group-details-row) only
+    // re-derive when the object identity changes; a live follower mutates the
+    // group in place, so the append swaps in a fresh reference.
+    expect(after).not.toBe(before);
+    expect(after?.eventList).toHaveLength(3);
+  });
+
   it('clears pendingActivity when a live timeout resolves a short activity group', async () => {
     reset(10);
     resetLive();

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -1001,12 +1001,16 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
 
   if (!isHead) {
     // Option A: head already in a live group — extend it directly.
-    const existing = liveGroups.find((g) => g.id === gid);
-    if (existing) {
+    const existingIdx = liveGroups.findIndex((g) => g.id === gid);
+    if (existingIdx !== -1) {
+      const existing = liveGroups[existingIdx];
       insertEventById(existing.eventList, event);
       existing.timestamp = event.timestamp;
       addEventToGroup(existing, event);
       clearResolvedPendingState(existing);
+      // Swap in a fresh reference so reference-tracking views re-derive from
+      // the grown eventList / cleared pending (a live follower mutates in place).
+      liveGroups[existingIdx] = cloneEventGroup(existing);
       _liveVersion++;
       invalidateGroupArrayCaches();
       return true;
@@ -1025,6 +1029,9 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
         meta.group.timestamp = event.timestamp;
         addEventToGroup(meta.group, event);
         clearResolvedPendingState(meta.group);
+        // Swap in a fresh reference so reference-tracking views re-derive from
+        // the grown eventList / cleared pending (a live follower mutates in place).
+        meta.group = cloneEventGroup(meta.group);
         growArraysFor(slotIdx);
         eventToGroup[slotIdx] = eventToGroup[headSlotIdx];
         const followerMs = toMs(event.eventTime);


### PR DESCRIPTION
Follow-up to #3693 (the pause/unpause fix).

When a live-poll event extends an existing group, `appendLiveEvent` mutated the group **in place** without reassigning the reference. Reference-tracking views (`event-summary-row`, `group-details-row`) only re-derive on object-identity change, so a completing activity or newly-arrived event could stay stale until reload.

**Fix:** swap in a fresh `cloneEventGroup` reference after the in-place mutation in both live-append branches (existing live group, and head-in-pool). Live path only — the initial bidirectional fetch (`processEvent`) is untouched, so no per-event clone regression. Row keys are id-based, so the swap preserves expanded/active state on both the Events list and Timeline.

**Test:** unit coverage that a live append swaps the group ref (existing live-completion tests still assert the in-place content is correct).