### PR TITLE
[DT-4296] Add Terraform setup instructions to the GCP Cloud Run deployment form

### DIFF
--- a/src/lib/components/deployments/deployment-client-test-runner-entry.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner-entry.ts
@@ -1,0 +1,126 @@
+import i18next from 'i18next';
+import { flushSync, mount, unmount } from 'svelte';
+
+import { page } from '$app/state';
+
+import { i18nNamespaces } from '$lib/i18n';
+import resources from '$lib/i18n/locales';
+import Deployment from '$lib/pages/deployment.svelte';
+import type {
+  ComputeStatus,
+  WorkerDeploymentSummary,
+} from '$lib/types/deployments';
+
+import { resetDeploymentsServiceMock } from './deployments-service-client-test-double';
+
+import DeploymentTableRow from './deployment-table-row.svelte';
+
+const mounted: ReturnType<typeof mount>[] = [];
+
+export async function initialize() {
+  await i18next.init({
+    fallbackLng: 'en',
+    load: 'languageOnly',
+    ns: i18nNamespaces,
+    defaultNS: 'common',
+    resources,
+  });
+}
+
+function setPageState() {
+  Object.assign(page.params, {
+    namespace: 'default',
+    deployment: 'deployment',
+  });
+  Object.assign(page.data, {
+    systemInfo: { capabilities: { serverScaledDeployments: true } },
+  });
+}
+
+export async function cleanup() {
+  await Promise.all(mounted.splice(0).map((component) => unmount(component)));
+  document.body.replaceChildren();
+}
+
+export async function renderDeployment({
+  fetchDeployment,
+  fetchDeploymentVersion,
+  showConnectionStatus,
+}: {
+  fetchDeployment: unknown;
+  fetchDeploymentVersion: unknown;
+  showConnectionStatus: boolean;
+}) {
+  setPageState();
+  resetDeploymentsServiceMock({ fetchDeployment, fetchDeploymentVersion });
+
+  const target = document.body.appendChild(document.createElement('div'));
+  mounted.push(
+    mount(Deployment, {
+      target,
+      props: { showConnectionStatus },
+    }),
+  );
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+  return target;
+}
+
+export function expandDetails(target: HTMLElement) {
+  const expand = target.querySelector<HTMLButtonElement>(
+    'button[aria-label="Expand"]',
+  );
+  expand?.click();
+  flushSync();
+  return target.querySelector<HTMLTableCellElement>(
+    'tr.surface-primary > td[colspan]',
+  );
+}
+
+export function renderRows({
+  computeStatuses,
+  showConnectionStatus = false,
+}: {
+  computeStatuses: Record<string, ComputeStatus>;
+  showConnectionStatus?: boolean;
+}) {
+  setPageState();
+  const table = document.body.appendChild(document.createElement('table'));
+  const target = table.appendChild(document.createElement('tbody'));
+
+  for (const [status, computeStatus] of Object.entries(computeStatuses)) {
+    mounted.push(
+      mount(DeploymentTableRow, {
+        target,
+        props: {
+          deployment: deployment(status.toLowerCase(), computeStatus),
+          columns: [{ label: 'Current Version' }],
+          showConnectionStatus,
+        },
+      }),
+    );
+  }
+  flushSync();
+  return target;
+}
+
+function deployment(
+  name: string,
+  computeStatus: ComputeStatus,
+): WorkerDeploymentSummary {
+  return {
+    name,
+    createTime: { seconds: 1, nanos: 0 },
+    routingConfig: {},
+    currentVersionSummary: {
+      version: `${name}.current`,
+      deploymentVersion: { deploymentName: name, buildId: 'current' },
+      createTime: { seconds: 1, nanos: 0 },
+      computeConfig: {
+        scalingGroups: { default: { provider: { type: 'aws-lambda' } } },
+      },
+      computeStatus,
+    },
+  };
+}

--- a/src/lib/components/deployments/deployment-client-test-runner-entry.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner-entry.ts
@@ -1,3 +1,4 @@
+import { msNumberToTs } from '@temporalio/common';
 import i18next from 'i18next';
 import { flushSync, mount, unmount } from 'svelte';
 
