### PR TITLE
Update holocene toggle-switch to runes syntax

### DIFF
--- a/src/lib/components/auto-refresh-workflow.svelte
+++ b/src/lib/components/auto-refresh-workflow.svelte
@@ -18,6 +18,6 @@
     labelPosition="left"
     id="autorefresh"
     {checked}
-    on:change={onChange}
+    onchange={onChange}
   />
 </Tooltip>

--- a/src/lib/components/batch-operations/header.svelte
+++ b/src/lib/components/batch-operations/header.svelte
@@ -66,7 +66,7 @@
         label={translate('common.auto-refresh')}
         labelPosition="left"
         checked={$autoRefresh}
-        on:change={handleToggleAutoRefresh}
+        onchange={handleToggleAutoRefresh}
       />
     </Tooltip>
   {/if}

--- a/src/lib/components/timezone-select.svelte
+++ b/src/lib/components/timezone-select.svelte
@@ -167,7 +167,7 @@
         id="relative-toggle"
         bind:checked={$relativeTime}
         labelPosition="left"
-        on:change={handleRelativeToggle}
+        onchange={handleRelativeToggle}
         data-testid="timezones-relative-toggle"
       />
     </div>

--- a/src/lib/components/workflow/relationships/workflow-family-tree.svelte
+++ b/src/lib/components/workflow/relationships/workflow-family-tree.svelte
@@ -78,7 +78,7 @@
             labelPosition="left"
             id="autorefresh"
             checked={expandAll}
-            on:change={onExpandAll}
+            onchange={onExpandAll}
           />
         {/if}
       </div>

--- a/src/lib/holocene/toggle-switch.stories.svelte
+++ b/src/lib/holocene/toggle-switch.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
 
@@ -30,7 +31,7 @@
         table: { disable: true },
       },
     },
-  } satisfies Meta<ToggleSwitch>;
+  } satisfies Meta<ComponentProps<typeof ToggleSwitch>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/toggle-switch.svelte
+++ b/src/lib/holocene/toggle-switch.svelte
@@ -4,12 +4,27 @@
 
   import Label from '$lib/holocene/label.svelte';
 
-  export let id: string;
-  export let label: string;
-  export let disabled = false;
-  export let checked = false;
-  export let labelPosition: 'left' | 'right' = 'right';
-  export let labelHidden = false;
+  interface Props {
+    id: string;
+    label: string;
+    disabled?: boolean;
+    checked?: boolean;
+    labelPosition?: 'left' | 'right';
+    labelHidden?: boolean;
+    'data-testid'?: string;
+    onchange?: (event: Event) => void;
+  }
+
+  let {
+    id,
+    label,
+    disabled = false,
+    checked = $bindable(false),
+    labelPosition = 'right',
+    labelHidden = false,
+    'data-testid': testId,
+    onchange,
+  }: Props = $props();
 </script>
 
 <Label
@@ -19,7 +34,7 @@
     disabled && 'opacity-50',
   )}
   {disabled}
-  data-testid={$$props['data-testid']}
+  data-testid={testId}
 >
   <span
     class="whitespace-nowrap text-sm font-medium"
@@ -28,7 +43,7 @@
     {label}
   </span>
   <input
-    on:change
+    {onchange}
     bind:checked
     {id}
     {disabled}

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -174,7 +174,7 @@
               labelPosition="left"
               id="json-formatting"
               checked={jsonFormatting}
-              on:change={() => (jsonFormatting = !jsonFormatting)}
+              onchange={() => (jsonFormatting = !jsonFormatting)}
             />
           </div>
           <CodeBlock


### PR DESCRIPTION
Migrates `toggle-switch` to Svelte 5 runes and updates its consumers (`on:change` → `onchange`).

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3007