### PR TITLE
Update holocene textarea to runes syntax

### DIFF
--- a/src/lib/holocene/textarea.stories.svelte
+++ b/src/lib/holocene/textarea.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import Textarea from './textarea.svelte';
 
@@ -37,7 +38,7 @@
       labelHidden: { name: 'Label Hidden', control: 'boolean' },
       id: { name: 'Id', control: 'text', table: { disable: true } },
     },
-  } satisfies Meta<Textarea>;
+  } satisfies Meta<ComponentProps<typeof Textarea>>;
 </script>
 
 <script lang="ts">
@@ -50,11 +51,11 @@
 
 <Template let:args let:context>
   <Textarea
-    on:input={action('input')}
-    on:blur={action('blue')}
-    on:change={action('change')}
-    on:focus={action('focus')}
-    on:keydown={action('keydown')}
+    oninput={action('input')}
+    onblur={action('blue')}
+    onchange={action('change')}
+    onfocus={action('focus')}
+    onkeydown={action('keydown')}
     id={context.id}
     {...args}
   />

--- a/src/lib/holocene/textarea.svelte
+++ b/src/lib/holocene/textarea.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import type { HTMLTextareaAttributes } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import Label from './label.svelte';
 
-  type $$Props = HTMLTextareaAttributes & {
+  interface Props extends HTMLTextareaAttributes {
     disabled?: boolean;
     error?: string;
     isValid?: boolean;
@@ -20,26 +21,37 @@
     description?: string;
     maxLength?: number;
     class?: string;
+    errorSnippet?: Snippet;
+  }
+
+  let {
+    disabled = false,
+    error = '',
+    isValid = true,
+    placeholder = '',
+    rows = 5,
+    spellcheck,
+    value = $bindable(),
+    label,
+    labelHidden = false,
+    id,
+    required = false,
+    description = '',
+    maxLength = 0,
+    class: className = 'text-primary',
+    onkeydown,
+    errorSnippet,
+    ...rest
+  }: Props = $props();
+
+  const errorId = $derived(`${id}-error`);
+
+  const handleKeydown = (
+    event: KeyboardEvent & { currentTarget: HTMLTextAreaElement },
+  ) => {
+    event.stopPropagation();
+    onkeydown?.(event);
   };
-
-  export let disabled = false;
-  export let error = '';
-  export let isValid = true;
-  export let placeholder = '';
-  export let rows = 5;
-  export let spellcheck: boolean | undefined = undefined;
-  export let value: string;
-  export let label: string;
-  export let labelHidden = false;
-  export let id: string;
-  export let required = false;
-  export let description = '';
-  export let maxLength = 0;
-
-  let className = 'text-primary';
-  export { className as class };
-
-  $: errorId = `${id}-error`;
 </script>
 
 <div class={merge('group flex flex-col gap-1', className)}>
@@ -68,14 +80,10 @@
       {required}
       aria-invalid={!isValid ? 'true' : undefined}
       aria-describedby={!isValid && error ? errorId : undefined}
-      on:input
-      on:change
-      on:focus
-      on:blur
-      on:keydown|stopPropagation
+      onkeydown={handleKeydown}
       maxlength={maxLength > 0 ? maxLength : undefined}
       data-testid={id}
-      {...$$restProps}
+      {...rest}
     ></textarea>
   </div>
   <div class="flex justify-between gap-2">
@@ -89,7 +97,7 @@
         {#if error}
           <p>{error}</p>
         {/if}
-        <slot name="error" />
+        {@render errorSnippet?.()}
       {/if}
     </div>
     {#if maxLength && !disabled}


### PR DESCRIPTION
Migrates `textarea` to Svelte 5 runes.

The `error` **slot** becomes an `errorSnippet` prop — Svelte 5 can't have both a prop and a snippet named `error` (the `error` string prop keeps that name), so the slot name couldn't survive the migration regardless.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3008