### PR TITLE
refactor(runes): Update holocene empty-state to runes syntax

### DIFF
--- a/src/lib/holocene/empty-state.stories.svelte
+++ b/src/lib/holocene/empty-state.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import { iconNames } from './icon';
 
@@ -28,7 +29,7 @@
         },
       },
     },
-  } satisfies Meta<EmptyState>;
+  } satisfies Meta<ComponentProps<typeof EmptyState>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/empty-state.svelte
+++ b/src/lib/holocene/empty-state.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
 
-  export let title: string;
-  export let content = '';
-  export let error = '';
-  export let icon: IconName = 'comet';
+  interface Props {
+    title: string;
+    content?: string;
+    error?: string;
+    icon?: IconName;
+    class?: string;
+    testId?: string;
+    children?: Snippet;
+  }
+
+  let {
+    title,
+    content = '',
+    error = '',
+    icon = 'comet',
+    class: className = '',
+    testId,
+    children,
+  }: Props = $props();
 </script>
 
 <div
-  class="my-12 flex w-full flex-col items-center justify-start gap-2 text-primary {$$props.class}"
-  data-testid={$$props.testId}
+  class="my-12 flex w-full flex-col items-center justify-start gap-2 text-primary {className}"
+  data-testid={testId}
 >
   <span class="flex h-16 w-16 items-center justify-center rounded-full">
     <Icon name={icon} class="block h-full w-full" /></span
@@ -24,5 +41,5 @@
       {error}
     </p>
   {/if}
-  <slot />
+  {@render children?.()}
 </div>


### PR DESCRIPTION
Updates holocene empty-state to runes syntax.

Since the we were using a default slot, no consumer changes are needed even though it's now a children snippet.