### PR TITLE
Fix state unsafe mutation error in EndTimeInterval

### DIFF
--- a/src/lib/components/lines-and-dots/end-time-interval.svelte
+++ b/src/lib/components/lines-and-dots/end-time-interval.svelte
@@ -29,8 +29,8 @@
     children,
   }: Props = $props();
 
-  let endTime = $derived(workflow?.endTime || currentTime + 1000);
-  let duration = $derived(
+  const endTime = $derived(workflow?.endTime || currentTime + 1000);
+  const duration = $derived(
     getMillisecondDuration({
       start: startTime,
       end: endTime,
@@ -38,36 +38,18 @@
     }),
   );
 
-  let endTimeInterval: ReturnType<typeof setInterval> | null = $state(null);
-
-  const clearEndTimeInterval = (endTime: string) => {
-    if (endTime) {
-      clearInterval(endTimeInterval ?? undefined);
-      endTimeInterval = null;
-    }
-  };
-
-  const startStopInterval = (pauseLiveUpdates: boolean) => {
-    if (pauseLiveUpdates) {
-      clearInterval(endTimeInterval ?? undefined);
-      endTimeInterval = null;
-    } else if (!endTimeInterval && (workflow.isRunning || workflow.isPaused)) {
-      endTimeInterval = setInterval(() => {
-        currentTime = Date.now();
-      }, 1000);
-    }
-  };
-
   $effect(() => {
-    clearEndTimeInterval(workflow.endTime);
-  });
-  $effect(() => {
-    startStopInterval($pauseLiveUpdates);
+    if ($pauseLiveUpdates) return;
+    if (workflow.endTime) return;
+    if (!(workflow.isRunning || workflow.isPaused)) return;
+
+    const interval = setInterval(() => {
+      currentTime = Date.now();
+    }, 1000);
+    return () => clearInterval(interval);
   });
 
   onDestroy(() => {
-    clearInterval(endTimeInterval ?? undefined);
-    endTimeInterval = null;
     $pauseLiveUpdates = false;
   });
 </script>

--- a/src/lib/components/lines-and-dots/end-time-interval.svelte
+++ b/src/lib/components/lines-and-dots/end-time-interval.svelte
@@ -29,12 +29,7 @@
     children,
   }: Props = $props();
 
