### PR TITLE
Update holocene radio-input and radio-card to runes syntax

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
@@ -88,17 +88,20 @@
       description={providerDescription(option.value)}
       disabled={option.disabled}
     >
-      <span slot="label-badge">
-        {#if option.disabled && option.disabledReason}
-          <Badge type="secondary">{option.disabledReason}</Badge>
-        {/if}
-      </span>
-      <div
-        slot="icon"
-        class="bg-surface-primary flex h-11 w-11 items-center justify-center rounded-none border border-subtle"
-      >
-        <Icon name={providerIcon[option.value]} width={32} height={32} />
-      </div>
+      {#snippet labelBadge()}
+        <span>
+          {#if option.disabled && option.disabledReason}
+            <Badge type="secondary">{option.disabledReason}</Badge>
+          {/if}
+        </span>
+      {/snippet}
+      {#snippet icon()}
+        <div
+          class="bg-surface-primary flex h-11 w-11 items-center justify-center rounded-none border border-subtle"
+        >
+          <Icon name={providerIcon[option.value]} width={32} height={32} />
+        </div>
+      {/snippet}
     </RadioCard>
   {/each}
 </RadioGroup>

--- a/src/lib/holocene/radio-input/radio-card.svelte
+++ b/src/lib/holocene/radio-input/radio-card.svelte
@@ -1,27 +1,42 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import { writable, type Writable } from 'svelte/store';
 
-  import { getContext } from 'svelte';
+  import { getContext, type Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import type { RadioGroupContext } from './types';
 
   import { RADIO_GROUP_CONTEXT } from './radio-group.svelte';
 
-  type T = $$Generic;
+  interface Props {
+    value: T;
+    id: string;
+    label: string;
+    labelContainerClass?: string;
+    description?: string;
+    disabled?: boolean;
+    class?: string;
+    labelBadge?: Snippet;
+    icon?: Snippet;
+    children?: Snippet;
+  }
 
-  export let value: T;
-  export let id: string;
-  export let label: string;
-  export let labelContainerClass: string = '';
-  export let description: string = '';
-  export let disabled: boolean = false;
+  let {
+    value,
+    id,
+    label,
+    labelContainerClass = '',
+    description = '',
+    disabled = false,
+    class: className = '',
+    labelBadge,
+    icon,
+    children,
+  }: Props = $props();
 
-  let className: string = '';
-  export { className as class };
-
-  let internalGroup: Writable<T> = writable(value);
-  let internalName: string = '';
+  // svelte-ignore state_referenced_locally
+  const internalGroup: Writable<T> = writable(value);
+  const internalName = '';
 
   const ctx = getContext<RadioGroupContext<T>>(RADIO_GROUP_CONTEXT) ?? {
     name: internalName,
@@ -30,7 +45,7 @@
 
   const { name, group } = ctx;
 
-  $: selected = $group === value;
+  const selected = $derived($group === value);
 </script>
 
 <div class={merge('flex flex-col', className)}>
@@ -61,23 +76,23 @@
       <div class="flex-1">
         <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
           <span class="text-sm font-medium">{label}</span>
-          <slot name="label-badge" />
+          {@render labelBadge?.()}
         </div>
         {#if description}
           <p class="text-sm text-secondary">{description}</p>
         {/if}
       </div>
     </label>
-    {#if $$slots.icon}
+    {#if icon}
       <div class="shrink-0">
-        <slot name="icon" />
+        {@render icon()}
       </div>
     {/if}
   </div>
 
-  {#if selected && $$slots.default}
+  {#if selected && children}
     <div class="surface-background border border-t-0 border-subtle p-5">
-      <slot />
+      {@render children()}
     </div>
   {/if}
 </div>

--- a/src/lib/holocene/radio-input/radio-input.svelte
+++ b/src/lib/holocene/radio-input/radio-input.svelte
@@ -1,7 +1,6 @@
-<script lang="ts">
-  import { writable, type Writable } from 'svelte/store';
+<script lang="ts" generics="T">
+  import { writable } from 'svelte/store';
 
-  import { omit } from 'es-toolkit';
   import { getContext } from 'svelte';
 
   import Label from '$lib/holocene/label.svelte';
@@ -10,27 +9,26 @@
 
   import { RADIO_GROUP_CONTEXT } from './radio-group.svelte';
 
-  type T = $$Generic;
-
-  type $$Props = RadioInputProps<T>;
-  export let value: T;
-  export let id: string;
-  export let label: string;
-  export let description: string | undefined = undefined;
-  export let labelHidden = false;
-  export let disabled = false;
-
-  let internalGroup: Writable<T> = writable(value);
-  let internalName: string = '';
-  let className: string | undefined = undefined;
-
-  export { internalGroup as group };
-  export { internalName as name };
-  export { className as class };
+  let {
+    value,
+    id,
+    label,
+    description = undefined,
+    labelHidden = false,
+    disabled = false,
+    group: internalGroup = writable(value),
+    name: internalName = '',
+    class: className = undefined,
+    ...rest
+  }: RadioInputProps<T> = $props();
 
   const ctx = getContext<RadioGroupContext<T>>(RADIO_GROUP_CONTEXT) ?? {
-    name: internalName,
-    group: internalGroup,
+    get name() {
+      return internalName;
+    },
+    get group() {
+      return internalGroup;
+    },
   };
 
   const { name, group } = ctx;
@@ -51,7 +49,7 @@
         {value}
         {id}
         {disabled}
-        {...omit($$restProps, ['class'])}
+        {...rest}
       />
       <span class="font-normal" class:hidden={labelHidden}>
         {label}


### PR DESCRIPTION
Migrates the radio cluster to Svelte 5 runes. `radio-group` was already runes and is the shared context anchor; this covers the two remaining legacy files.

- `radio-input.svelte` & `radio-card.svelte`: `$$Generic` → `generics="T"`, `export let` + aliased `export { … as group/name/class }` → `$props()`, `$:` → `$derived`.
- `radio-card` named slots → snippet props: `label-badge` → `labelBadge`, `icon`, and default → `children`.
- The `Writable<T>` context contract is unchanged, so `bind:group={$group}` works as before.

Consumer churn: only `compute-provider-picker.svelte` used RadioCard's named slots (converted `slot=` → `{#snippet}`); all other consumers are prop-only. No cloud-ui consumer uses `on:`/`bind:`/`slot=`, so nothing breaks there.