### PR TITLE
feat: Add server-side column sorting to the workflows table.

### DIFF
--- a/server/config/development.yaml
+++ b/server/config/development.yaml
@@ -24,6 +24,7 @@ startWorkflowDisabled: false
 hideWorkflowQueryErrors: false
 refreshWorkflowCountsDisabled: false
 activityCommandsDisabled: false
+workflowSortingEnabled: false
 auth:
   enabled: false
   redirectToProvider: false

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -25,6 +25,7 @@ startWorkflowDisabled: {{ env "TEMPORAL_START_WORKFLOW_DISABLED" | default "fals
 hideWorkflowQueryErrors: {{ env "TEMPORAL_HIDE_WORKFLOW_QUERY_ERRORS" | default "false" }} 
 refreshWorkflowCountsDisabled: {{ env "TEMPORAL_REFRESH_WORKFLOW_COUNTS_DISABLED" | default "false" }}
 activityCommandsDisabled: {{ env "TEMPORAL_ACTIVITY_COMMANDS_DISABLED" | default "false" }}
+workflowSortingEnabled: {{ env "TEMPORAL_WORKFLOW_SORTING_ENABLED" | default "false" }}
 cors:
   cookieInsecure: {{ env "TEMPORAL_CSRF_COOKIE_INSECURE" | default "false" }}
   unsafeAllowAllOrigins: {{ env "TEMPORAL_CORS_UNSAFE_ALLOW_ALL_ORIGINS" | default "false" }}

--- a/server/config/with-auth.yaml
+++ b/server/config/with-auth.yaml
@@ -21,6 +21,7 @@ batchActionsDisabled: false
 startWorkflowDisabled: false
 hideWorkflowQueryErrors: false
 refreshWorkflowCountsDisabled: false
+workflowSortingEnabled: false
 # =============================================================================
 # Auth Testing Configuration
 # =============================================================================

--- a/server/server/api/handler.go
+++ b/server/server/api/handler.go
@@ -79,6 +79,7 @@ type SettingsResponse struct {
 	HideWorkflowQueryErrors       bool
 	RefreshWorkflowCountsDisabled bool
 	ActivityCommandsDisabled      bool
+	WorkflowSortingEnabled        bool
 }
 
 func TemporalAPIHandler(cfgProvider *config.ConfigProviderWithRefresh, apiMiddleware []Middleware, conn *grpc.ClientConn) echo.HandlerFunc {
@@ -159,6 +160,7 @@ func GetSettings(cfgProvider *config.ConfigProviderWithRefresh) func(echo.Contex
 			HideWorkflowQueryErrors:       cfg.HideWorkflowQueryErrors,
 			RefreshWorkflowCountsDisabled: cfg.RefreshWorkflowCountsDisabled,
 			ActivityCommandsDisabled:      cfg.ActivityCommandsDisabled,
+			WorkflowSortingEnabled:        cfg.WorkflowSortingEnabled,
 		}
 
 		return c.JSON(http.StatusOK, settings)

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -68,6 +68,9 @@ type (
 		HideWorkflowQueryErrors bool `yaml:"hideWorkflowQueryErrors"`
 		// Whether to disable refreshing workflow counts in UI
 		RefreshWorkflowCountsDisabled bool `yaml:"refreshWorkflowCountsDisabled"`
+		// Whether to enable sorting the Workflows table by column. Requires an Elasticsearch
+		// Visibility store with the server's system.visibilityDisableOrderByClause set to false.
+		WorkflowSortingEnabled bool `yaml:"workflowSortingEnabled"`
 		// Whether to disable activity commands in the UI
 		ActivityCommandsDisabled bool `yaml:"activityCommandsDisabled"`
 		// Forward specified HTTP headers from HTTP API requests to Temporal gRPC backend

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -21,9 +21,14 @@
     fetchAllChildWorkflows,
     fetchPaginatedWorkflows,
   } from '$lib/services/workflow-service';
+  import {
+    orderByClauseRejected,
+    supportsAdvancedVisibilityWithOrderBy,
+  } from '$lib/stores/advanced-visibility';
   import { configurableTableColumns } from '$lib/stores/configurable-table-columns';
   import { viewFeature } from '$lib/stores/new-feature-tags';
   import { tableDensity } from '$lib/stores/table-density';
+  import { toaster } from '$lib/stores/toaster';
   import { refresh, workflowCount } from '$lib/stores/workflows';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import {
@@ -31,6 +36,13 @@
     getPageSelectionStatus,
     type PageSelectionStatus,
   } from '$lib/utilities/batch-selection';
+  import {
+    SORT_COLUMN_PARAM,
+    SORT_ORDER_PARAM,
+    toQueryWithOrderBy,
+    toWorkflowSort,
+  } from '$lib/utilities/query/order-by';
+  import { updateMultipleQueryParameters } from '$lib/utilities/update-query-parameters';
 
   import TableBodyCell from './workflows-summary-configurable-table/table-body-cell.svelte';
   import TableHeaderCell from './workflows-summary-configurable-table/table-header-cell.svelte';
@@ -116,7 +128,30 @@
     }
   };
 
-  const onFetch = $derived(() => fetchPaginatedWorkflows(namespace, query));
+  const sortParam = $derived(toWorkflowSort(page.url.searchParams));
+  const sort = $derived(
+    $supportsAdvancedVisibilityWithOrderBy ? sortParam : undefined,
+  );
+  const listQuery = $derived(toQueryWithOrderBy(query, sort));
+
+  const onFetch = $derived(() => fetchPaginatedWorkflows(namespace, listQuery));
+
+  $effect(() => {
+    if (!sortParam || !$orderByClauseRejected) return;
+
+    toaster.push({
+      variant: 'error',
+      message: translate('workflows.sorting-not-supported'),
+      duration: 8000,
+    });
+    updateMultipleQueryParameters({
+      url: page.url,
+      parameters: [
+        { parameter: SORT_COLUMN_PARAM },
+        { parameter: SORT_ORDER_PARAM },
+      ],
+    });
+  });
 
   const dense = $derived($tableDensity === 'dense');
 
@@ -214,7 +249,7 @@
   });
 </script>
 
