### PR TITLE
Update holocene range-input to runes syntax

### DIFF
--- a/src/lib/holocene/input/range-input.stories.svelte
+++ b/src/lib/holocene/input/range-input.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import RangeInput from '$lib/holocene/input/range-input.svelte';
 
@@ -42,7 +43,7 @@
       },
       labelHidden: { name: 'Label Hidden', control: 'boolean' },
     },
-  } satisfies Meta<RangeInput>;
+  } satisfies Meta<ComponentProps<typeof RangeInput>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/input/range-input.svelte
+++ b/src/lib/holocene/input/range-input.svelte
@@ -1,54 +1,34 @@
 <script lang="ts">
   import type { HTMLInputAttributes } from 'svelte/elements';
 
-  import { omit } from 'es-toolkit';
-
   import Label from '$lib/holocene/label.svelte';
 
-  interface $$Props extends HTMLInputAttributes {
-    value: number;
+  interface Props extends HTMLInputAttributes {
+    value?: number;
     id: string;
     label: string;
     labelHidden?: boolean;
     min: number;
     max: number;
     step?: number;
+    class?: string;
     'data-testid'?: string;
   }
 
-  export let label: string;
-  export let labelHidden = false;
-  export let min: number;
-  export let max: number;
-  export let step: number | undefined = undefined;
-  export let id: string;
-  export let value: number = Math.round((min + max) / 2);
-  let valid = true;
-  let outputElement: HTMLOutputElement;
+  let {
+    label,
+    labelHidden = false,
+    min,
+    max,
+    step,
+    id,
+    value = $bindable(Math.round((min + max) / 2)),
+    class: className = '',
+    ...rest
+  }: Props = $props();
 
-  $: outputXPos = getOutputXPos({ value, min, max });
-  $: outputXPosOffset = getOutputXPosOffset({ outputElement, outputXPos });
-  $: {
-    if (value) {
-      outputXPos = getOutputXPos({ value, min, max });
-      outputXPosOffset = getOutputXPosOffset({ outputElement, outputXPos });
-    } else {
-      outputXPos = 0;
-      outputXPosOffset = 0;
-    }
-  }
-
-  const handleInput = (
-    event: Event & { currentTarget: EventTarget & HTMLInputElement },
-  ) => {
-    if (Number.isNaN(event.currentTarget.valueAsNumber)) {
-      value = min;
-      return;
-    }
-    valid =
-      event.currentTarget.valueAsNumber >= min &&
-      event.currentTarget.valueAsNumber <= max;
-  };
+  let valid = $state(true);
+  let outputElement = $state<HTMLOutputElement>();
 
   const getOutputXPos = ({
     value,
@@ -76,14 +56,30 @@
     return Math.floor((outputXPos * offset) / 100);
   };
 
+  const outputXPos = $derived(value ? getOutputXPos({ value, min, max }) : 0);
+  let outputXPosOffset = $derived(
+    value ? getOutputXPosOffset({ outputElement, outputXPos }) : 0,
+  );
+
+  const handleInput = (
+    event: Event & { currentTarget: EventTarget & HTMLInputElement },
+  ) => {
+    if (Number.isNaN(event.currentTarget.valueAsNumber)) {
+      value = min;
+      return;
+    }
+    valid =
+      event.currentTarget.valueAsNumber >= min &&
+      event.currentTarget.valueAsNumber <= max;
+  };
+
   const handleWindowResize = () => {
-    outputXPos = getOutputXPos({ value, min, max });
     outputXPosOffset = getOutputXPosOffset({ outputElement, outputXPos });
   };
 </script>
 
-<svelte:window on:resize={handleWindowResize} />
-<div class="w-full px-1 py-4 {$$props.class}">
+<svelte:window onresize={handleWindowResize} />
+<div class="w-full px-1 py-4 {className}">
   <div class="range-input-container">
     <div class="relative w-auto grow">
       <span class="absolute -bottom-6 left-0 text-xs font-normal">
@@ -103,11 +99,11 @@
           type="range"
           class="h-0 w-full cursor-pointer appearance-none rounded border-y border-primary"
           bind:value
-          on:input={handleInput}
+          oninput={handleInput}
           {min}
           {max}
           {step}
-          {...omit($$restProps, ['class'])}
+          {...rest}
         />
         <Label hidden {label} for="{id}-range" />
       </div>
@@ -123,10 +119,10 @@
         type="number"
         inputmode="numeric"
         bind:value
-        on:input={handleInput}
+        oninput={handleInput}
         {min}
         {max}
-        step={$$props.step}
+        {step}
       />
     </div>
     <Label hidden={labelHidden} class="shrink" {label} for={id} />

--- a/src/lib/holocene/input/range-input.svelte
+++ b/src/lib/holocene/input/range-input.svelte
@@ -24,6 +24,7 @@
     id,
     value = $bindable(Math.round((min + max) / 2)),
     class: className = '',
+    oninput,
     ...rest
   }: Props = $props();
 
@@ -73,6 +74,13 @@
       event.currentTarget.valueAsNumber <= max;
   };
 
+  const handleRangeInput = (
+    event: Event & { currentTarget: EventTarget & HTMLInputElement },
+  ) => {
+    handleInput(event);
+    oninput?.(event);
+  };
+
   const handleWindowResize = () => {
     outputXPosOffset = getOutputXPosOffset({ outputElement, outputXPos });
   };
@@ -99,11 +107,11 @@
           type="range"
           class="h-0 w-full cursor-pointer appearance-none rounded border-y border-primary"
           bind:value
-          oninput={handleInput}
           {min}
           {max}
           {step}
           {...rest}
+          oninput={handleRangeInput}
         />
         <Label hidden {label} for="{id}-range" />
       </div>


### PR DESCRIPTION
Migrates `input/range-input.svelte` to Svelte 5 runes: `$props()` (`value` is `$bindable()`), `$:` → `$derived` (the DOM-measurement offset is a reassignable `$derived` so the window-resize handler can force a recompute), `on:input`/`on:resize` → `oninput`/`onresize`, `$$restProps` → `...rest`.

Single ui consumer (`workflow-json-navigator`) uses `bind:value` — kept working via `$bindable()`, so no consumer change. No cloud-ui consumers.