### PR TITLE
Update holocene copyable/button to runes syntax

### DIFF
--- a/src/lib/components/detail-list/detail-list-value.svelte
+++ b/src/lib/components/detail-list/detail-list-value.svelte
@@ -38,7 +38,7 @@
         copyIconTitle={translate('common.copy-icon-title')}
         copySuccessIconTitle={translate('common.copy-success-icon-title')}
         copied={$copied}
-        on:click={handleCopy}
+        onclick={handleCopy}
         class="absolute left-0"
       />
     </div>

--- a/src/lib/holocene/code-block.svelte
+++ b/src/lib/holocene/code-block.svelte
@@ -319,7 +319,7 @@
             {copyIconTitle}
             {copySuccessIconTitle}
             class="m-0 rounded-full text-secondary"
-            on:click={handleCopy}
+            onclick={handleCopy}
             copied={!!$copied}
           />
         {/if}
@@ -359,7 +359,7 @@
             {copyIconTitle}
             {copySuccessIconTitle}
             class="m-0 rounded-full text-secondary"
-            on:click={handleCopy}
+            onclick={handleCopy}
             copied={$copied}
           />
         {/if}

--- a/src/lib/holocene/copyable/button.svelte
+++ b/src/lib/holocene/copyable/button.svelte
@@ -6,7 +6,7 @@
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  interface $$Props extends HTMLButtonAttributes {
+  interface Props extends HTMLButtonAttributes {
     copyIconTitle?: string;
     copySuccessIconTitle?: string;
     copied: boolean;
@@ -15,14 +15,13 @@
     class?: string;
   }
 
-  export let copyIconTitle: string = translate('common.copy-icon-title');
-  export let copySuccessIconTitle: string = translate(
-    'common.copy-success-icon-title',
-  );
-  export let copied: boolean;
-
-  let className = '';
-  export { className as class };
+  let {
+    copyIconTitle = translate('common.copy-icon-title'),
+    copySuccessIconTitle = translate('common.copy-success-icon-title'),
+    copied,
+    class: className = '',
+    ...rest
+  }: Props = $props();
 </script>
 
 <button
@@ -33,8 +32,7 @@
   data-track-name="copyable-button"
   data-track-intent="copy"
   data-track-text={copyIconTitle}
-  on:click
-  {...$$restProps}
+  {...rest}
 >
   <Icon
     title={copied ? copySuccessIconTitle : copyIconTitle}

--- a/src/lib/holocene/copyable/index.svelte
+++ b/src/lib/holocene/copyable/index.svelte
@@ -43,7 +43,7 @@
     class={visible
       ? 'visible'
       : 'invisible group-focus-within:visible group-hover:visible'}
-    on:click={handleOnClick}
+    onclick={handleOnClick}
     copied={$copied}
   />
 </div>

--- a/src/lib/layouts/workflow-run-layout.svelte
+++ b/src/lib/layouts/workflow-run-layout.svelte
@@ -379,7 +379,7 @@
       copyIconTitle={translate('common.copy-icon-title')}
       copySuccessIconTitle={translate('common.copy-success-icon-title')}
       class="absolute right-1 top-1"
-      on:click={handleCopy}
+      onclick={handleCopy}
       copied={$copied}
     />
     {stringifyWithBigInt(fullJson, undefined, 2)}


### PR DESCRIPTION
Migrates `copyable/button.svelte` to Svelte 5 runes. Click now forwards through `{...rest}` (`Props extends HTMLButtonAttributes`) instead of the legacy `on:click` directive, so all 5 consumer usages (across `detail-list-value`, `workflow-run-layout`, `code-block`, and `copyable/index`) switch `on:click` → `onclick`. No cloud-ui consumers.