-{#key [namespace, query, $refresh]}
+{#key [namespace, listQuery, $refresh]}
   <PaginatedTable
     total={$workflowCount.count}
     {onFetch}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-header-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-header-cell.svelte
@@ -1,7 +1,22 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
+  import { page } from '$app/state';
+
+  import Icon from '$lib/holocene/icon/icon.svelte';
+  import { translate } from '$lib/i18n/translate';
+  import { supportsAdvancedVisibilityWithOrderBy } from '$lib/stores/advanced-visibility';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
+  import { currentPageKey } from '$lib/stores/pagination';
+  import { searchAttributes } from '$lib/stores/search-attributes';
+  import {
+    SORT_COLUMN_PARAM,
+    SORT_ORDER_PARAM,
+    type SortOrder,
+    toSortAttribute,
+    toWorkflowSort,
+  } from '$lib/utilities/query/order-by';
+  import { updateMultipleQueryParameters } from '$lib/utilities/update-query-parameters';
 
   interface Props {
     column: ConfigurableTableHeader;
@@ -10,11 +25,69 @@
 
   let { children, column }: Props = $props();
   let { label } = $derived(column);
+
+  const sortAttribute = $derived(toSortAttribute(label, $searchAttributes));
+  const sortable = $derived(
+    !!sortAttribute && $supportsAdvancedVisibilityWithOrderBy,
+  );
+
+  const sort = $derived(toWorkflowSort(page.url.searchParams));
+  const order = $derived(
+    sortable && sort && sort.attribute === sortAttribute
+      ? sort.order
+      : undefined,
+  );
+
+  const nextOrder = (current: SortOrder | undefined): SortOrder | undefined => {
+    if (current === undefined) return 'desc';
+    if (current === 'desc') return 'asc';
+    return undefined;
+  };
+
+  const onSort = () => {
+    const next = nextOrder(order);
+    updateMultipleQueryParameters({
+      url: page.url,
+      parameters: [
+        { parameter: SORT_COLUMN_PARAM, value: next ? sortAttribute : '' },
+        { parameter: SORT_ORDER_PARAM, value: next ?? '' },
+      ],
+      clearParameters: [currentPageKey],
+    });
+  };
+
+  const ariaSort = $derived.by(() => {
+    if (order === 'asc') return 'ascending';
+    if (order === 'desc') return 'descending';
+    return sortable ? 'none' : undefined;
+  });
 </script>
 
-<th scope="col" data-testid="workflows-summary-table-header-cell-{label}">
+<th
+  scope="col"
+  aria-sort={ariaSort}
+  data-testid="workflows-summary-table-header-cell-{label}"
+>
   <div class="flex items-center gap-2">
-    {label}
+    {#if sortable}
+      <button
+        type="button"
+        class="group flex items-center gap-1 whitespace-nowrap"
+        onclick={onSort}
+        data-testid="workflows-summary-table-header-sort-{label}"
+        aria-label={translate('workflows.sort-by-column', { column: label })}
+      >
+        {label}
+        <Icon
+          name={order === 'asc' ? 'ascending' : 'descending'}
+          class={order
+            ? 'text-primary'
+            : 'text-subtle opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100'}
+        />
+      </button>
+    {:else}
+      {label}
+    {/if}
     {@render children?.()}
   </div>
 </th>

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -292,6 +292,9 @@ export const Strings = {
   'workflow-task-failures-query-empty-state-description':
     'None of your Workflows currently match your task failure criteria',
   'workflow-query-error-state': 'Error Filtering Workflows',
+  'sort-by-column': 'Sort by {{column}}',
+  'sorting-not-supported':
+    'Sorting is not supported by this Namespace’s Visibility store.',
   'workflow-empty-state-title': 'No Workflows running in this Namespace',
   'workflow-empty-state-description':
     'You can populate the Web UI with sample Workflows. You can find a complete list of executable code samples at',

--- a/src/lib/services/settings-service.test.ts
+++ b/src/lib/services/settings-service.test.ts
@@ -39,6 +39,7 @@ const settingsResponse = (
   HideWorkflowQueryErrors: false,
   RefreshWorkflowCountsDisabled: false,
   ActivityCommandsDisabled: false,
+  WorkflowSortingEnabled: false,
   ShowTemporalSystemNamespace: false,
   NavCollapsedByDefault: false,
   FeedbackURL: '',
@@ -86,6 +87,26 @@ describe('fetchSettings', () => {
     const settings = await fetchSettings();
 
     expect(settings.navCollapsedByDefault).toBe(false);
+  });
+
+  it('maps workflowSortingEnabled from settings response', async () => {
+    vi.mocked(requestFromAPI).mockResolvedValue(
+      settingsResponse({ WorkflowSortingEnabled: true }),
+    );
+
+    const settings = await fetchSettings();
+
+    expect(settings.workflowSortingEnabled).toBe(true);
+  });
+
+  it('defaults workflowSortingEnabled to false when omitted', async () => {
+    const response = settingsResponse();
+    delete (response as Partial<SettingsResponse>).WorkflowSortingEnabled;
+    vi.mocked(requestFromAPI).mockResolvedValue(response);
+
+    const settings = await fetchSettings();
+
+    expect(settings.workflowSortingEnabled).toBe(false);
   });
 
   it('maps disableNewsFetch from settings response', async () => {

--- a/src/lib/services/settings-service.ts
+++ b/src/lib/services/settings-service.ts
@@ -30,6 +30,7 @@ const emptySettingsResponse: SettingsResponse = {
   HideWorkflowQueryErrors: false,
   RefreshWorkflowCountsDisabled: false,
   ActivityCommandsDisabled: false,
+  WorkflowSortingEnabled: false,
   ShowTemporalSystemNamespace: false,
   NavCollapsedByDefault: false,
   FeedbackURL: '',
@@ -78,6 +79,7 @@ export const fetchSettings = async (request = fetch): Promise<Settings> => {
     refreshWorkflowCountsDisabled:
       !!settingsResponse?.RefreshWorkflowCountsDisabled,
     activityCommandsDisabled: !!settingsResponse?.ActivityCommandsDisabled,
+    workflowSortingEnabled: !!settingsResponse?.WorkflowSortingEnabled,
 
     showTemporalSystemNamespace: settingsResponse?.ShowTemporalSystemNamespace,
     navCollapsedByDefault: !!settingsResponse?.NavCollapsedByDefault,

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -11,7 +11,7 @@ import {
   toWorkflowExecution,
   toWorkflowExecutions,
 } from '$lib/models/workflow-execution';
-import { isCloud } from '$lib/stores/advanced-visibility';
+import { isCloud, rejectOrderByClause } from '$lib/stores/advanced-visibility';
 import type {
   SearchAttributeInput,
   SearchAttributesSchema,
@@ -64,6 +64,7 @@ import {
 import { paginated } from '$lib/utilities/paginated';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
+import { isOrderByUnsupportedError } from '$lib/utilities/query/order-by';
 import type { ErrorCallback } from '$lib/utilities/request-from-api';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { base, pathForApi, routeForApi } from '$lib/utilities/route-for-api';
@@ -1128,6 +1129,13 @@ export const fetchPaginatedWorkflows = async (
 
     const onError: ErrorCallback = (err) => {
       handleUnauthorizedOrForbiddenError(err);
+
+      if (
+        query.toLowerCase().includes('order by') &&
+        isOrderByUnsupportedError(err?.body?.message)
+      ) {
+        rejectOrderByClause(namespace);
+      }
 
       if (get(hideWorkflowQueryErrors)) {
         workflowError.set(translate('workflows.workflows-error-querying'));

--- a/src/lib/stores/advanced-visibility.test.ts
+++ b/src/lib/stores/advanced-visibility.test.ts
@@ -1,0 +1,85 @@
+import { get, writable } from 'svelte/store';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const page = writable({ params: {}, data: {} });
+
+vi.mock('$app/stores', () => ({ page }));
+
+const {
+  orderByClauseRejected,
+  rejectOrderByClause,
+  supportsAdvancedVisibilityWithOrderBy,
+} = await import('./advanced-visibility');
+
+type PageOverrides = {
+  namespace?: string;
+  visibilityStore?: string;
+  isCloud?: boolean;
+  workflowSortingEnabled?: boolean;
+};
+
+const setPage = ({
+  namespace = 'default',
+  visibilityStore = 'elasticsearch',
+  isCloud = false,
+  workflowSortingEnabled = true,
+}: PageOverrides = {}) => {
+  page.set({
+    params: { namespace },
+    data: {
+      cluster: { visibilityStore },
+      settings: {
+        workflowSortingEnabled,
+        runtimeEnvironment: { isCloud },
+      },
+    },
+  });
+};
+
+beforeEach(() => {
+  rejectOrderByClause('');
+  setPage();
+});
+
+describe('supportsAdvancedVisibilityWithOrderBy', () => {
+  it('should be supported on Elasticsearch when the setting is enabled', () => {
+    setPage();
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(true);
+  });
+
+  it('should not be supported when the setting is disabled', () => {
+    setPage({ workflowSortingEnabled: false });
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(false);
+  });
+
+  it('should not be supported on a SQL visibility store', () => {
+    setPage({ visibilityStore: 'postgres12' });
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(false);
+  });
+
+  it('should not be supported on Cloud', () => {
+    setPage({ isCloud: true });
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(false);
+  });
+});
+
+describe('rejectOrderByClause', () => {
+  it('should disable sorting for a namespace the server rejected', () => {
+    setPage({ namespace: 'rejected-namespace' });
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(true);
+
+    rejectOrderByClause('rejected-namespace');
+
+    expect(get(orderByClauseRejected)).toBe(true);
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(false);
+  });
+
+  it('should leave other namespaces unaffected', () => {
+    rejectOrderByClause('other-namespace');
+    setPage({ namespace: 'default' });
+
+    expect(get(orderByClauseRejected)).toBe(false);
+    expect(get(supportsAdvancedVisibilityWithOrderBy)).toBe(true);
+  });
+});

--- a/src/lib/stores/advanced-visibility.ts
+++ b/src/lib/stores/advanced-visibility.ts
@@ -1,4 +1,4 @@
-import { derived } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
 
 import { page } from '$app/stores';
 
@@ -21,8 +21,30 @@ export const supportsAdvancedVisibility = derived(
     advancedVisibilityEnabled($cluster, $temporalVersion) || $isCloud,
 );
 
+const orderByClauseRejectedNamespaces = writable<string[]>([]);
+
+export const rejectOrderByClause = (namespace: string) => {
+  orderByClauseRejectedNamespaces.update((namespaces) =>
+    namespaces.includes(namespace) ? namespaces : [...namespaces, namespace],
+  );
+};
+
+export const orderByClauseRejected = derived(
+  [page, orderByClauseRejectedNamespaces],
+  ([$page, $orderByClauseRejectedNamespaces]) =>
+    $orderByClauseRejectedNamespaces.includes($page.params?.namespace),
+);
+
+export const workflowSortingEnabled = derived(
+  [page],
+  ([$page]) => !!$page.data?.settings?.workflowSortingEnabled,
+);
+
 export const supportsAdvancedVisibilityWithOrderBy = derived(
-  [cluster, isCloud],
-  ([$cluster, $isCloud]) =>
-    advancedVisibilityEnabledWithOrderBy($cluster) || $isCloud,
+  [cluster, isCloud, orderByClauseRejected, workflowSortingEnabled],
+  ([$cluster, $isCloud, $orderByClauseRejected, $workflowSortingEnabled]) =>
+    $workflowSortingEnabled &&
+    !$isCloud &&
+    !$orderByClauseRejected &&
+    advancedVisibilityEnabledWithOrderBy($cluster),
 );

--- a/src/lib/svelte-mocks/app/state.ts
+++ b/src/lib/svelte-mocks/app/state.ts
@@ -25,6 +25,7 @@ const settings: Settings = {
   workflowTerminateDisabled: false,
   hideWorkflowQueryErrors: false,
   activityCommandsDisabled: false,
+  workflowSortingEnabled: false,
   feedbackURL: '',
   disableNewsFetch: false,
   runtimeEnvironment: {

--- a/src/lib/svelte-mocks/app/stores.ts
+++ b/src/lib/svelte-mocks/app/stores.ts
@@ -36,6 +36,7 @@ const settings: Settings = {
   workflowTerminateDisabled: false,
   hideWorkflowQueryErrors: false,
   activityCommandsDisabled: false,
+  workflowSortingEnabled: false,
   feedbackURL: '',
   disableNewsFetch: false,
   runtimeEnvironment: {

--- a/src/lib/types/global.ts
+++ b/src/lib/types/global.ts
@@ -100,6 +100,7 @@ export type Settings = {
   hideWorkflowQueryErrors: boolean;
   batchActionsDisabled: boolean;
   activityCommandsDisabled: boolean;
+  workflowSortingEnabled: boolean;
   showTemporalSystemNamespace: boolean;
   navCollapsedByDefault: boolean;
   feedbackURL: string;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -381,6 +381,7 @@ export type SettingsResponse = {
   HideWorkflowQueryErrors: boolean;
   RefreshWorkflowCountsDisabled: boolean;
   ActivityCommandsDisabled: boolean;
+  WorkflowSortingEnabled: boolean;
   ShowTemporalSystemNamespace: boolean;
   NavCollapsedByDefault: boolean;
   FeedbackURL: string;

--- a/src/lib/utilities/query/order-by.test.ts
+++ b/src/lib/utilities/query/order-by.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+
+import { SEARCH_ATTRIBUTE_TYPE } from '$lib/types/workflows';
+
+import {
+  isOrderByUnsupportedError,
+  toQueryWithOrderBy,
+  toSortAttribute,
+  toWorkflowSort,
+} from './order-by';
+
+const searchAttributes = {
+  ExecutionStatus: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
+  StartTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
+  CloseTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
+  ExecutionDuration: SEARCH_ATTRIBUTE_TYPE.INT,
+  TemporalChangeVersion: SEARCH_ATTRIBUTE_TYPE.KEYWORDLIST,
+  CustomTextField: SEARCH_ATTRIBUTE_TYPE.TEXT,
+  CustomIntField: SEARCH_ATTRIBUTE_TYPE.INT,
+  'Custom Spaced Field': SEARCH_ATTRIBUTE_TYPE.KEYWORD,
+};
+
+describe('toSortAttribute', () => {
+  it('should map a column label to its search attribute', () => {
+    expect(toSortAttribute('Start', searchAttributes)).toBe('StartTime');
+    expect(toSortAttribute('End', searchAttributes)).toBe('CloseTime');
+    expect(toSortAttribute('Status', searchAttributes)).toBe('ExecutionStatus');
+  });
+
+  it('should pass through custom search attribute labels', () => {
+    expect(toSortAttribute('CustomIntField', searchAttributes)).toBe(
+      'CustomIntField',
+    );
+  });
+
+  it('should not sort by attributes missing from the namespace', () => {
+    expect(
+      toSortAttribute('Parent Namespace', searchAttributes),
+    ).toBeUndefined();
+    expect(toSortAttribute('History Size', searchAttributes)).toBeUndefined();
+  });
+
+  it('should not sort by Text or KeywordList attributes', () => {
+    expect(
+      toSortAttribute('CustomTextField', searchAttributes),
+    ).toBeUndefined();
+    expect(toSortAttribute('Change Version', searchAttributes)).toBeUndefined();
+  });
+});
+
+describe('toWorkflowSort', () => {
+  it('should return undefined without a sort parameter', () => {
+    expect(toWorkflowSort(new URLSearchParams(''))).toBeUndefined();
+    expect(
+      toWorkflowSort(new URLSearchParams('sort-order=asc')),
+    ).toBeUndefined();
+  });
+
+  it('should default to descending', () => {
+    expect(toWorkflowSort(new URLSearchParams('sort=StartTime'))).toEqual({
+      attribute: 'StartTime',
+      order: 'desc',
+    });
+    expect(
+      toWorkflowSort(new URLSearchParams('sort=StartTime&sort-order=nonsense')),
+    ).toEqual({ attribute: 'StartTime', order: 'desc' });
+  });
+
+  it('should parse an ascending sort', () => {
+    expect(
+      toWorkflowSort(new URLSearchParams('sort=StartTime&sort-order=asc')),
+    ).toEqual({ attribute: 'StartTime', order: 'asc' });
+  });
+});
+
+describe('toQueryWithOrderBy', () => {
+  it('should return the query unchanged without a sort', () => {
+    expect(toQueryWithOrderBy('ExecutionStatus="Running"')).toBe(
+      'ExecutionStatus="Running"',
+    );
+    expect(toQueryWithOrderBy('')).toBe('');
+  });
+
+  it('should append an order by clause to a query', () => {
+    expect(
+      toQueryWithOrderBy('ExecutionStatus="Running"', {
+        attribute: 'StartTime',
+        order: 'asc',
+      }),
+    ).toBe('ExecutionStatus="Running" order by StartTime asc');
+  });
+
+  it('should build an order by only query', () => {
+    expect(
+      toQueryWithOrderBy('', { attribute: 'CloseTime', order: 'desc' }),
+    ).toBe('order by CloseTime desc');
+  });
+
+  it('should escape attributes containing spaces', () => {
+    expect(
+      toQueryWithOrderBy('', {
+        attribute: 'Custom Spaced Field',
+        order: 'asc',
+      }),
+    ).toBe('order by `Custom Spaced Field` asc');
+  });
+});
+
+describe('isOrderByUnsupportedError', () => {
+  it('should detect the SQL visibility store rejection', () => {
+    expect(isOrderByUnsupportedError("not supported: 'ORDER BY' clause")).toBe(
+      true,
+    );
+  });
+
+  it('should detect the disabled order by dynamic config rejection', () => {
+    expect(isOrderByUnsupportedError('ORDER BY clause is not supported')).toBe(
+      true,
+    );
+  });
+
+  it('should detect an unsortable search attribute type', () => {
+    expect(
+      isOrderByUnsupportedError(
+        'not supported: unable to sort by search attribute type Text',
+      ),
+    ).toBe(true);
+  });
+
+  it('should ignore unrelated errors', () => {
+    expect(isOrderByUnsupportedError('invalid query syntax')).toBe(false);
+    expect(isOrderByUnsupportedError('')).toBe(false);
+    expect(isOrderByUnsupportedError(undefined)).toBe(false);
+  });
+});

--- a/src/lib/utilities/query/order-by.ts
+++ b/src/lib/utilities/query/order-by.ts
@@ -1,0 +1,101 @@
+import {
+  SEARCH_ATTRIBUTE_TYPE,
+  type SearchAttributes,
+  type SearchAttributeType,
+} from '$lib/types/workflows';
+
+export const SORT_COLUMN_PARAM = 'sort';
+export const SORT_ORDER_PARAM = 'sort-order';
+
+export type SortOrder = 'asc' | 'desc';
+
+export type WorkflowSort = {
+  attribute: string;
+  order: SortOrder;
+};
+
+const unsortableTypes: readonly SearchAttributeType[] = [
+  SEARCH_ATTRIBUTE_TYPE.TEXT,
+  SEARCH_ATTRIBUTE_TYPE.KEYWORDLIST,
+  SEARCH_ATTRIBUTE_TYPE.UNSPECIFIED,
+] as const;
+
+export const columnSortAttributes: Readonly<Record<string, string>> = {
+  Status: 'ExecutionStatus',
+  'Workflow ID': 'WorkflowId',
+  'Run ID': 'RunId',
+  Type: 'WorkflowType',
+  Start: 'StartTime',
+  End: 'CloseTime',
+  'Execution Time': 'ExecutionTime',
+  'Execution Duration': 'ExecutionDuration',
+  'History Size': 'HistorySizeBytes',
+  'History Length': 'HistoryLength',
+  'State Transitions': 'StateTransitionCount',
+  'Task Queue': 'TaskQueue',
+  'Scheduled By ID': 'TemporalScheduledById',
+  'Scheduled Start Time': 'TemporalScheduledStartTime',
+  Deployment: 'TemporalWorkerDeployment',
+  'Deployment Version': 'TemporalWorkerDeploymentVersion',
+  'Versioning Behavior': 'TemporalWorkflowVersioningBehavior',
+  'Build ID': 'TemporalWorkerBuildId',
+  'Change Version': 'TemporalChangeVersion',
+} as const;
+
+export const toSortAttribute = (
+  label: string,
+  searchAttributes: SearchAttributes = {},
+): string | undefined => {
+  const attribute = columnSortAttributes[label] ?? label;
+  const type = searchAttributes[attribute];
+
+  if (!type) return undefined;
+  if (unsortableTypes.includes(type)) return undefined;
+
+  return attribute;
+};
+
+export const toWorkflowSort = (
+  searchParams: URLSearchParams,
+): WorkflowSort | undefined => {
+  const attribute = searchParams.get(SORT_COLUMN_PARAM);
+
+  if (!attribute) return undefined;
+
+  const order: SortOrder =
+    searchParams.get(SORT_ORDER_PARAM) === 'asc' ? 'asc' : 'desc';
+
+  return { attribute, order };
+};
+
+const escapeAttribute = (attribute: string): string =>
+  /\s/.test(attribute) ? `\`${attribute}\`` : attribute;
+
+export const toQueryWithOrderBy = (
+  query = '',
+  sort: WorkflowSort | undefined = undefined,
+): string => {
+  if (!sort?.attribute) return query;
+
+  const orderBy = `order by ${escapeAttribute(sort.attribute)} ${sort.order}`;
+
+  return query ? `${query} ${orderBy}` : orderBy;
+};
+
+const orderByUnsupportedMessages = [
+  "'order by' clause",
+  'order by clause is not supported',
+  'unable to sort by search attribute',
+];
+
+export const isOrderByUnsupportedError = (
+  message: string | undefined,
+): boolean => {
+  if (!message) return false;
+
+  const normalizedMessage = message.toLowerCase();
+
+  return orderByUnsupportedMessages.some((unsupportedMessage) =>
+    normalizedMessage.includes(unsupportedMessage),
+  );
+};


### PR DESCRIPTION
## Description & motivation 💭
Workflows always come back in the server's default order (`CloseTime DESC NULLS FIRST, StartTime DESC`). Filtering is the only way to narrow them down.

Click a column header to sort: desc > asc > off. This goes to the server as an `ORDER BY` clause on `ListWorkflowExecutions`, so it sorts the whole result set and not just the visible page.

- Sort lives in the URL (`?sort=StartTime&sort-order=desc`), so it's shareable. Changing it resets pagination.
- Sortable columns come from the namespace's search attributes. `Text` and `KeywordList` are excluded since the server can't sort them. Custom attribute columns work, Parent Namespace and friends don't.
- `order by` is appended to the list query only, never the count query (which appends its own `GROUP BY`), so the header counts stay correct.

Off by default behind `workflowSortingEnabled` / `TEMPORAL_WORKFLOW_SORTING_ENABLED`, because server support is thin:

| Visibility store | `ORDER BY` |
|---|---|
| SQL (MySQL/Postgres/SQLite) | rejected |
| Elasticsearch, default config | rejected, `visibilityDisableOrderByClause` defaults to `true` |
| Elasticsearch + that set to `false` | works |
| Temporal Cloud | not supported |

Gate is `workflowSortingEnabled && !isCloud && visibilityStore == elasticsearch`. That last part also fixes `supportsAdvancedVisibilityWithOrderBy`, which OR'd in `isCloud` — backwards, Cloud doesn't support it.

### Screenshots (if applicable) 📸

<img width="1316" height="904" alt="1-sort-affordance-on-hover" src="https://github.com/user-attachments/assets/c59510cd-afa4-49d6-9983-8a072c7deeb7" />
<img width="1316" height="904" alt="2-sorted-ascending-workflow-id" src="https://github.com/user-attachments/assets/b7380631-13dc-4fa6-85d7-20afdcc8c895" />
<img width="1316" height="904" alt="3-sorted-descending-type" src="https://github.com/user-attachments/assets/8d099400-7036-4bb9-9162-68e9d2f737e1" />
<img width="1316" height="904" alt="4-unsupported-toast" src="https://github.com/user-attachments/assets/47f5c8ac-ca8a-4cf7-b7ec-eb5c770d24c2" />

### Design Considerations 🎨

Chevrons stay hidden until you hover or focus a sortable header; the active one stays lit. Headers carry `aria-sort` and the control is a real button.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [X] Manual testing
- [ ] E2E tests added
- [X] Unit tests added
