### PR TITLE
fix(serverless-workers): interpolate form values into Terraform snippet (COM-216)

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -11,6 +11,7 @@
 
   import { GCP_REGIONS } from './gcp-regions';
   import defaultTerraformTemplate from './serverless-worker-lambda.tf?raw';
+  import { interpolateTerraformTemplate } from './shared';
   import cfnTemplate from './temporal-worker-role.yaml?raw';
 
   interface Props {
@@ -79,7 +80,13 @@
 
   const resolvedCfnTemplate = $derived(cfnTemplateProp ?? cfnTemplate);
   const resolvedTerraformTemplate = $derived(
-    terraformTemplate ?? defaultTerraformTemplate,
+    interpolateTerraformTemplate(
+      terraformTemplate ?? defaultTerraformTemplate,
+      {
+        externalId: roleExternalId,
+        lambdaArn,
+      },
+    ),
   );
 
   const launchStackHref = $derived.by(() => {

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-lambda.tf
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-lambda.tf
@@ -3,8 +3,14 @@
 module "serverless-worker-lambda" {
   source = "terraform-modules/modules/serverless-workers/aws/lambda"
 
-  external_id               = "<external-id>"
-  temporal_cloud_principals = "<provided by Temporal Cloud>"
+  external_id = "<external-id>"
+
+  # IAM principals allowed to assume this role to invoke your workers.
+  # Temporal Cloud provides these values; for self-hosted deployments,
+  # use the IAM identity your Temporal service runs as.
+  temporal_cloud_principals = [
+    "<principal-arn>",
+  ]
 
   lambda_function_arns = [
     "arn:aws:lambda:us-east-1:123456789012:function:my-worker-1",

--- a/src/lib/components/workers/serverless-worker-form/shared.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.test.ts
@@ -4,6 +4,7 @@ import {
   createDeploymentSchema,
   editVersionSchema,
   getInitialComputeProvider,
+  interpolateTerraformTemplate,
 } from './shared';
 
 describe('getInitialComputeProvider', () => {
@@ -135,5 +136,76 @@ describe('Cloud Run replica validation', () => {
       initialReplicas: 0,
       utilizationTarget: 0.8,
     });
+  });
+});
+
+describe('interpolateTerraformTemplate', () => {
+  const template = `module "serverless-worker-lambda" {
+  source = "terraform-modules/modules/serverless-workers/aws/lambda"
+
+  external_id               = "<external-id>"
+  temporal_cloud_principals = "<provided by Temporal Cloud>"
+
+  lambda_function_arns = [
+    "arn:aws:lambda:us-east-1:123456789012:function:my-worker-1",
+    "arn:aws:lambda:us-east-1:123456789012:function:my-worker-2",
+  ]
+}`;
+
+  it('replaces the external id placeholder with the provided value', () => {
+    const result = interpolateTerraformTemplate(template, {
+      externalId: 'my-external-id',
+    });
+
+    expect(result).toContain('external_id               = "my-external-id"');
+    expect(result).not.toContain('<external-id>');
+  });
+
+  it('replaces the example lambda function ARNs with the provided ARN', () => {
+    const arn = 'arn:aws:lambda:us-west-2:093235337669:function:hello-activity';
+    const result = interpolateTerraformTemplate(template, { lambdaArn: arn });
+
+    expect(result).toContain(`lambda_function_arns = [\n    "${arn}",\n  ]`);
+    expect(result).not.toContain('my-worker-1');
+  });
+
+  it('replaces both values together', () => {
+    const arn = 'arn:aws:lambda:us-east-1:093235337669:function:surveypoll';
+    const result = interpolateTerraformTemplate(template, {
+      externalId: 'test',
+      lambdaArn: arn,
+    });
+
+    expect(result).toContain('external_id               = "test"');
+    expect(result).toContain(`"${arn}"`);
+    expect(result).not.toContain('<external-id>');
+    expect(result).not.toContain('123456789012');
+  });
+
+  it('returns the template unchanged when no values are provided', () => {
+    expect(interpolateTerraformTemplate(template, {})).toBe(template);
+    expect(
+      interpolateTerraformTemplate(template, { externalId: '', lambdaArn: '' }),
+    ).toBe(template);
+  });
+
+  it('does not treat replacement-pattern characters in values specially', () => {
+    const result = interpolateTerraformTemplate(template, {
+      externalId: "$' $& $1",
+    });
+
+    expect(result).toContain('external_id               = "$\' $& $1"');
+  });
+
+  it('leaves other principals and comments untouched', () => {
+    const result = interpolateTerraformTemplate(template, {
+      externalId: 'abc',
+      lambdaArn: 'arn:aws:lambda:us-east-1:093235337669:function:f',
+    });
+
+    expect(result).toContain(
+      'temporal_cloud_principals = "<provided by Temporal Cloud>"',
+    );
+    expect(result).toContain('source = "terraform-modules/modules');
   });
 });

--- a/src/lib/components/workers/serverless-worker-form/shared.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.test.ts
@@ -169,6 +169,28 @@ describe('interpolateTerraformTemplate', () => {
     expect(result).not.toContain('my-worker-1');
   });
 
+  it('renders comma-separated ARNs as separate list entries', () => {
+    const first = 'arn:aws:lambda:us-east-1:093235337669:function:worker-a';
+    const second = 'arn:aws:lambda:us-east-1:093235337669:function:worker-b';
+    const result = interpolateTerraformTemplate(template, {
+      lambdaArn: `${first}, ${second}`,
+    });
+
+    expect(result).toContain(
+      `lambda_function_arns = [\n    "${first}",\n    "${second}",\n  ]`,
+    );
+    expect(result).not.toContain('my-worker-1');
+  });
+
+  it('ignores empty segments from stray commas and whitespace', () => {
+    const arn = 'arn:aws:lambda:us-east-1:093235337669:function:worker-a';
+    const result = interpolateTerraformTemplate(template, {
+      lambdaArn: ` ${arn}, `,
+    });
+
+    expect(result).toContain(`lambda_function_arns = [\n    "${arn}",\n  ]`);
+  });
+
   it('replaces both values together', () => {
     const arn = 'arn:aws:lambda:us-east-1:093235337669:function:surveypoll';
     const result = interpolateTerraformTemplate(template, {

--- a/src/lib/components/workers/serverless-worker-form/shared.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.test.ts
@@ -143,8 +143,12 @@ describe('interpolateTerraformTemplate', () => {
   const template = `module "serverless-worker-lambda" {
   source = "terraform-modules/modules/serverless-workers/aws/lambda"
 
-  external_id               = "<external-id>"
-  temporal_cloud_principals = "<provided by Temporal Cloud>"
+  external_id = "<external-id>"
+
+  # IAM principals allowed to assume this role to invoke your workers.
+  temporal_cloud_principals = [
+    "<principal-arn>",
+  ]
 
   lambda_function_arns = [
     "arn:aws:lambda:us-east-1:123456789012:function:my-worker-1",
@@ -157,7 +161,7 @@ describe('interpolateTerraformTemplate', () => {
       externalId: 'my-external-id',
     });
 
-    expect(result).toContain('external_id               = "my-external-id"');
+    expect(result).toContain('external_id = "my-external-id"');
     expect(result).not.toContain('<external-id>');
   });
 
@@ -198,7 +202,7 @@ describe('interpolateTerraformTemplate', () => {
       lambdaArn: arn,
     });
 
-    expect(result).toContain('external_id               = "test"');
+    expect(result).toContain('external_id = "test"');
     expect(result).toContain(`"${arn}"`);
     expect(result).not.toContain('<external-id>');
     expect(result).not.toContain('123456789012');
@@ -216,7 +220,7 @@ describe('interpolateTerraformTemplate', () => {
       externalId: "$' $& $1",
     });
 
-    expect(result).toContain('external_id               = "$\' $& $1"');
+    expect(result).toContain('external_id = "$\' $& $1"');
   });
 
   it('leaves other principals and comments untouched', () => {
@@ -226,7 +230,7 @@ describe('interpolateTerraformTemplate', () => {
     });
 
     expect(result).toContain(
-      'temporal_cloud_principals = "<provided by Temporal Cloud>"',
+      'temporal_cloud_principals = [\n    "<principal-arn>",\n  ]',
     );
     expect(result).toContain('source = "terraform-modules/modules');
   });

--- a/src/lib/components/workers/serverless-worker-form/shared.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.ts
@@ -193,11 +193,16 @@ export const interpolateTerraformTemplate = (
     );
   }
 
-  if (lambdaArn) {
+  const arns = (lambdaArn ?? '')
+    .split(',')
+    .map((arn) => arn.trim())
+    .filter(Boolean);
+
+  if (arns.length) {
+    const entries = arns.map((arn) => `    "${arn}",`).join('\n');
     result = result.replace(
       /(lambda_function_arns\s*=\s*\[)[^\]]*(\])/,
-      (_, open: string, close: string) =>
-        `${open}\n    "${lambdaArn}",\n  ${close}`,
+      (_, open: string, close: string) => `${open}\n${entries}\n  ${close}`,
     );
   }
 

--- a/src/lib/components/workers/serverless-worker-form/shared.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.ts
@@ -174,3 +174,32 @@ export const getInitialComputeProvider = ({
     'lambda'
   );
 };
+
+interface TerraformTemplateValues {
+  externalId?: string;
+  lambdaArn?: string;
+}
+
+export const interpolateTerraformTemplate = (
+  template: string,
+  { externalId, lambdaArn }: TerraformTemplateValues,
+): string => {
+  let result = template;
+
+  if (externalId) {
+    result = result.replace(
+      /(external_id\s*=\s*)"[^"]*"/,
+      (_, assignment: string) => `${assignment}"${externalId}"`,
+    );
+  }
+
+  if (lambdaArn) {
+    result = result.replace(
+      /(lambda_function_arns\s*=\s*\[)[^\]]*(\])/,
+      (_, open: string, close: string) =>
+        `${open}\n    "${lambdaArn}",\n  ${close}`,
+    );
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Description & motivation 💭

The Terraform role snippet in the serverless worker create form rendered the static template verbatim: the user's **External ID** and **Lambda Function ARN** were never substituted for the `<external-id>` and example-ARN placeholders (reported against production, COM-216).

This PR derives the displayed snippet through a new pure helper, `interpolateTerraformTemplate`, in `shared.ts`:

- Replaces the value of `external_id = "…"` with the bound External ID field.
- Replaces the entire example `lambda_function_arns = […]` list with the user's ARN(s) — comma-separated input becomes one list entry per ARN, matching the CloudFormation `LambdaFunctionARNs` parameter semantics.
- Uses replacer functions so `$`-pattern characters in user input are inserted literally.
- Empty values leave the template untouched; `temporal_cloud_principals` and comments are never modified.

Also fixes the default (self-hosted) template's `temporal_cloud_principals`: it was a bare string, but the terraform module declares a required `list(string)` — so the copy-pasted snippet failed with a type error — and its "provided by Temporal Cloud" placeholder was wrong for the OSS UI's self-hosted context. It is now a type-correct placeholder list with a comment covering both Cloud and self-hosted deployments (where the principals are the IAM identity the operator's Temporal service runs as).

Because the regexes match the assignments rather than specific placeholder text, this works for both the built-in default template and host-provided templates (Cloud UI passes its own prod/test variants).

The CloudFormation path needs no snippet interpolation — its values already flow through the Launch Stack URL's `param_AssumeRoleExternalId` / `param_LambdaFunctionARNs` prefills.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Six new unit tests in `shared.test.ts` cover: each substitution alone, both together, no-op on empty values, regex-special characters in input, and non-target lines remaining untouched. All 26 tests in the file pass; `svelte-check` reports 0 errors.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open the serverless worker deployment create form.
2. Expand "Don't have a role yet? Create one" → Terraform tab.
3. Type an External ID and Lambda ARN — the snippet should update live with your values.

## Checklists

### Issue(s) closed

COM-216