-  const rightNow = () => {
-    currentTime = Date.now();
-    return currentTime + 1000;
-  };
-
-  let endTime = $derived(workflow?.endTime || rightNow());
+  let endTime = $derived(workflow?.endTime || currentTime + 1000);
   let duration = $derived(
     getMillisecondDuration({
       start: startTime,
@@ -58,7 +53,7 @@
       endTimeInterval = null;
     } else if (!endTimeInterval && (workflow.isRunning || workflow.isPaused)) {
       endTimeInterval = setInterval(() => {
-        endTime = rightNow();
+        currentTime = Date.now();
       }, 1000);
     }
   };

--- a/src/lib/components/lines-and-dots/end-time-interval.svelte
+++ b/src/lib/components/lines-and-dots/end-time-interval.svelte
@@ -1,29 +1,49 @@
 <script lang="ts">
   import type { Timestamp } from '@temporalio/common';
+  import type { Snippet } from 'svelte';
   import { onDestroy } from 'svelte';
 
   import { pauseLiveUpdates } from '$lib/stores/events';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { getMillisecondDuration } from '$lib/utilities/format-time';
 
-  export let workflow: WorkflowExecution;
-  export let startTime: string | Timestamp;
+  interface Props {
+    workflow: WorkflowExecution;
+    startTime: string | Timestamp;
+    currentTime?: number;
+    children?: Snippet<
+      [
+        {
+          endTime: string | number;
+          duration: number | null;
+          currentTime: number;
+        },
+      ]
+    >;
+  }
 
-  export let currentTime = Date.now();
+  let {
+    workflow,
+    startTime,
+    currentTime = $bindable(Date.now()),
+    children,
+  }: Props = $props();
 
   const rightNow = () => {
     currentTime = Date.now();
     return currentTime + 1000;
   };
 
-  $: endTime = workflow?.endTime || rightNow();
-  $: duration = getMillisecondDuration({
-    start: startTime,
-    end: endTime,
-    onlyUnderSecond: false,
-  });
+  let endTime = $derived(workflow?.endTime || rightNow());
+  let duration = $derived(
+    getMillisecondDuration({
+      start: startTime,
+      end: endTime,
+      onlyUnderSecond: false,
+    }),
+  );
 
-  let endTimeInterval: ReturnType<typeof setInterval> | null;
+  let endTimeInterval: ReturnType<typeof setInterval> | null = $state(null);
 
   const clearEndTimeInterval = (endTime: string) => {
     if (endTime) {
@@ -43,8 +63,12 @@
     }
   };
 
-  $: clearEndTimeInterval(workflow.endTime);
-  $: startStopInterval($pauseLiveUpdates);
+  $effect(() => {
+    clearEndTimeInterval(workflow.endTime);
+  });
+  $effect(() => {
+    startStopInterval($pauseLiveUpdates);
+  });
 
   onDestroy(() => {
     clearInterval(endTimeInterval ?? undefined);
@@ -53,4 +77,4 @@
   });
 </script>
 
-<slot {endTime} {duration} {currentTime} />
+{@render children?.({ endTime, duration, currentTime })}

--- a/src/lib/components/lines-and-dots/timeline-graph/timeline-graph.svelte
+++ b/src/lib/components/lines-and-dots/timeline-graph/timeline-graph.svelte
@@ -459,131 +459,133 @@
   style:height="{svgHeight}px"
   bind:this={containerEl}
 >
-  <EndTimeInterval {workflow} {startTime} bind:currentTime={nowMs} let:endTime>
-    <div
-      class="pointer-events-none sticky top-[120px]"
-      class:invisible={!!$activeGroups.length}
-    >
-      <div class="flex w-full justify-between text-xs">
-        <p class="w-60 -translate-x-24 rotate-90">
-          {$timestamp(startTime, { format: 'short' })}
-        </p>
-        <p class="w-60 translate-x-24 rotate-90">
-          {$timestamp(endTime, { format: 'short' })}
-        </p>
-      </div>
-    </div>
-    <!-- Tall scrolled layer; rows/lines/dots are absolutely-positioned divs,
-         only the windowed slots exist in the DOM. -->
-    <div
-      class="canvas"
-      style:width="{canvasWidth}px"
-      style:height="{svgHeight}px"
-      style:--dot="{dotSize}px"
-      style:--dot-r="{dotRadius}px"
-    >
-      <TimelineIconDefs />
-
-      <!-- Border rails -->
+  <EndTimeInterval {workflow} {startTime} bind:currentTime={nowMs}>
+    {#snippet children({ endTime })}
       <div
-        class="absolute bg-current"
-        style:left="{GUTTER - RADIUS / 4}px"
-        style:top="{lineTop}px"
-        style:width="{RADIUS / 2}px"
-        style:height="{lineBottom}px"
-      ></div>
-      <div
-        class="absolute bg-current"
-        style:left="{canvasWidth - GUTTER - RADIUS / 4}px"
-        style:top="{lineTop}px"
-        style:width="{RADIUS / 2}px"
-        style:height="{lineBottom}px"
-      ></div>
-
-      <TimelineAxis
-        x1={GUTTER - RADIUS / 4}
-        x2={canvasWidth - GUTTER + RADIUS / 4}
-        gutter={GUTTER}
-        {timelineHeight}
-        {startTime}
-        {scale}
-      />
-      <WorkflowRow {workflow} y={ROW_HEIGHT} length={canvasWidth} />
-      {#if !loading}
-        <!-- Anchor's left provides the gutter offset for the layer's 0-based coords. -->
-        <div class="absolute top-0" style:left="{GUTTER}px">
-          <TimelineCollapsedLayer
-            {scale}
-            {timelineHeight}
-            bandTop={layerBandTop}
-            bandHeight={layerBandHeight}
-            {readOnly}
-            onToggle={toggleSegment}
-          />
+        class="pointer-events-none sticky top-[120px]"
+        class:invisible={!!$activeGroups.length}
+      >
+        <div class="flex w-full justify-between text-xs">
+          <p class="w-60 -translate-x-24 rotate-90">
+            {$timestamp(startTime, { format: 'short' })}
+          </p>
+          <p class="w-60 translate-x-24 rotate-90">
+            {$timestamp(endTime, { format: 'short' })}
+          </p>
         </div>
-      {/if}
+      </div>
+      <!-- Tall scrolled layer; rows/lines/dots are absolutely-positioned divs,
+         only the windowed slots exist in the DOM. -->
+      <div
+        class="canvas"
+        style:width="{canvasWidth}px"
+        style:height="{svgHeight}px"
+        style:--dot="{dotSize}px"
+        style:--dot-r="{dotRadius}px"
+      >
+        <TimelineIconDefs />
 
-      <!-- Keyed by slot index so Svelte reuses the <li>s in place; the <li>
+        <!-- Border rails -->
+        <div
+          class="absolute bg-current"
+          style:left="{GUTTER - RADIUS / 4}px"
+          style:top="{lineTop}px"
+          style:width="{RADIUS / 2}px"
+          style:height="{lineBottom}px"
+        ></div>
+        <div
+          class="absolute bg-current"
+          style:left="{canvasWidth - GUTTER - RADIUS / 4}px"
+          style:top="{lineTop}px"
+          style:width="{RADIUS / 2}px"
+          style:height="{lineBottom}px"
+        ></div>
+
+        <TimelineAxis
+          x1={GUTTER - RADIUS / 4}
+          x2={canvasWidth - GUTTER + RADIUS / 4}
+          gutter={GUTTER}
+          {timelineHeight}
+          {startTime}
+          {scale}
+        />
+        <WorkflowRow {workflow} y={ROW_HEIGHT} length={canvasWidth} />
+        {#if !loading}
+          <!-- Anchor's left provides the gutter offset for the layer's 0-based coords. -->
+          <div class="absolute top-0" style:left="{GUTTER}px">
+            <TimelineCollapsedLayer
+              {scale}
+              {timelineHeight}
+              bandTop={layerBandTop}
+              bandHeight={layerBandHeight}
+              {readOnly}
+              onToggle={toggleSegment}
+            />
+          </div>
+        {/if}
+
+        <!-- Keyed by slot index so Svelte reuses the <li>s in place; the <li>
            persists when its slot is null, only the inner row toggles.
            pointer-events-none so clicks fall through to the collapse toggles;
            event buttons opt back in with pointer-events:auto. -->
-      <ul class="pointer-events-none absolute inset-0 m-0 list-none p-0">
-        {#each pool as slot, slotIndex (slotIndex)}
-          <li
-            class="absolute left-0 right-0 top-0"
-            style:display={slot ? 'block' : 'none'}
-            style:height="{ROW_HEIGHT}px"
-            style:contain="layout"
-            style:transform={slot
-              ? `translateY(${getY(slot.index) - ROW_HEIGHT / 2 + shiftFor(slot.index)}px)`
-              : undefined}
-          >
-            {#if slot}
-              <TimelineGraphRow
-                group={slot.group}
-                eventCount={slot.group.eventList.length}
-                {canvasWidth}
-                project={projectX}
-                {readOnly}
-              />
-            {/if}
-          </li>
-        {/each}
-      </ul>
+        <ul class="pointer-events-none absolute inset-0 m-0 list-none p-0">
+          {#each pool as slot, slotIndex (slotIndex)}
+            <li
+              class="absolute left-0 right-0 top-0"
+              style:display={slot ? 'block' : 'none'}
+              style:height="{ROW_HEIGHT}px"
+              style:contain="layout"
+              style:transform={slot
+                ? `translateY(${getY(slot.index) - ROW_HEIGHT / 2 + shiftFor(slot.index)}px)`
+                : undefined}
+            >
+              {#if slot}
+                <TimelineGraphRow
+                  group={slot.group}
+                  eventCount={slot.group.eventList.length}
+                  {canvasWidth}
+                  project={projectX}
+                  {readOnly}
+                />
+              {/if}
+            </li>
+          {/each}
+        </ul>
 
-      {#if loading && pendingGroupCount > 0}
-        {@const rectY = getPendingBlockY({
-          descStart,
-          filteredGroupsLength: filteredGroups.length,
-          reverseSort,
-        })}
-        {@const rectH = pendingGroupCount * ROW_HEIGHT + RADIUS}
-        <div
-          class="absolute animate-pulse rounded bg-slate-400/30"
-          style:left="{GUTTER}px"
-          style:top="{rectY}px"
-          style:width="{canvasWidth - GUTTER * 2}px"
-          style:height="{rectH}px"
-        ></div>
-      {/if}
-
-      <!-- Last child so it paints above rows; onHeight feeds shiftFor. -->
-      {#if !readOnly && activeIdx >= 0}
-        {@const activeGroup = filteredGroups[activeIdx]}
-        {#if activeGroup}
-          {@const panelY = getY(activeIdx) + 1.33 * RADIUS}
-          <GroupDetailsRow
-            y={panelY}
-            group={activeGroup}
-            {canvasWidth}
-            endTime={workflow?.endTime ? endTime : nowMs}
-            onHeight={(height) => {
-              panelHeight = height;
-            }}
-          />
+        {#if loading && pendingGroupCount > 0}
+          {@const rectY = getPendingBlockY({
+            descStart,
+            filteredGroupsLength: filteredGroups.length,
+            reverseSort,
+          })}
+          {@const rectH = pendingGroupCount * ROW_HEIGHT + RADIUS}
+          <div
+            class="absolute animate-pulse rounded bg-slate-400/30"
+            style:left="{GUTTER}px"
+            style:top="{rectY}px"
+            style:width="{canvasWidth - GUTTER * 2}px"
+            style:height="{rectH}px"
+          ></div>
         {/if}
-      {/if}
-    </div>
+
+        <!-- Last child so it paints above rows; onHeight feeds shiftFor. -->
+        {#if !readOnly && activeIdx >= 0}
+          {@const activeGroup = filteredGroups[activeIdx]}
+          {#if activeGroup}
+            {@const panelY = getY(activeIdx) + 1.33 * RADIUS}
+            <GroupDetailsRow
+              y={panelY}
+              group={activeGroup}
+              {canvasWidth}
+              endTime={workflow?.endTime ? endTime : nowMs}
+              onHeight={(height) => {
+                panelHeight = height;
+              }}
+            />
+          {/if}
+        {/if}
+      </div>
+    {/snippet}
   </EndTimeInterval>
 </div>
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

On a running workflow (when `workflow.endTime` is empty) the derived `endTime` was calling `rightNow()`, which rewrote `currentTime` and was causing a [state_unsafe_mutation](https://svelte.dev/docs/svelte/runtime-errors#Client-errors-state_unsafe_mutation). Now `currentTime` is written only inside the timer callback and `endTime` only reads `currentTime`.

This PR also refactors logic into a single `$effect` that owns the interval's lifecycle. It starts the timer only when live, and its cleanup return clears it whenever `$pauseLiveUpdates`, `workflow.endTime`, or the running/paused flags change. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
