### PR TITLE
Update holocene accordion-light to runes syntax

### DIFF
--- a/src/lib/components/workflow/workflow-callbacks.svelte
+++ b/src/lib/components/workflow/workflow-callbacks.svelte
@@ -15,17 +15,21 @@
 <WorkflowCallback callback={firstCallback} {link}>
   {#if callbacks.length > 1}
     <div class="py-2">
-      <AccordionLight let:open>
-        <p class="p-1" slot="title">
-          View {callbacks.length - 1} other Callbacks
-        </p>
-        {#if open}
-          <div class="flex flex-col gap-2">
-            {#each callbacks.slice(1) as callback}
-              <WorkflowCallback {callback} />
-            {/each}
-          </div>
-        {/if}
+      <AccordionLight>
+        {#snippet title()}
+          <p class="p-1">
+            View {callbacks.length - 1} other Callbacks
+          </p>
+        {/snippet}
+        {#snippet children(open)}
+          {#if open}
+            <div class="flex flex-col gap-2">
+              {#each callbacks.slice(1) as callback}
+                <WorkflowCallback {callback} />
+              {/each}
+            </div>
+          {/if}
+        {/snippet}
       </AccordionLight>
     </div>
   {/if}

--- a/src/lib/holocene/accordion/accordion-light.svelte
+++ b/src/lib/holocene/accordion/accordion-light.svelte
@@ -1,23 +1,40 @@
 <script lang="ts">
   import type { HTMLAttributes } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
+
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
 
-  interface $$Props extends HTMLAttributes<HTMLDivElement> {
+  interface Props extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'title' | 'children'
+  > {
     id?: string;
     icon?: IconName;
     open?: boolean;
     expandable?: boolean;
     error?: string;
     onToggle?: () => Promise<void>;
+    class?: string;
     'data-testid'?: string;
+    title?: Snippet;
+    description?: Snippet;
+    action?: Snippet;
+    children?: Snippet<[boolean]>;
   }
 
-  export let id: string = crypto.randomUUID();
-  export let open = false;
-  export let onToggle: (() => Promise<void>) | undefined = undefined;
-  export let icon: IconName | undefined = undefined;
+  let {
+    id = crypto.randomUUID(),
+    open = $bindable(false),
+    onToggle,
+    icon,
+    class: className,
+    title,
+    description,
+    action,
+    children,
+  }: Props = $props();
 
   const toggleAccordion = async () => {
     if (onToggle) {
@@ -29,7 +46,7 @@
   };
 </script>
 
-<div class="w-full {$$restProps.class}">
+<div class="w-full {className}">
   <div class="flex w-full flex-row items-center">
     <button
       id="{id}-trigger"
@@ -37,16 +54,16 @@
       aria-controls="{id}-content"
       class="focus-visible:outline-interactive grow cursor-pointer hover:bg-interactive-secondary-hover"
       type="button"
-      on:click={toggleAccordion}
+      onclick={toggleAccordion}
     >
       <div class="flex w-full flex-row items-center justify-between gap-2 pr-4">
-        <slot name="title" />
-        <slot name="description" />
+        {@render title?.()}
+        {@render description?.()}
         <Icon name={icon ? icon : open ? 'arrow-down' : 'arrow-right'} />
       </div>
     </button>
     <div class="flex shrink-0 items-center gap-4 pr-4">
-      <slot name="action" />
+      {@render action?.()}
     </div>
   </div>
   <div
@@ -55,6 +72,6 @@
     class="block w-full bg-primary p-2"
     class:hidden={!open}
   >
-    <slot {open} />
+    {@render children?.(open)}
   </div>
 </div>


### PR DESCRIPTION
Migrates `accordion/accordion-light.svelte` to Svelte 5 runes: `$props()` (`open` is `$bindable()`), `on:click` on the native trigger button → `onclick`, named slots `title`/`description`/`action` → snippet props, and the scoped default slot `<slot {open}>` → `children` snippet (`Snippet<[boolean]>`). `title`/`children` are `Omit`ted from the extended `HTMLAttributes` since they'd collide with the DOM `title` string / base `children`.

Single consumer (`workflow-callbacks`) converted: `slot="title"` → `{#snippet title()}`, `let:open` default slot → `{#snippet children(open)}`. No cloud-ui consumers.