@@ -111,12 +112,12 @@ function deployment(
 ): WorkerDeploymentSummary {
   return {
     name,
-    createTime: { seconds: 1, nanos: 0 },
+    createTime: msNumberToTs(1_000),
     routingConfig: {},
     currentVersionSummary: {
       version: `${name}.current`,
       deploymentVersion: { deploymentName: name, buildId: 'current' },
-      createTime: { seconds: 1, nanos: 0 },
+      createTime: msNumberToTs(1_000),
       computeConfig: {
         scalingGroups: { default: { provider: { type: 'aws-lambda' } } },
       },

--- a/src/lib/components/deployments/deployment-client-test-runner.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner.ts
@@ -1,6 +1,9 @@
 import { Buffer } from 'node:buffer';
 import path from 'node:path';
-import { TextEncoder as NodeTextEncoder } from 'node:util';
+import {
+  TextDecoder as NodeTextDecoder,
+  TextEncoder as NodeTextEncoder,
+} from 'node:util';
 
 import type { ViteDevServer } from 'vite';
 
@@ -8,8 +11,17 @@ type ClientRunner = typeof import('./deployment-client-test-runner-entry');
 
 let viteServer: ViteDevServer | undefined;
 let runner: ClientRunner | undefined;
-let textEncoder: typeof TextEncoder | undefined;
+let textEncoder: PropertyDescriptor | undefined;
+let textDecoder: PropertyDescriptor | undefined;
 let uint8Array: typeof Uint8Array | undefined;
+
+function defineGlobal(name: string, value: unknown) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
 
 export async function getDeploymentClientTestRunner(): Promise<ClientRunner> {
   if (runner) return runner;
@@ -18,15 +30,19 @@ export async function getDeploymentClientTestRunner(): Promise<ClientRunner> {
   try {
     // Vitest's JSDOM realm supplies a Uint8Array that differs from Node's
     // TextEncoder result. esbuild validates that pair while Vite starts.
-    textEncoder = globalThis.TextEncoder;
+    textEncoder = Object.getOwnPropertyDescriptor(globalThis, 'TextEncoder');
+    textDecoder = Object.getOwnPropertyDescriptor(globalThis, 'TextDecoder');
     uint8Array = globalThis.Uint8Array;
-    globalThis.TextEncoder = NodeTextEncoder;
+    defineGlobal('TextEncoder', NodeTextEncoder);
+    defineGlobal('TextDecoder', NodeTextDecoder);
     globalThis.Uint8Array = Object.getPrototypeOf(Buffer) as typeof Uint8Array;
-    const [{ svelte }, { createRunnableDevEnvironment, createServer }] =
-      await Promise.all([
-        import('@sveltejs/vite-plugin-svelte'),
-        import('vite'),
-      ]);
+    const [
+      { svelte },
+      { createRunnableDevEnvironment, createServer, isRunnableDevEnvironment },
+    ] = await Promise.all([
+      import('@sveltejs/vite-plugin-svelte'),
+      import('vite'),
+    ]);
     viteServer = await createServer({
       root: projectRoot,
       configFile: false,
@@ -35,7 +51,7 @@ export async function getDeploymentClientTestRunner(): Promise<ClientRunner> {
       optimizeDeps: {
         noDiscovery: true,
         exclude: ['svelte'],
-        include: ['json-bigint'],
+        include: ['@temporalio/common', 'json-bigint'],
       },
       resolve: {
         dedupe: ['svelte'],
@@ -88,7 +104,11 @@ export async function getDeploymentClientTestRunner(): Promise<ClientRunner> {
         },
       },
     });
-    runner = (await viteServer.environments.client.runner.import(
+    const clientEnvironment = viteServer.environments.client;
+    if (!isRunnableDevEnvironment(clientEnvironment)) {
+      throw new Error('The Vite client test environment is not runnable');
+    }
+    runner = (await clientEnvironment.runner.import(
       '/src/lib/components/deployments/deployment-client-test-runner-entry.ts',
     )) as ClientRunner;
     await runner.initialize();
@@ -104,8 +124,12 @@ export async function closeDeploymentClientTestRunner() {
   const server = viteServer;
   viteServer = undefined;
   await server?.close();
-  if (textEncoder) globalThis.TextEncoder = textEncoder;
+  if (textEncoder)
+    Object.defineProperty(globalThis, 'TextEncoder', textEncoder);
+  if (textDecoder)
+    Object.defineProperty(globalThis, 'TextDecoder', textDecoder);
   if (uint8Array) globalThis.Uint8Array = uint8Array;
   textEncoder = undefined;
+  textDecoder = undefined;
   uint8Array = undefined;
 }

--- a/src/lib/components/deployments/deployment-client-test-runner.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner.ts
@@ -1,0 +1,111 @@
+import { Buffer } from 'node:buffer';
+import path from 'node:path';
+import { TextEncoder as NodeTextEncoder } from 'node:util';
+
+import type { ViteDevServer } from 'vite';
+
+type ClientRunner = typeof import('./deployment-client-test-runner-entry');
+
+let viteServer: ViteDevServer | undefined;
+let runner: ClientRunner | undefined;
+let textEncoder: typeof TextEncoder | undefined;
+let uint8Array: typeof Uint8Array | undefined;
+
+export async function getDeploymentClientTestRunner(): Promise<ClientRunner> {
+  if (runner) return runner;
+
+  const projectRoot = process.cwd();
+  try {
+    // Vitest's JSDOM realm supplies a Uint8Array that differs from Node's
+    // TextEncoder result. esbuild validates that pair while Vite starts.
+    textEncoder = globalThis.TextEncoder;
+    uint8Array = globalThis.Uint8Array;
+    globalThis.TextEncoder = NodeTextEncoder;
+    globalThis.Uint8Array = Object.getPrototypeOf(Buffer) as typeof Uint8Array;
+    const [{ svelte }, { createRunnableDevEnvironment, createServer }] =
+      await Promise.all([
+        import('@sveltejs/vite-plugin-svelte'),
+        import('vite'),
+      ]);
+    viteServer = await createServer({
+      root: projectRoot,
+      configFile: false,
+      appType: 'custom',
+      plugins: [svelte({ hot: false, prebundleSvelteLibraries: false })],
+      optimizeDeps: {
+        noDiscovery: true,
+        exclude: ['svelte'],
+        include: ['json-bigint'],
+      },
+      resolve: {
+        dedupe: ['svelte'],
+        alias: [
+          {
+            find: '/@vite/client',
+            replacement: path.resolve(
+              projectRoot,
+              'src/lib/components/deployments/vite-client-test-double.ts',
+            ),
+          },
+          {
+            find: '$lib/services/deployments-service',
+            replacement: path.resolve(
+              projectRoot,
+              'src/lib/components/deployments/deployments-service-client-test-double.ts',
+            ),
+          },
+          {
+            find: '$lib/components/timestamp.svelte',
+            replacement: path.resolve(
+              projectRoot,
+              'src/lib/components/deployments/timestamp-client-test-double.svelte',
+            ),
+          },
+          { find: '$lib', replacement: path.resolve(projectRoot, 'src/lib') },
+          {
+            find: '$types',
+            replacement: path.resolve(projectRoot, 'src/types'),
+          },
+          {
+            find: '$app',
+            replacement: path.resolve(projectRoot, 'src/lib/svelte-mocks/app'),
+          },
+        ],
+      },
+      server: { middlewareMode: true, hmr: false },
+      environments: {
+        client: {
+          consumer: 'client',
+          dev: {
+            createEnvironment: (name, config, context) =>
+              createRunnableDevEnvironment(name, config, {
+                ...context,
+                hot: false,
+                runnerOptions: { hmr: false },
+              }),
+            moduleRunnerTransform: true,
+          },
+        },
+      },
+    });
+    runner = (await viteServer.environments.client.runner.import(
+      '/src/lib/components/deployments/deployment-client-test-runner-entry.ts',
+    )) as ClientRunner;
+    await runner.initialize();
+    return runner;
+  } catch (error) {
+    await closeDeploymentClientTestRunner();
+    throw error;
+  }
+}
+
+export async function closeDeploymentClientTestRunner() {
+  runner = undefined;
+  const server = viteServer;
+  viteServer = undefined;
+  await server?.close();
+  if (textEncoder) globalThis.TextEncoder = textEncoder;
+  if (uint8Array) globalThis.Uint8Array = uint8Array;
+  textEncoder = undefined;
+  uint8Array = undefined;
+}

--- a/src/lib/components/deployments/deployment-table-row.svelte.test.ts
+++ b/src/lib/components/deployments/deployment-table-row.svelte.test.ts
@@ -1,3 +1,4 @@
+import { msNumberToTs } from '@temporalio/common';
 import {
   afterAll,
   afterEach,
@@ -19,11 +20,11 @@ import {
 const computeStatuses: Record<string, ComputeStatus> = {
   Pending: { providerValidation: {} },
   Connected: {
-    providerValidation: { lastCheckTime: { seconds: 1, nanos: 0 } },
+    providerValidation: { lastCheckTime: msNumberToTs(1_000) },
   },
   Failed: {
     providerValidation: {
-      lastCheckTime: { seconds: 1, nanos: 0 },
+      lastCheckTime: msNumberToTs(1_000),
       errorMessage: 'Connection failed',
     },
   },

--- a/src/lib/components/deployments/deployment-table-row.svelte.test.ts
+++ b/src/lib/components/deployments/deployment-table-row.svelte.test.ts
@@ -1,73 +1,41 @@
-import type { Timestamp } from '@temporalio/common';
-import { flushSync, mount, unmount } from 'svelte';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 
-import { page } from '$app/state';
+import type { ComputeStatus } from '$lib/types/deployments';
 
-import type {
-  ComputeStatus,
-  WorkerDeploymentSummary,
-} from '$lib/types/deployments';
-
-import DeploymentTableRow from './deployment-table-row.svelte';
-
-const mounted: ReturnType<typeof mount>[] = [];
-const timestamp = { seconds: 1, nanos: 0 } as unknown as Timestamp;
+import {
+  closeDeploymentClientTestRunner,
+  getDeploymentClientTestRunner,
+} from './deployment-client-test-runner';
 
 const computeStatuses: Record<string, ComputeStatus> = {
   Pending: { providerValidation: {} },
   Connected: {
-    providerValidation: { lastCheckTime: timestamp },
+    providerValidation: { lastCheckTime: { seconds: 1, nanos: 0 } },
   },
   Failed: {
     providerValidation: {
-      lastCheckTime: timestamp,
+      lastCheckTime: { seconds: 1, nanos: 0 },
       errorMessage: 'Connection failed',
     },
   },
 };
 
-function deployment(
-  name: string,
-  computeStatus: ComputeStatus,
-): WorkerDeploymentSummary {
-  return {
-    name,
-    createTime: timestamp,
-    routingConfig: {},
-    currentVersionSummary: {
-      version: `${name}.current`,
-      deploymentVersion: { deploymentName: name, buildId: 'current' },
-      createTime: timestamp,
-      computeConfig: {
-        scalingGroups: { default: { provider: { type: 'aws-lambda' } } },
-      },
-      computeStatus,
-    },
-  };
-}
-
-function renderRows(showConnectionStatus = false) {
-  const table = document.body.appendChild(document.createElement('table'));
-  const target = table.appendChild(document.createElement('tbody'));
-
-  for (const [status, computeStatus] of Object.entries(computeStatuses)) {
-    mounted.push(
-      mount(DeploymentTableRow, {
-        target,
-        props: {
-          deployment: deployment(status.toLowerCase(), computeStatus),
-          columns: [{ label: 'Current Version' }],
-          showConnectionStatus,
-        },
-      }),
-    );
-  }
-  flushSync();
-  return target;
-}
-
 describe('deployment list connection status visibility', () => {
+  let client: Awaited<ReturnType<typeof getDeploymentClientTestRunner>>;
+
+  beforeAll(async () => {
+    client = await getDeploymentClientTestRunner();
+  });
+
   beforeEach(() => {
     vi.stubGlobal(
       'ResizeObserver',
@@ -99,30 +67,29 @@ describe('deployment list connection status visibility', () => {
         },
       },
     });
-    Object.assign(page.params, { namespace: 'default' });
-    Object.assign(page.data, {
-      systemInfo: { capabilities: { serverScaledDeployments: true } },
-    });
   });
 
   afterEach(async () => {
-    await Promise.all(mounted.splice(0).map((component) => unmount(component)));
-    document.body.replaceChildren();
+    await client.cleanup();
     vi.unstubAllGlobals();
   });
 
+  afterAll(closeDeploymentClientTestRunner);
+
   test('keeps providers visible while hiding statuses by default and restores statuses when enabled', async () => {
-    const hidden = renderRows();
+    const hidden = client.renderRows({ computeStatuses });
 
     expect(hidden.textContent?.match(/Lambda/g)).toHaveLength(3);
     for (const status of Object.keys(computeStatuses)) {
       expect(hidden.textContent).not.toContain(status);
     }
 
-    await Promise.all(mounted.splice(0).map((component) => unmount(component)));
-    document.body.replaceChildren();
+    await client.cleanup();
 
-    const visible = renderRows(true);
+    const visible = client.renderRows({
+      computeStatuses,
+      showConnectionStatus: true,
+    });
 
     expect(visible.textContent?.match(/Lambda/g)).toHaveLength(3);
     for (const status of Object.keys(computeStatuses)) {

--- a/src/lib/components/deployments/deployments-service-client-test-double.ts
+++ b/src/lib/components/deployments/deployments-service-client-test-double.ts
@@ -1,0 +1,41 @@
+let deployment: unknown;
+let deploymentVersion: unknown;
+
+export function resetDeploymentsServiceMock({
+  fetchDeployment,
+  fetchDeploymentVersion,
+}: {
+  fetchDeployment?: unknown;
+  fetchDeploymentVersion?: unknown;
+} = {}) {
+  deployment = fetchDeployment;
+  deploymentVersion = fetchDeploymentVersion;
+}
+
+export async function fetchDeployment(): Promise<unknown> {
+  return deployment;
+}
+
+export async function fetchDeploymentVersion(): Promise<unknown> {
+  return deploymentVersion;
+}
+
+export async function deleteWorkerDeployment(): Promise<void> {}
+
+export async function deleteWorkerDeploymentVersion(): Promise<void> {}
+
+export async function removeRampingUnversionedWorkers(): Promise<void> {}
+
+export async function setRampingUnversionedWorkers(): Promise<void> {}
+
+export function decodeLambdaProviderDetails() {
+  return {};
+}
+
+export function decodeGcpCloudRunProviderDetails() {
+  return {};
+}
+
+export function decodeScalerDetails() {
+  return {};
+}

--- a/src/lib/components/deployments/timestamp-client-test-double.svelte
+++ b/src/lib/components/deployments/timestamp-client-test-double.svelte
@@ -1,0 +1,7 @@
+<script module lang="ts">
+  export function timestamp() {
+    return '';
+  }
+</script>
+
+<span></span>

--- a/src/lib/components/deployments/vite-client-test-double.ts
+++ b/src/lib/components/deployments/vite-client-test-double.ts
@@ -1,0 +1,22 @@
+export function createHotContext() {
+  return {
+    accept() {},
+    acceptExports() {},
+    data: {},
+    decline() {},
+    dispose() {},
+    invalidate() {},
+    off() {},
+    on() {},
+    prune() {},
+    send() {},
+  };
+}
+
+export function injectQuery(url: string) {
+  return url;
+}
+
+export function removeStyle() {}
+
+export function updateStyle() {}

--- a/src/lib/components/workers/serverless-worker-form/cloud-run-terraform.ts
+++ b/src/lib/components/workers/serverless-worker-form/cloud-run-terraform.ts
@@ -1,12 +1,24 @@
 const CLOUD_RUN_PROJECT_TOKEN = '"__TEMPORAL_GCP_PROJECT_ID__"';
 const CLOUD_RUN_PROJECT_PLACEHOLDER = '<YOUR-GCP-PROJECT-ID>';
+const CLOUD_RUN_IMPERSONATOR_PLACEHOLDER =
+  '<REPLACE-WITH-IMPERSONATOR-SERVICE-ACCOUNT-EMAIL>';
+
+const escapeTerraformTemplateSequences = (value: string): string =>
+  value.replaceAll('${', () => '$${').replaceAll('%{', () => '%%{');
 
 export function interpolateCloudRunTerraformTemplate(
   template: string,
   projectId: string,
 ): string {
-  return template.replace(
-    CLOUD_RUN_PROJECT_TOKEN,
-    JSON.stringify(projectId || CLOUD_RUN_PROJECT_PLACEHOLDER),
+  const resolvedProjectId = escapeTerraformTemplateSequences(
+    projectId || CLOUD_RUN_PROJECT_PLACEHOLDER,
   );
+
+  return template.replaceAll(CLOUD_RUN_PROJECT_TOKEN, () =>
+    JSON.stringify(resolvedProjectId),
+  );
+}
+
+export function hasCloudRunImpersonatorPlaceholder(template: string): boolean {
+  return template.includes(CLOUD_RUN_IMPERSONATOR_PLACEHOLDER);
 }

--- a/src/lib/components/workers/serverless-worker-form/cloud-run-terraform.ts
+++ b/src/lib/components/workers/serverless-worker-form/cloud-run-terraform.ts
@@ -1,0 +1,12 @@
+const CLOUD_RUN_PROJECT_TOKEN = '"__TEMPORAL_GCP_PROJECT_ID__"';
+const CLOUD_RUN_PROJECT_PLACEHOLDER = '<YOUR-GCP-PROJECT-ID>';
+
+export function interpolateCloudRunTerraformTemplate(
+  template: string,
+  projectId: string,
+): string {
+  return template.replace(
+    CLOUD_RUN_PROJECT_TOKEN,
+    JSON.stringify(projectId || CLOUD_RUN_PROJECT_PLACEHOLDER),
+  );
+}

--- a/src/lib/components/workers/serverless-worker-form/compute-fields-code-block-test-double.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields-code-block-test-double.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  interface Props {
+    content: string;
+    label?: string;
+  }
+
+  let { content, label }: Props = $props();
+</script>
+
+<pre data-testid="terraform-code-block" aria-label={label}>{content}</pre>

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -10,9 +10,13 @@
   import { translate } from '$lib/i18n/translate';
 
   import { GCP_REGIONS } from './gcp-regions';
+  import cloudRunTerraformTemplate from './serverless-worker-cloud-run.tf?raw';
   import defaultTerraformTemplate from './serverless-worker-lambda.tf?raw';
   import { interpolateTerraformTemplate } from './shared';
   import cfnTemplate from './temporal-worker-role.yaml?raw';
+
+  const CLOUD_RUN_PROJECT_TOKEN = '"__TEMPORAL_GCP_PROJECT_ID__"';
+  const CLOUD_RUN_PROJECT_PLACEHOLDER = '<YOUR-GCP-PROJECT-ID>';
 
   interface Props {
     provider?: string;
@@ -88,6 +92,12 @@
       },
     ),
   );
+  const resolvedCloudRunTerraformTemplate = $derived(
+    cloudRunTerraformTemplate.replace(
+      CLOUD_RUN_PROJECT_TOKEN,
+      JSON.stringify(gcpProject || CLOUD_RUN_PROJECT_PLACEHOLDER),
+    ),
+  );
 
   const launchStackHref = $derived.by(() => {
     if (!cfnTemplateUrl) {
@@ -106,6 +116,7 @@
   });
 
   let showRoleHelp = $state(false);
+  let showCloudRunHelp = $state(false);
   let showScaling = $state(false);
   let activeRoleHelpTab = $state<'cloudformation' | 'terraform'>(
     'cloudformation',
@@ -302,17 +313,51 @@
     </Accordion>
   </div>
 {:else}
-  <Input
-    bind:value={gcpServiceAccount}
-    id="gcpServiceAccount"
-    name="gcpServiceAccount"
-    label={translate('workers.gcp-service-account-label')}
-    hintText={errors.gcpServiceAccount?.[0] ||
-      translate('workers.gcp-service-account-hint')}
-    error={!!errors.gcpServiceAccount?.[0]}
-    placeholder={translate('workers.gcp-service-account-placeholder')}
-    required
-  />
+  <div class="flex flex-col gap-4">
+    <Input
+      bind:value={gcpServiceAccount}
+      id="gcpServiceAccount"
+      name="gcpServiceAccount"
+      label={translate('workers.gcp-service-account-label')}
+      hintText={errors.gcpServiceAccount?.[0] ||
+        translate('workers.gcp-service-account-hint')}
+      error={!!errors.gcpServiceAccount?.[0]}
+      placeholder={translate('workers.gcp-service-account-placeholder')}
+      required
+    />
+    {#if provider === 'cloud-run'}
+      <Accordion
+        icon="info"
+        title={translate('workers.cloud-run-setup-prompt')}
+        bind:open={showCloudRunHelp}
+        class="[&_h3]:text-sm"
+      >
+        <div class="-mt-8 flex flex-col gap-3 border-t border-subtle pt-3">
+          <p class="text-sm text-secondary">
+            {translate('workers.cloud-run-terraform-description-before')}<Link
+              href="https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/gcp/cloud-run"
+              newTab
+              >{translate('workers.cloud-run-terraform-module-link')}</Link
+            >{translate('workers.cloud-run-terraform-description-after')}
+          </p>
+          <p class="text-sm text-warning">
+            {translate('workers.cloud-run-impersonator-warning')}
+          </p>
+          <CodeBlock
+            content={resolvedCloudRunTerraformTemplate}
+            language="text"
+            maxHeight={300}
+            copyable
+            copyIconTitle={translate('workers.copy-snippet')}
+            copySuccessIconTitle={translate('workers.copied')}
+          />
+          <p class="text-sm text-secondary">
+            {translate('workers.cloud-run-invoker-handoff')}
+          </p>
+        </div>
+      </Accordion>
+    {/if}
+  </div>
 {/if}
 
 <hr class="my-5 border-subtle" />

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -9,14 +9,12 @@
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
   import { translate } from '$lib/i18n/translate';
 
+  import { interpolateCloudRunTerraformTemplate } from './cloud-run-terraform';
   import { GCP_REGIONS } from './gcp-regions';
   import cloudRunTerraformTemplate from './serverless-worker-cloud-run.tf?raw';
   import defaultTerraformTemplate from './serverless-worker-lambda.tf?raw';
   import { interpolateTerraformTemplate } from './shared';
   import cfnTemplate from './temporal-worker-role.yaml?raw';
-
-  const CLOUD_RUN_PROJECT_TOKEN = '"__TEMPORAL_GCP_PROJECT_ID__"';
-  const CLOUD_RUN_PROJECT_PLACEHOLDER = '<YOUR-GCP-PROJECT-ID>';
 
   interface Props {
     provider?: string;
@@ -93,10 +91,7 @@
     ),
   );
   const resolvedCloudRunTerraformTemplate = $derived(
-    cloudRunTerraformTemplate.replace(
-      CLOUD_RUN_PROJECT_TOKEN,
-      JSON.stringify(gcpProject || CLOUD_RUN_PROJECT_PLACEHOLDER),
-    ),
+    interpolateCloudRunTerraformTemplate(cloudRunTerraformTemplate, gcpProject),
   );
 
   const launchStackHref = $derived.by(() => {

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -9,9 +9,12 @@
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  import { interpolateCloudRunTerraformTemplate } from './cloud-run-terraform';
+  import {
+    hasCloudRunImpersonatorPlaceholder,
+    interpolateCloudRunTerraformTemplate,
+  } from './cloud-run-terraform';
   import { GCP_REGIONS } from './gcp-regions';
-  import cloudRunTerraformTemplate from './serverless-worker-cloud-run.tf?raw';
+  import defaultCloudRunTerraformTemplate from './serverless-worker-cloud-run.tf?raw';
   import defaultTerraformTemplate from './serverless-worker-lambda.tf?raw';
   import { interpolateTerraformTemplate } from './shared';
   import cfnTemplate from './temporal-worker-role.yaml?raw';
@@ -37,6 +40,7 @@
     cfnTemplateUrl?: string;
     cfnTemplate?: string;
     terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
     errors?: {
       lambdaArn?: string[];
       iamRoleArn?: string[];
@@ -77,6 +81,7 @@
     cfnTemplateUrl,
     cfnTemplate: cfnTemplateProp,
     terraformTemplate,
+    cloudRunTerraformTemplate,
     errors = {},
   }: Props = $props();
 
@@ -91,7 +96,13 @@
     ),
   );
   const resolvedCloudRunTerraformTemplate = $derived(
-    interpolateCloudRunTerraformTemplate(cloudRunTerraformTemplate, gcpProject),
+    interpolateCloudRunTerraformTemplate(
+      cloudRunTerraformTemplate ?? defaultCloudRunTerraformTemplate,
+      gcpProject,
+    ),
+  );
+  const showCloudRunImpersonatorWarning = $derived(
+    hasCloudRunImpersonatorPlaceholder(resolvedCloudRunTerraformTemplate),
   );
 
   const launchStackHref = $derived.by(() => {
@@ -335,14 +346,17 @@
               >{translate('workers.cloud-run-terraform-module-link')}</Link
             >{translate('workers.cloud-run-terraform-description-after')}
           </p>
-          <p class="text-sm text-warning">
-            {translate('workers.cloud-run-impersonator-warning')}
-          </p>
+          {#if showCloudRunImpersonatorWarning}
+            <p class="text-sm text-warning">
+              {translate('workers.cloud-run-impersonator-warning')}
+            </p>
+          {/if}
           <CodeBlock
             content={resolvedCloudRunTerraformTemplate}
             language="text"
             maxHeight={300}
             copyable
+            label={translate('workers.cloud-run-terraform-module-link')}
             copyIconTitle={translate('workers.copy-snippet')}
             copySuccessIconTitle={translate('workers.copied')}
           />

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
@@ -1,0 +1,145 @@
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ComputeFields from './compute-fields.svelte';
+
+vi.stubGlobal(
+  'ResizeObserver',
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+const cloudRunModuleUrl =
+  'https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/gcp/cloud-run';
+const mountedComponents: Record<string, unknown>[] = [];
+
+const expectedTerraform = (
+  projectId: string,
+) => `# Terraform GCP Service Account Module for Cloud Run Serverless Workers.
+module "serverless-worker-cloud-run" {
+  source = "github.com/temporalio/terraform-modules//modules/serverless-workers/gcp/cloud-run"
+
+  project_id         = "${projectId}"
+  invoker_account_id = "temporal-worker-pool-invoker"
+
+  # REPLACE BEFORE APPLY with the service account email provided by Temporal Cloud.
+  impersonator_service_account_emails = [
+    "<REPLACE-WITH-TEMPORAL-CLOUD-SERVICE-ACCOUNT-EMAIL>",
+  ]
+}
+
+# Once applied, provide the invoker_email output value to Temporal Cloud.
+`;
+
+const renderComputeFields = (provider: string, gcpProject = '') => {
+  const target = document.createElement('div');
+  document.body.append(target);
+  const component = mount(ComputeFields, {
+    target,
+    props: {
+      provider,
+      lambdaArn: '',
+      iamRoleArn: '',
+      roleExternalId: '',
+      gcpProject,
+    },
+  });
+  mountedComponents.push(component);
+  return target;
+};
+
+const getCopyButton = (target: HTMLElement) => {
+  const button = target.querySelector<HTMLButtonElement>(
+    '[data-track-name="copyable-button"]',
+  );
+  expect(button).not.toBeNull();
+  return button as HTMLButtonElement;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    mountedComponents.splice(0).map((component) => unmount(component)),
+  );
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('ComputeFields Cloud Run setup guidance', () => {
+  it('renders expandable setup guidance with the Cloud Run module link', async () => {
+    const target = renderComputeFields('cloud-run', 'initial-project');
+    await tick();
+
+    const accordion = target.querySelector<HTMLButtonElement>(
+      '[data-track-name="accordion"]',
+    );
+    expect(accordion?.textContent).toContain(
+      "Don't have a service account yet? Create one",
+    );
+    expect(accordion?.getAttribute('aria-expanded')).toBe('false');
+
+    accordion?.click();
+    await tick();
+
+    expect(accordion?.getAttribute('aria-expanded')).toBe('true');
+    const moduleLink = target.querySelector<HTMLAnchorElement>(
+      `a[href="${cloudRunModuleUrl}"]`,
+    );
+    expect(moduleLink?.textContent.trim()).toBe('Google Cloud Run Module');
+    expect(moduleLink?.target).toBe('_blank');
+    expect(target.textContent).toContain(
+      'Before applying, replace the impersonator service account placeholder',
+    );
+    expect(target.textContent).toContain(
+      "copy the module's invoker_email output into the Service Account field above",
+    );
+  });
+
+  it('copies the current project and updates the snippet reactively', async () => {
+    const writeText = vi.fn<(content: string) => Promise<void>>();
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const target = renderComputeFields('cloud-run', 'initial-project');
+    await tick();
+
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expectedTerraform('initial-project'),
+      );
+    });
+
+    const projectInput = target.querySelector<HTMLInputElement>('#gcpProject');
+    expect(projectInput).not.toBeNull();
+    if (!projectInput) return;
+
+    projectInput.value = 'updated-project';
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+    writeText.mockClear();
+
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expectedTerraform('updated-project'),
+      );
+    });
+  });
+
+  it('does not render Cloud Run guidance for Lambda', async () => {
+    const target = renderComputeFields('lambda');
+    await tick();
+
+    expect(target.textContent).toContain("Don't have a role yet? Create one");
+    expect(target.textContent).not.toContain(
+      "Don't have a service account yet? Create one",
+    );
+    expect(target.querySelector(`a[href="${cloudRunModuleUrl}"]`)).toBeNull();
+  });
+});

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
@@ -1,25 +1,289 @@
-import { describe, expect, it } from 'vitest';
+import { mount, tick, unmount } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { interpolateCloudRunTerraformTemplate } from './cloud-run-terraform';
+import {
+  hasCloudRunImpersonatorPlaceholder,
+  interpolateCloudRunTerraformTemplate,
+} from './cloud-run-terraform';
 
-const template = 'project_id = "__TEMPORAL_GCP_PROJECT_ID__"';
+import ComputeFields from './compute-fields.svelte';
 
-describe('interpolateCloudRunTerraformTemplate', () => {
-  it('inserts the current GCP project ID as a Terraform string value', () => {
+vi.stubGlobal(
+  'ResizeObserver',
+  class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  },
+);
+
+const projectToken = '"__TEMPORAL_GCP_PROJECT_ID__"';
+const impersonatorPlaceholder =
+  '<REPLACE-WITH-IMPERSONATOR-SERVICE-ACCOUNT-EMAIL>';
+const impersonatorWarning =
+  'Before applying, replace the impersonator service account placeholder with the email of the service account permitted to impersonate the invoker.';
+const cloudRunModuleUrl =
+  'https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/gcp/cloud-run';
+const mountedComponents: Record<string, unknown>[] = [];
+
+const expectedTerraform = (
+  projectId: string,
+) => `# Terraform GCP Service Account Module for Cloud Run Serverless Workers.
+module "serverless-worker-cloud-run" {
+  source = "github.com/temporalio/terraform-modules//modules/serverless-workers/gcp/cloud-run"
+
+  project_id         = "${projectId}"
+  invoker_account_id = "temporal-worker-pool-invoker"
+
+  # REPLACE BEFORE APPLY with the email of the service account permitted to impersonate the invoker.
+  impersonator_service_account_emails = [
+    "${impersonatorPlaceholder}",
+  ]
+}
+
+# Once applied, use the invoker_email output value as the Service Account for the Worker deployment.
+`;
+
+interface ComputeFieldsOptions {
+  provider: string;
+  gcpProject?: string;
+  cloudRunTerraformTemplate?: string;
+  terraformTemplate?: string;
+}
+
+const renderComputeFields = ({
+  provider,
+  gcpProject = '',
+  cloudRunTerraformTemplate,
+  terraformTemplate,
+}: ComputeFieldsOptions) => {
+  const target = document.createElement('div');
+  document.body.append(target);
+  const component = mount(ComputeFields, {
+    target,
+    props: {
+      provider,
+      lambdaArn: '',
+      iamRoleArn: '',
+      roleExternalId: '',
+      gcpProject,
+      cloudRunTerraformTemplate,
+      terraformTemplate,
+    },
+  });
+  mountedComponents.push(component);
+  return target;
+};
+
+const openAccordion = async (target: HTMLElement) => {
+  const accordion = target.querySelector<HTMLButtonElement>(
+    '[data-track-name="accordion"]',
+  );
+  expect(accordion).not.toBeNull();
+  accordion?.click();
+  await tick();
+  return accordion;
+};
+
+const getCopyButton = (target: HTMLElement) => {
+  const button = target.querySelector<HTMLButtonElement>(
+    '[data-track-name="copyable-button"]',
+  );
+  expect(button).not.toBeNull();
+  return button as HTMLButtonElement;
+};
+
+const stubClipboard = () => {
+  const writeText = vi.fn<(content: string) => Promise<void>>();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+  return writeText;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    mountedComponents.splice(0).map((component) => unmount(component)),
+  );
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('Cloud Run Terraform helpers', () => {
+  it('interpolates every project token and uses the setup placeholder when empty', () => {
+    const template = `first = ${projectToken}\nsecond = ${projectToken}`;
+
     expect(interpolateCloudRunTerraformTemplate(template, 'my-project')).toBe(
-      'project_id = "my-project"',
+      'first = "my-project"\nsecond = "my-project"',
+    );
+    expect(interpolateCloudRunTerraformTemplate(projectToken, '')).toBe(
+      '"<YOUR-GCP-PROJECT-ID>"',
     );
   });
 
-  it('uses the setup placeholder when no GCP project ID is available', () => {
-    expect(interpolateCloudRunTerraformTemplate(template, '')).toBe(
-      'project_id = "<YOUR-GCP-PROJECT-ID>"',
+  it('escapes the project as an HCL string without enabling template interpolation', () => {
+    expect(
+      interpolateCloudRunTerraformTemplate(
+        `project_id = ${projectToken}`,
+        'project"\\name-${region}-%{if true}',
+      ),
+    ).toBe('project_id = "project\\"\\\\name-$${region}-%%{if true}"');
+  });
+
+  it('preserves JavaScript replacement-pattern characters in the project value', () => {
+    expect(interpolateCloudRunTerraformTemplate(projectToken, "$&-$`-$'")).toBe(
+      '"$&-$`-$\'"',
     );
   });
 
-  it('escapes project IDs safely for Terraform', () => {
-    expect(interpolateCloudRunTerraformTemplate(template, 'project"name')).toBe(
-      'project_id = "project\\"name"',
+  it('detects only the bundled impersonator placeholder in resolved content', () => {
+    expect(
+      hasCloudRunImpersonatorPlaceholder(
+        `impersonator_service_account_emails = ["${impersonatorPlaceholder}"]`,
+      ),
+    ).toBe(true);
+    expect(
+      hasCloudRunImpersonatorPlaceholder(
+        '<REPLACE-WITH-TEMPORAL-CLOUD-SERVICE-ACCOUNT-EMAIL>',
+      ),
+    ).toBe(false);
+    expect(hasCloudRunImpersonatorPlaceholder('host@example.com')).toBe(false);
+  });
+});
+
+describe('ComputeFields Cloud Run setup guidance', () => {
+  it('renders the guidance link and an accessible Terraform snippet label', async () => {
+    const target = renderComputeFields({
+      provider: 'cloud-run',
+      gcpProject: 'initial-project',
+    });
+    await tick();
+
+    const accordion = await openAccordion(target);
+    expect(accordion?.textContent).toContain(
+      "Don't have a service account yet? Create one",
     );
+    expect(accordion?.getAttribute('aria-expanded')).toBe('true');
+
+    const moduleLink = target.querySelector<HTMLAnchorElement>(
+      `a[href="${cloudRunModuleUrl}"]`,
+    );
+    expect(moduleLink?.textContent.trim()).toBe('Google Cloud Run Module');
+    expect(moduleLink?.target).toBe('_blank');
+    expect(target.textContent).toContain(impersonatorWarning);
+    expect(target.textContent).toContain(
+      "copy the module's invoker_email output into the Service Account field above",
+    );
+    expect(
+      target.querySelector(
+        '.cm-content[aria-label="Google Cloud Run Module"][aria-readonly="true"]',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('uses the bundled template and updates its project reactively', async () => {
+    const writeText = stubClipboard();
+    const target = renderComputeFields({
+      provider: 'cloud-run',
+      gcpProject: 'initial-project',
+    });
+    await tick();
+    await openAccordion(target);
+
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expectedTerraform('initial-project'),
+      );
+    });
+
+    const projectInput = target.querySelector<HTMLInputElement>('#gcpProject');
+    expect(projectInput).not.toBeNull();
+    if (!projectInput) return;
+
+    projectInput.value = 'updated-project';
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }));
+    await tick();
+    writeText.mockClear();
+
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        expectedTerraform('updated-project'),
+      );
+    });
+  });
+
+  it('uses a host template and shows the warning only when its content has the placeholder', async () => {
+    const writeText = stubClipboard();
+    const target = renderComputeFields({
+      provider: 'cloud-run',
+      gcpProject: 'host-project',
+      cloudRunTerraformTemplate: `project_id = ${projectToken}\nprincipal = "${impersonatorPlaceholder}"`,
+    });
+    await tick();
+    await openAccordion(target);
+
+    expect(target.textContent).toContain(impersonatorWarning);
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(
+        `project_id = "host-project"\nprincipal = "${impersonatorPlaceholder}"`,
+      );
+    });
+  });
+
+  it('omits the warning for a host template without the placeholder', async () => {
+    const target = renderComputeFields({
+      provider: 'cloud-run',
+      cloudRunTerraformTemplate: 'principal = "host-provided@example.com"',
+    });
+    await tick();
+    await openAccordion(target);
+
+    expect(target.textContent).not.toContain(impersonatorWarning);
+  });
+
+  it('treats an explicit empty host template as an override', async () => {
+    const target = renderComputeFields({
+      provider: 'cloud-run',
+      cloudRunTerraformTemplate: '',
+    });
+    await tick();
+    await openAccordion(target);
+
+    expect(target.textContent).not.toContain(impersonatorWarning);
+  });
+
+  it('isolates Cloud Run guidance from Lambda and preserves the AWS override', async () => {
+    const writeText = stubClipboard();
+    const target = renderComputeFields({
+      provider: 'lambda',
+      cloudRunTerraformTemplate: `principal = "${impersonatorPlaceholder}"`,
+      terraformTemplate: 'aws-template-from-host',
+    });
+    await tick();
+
+    expect(target.textContent).toContain("Don't have a role yet? Create one");
+    expect(target.textContent).not.toContain(
+      "Don't have a service account yet? Create one",
+    );
+    expect(target.querySelector(`a[href="${cloudRunModuleUrl}"]`)).toBeNull();
+    expect(target.textContent).not.toContain(impersonatorWarning);
+
+    await openAccordion(target);
+    const terraformTab = Array.from(
+      target.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent?.trim() === 'Terraform');
+    expect(terraformTab).not.toBeUndefined();
+    terraformTab?.click();
+    await tick();
+
+    getCopyButton(target).click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith('aws-template-from-host');
+    });
   });
 });

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
@@ -1,21 +1,67 @@
-import { mount, tick, unmount } from 'svelte';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+// @vitest-environment node
+
+import path from 'node:path';
+
+import type { render } from 'svelte/server';
+
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import type { Component } from 'svelte';
+import { createServer, type ViteDevServer } from 'vite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
   hasCloudRunImpersonatorPlaceholder,
   interpolateCloudRunTerraformTemplate,
 } from './cloud-run-terraform';
+import defaultCloudRunTerraformTemplate from './serverless-worker-cloud-run.tf?raw';
 
-import ComputeFields from './compute-fields.svelte';
+let computeFields: Component<Record<string, unknown>>;
+let renderComponent: typeof render;
+let viteServer: ViteDevServer;
 
-vi.stubGlobal(
-  'ResizeObserver',
-  class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  },
-);
+beforeAll(async () => {
+  const projectRoot = process.cwd();
+  viteServer = await createServer({
+    root: projectRoot,
+    configFile: false,
+    appType: 'custom',
+    plugins: [svelte({ hot: false })],
+    resolve: {
+      alias: [
+        {
+          find: '$lib/holocene/code-block.svelte',
+          replacement: path.resolve(
+            projectRoot,
+            'src/lib/components/workers/serverless-worker-form/compute-fields-code-block-test-double.svelte',
+          ),
+        },
+        {
+          find: '$lib',
+          replacement: path.resolve(projectRoot, 'src/lib'),
+        },
+        {
+          find: '$types',
+          replacement: path.resolve(projectRoot, 'src/types'),
+        },
+        {
+          find: '$app',
+          replacement: path.resolve(projectRoot, 'src/lib/svelte-mocks/app'),
+        },
+      ],
+    },
+    server: { middlewareMode: true },
+  });
+  computeFields = (
+    await viteServer.ssrLoadModule(
+      '/src/lib/components/workers/serverless-worker-form/compute-fields.svelte',
+    )
+  ).default;
+  renderComponent = (await viteServer.ssrLoadModule('svelte/server')).render;
+});
+
+afterAll(async () => {
+  await viteServer?.close();
+});
 
 const projectToken = '"__TEMPORAL_GCP_PROJECT_ID__"';
 const impersonatorPlaceholder =
@@ -24,25 +70,6 @@ const impersonatorWarning =
   'Before applying, replace the impersonator service account placeholder with the email of the service account permitted to impersonate the invoker.';
 const cloudRunModuleUrl =
   'https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/gcp/cloud-run';
-const mountedComponents: Record<string, unknown>[] = [];
-
-const expectedTerraform = (
-  projectId: string,
-) => `# Terraform GCP Service Account Module for Cloud Run Serverless Workers.
-module "serverless-worker-cloud-run" {
-  source = "github.com/temporalio/terraform-modules//modules/serverless-workers/gcp/cloud-run"
-
-  project_id         = "${projectId}"
-  invoker_account_id = "temporal-worker-pool-invoker"
-
-  # REPLACE BEFORE APPLY with the email of the service account permitted to impersonate the invoker.
-  impersonator_service_account_emails = [
-    "${impersonatorPlaceholder}",
-  ]
-}
-
-# Once applied, use the invoker_email output value as the Service Account for the Worker deployment.
-`;
 
 interface ComputeFieldsOptions {
   provider: string;
@@ -56,11 +83,8 @@ const renderComputeFields = ({
   gcpProject = '',
   cloudRunTerraformTemplate,
   terraformTemplate,
-}: ComputeFieldsOptions) => {
-  const target = document.createElement('div');
-  document.body.append(target);
-  const component = mount(ComputeFields, {
-    target,
+}: ComputeFieldsOptions): string => {
+  const { body } = renderComponent(computeFields, {
     props: {
       provider,
       lambdaArn: '',
@@ -71,45 +95,17 @@ const renderComputeFields = ({
       terraformTemplate,
     },
   });
-  mountedComponents.push(component);
-  return target;
+  return body;
 };
 
-const openAccordion = async (target: HTMLElement) => {
-  const accordion = target.querySelector<HTMLButtonElement>(
-    '[data-track-name="accordion"]',
-  );
-  expect(accordion).not.toBeNull();
-  accordion?.click();
-  await tick();
-  return accordion;
-};
-
-const getCopyButton = (target: HTMLElement) => {
-  const button = target.querySelector<HTMLButtonElement>(
-    '[data-track-name="copyable-button"]',
-  );
-  expect(button).not.toBeNull();
-  return button as HTMLButtonElement;
-};
-
-const stubClipboard = () => {
-  const writeText = vi.fn<(content: string) => Promise<void>>();
-  writeText.mockResolvedValue(undefined);
-  Object.defineProperty(navigator, 'clipboard', {
-    configurable: true,
-    value: { writeText },
-  });
-  return writeText;
-};
-
-afterEach(async () => {
-  await Promise.all(
-    mountedComponents.splice(0).map((component) => unmount(component)),
-  );
-  document.body.innerHTML = '';
-  vi.restoreAllMocks();
-});
+const getTerraformSnippet = (body: string): string | undefined =>
+  body
+    .match(
+      /<pre[^>]*data-testid="terraform-code-block"[^>]*>([\s\S]*?)<\/pre>/,
+    )?.[1]
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&');
 
 describe('Cloud Run Terraform helpers', () => {
   it('interpolates every project token and uses the setup placeholder when empty', () => {
@@ -138,11 +134,9 @@ describe('Cloud Run Terraform helpers', () => {
     );
   });
 
-  it('detects only the bundled impersonator placeholder in resolved content', () => {
+  it('detects the actual bundled placeholder rather than how the template was supplied', () => {
     expect(
-      hasCloudRunImpersonatorPlaceholder(
-        `impersonator_service_account_emails = ["${impersonatorPlaceholder}"]`,
-      ),
+      hasCloudRunImpersonatorPlaceholder(defaultCloudRunTerraformTemplate),
     ).toBe(true);
     expect(
       hasCloudRunImpersonatorPlaceholder(
@@ -153,137 +147,79 @@ describe('Cloud Run Terraform helpers', () => {
   });
 });
 
-describe('ComputeFields Cloud Run setup guidance', () => {
-  it('renders the guidance link and an accessible Terraform snippet label', async () => {
-    const target = renderComputeFields({
+describe('ComputeFields server-rendered setup guidance', () => {
+  it('renders Cloud Run guidance, link, warning, and accessible snippet label', () => {
+    const body = renderComputeFields({
       provider: 'cloud-run',
       gcpProject: 'initial-project',
     });
-    await tick();
 
-    const accordion = await openAccordion(target);
-    expect(accordion?.textContent).toContain(
-      "Don't have a service account yet? Create one",
-    );
-    expect(accordion?.getAttribute('aria-expanded')).toBe('true');
-
-    const moduleLink = target.querySelector<HTMLAnchorElement>(
-      `a[href="${cloudRunModuleUrl}"]`,
-    );
-    expect(moduleLink?.textContent.trim()).toBe('Google Cloud Run Module');
-    expect(moduleLink?.target).toBe('_blank');
-    expect(target.textContent).toContain(impersonatorWarning);
-    expect(target.textContent).toContain(
+    expect(body).toContain("Don't have a service account yet? Create one");
+    expect(body).toContain(`href="${cloudRunModuleUrl}"`);
+    expect(body).toContain('target="_blank"');
+    expect(body).toContain('Google Cloud Run Module');
+    expect(body).toContain(impersonatorWarning);
+    expect(body).toContain(
       "copy the module's invoker_email output into the Service Account field above",
     );
-    expect(
-      target.querySelector(
-        '.cm-content[aria-label="Google Cloud Run Module"][aria-readonly="true"]',
-      ),
-    ).not.toBeNull();
+
+    expect(body).toContain('aria-label="Google Cloud Run Module"');
+    expect(getTerraformSnippet(body)).toContain(
+      'project_id         = "initial-project"',
+    );
   });
 
-  it('uses the bundled template and updates its project reactively', async () => {
-    const writeText = stubClipboard();
-    const target = renderComputeFields({
-      provider: 'cloud-run',
-      gcpProject: 'initial-project',
-    });
-    await tick();
-    await openAccordion(target);
+  it('reflects project changes at the helper/component boundary', () => {
+    const initial = getTerraformSnippet(
+      renderComputeFields({ provider: 'cloud-run', gcpProject: 'initial' }),
+    );
+    const updated = getTerraformSnippet(
+      renderComputeFields({ provider: 'cloud-run', gcpProject: 'updated' }),
+    );
 
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        expectedTerraform('initial-project'),
-      );
-    });
-
-    const projectInput = target.querySelector<HTMLInputElement>('#gcpProject');
-    expect(projectInput).not.toBeNull();
-    if (!projectInput) return;
-
-    projectInput.value = 'updated-project';
-    projectInput.dispatchEvent(new Event('input', { bubbles: true }));
-    await tick();
-    writeText.mockClear();
-
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        expectedTerraform('updated-project'),
-      );
-    });
+    expect(initial).toContain('project_id         = "initial"');
+    expect(updated).toContain('project_id         = "updated"');
+    expect(updated).not.toContain('project_id         = "initial"');
   });
 
-  it('uses a host template and shows the warning only when its content has the placeholder', async () => {
-    const writeText = stubClipboard();
-    const target = renderComputeFields({
+  it('uses a host template and derives its warning from placeholder content', () => {
+    const body = renderComputeFields({
       provider: 'cloud-run',
       gcpProject: 'host-project',
       cloudRunTerraformTemplate: `project_id = ${projectToken}\nprincipal = "${impersonatorPlaceholder}"`,
     });
-    await tick();
-    await openAccordion(target);
 
-    expect(target.textContent).toContain(impersonatorWarning);
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        `project_id = "host-project"\nprincipal = "${impersonatorPlaceholder}"`,
-      );
-    });
+    expect(body).toContain(impersonatorWarning);
+    expect(getTerraformSnippet(body)).toBe(
+      `project_id = "host-project"\nprincipal = "${impersonatorPlaceholder}"`,
+    );
   });
 
-  it('omits the warning for a host template without the placeholder', async () => {
-    const target = renderComputeFields({
+  it.each([
+    ['custom content', 'principal = "host-provided@example.com"'],
+    ['an explicit empty override', ''],
+  ])('omits the warning for %s without the placeholder', (_, template) => {
+    const body = renderComputeFields({
       provider: 'cloud-run',
-      cloudRunTerraformTemplate: 'principal = "host-provided@example.com"',
+      cloudRunTerraformTemplate: template,
     });
-    await tick();
-    await openAccordion(target);
 
-    expect(target.textContent).not.toContain(impersonatorWarning);
+    expect(body).not.toContain(impersonatorWarning);
+    expect(getTerraformSnippet(body)).toBe(template);
   });
 
-  it('treats an explicit empty host template as an override', async () => {
-    const target = renderComputeFields({
-      provider: 'cloud-run',
-      cloudRunTerraformTemplate: '',
-    });
-    await tick();
-    await openAccordion(target);
-
-    expect(target.textContent).not.toContain(impersonatorWarning);
-  });
-
-  it('isolates Cloud Run guidance from Lambda and preserves the AWS override', async () => {
-    const writeText = stubClipboard();
-    const target = renderComputeFields({
+  it('isolates Cloud Run guidance and templates from Lambda', () => {
+    const body = renderComputeFields({
       provider: 'lambda',
       cloudRunTerraformTemplate: `principal = "${impersonatorPlaceholder}"`,
       terraformTemplate: 'aws-template-from-host',
     });
-    await tick();
 
-    expect(target.textContent).toContain("Don't have a role yet? Create one");
-    expect(target.textContent).not.toContain(
-      "Don't have a service account yet? Create one",
-    );
-    expect(target.querySelector(`a[href="${cloudRunModuleUrl}"]`)).toBeNull();
-    expect(target.textContent).not.toContain(impersonatorWarning);
-
-    await openAccordion(target);
-    const terraformTab = Array.from(
-      target.querySelectorAll<HTMLButtonElement>('button'),
-    ).find((button) => button.textContent?.trim() === 'Terraform');
-    expect(terraformTab).not.toBeUndefined();
-    terraformTab?.click();
-    await tick();
-
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith('aws-template-from-host');
-    });
+    expect(body).toContain("Don't have a role yet? Create one");
+    expect(body).not.toContain("Don't have a service account yet? Create one");
+    expect(body).not.toContain(`href="${cloudRunModuleUrl}"`);
+    expect(body).not.toContain(impersonatorWarning);
+    expect(body).not.toContain(impersonatorPlaceholder);
+    expect(getTerraformSnippet(body)).toBeUndefined();
   });
 });

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.test.ts
@@ -1,145 +1,25 @@
-import { mount, tick, unmount } from 'svelte';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import ComputeFields from './compute-fields.svelte';
+import { interpolateCloudRunTerraformTemplate } from './cloud-run-terraform';
 
-vi.stubGlobal(
-  'ResizeObserver',
-  class ResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
-  },
-);
+const template = 'project_id = "__TEMPORAL_GCP_PROJECT_ID__"';
 
-const cloudRunModuleUrl =
-  'https://github.com/temporalio/terraform-modules/tree/main/modules/serverless-workers/gcp/cloud-run';
-const mountedComponents: Record<string, unknown>[] = [];
-
-const expectedTerraform = (
-  projectId: string,
-) => `# Terraform GCP Service Account Module for Cloud Run Serverless Workers.
-module "serverless-worker-cloud-run" {
-  source = "github.com/temporalio/terraform-modules//modules/serverless-workers/gcp/cloud-run"
-
-  project_id         = "${projectId}"
-  invoker_account_id = "temporal-worker-pool-invoker"
-
-  # REPLACE BEFORE APPLY with the service account email provided by Temporal Cloud.
-  impersonator_service_account_emails = [
-    "<REPLACE-WITH-TEMPORAL-CLOUD-SERVICE-ACCOUNT-EMAIL>",
-  ]
-}
-
-# Once applied, provide the invoker_email output value to Temporal Cloud.
-`;
-
-const renderComputeFields = (provider: string, gcpProject = '') => {
-  const target = document.createElement('div');
-  document.body.append(target);
-  const component = mount(ComputeFields, {
-    target,
-    props: {
-      provider,
-      lambdaArn: '',
-      iamRoleArn: '',
-      roleExternalId: '',
-      gcpProject,
-    },
-  });
-  mountedComponents.push(component);
-  return target;
-};
-
-const getCopyButton = (target: HTMLElement) => {
-  const button = target.querySelector<HTMLButtonElement>(
-    '[data-track-name="copyable-button"]',
-  );
-  expect(button).not.toBeNull();
-  return button as HTMLButtonElement;
-};
-
-afterEach(async () => {
-  await Promise.all(
-    mountedComponents.splice(0).map((component) => unmount(component)),
-  );
-  document.body.innerHTML = '';
-  vi.restoreAllMocks();
-});
-
-describe('ComputeFields Cloud Run setup guidance', () => {
-  it('renders expandable setup guidance with the Cloud Run module link', async () => {
-    const target = renderComputeFields('cloud-run', 'initial-project');
-    await tick();
-
-    const accordion = target.querySelector<HTMLButtonElement>(
-      '[data-track-name="accordion"]',
-    );
-    expect(accordion?.textContent).toContain(
-      "Don't have a service account yet? Create one",
-    );
-    expect(accordion?.getAttribute('aria-expanded')).toBe('false');
-
-    accordion?.click();
-    await tick();
-
-    expect(accordion?.getAttribute('aria-expanded')).toBe('true');
-    const moduleLink = target.querySelector<HTMLAnchorElement>(
-      `a[href="${cloudRunModuleUrl}"]`,
-    );
-    expect(moduleLink?.textContent.trim()).toBe('Google Cloud Run Module');
-    expect(moduleLink?.target).toBe('_blank');
-    expect(target.textContent).toContain(
-      'Before applying, replace the impersonator service account placeholder',
-    );
-    expect(target.textContent).toContain(
-      "copy the module's invoker_email output into the Service Account field above",
+describe('interpolateCloudRunTerraformTemplate', () => {
+  it('inserts the current GCP project ID as a Terraform string value', () => {
+    expect(interpolateCloudRunTerraformTemplate(template, 'my-project')).toBe(
+      'project_id = "my-project"',
     );
   });
 
-  it('copies the current project and updates the snippet reactively', async () => {
-    const writeText = vi.fn<(content: string) => Promise<void>>();
-    writeText.mockResolvedValue(undefined);
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText },
-    });
-
-    const target = renderComputeFields('cloud-run', 'initial-project');
-    await tick();
-
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        expectedTerraform('initial-project'),
-      );
-    });
-
-    const projectInput = target.querySelector<HTMLInputElement>('#gcpProject');
-    expect(projectInput).not.toBeNull();
-    if (!projectInput) return;
-
-    projectInput.value = 'updated-project';
-    projectInput.dispatchEvent(new Event('input', { bubbles: true }));
-    await tick();
-    writeText.mockClear();
-
-    getCopyButton(target).click();
-    await vi.waitFor(() => {
-      expect(writeText).toHaveBeenCalledWith(
-        expectedTerraform('updated-project'),
-      );
-    });
+  it('uses the setup placeholder when no GCP project ID is available', () => {
+    expect(interpolateCloudRunTerraformTemplate(template, '')).toBe(
+      'project_id = "<YOUR-GCP-PROJECT-ID>"',
+    );
   });
 
-  it('does not render Cloud Run guidance for Lambda', async () => {
-    const target = renderComputeFields('lambda');
-    await tick();
-
-    expect(target.textContent).toContain("Don't have a role yet? Create one");
-    expect(target.textContent).not.toContain(
-      "Don't have a service account yet? Create one",
+  it('escapes project IDs safely for Terraform', () => {
+    expect(interpolateCloudRunTerraformTemplate(template, 'project"name')).toBe(
+      'project_id = "project\\"name"',
     );
-    expect(target.querySelector(`a[href="${cloudRunModuleUrl}"]`)).toBeNull();
   });
 });

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -29,6 +29,8 @@
     computeProviders?: readonly ComputeProviderOption[];
     initialProvider?: ComputeProviderOption['value'];
     gcpRegions?: string[];
+    terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
   }
 
   let {
@@ -39,6 +41,8 @@
     computeProviders,
     initialProvider,
     gcpRegions,
+    terraformTemplate,
+    cloudRunTerraformTemplate,
   }: Props = $props();
 
   const superform = superForm(
@@ -136,6 +140,8 @@
           bind:scaleUpBacklogThreshold={$form.scaleUpBacklogThreshold}
           bind:maxWorkerLifetimeMs={$form.maxWorkerLifetimeMs}
           bind:metricsPollIntervalMs={$form.metricsPollIntervalMs}
+          {terraformTemplate}
+          {cloudRunTerraformTemplate}
           errors={$errors}
         />
       </ComputeProviderPicker>

--- a/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
@@ -43,6 +43,8 @@
     error?: string;
     computeProviders?: readonly ComputeProviderOption[];
     gcpRegions?: string[];
+    terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
   }
 
   let {
@@ -53,6 +55,8 @@
     error,
     computeProviders,
     gcpRegions,
+    terraformTemplate,
+    cloudRunTerraformTemplate,
   }: Props = $props();
 
   const superform = superForm(
@@ -128,6 +132,8 @@
         bind:scaleUpBacklogThreshold={$form.scaleUpBacklogThreshold}
         bind:maxWorkerLifetimeMs={$form.maxWorkerLifetimeMs}
         bind:metricsPollIntervalMs={$form.metricsPollIntervalMs}
+        {terraformTemplate}
+        {cloudRunTerraformTemplate}
         errors={$errors}
       />
     </Card>

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-cloud-run.tf
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-cloud-run.tf
@@ -1,0 +1,14 @@
+# Terraform GCP Service Account Module for Cloud Run Serverless Workers.
+module "serverless-worker-cloud-run" {
+  source = "github.com/temporalio/terraform-modules//modules/serverless-workers/gcp/cloud-run"
+
+  project_id         = "__TEMPORAL_GCP_PROJECT_ID__"
+  invoker_account_id = "temporal-worker-pool-invoker"
+
+  # REPLACE BEFORE APPLY with the service account email provided by Temporal Cloud.
+  impersonator_service_account_emails = [
+    "<REPLACE-WITH-TEMPORAL-CLOUD-SERVICE-ACCOUNT-EMAIL>",
+  ]
+}
+
+# Once applied, provide the invoker_email output value to Temporal Cloud.

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-cloud-run.tf
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-cloud-run.tf
@@ -5,10 +5,10 @@ module "serverless-worker-cloud-run" {
   project_id         = "__TEMPORAL_GCP_PROJECT_ID__"
   invoker_account_id = "temporal-worker-pool-invoker"
 
-  # REPLACE BEFORE APPLY with the service account email provided by Temporal Cloud.
+  # REPLACE BEFORE APPLY with the email of the service account permitted to impersonate the invoker.
   impersonator_service_account_emails = [
-    "<REPLACE-WITH-TEMPORAL-CLOUD-SERVICE-ACCOUNT-EMAIL>",
+    "<REPLACE-WITH-IMPERSONATOR-SERVICE-ACCOUNT-EMAIL>",
   ]
 }
 
-# Once applied, provide the invoker_email output value to Temporal Cloud.
+# Once applied, use the invoker_email output value as the Service Account for the Worker deployment.

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
@@ -33,6 +33,7 @@
     cfnTemplateUrl?: string;
     cfnTemplate?: string;
     terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
     computeProviders?: readonly ComputeProviderOption[];
     gcpRegions?: string[];
   }
@@ -44,6 +45,7 @@
     cfnTemplateUrl,
     cfnTemplate,
     terraformTemplate,
+    cloudRunTerraformTemplate,
     computeProviders,
     gcpRegions,
   }: Props = $props();
@@ -170,6 +172,7 @@
         {cfnTemplateUrl}
         {cfnTemplate}
         {terraformTemplate}
+        {cloudRunTerraformTemplate}
         errors={$errors}
       />
     </Card>

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -338,9 +338,9 @@ export const Strings = {
   'cloud-run-terraform-description-before': 'Use our Terraform ',
   'cloud-run-terraform-module-link': 'Google Cloud Run Module',
   'cloud-run-terraform-description-after':
-    ' to create the service account Temporal Cloud impersonates to manage your Worker Pool.',
+    ' to create the invoker service account for your Worker Pool.',
   'cloud-run-impersonator-warning':
-    'Before applying, replace the impersonator service account placeholder with the service account email provided by Temporal Cloud.',
+    'Before applying, replace the impersonator service account placeholder with the email of the service account permitted to impersonate the invoker.',
   'cloud-run-invoker-handoff':
     "After applying, copy the module's invoker_email output into the Service Account field above.",
   'hide-defaults': 'Hide Defaults',

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -334,6 +334,15 @@ export const Strings = {
   'terraform-iam-module-link': 'AWS IAM Role Module',
   'terraform-description-after':
     ' to create the IAM role Temporal Cloud assumes to invoke your Lambda functions.',
+  'cloud-run-setup-prompt': "Don't have a service account yet? Create one",
+  'cloud-run-terraform-description-before': 'Use our Terraform ',
+  'cloud-run-terraform-module-link': 'Google Cloud Run Module',
+  'cloud-run-terraform-description-after':
+    ' to create the service account Temporal Cloud impersonates to manage your Worker Pool.',
+  'cloud-run-impersonator-warning':
+    'Before applying, replace the impersonator service account placeholder with the service account email provided by Temporal Cloud.',
+  'cloud-run-invoker-handoff':
+    "After applying, copy the module's invoker_email output into the Service Account field above.",
   'hide-defaults': 'Hide Defaults',
   'show-defaults': 'Show Defaults',
   'gcp-project-label': 'Project ID',

--- a/src/lib/pages/deployment.svelte.test.ts
+++ b/src/lib/pages/deployment.svelte.test.ts
@@ -1,23 +1,19 @@
-import { flushSync, mount, unmount } from 'svelte';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { page } from '$app/state';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest';
 
 import {
-  fetchDeployment,
-  fetchDeploymentVersion,
-} from '$lib/services/deployments-service';
+  closeDeploymentClientTestRunner,
+  getDeploymentClientTestRunner,
+} from '$lib/components/deployments/deployment-client-test-runner';
 import type { WorkerDeploymentResponse } from '$lib/types/deployments';
-
-import Deployment from './deployment.svelte';
-
-vi.mock('$lib/services/deployments-service', async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import('$lib/services/deployments-service')
-  >()),
-  fetchDeployment: vi.fn(),
-  fetchDeploymentVersion: vi.fn(),
-}));
 
 const deployment = {
   conflictToken: 'token',
@@ -54,33 +50,13 @@ const deployment = {
   },
 } as unknown as WorkerDeploymentResponse;
 
-const mounted: ReturnType<typeof mount>[] = [];
-
-async function renderDeployment(showConnectionStatus: boolean) {
-  const target = document.body.appendChild(document.createElement('div'));
-  const component = mount(Deployment, {
-    target,
-    props: { showConnectionStatus },
-  });
-  mounted.push(component);
-  await Promise.resolve();
-  flushSync();
-  return target;
-}
-
-function expandDetails(target: HTMLElement) {
-  const expand = target.querySelector<HTMLButtonElement>(
-    'button[aria-label="Expand"]',
-  );
-  expect(expand).not.toBeNull();
-  expand?.click();
-  flushSync();
-  return target.querySelector<HTMLTableCellElement>(
-    'tr.surface-primary > td[colspan]',
-  );
-}
-
 describe('deployment connection status visibility', () => {
+  let client: Awaited<ReturnType<typeof getDeploymentClientTestRunner>>;
+
+  beforeAll(async () => {
+    client = await getDeploymentClientTestRunner();
+  });
+
   beforeEach(() => {
     vi.stubGlobal(
       'ResizeObserver',
@@ -116,44 +92,46 @@ describe('deployment connection status visibility', () => {
         },
       },
     });
-    Object.assign(page.params, {
-      namespace: 'default',
-      deployment: 'deployment',
-    });
-    Object.assign(page.data, {
-      systemInfo: { capabilities: { serverScaledDeployments: true } },
-    });
-    vi.mocked(fetchDeployment).mockResolvedValue(deployment);
-    vi.mocked(fetchDeploymentVersion).mockResolvedValue({
-      workerDeploymentVersionInfo: {},
-    } as Awaited<ReturnType<typeof fetchDeploymentVersion>>);
   });
 
   afterEach(async () => {
-    await Promise.all(mounted.splice(0).map((component) => unmount(component)));
-    document.body.replaceChildren();
+    await client.cleanup();
     delete (Element.prototype as { animate?: unknown }).animate;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
+  afterAll(closeDeploymentClientTestRunner);
+
   test('hides the connection header and cell by default', async () => {
-    const target = await renderDeployment(false);
+    const target = await client.renderDeployment({
+      fetchDeployment: deployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+      showConnectionStatus: false,
+    });
 
     expect(target.querySelector('th:nth-child(4)')?.textContent).toBe(
       'Deployed At',
     );
     expect(target.textContent).not.toContain('Connected');
-    expect(expandDetails(target)?.getAttribute('colspan')).toBe('5');
+    const details = client.expandDetails(target);
+    expect(details).not.toBeNull();
+    expect(details?.getAttribute('colspan')).toBe('5');
   });
 
   test('renders the matching connection header and cell when enabled', async () => {
-    const target = await renderDeployment(true);
+    const target = await client.renderDeployment({
+      fetchDeployment: deployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+      showConnectionStatus: true,
+    });
 
     expect(target.querySelector('th:nth-child(4)')?.textContent).toBe(
       'Connection',
     );
     expect(target.textContent).toContain('Connected');
-    expect(expandDetails(target)?.getAttribute('colspan')).toBe('6');
+    const details = client.expandDetails(target);
+    expect(details).not.toBeNull();
+    expect(details?.getAttribute('colspan')).toBe('6');
   });
 });

--- a/src/lib/pages/serverless-worker-create.svelte
+++ b/src/lib/pages/serverless-worker-create.svelte
@@ -24,6 +24,7 @@
     cfnTemplateUrl?: string;
     cfnTemplate?: string;
     terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
     computeProviders?: readonly ComputeProviderOption[];
     gcpRegions?: string[];
   }
@@ -39,6 +40,7 @@
     cfnTemplateUrl,
     cfnTemplate,
     terraformTemplate,
+    cloudRunTerraformTemplate,
     computeProviders,
     gcpRegions,
   }: Props = $props();
@@ -218,6 +220,7 @@
   {cfnTemplateUrl}
   {cfnTemplate}
   {terraformTemplate}
+  {cloudRunTerraformTemplate}
   {computeProviders}
   {gcpRegions}
 />

--- a/src/lib/pages/worker-deployment-version-create.svelte
+++ b/src/lib/pages/worker-deployment-version-create.svelte
@@ -22,6 +22,8 @@
     onSuccess: () => void;
     computeProviders?: readonly ComputeProviderOption[];
     gcpRegions?: string[];
+    terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
   }
 
   let {
@@ -30,6 +32,8 @@
     onSuccess,
     computeProviders,
     gcpRegions,
+    terraformTemplate,
+    cloudRunTerraformTemplate,
   }: Props = $props();
 
   let error = $state<string | undefined>();
@@ -96,6 +100,8 @@
       computeProviders={lockedProvider?.providers ?? computeProviders}
       initialProvider={lockedProvider?.provider}
       {gcpRegions}
+      {terraformTemplate}
+      {cloudRunTerraformTemplate}
       cancelHref={backHref}
       onSubmit={async (data) => {
         error = undefined;

--- a/src/lib/pages/worker-deployment-version-edit.svelte
+++ b/src/lib/pages/worker-deployment-version-edit.svelte
@@ -27,10 +27,19 @@
     buildId: string;
     computeProviders?: readonly ComputeProviderOption[];
     gcpRegions?: string[];
+    terraformTemplate?: string;
+    cloudRunTerraformTemplate?: string;
   }
 
-  let { namespace, deployment, buildId, computeProviders, gcpRegions }: Props =
-    $props();
+  let {
+    namespace,
+    deployment,
+    buildId,
+    computeProviders,
+    gcpRegions,
+    terraformTemplate,
+    cloudRunTerraformTemplate,
+  }: Props = $props();
 
   let error = $state<string | undefined>();
   let showDeleteModal = $state(false);
@@ -61,6 +70,8 @@
       {error}
       {computeProviders}
       {gcpRegions}
+      {terraformTemplate}
+      {cloudRunTerraformTemplate}
       initialData={{
         provider: gcpDetails.gcpWorkerPool ? 'cloud-run' : 'lambda',
         lambdaArn: providerDetails.lambdaArn ?? '',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,6 @@ import { configDefaults } from 'vitest/config';
 export default defineConfig({
   plugins: [svelte({ hot: false })],
   resolve: {
-    conditions: ['browser'],
     alias: {
       $lib: path.resolve(__dirname, './src/lib'),
       $types: path.resolve(__dirname, './src/types'),


### PR DESCRIPTION
## Summary

- Add expandable Terraform setup guidance to the shared GCP Cloud Run worker deployment fields.
- Provide a copyable module example that reactively prefills the GCP project and clearly marks the required impersonator identity placeholder.
- Preserve the existing Lambda guidance while covering create, create-version, and edit flows through the shared component.

## Jira

https://temporalio.atlassian.net/browse/DT-4296

## Test plan

- [x] Focused Cloud Run component tests pass: rendering, module link, copy/reactivity, and Lambda isolation.
- [x] pnpm check passes with zero errors.
- [x] Targeted Prettier, ESLint, and Stylelint checks pass.
- [ ] Full Vitest suite not run locally because its unbounded worker pool exhausted local memory; focused tests passed with a single fork.