### PR TITLE
Update holocene table-row and table-header-row to runes syntax

### DIFF
--- a/src/lib/holocene/table/table-header-row.svelte
+++ b/src/lib/holocene/table/table-header-row.svelte
@@ -1,3 +1,14 @@
-<tr class={$$props.class}>
-  <slot />
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  interface Props {
+    class?: string;
+    children?: Snippet;
+  }
+
+  let { class: className = undefined, children }: Props = $props();
+</script>
+
+<tr class={className}>
+  {@render children?.()}
 </tr>

--- a/src/lib/holocene/table/table-row.svelte
+++ b/src/lib/holocene/table/table-row.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
-  import type { HTMLAttributes } from 'svelte/elements';
+  import type { HTMLAttributes, MouseEventHandler } from 'svelte/elements';
 
-  interface $$Props extends HTMLAttributes<HTMLTableRowElement> {
+  import type { Snippet } from 'svelte';
+
+  interface Props extends HTMLAttributes<HTMLTableRowElement> {
     'data-testid'?: string;
     class?: string;
+    children?: Snippet;
   }
 
-  let className = '';
-  export { className as class };
+  let { class: className = '', children, onclick, ...rest }: Props = $props();
+
+  const handleClick: MouseEventHandler<HTMLTableRowElement> = (event) => {
+    event.stopPropagation();
+    onclick?.(event);
+  };
 </script>
 
-<tr on:click|stopPropagation class={className} {...$$restProps}>
-  <slot />
+<tr onclick={handleClick} class={className} {...rest}>
+  {@render children?.()}
 </tr>


### PR DESCRIPTION
Migrates the two default-slot-only table primitives to Svelte 5 runes.

- `table-header-row.svelte`: markup-only → runes (`class` prop + `children` snippet).
- `table-row.svelte`: `$props()`, default slot → `children`, and `on:click|stopPropagation` → an `onclick` callback that stops propagation then forwards. The stopPropagation (which was active on every click) is preserved; the event-forwarding half had no consumers.

No consumer changes and no cloud-ui impact: default-slot content interops both directions, and `<TableHeaderRow slot="headers">` targets the still-legacy `Table`. `table.svelte` (the named-slot one with cross-repo impact) is intentionally left for a separate PR.