### PR TITLE
Update holocene checkbox to runes syntax

### DIFF
--- a/src/lib/components/lines-and-dots/event-type-filter.svelte
+++ b/src/lib/components/lines-and-dots/event-type-filter.svelte
@@ -133,7 +133,7 @@
     <MenuItem data-testid={translate('common.all')} onclick={onAllClick}>
       {#snippet leading()}
         <Checkbox
-          on:change={onAllClick}
+          onChange={onAllClick}
           checked={!$eventStatusFilter &&
             $eventTypeFilter.length === defaultOptions.length}
           label={translate('common.all')}
@@ -152,7 +152,7 @@
       >
         {#snippet leading()}
           <Checkbox
-            on:change={onPendingClick}
+            onChange={onPendingClick}
             checked={$eventStatusFilter}
             label={translate('common.all')}
             labelHidden
@@ -165,7 +165,7 @@
     <MenuItem data-testid={translate('common.none')} onclick={onNoneClick}>
       {#snippet leading()}
         <Checkbox
-          on:change={onNoneClick}
+          onChange={onNoneClick}
           checked={!$eventStatusFilter && !$eventTypeFilter.length}
           label={translate('common.none')}
           labelHidden
@@ -186,7 +186,7 @@
       >
         {#snippet leading()}
           <Checkbox
-            on:click={() => onOptionClick(option)}
+            onclick={() => onOptionClick(option)}
             checked={$eventTypeFilter.some((type) => type === option.value)}
             label={option.label}
             labelHidden

--- a/src/lib/components/news-feed/news-feed-modal.svelte
+++ b/src/lib/components/news-feed/news-feed-modal.svelte
@@ -116,7 +116,7 @@
       id="news-feed-auto-fetch"
       checked={$newsFeed.autoFetchEnabled}
       label={translate('common.news-feed-auto-fetch')}
-      on:change={(event) => newsFeed.setAutoFetchEnabled(event.detail.checked)}
+      onChange={(event) => newsFeed.setAutoFetchEnabled(event.checked)}
     />
   </div>
 </Modal>

--- a/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
@@ -170,7 +170,7 @@
           description={translate('schedules.pause-schedule-description')}
           checked={$policies.pauseSchedule}
           error={$errors.pauseSchedule?.[0] ?? ''}
-          on:change={() => ($policies.pauseSchedule = !$policies.pauseSchedule)}
+          onChange={() => ($policies.pauseSchedule = !$policies.pauseSchedule)}
         />
       </div>
     </fieldset>

--- a/src/lib/components/search-attribute-filter/status-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/status-filter-chip.svelte
@@ -142,7 +142,7 @@
         >
           {#snippet leading()}
             <Checkbox
-              on:change={() => handleStatusSelect(status)}
+              onChange={() => handleStatusSelect(status)}
               {checked}
               label={status ?? undefined}
               labelHidden

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-header-row.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-header-row.svelte
@@ -39,8 +39,7 @@
     ACTIVITY_BATCH_OPERATION_CONTEXT,
   );
 
-  const handleCheckboxChange = (event: CustomEvent<{ checked: boolean }>) => {
-    const { checked } = event.detail;
+  const handleCheckboxChange = ({ checked }: { checked: boolean }) => {
     onSelectPage(checked, activities);
   };
 
@@ -57,7 +56,7 @@
         data-testid="batch-actions-checkbox"
         checked={pageSelectionStatus === 'checked'}
         indeterminate={pageSelectionStatus === 'partial'}
-        on:change={handleCheckboxChange}
+        onChange={handleCheckboxChange}
       />
     </th>
   {/if}

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/table-row.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/table-row.svelte
@@ -65,7 +65,7 @@
           data-testid="batch-checkbox"
           {label}
           labelHidden
-          on:click={onClickBatchSelect}
+          onclick={onClickBatchSelect}
           {checked}
           value={activity}
           disabled={$allSelected}

--- a/src/lib/components/workflow/dropdown-filter/workflow-status.svelte
+++ b/src/lib/components/workflow/dropdown-filter/workflow-status.svelte
@@ -105,7 +105,7 @@
             label={status ?? ''}
             labelHidden
             tabindex={-1}
-            on:click={() => onStatusClick(status ?? '')}
+            onclick={() => onStatusClick(status ?? '')}
             checked={statusFilters.some((filter) => filter.value === status) ||
               (!statusFilters.length && status === 'All')}
           />

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-header-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-header-row.svelte
@@ -34,8 +34,7 @@
     BATCH_OPERATION_CONTEXT,
   );
 
-  const handleCheckboxChange = (event: CustomEvent<{ checked: boolean }>) => {
-    const { checked } = event.detail;
+  const handleCheckboxChange = ({ checked }: { checked: boolean }) => {
     onSelectPage(checked, workflows);
   };
   const label = translate('workflows.select-all-workflows');
@@ -51,7 +50,7 @@
         data-testid="batch-actions-checkbox"
         checked={pageSelectionStatus === 'checked'}
         indeterminate={pageSelectionStatus === 'partial'}
-        on:change={handleCheckboxChange}
+        onChange={handleCheckboxChange}
       />
     </th>
   {/if}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
@@ -76,7 +76,7 @@
         data-testid="batch-checkbox"
         {label}
         labelHidden
-        on:click={onClickBatchSelect}
+        onclick={onClickBatchSelect}
         {checked}
         value={workflow}
         disabled={$allSelected}

--- a/src/lib/holocene/checkbox.stories.svelte
+++ b/src/lib/holocene/checkbox.stories.svelte
@@ -40,9 +40,9 @@
 <Template let:args>
   <Checkbox
     {...args}
-    on:change={action('change')}
-    on:click={action('click')}
-    on:keypress={action('keypress')}
+    onChange={action('change')}
+    onclick={action('click')}
+    onkeypress={action('keypress')}
   />
 </Template>
 

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -1,17 +1,14 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import type { HTMLInputAttributes } from 'svelte/elements';
 
-  import { omit } from 'es-toolkit';
-  import { createEventDispatcher } from 'svelte';
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import Icon from '$lib/holocene/icon/icon.svelte';
 
   import Label from './label.svelte';
 
-  type T = $$Generic;
-
-  interface $$Props extends HTMLInputAttributes {
+  interface Props extends HTMLInputAttributes {
     id?: string;
     disabled?: boolean;
     checked?: boolean;
@@ -26,32 +23,41 @@
     error?: string;
     class?: string;
     description?: string;
+    onChange?: (detail: { checked: boolean; value?: T }) => void;
+    flex?: Snippet;
   }
 
-  export let id: string = crypto.randomUUID();
-  export let checked = false;
-  export let label = '';
-  export let labelHidden = false;
-  export let indeterminate = false;
-  export let disabled = false;
-  export let value: T = undefined as T;
-  export let group: T[] | undefined = undefined;
-  export let valid = true;
-  export let error = '';
-  export let required = false;
-  export let description = '';
-
-  let className = '';
-  export { className as class };
+  let {
+    id = crypto.randomUUID(),
+    checked = $bindable(false),
+    label = '',
+    labelHidden = false,
+    indeterminate = false,
+    disabled = false,
+    value,
+    group = $bindable(),
+    valid = true,
+    error = '',
+    required = false,
+    description = '',
+    class: className = '',
+    'data-testid': testId,
+    onclick,
+    onChange,
+    flex,
+    ...rest
+  }: Props = $props();
 
   let inputElement: HTMLInputElement;
-  $: if (inputElement !== undefined) {
-    inputElement.indeterminate = indeterminate;
-  }
+  $effect(() => {
+    if (inputElement !== undefined) {
+      inputElement.indeterminate = indeterminate;
+    }
+  });
 
-  const dispatch = createEventDispatcher<{
-    change: { checked: boolean; value?: T };
-  }>();
+  const displayChecked = $derived(
+    group !== undefined ? group.includes(value as T) : checked,
+  );
 
   const handleChange = (
     event: Event & {
@@ -61,7 +67,7 @@
     const { checked: isChecked } = event.currentTarget;
     if (group !== undefined) {
       if (isChecked) {
-        group = [...group, value];
+        group = [...group, value as T];
       } else {
         group = group.filter((v) => v !== value);
       }
@@ -69,34 +75,33 @@
 
     checked = isChecked;
 
-    dispatch('change', { checked: event.currentTarget.checked, value });
+    onChange?.({ checked: isChecked, value });
   };
 
-  $: checked = group !== undefined ? group.includes(value) : checked;
+  const checkIconName = $derived(
+    indeterminate
+      ? ('hyphen' as const)
+      : displayChecked
+        ? ('checkmark' as const)
+        : null,
+  );
 
-  $: checkIconName = indeterminate
-    ? ('hyphen' as const)
-    : checked
-      ? ('checkmark' as const)
-      : null;
-
-  $: errorId = `${id}-error`;
-  $: showError = !valid && !!error;
+  const errorId = $derived(`${id}-error`);
+  const showError = $derived(!valid && !!error);
 </script>
 
 <div
-  data-testid={$$restProps['data-testid']}
-  on:click|stopPropagation={() => {
-    // applying noop handler because without it on:click handlers get forwarded
+  data-testid={testId}
+  onclick={(event) => {
+    // applying noop handler because without it onclick handlers get forwarded
     // to this div element (in addition to the input checkbox element).
+    event.stopPropagation();
   }}
-  on:keypress|stopPropagation
+  onkeypress={(event) => event.stopPropagation()}
   role="none"
 >
   <Label
-    data-testid={$$restProps['data-testid']
-      ? `${$$restProps['data-testid']}-label`
-      : undefined}
+    data-testid={testId ? `${testId}-label` : undefined}
     class={merge(
       [
         'flex',
@@ -115,8 +120,6 @@
     )}
   >
     <input
-      on:click
-      on:change={handleChange}
       {id}
       {value}
       type="checkbox"
@@ -126,11 +129,13 @@
       data-track-text={label}
       aria-invalid={!valid ? 'true' : undefined}
       aria-describedby={showError ? errorId : undefined}
-      bind:checked
       {disabled}
       {required}
+      {...rest}
+      {onclick}
+      onchange={handleChange}
+      checked={displayChecked}
       bind:this={inputElement}
-      {...omit($$restProps, ['data-testid'])}
     />
 
     <span
@@ -181,7 +186,9 @@
       {/if}
     </span>
 
-    <slot name="flex">
+    {#if flex}
+      {@render flex()}
+    {:else}
       <div>
         <span class="label" class:sr-only={labelHidden}>
           {label}
@@ -190,7 +197,7 @@
           <p class="text-xs font-normal text-secondary">{description}</p>
         {/if}
       </div>
-    </slot>
+    {/if}
   </Label>
   <span id={errorId} role="alert" class="text-xs text-danger">
     {#if showError}{error}{/if}

--- a/src/lib/holocene/checkbox.svelte
+++ b/src/lib/holocene/checkbox.svelte
@@ -34,7 +34,7 @@
     labelHidden = false,
     indeterminate = false,
     disabled = false,
-    value,
+    value = $bindable(),
     group = $bindable(),
     valid = true,
     error = '',

--- a/src/lib/holocene/select/multi-select.svelte
+++ b/src/lib/holocene/select/multi-select.svelte
@@ -110,7 +110,7 @@
       >
         {#snippet leading()}
           <Checkbox
-            on:click={() => onOptionClick(option)}
+            onclick={() => onOptionClick(option)}
             {checked}
             label={option.label}
             labelHidden


### PR DESCRIPTION
Migrates `checkbox` to Svelte 5 runes.

- Custom `change` event (`createEventDispatcher`) → an `onChange` callback receiving `{ checked, value }` (camelCase = custom callback).
- Native forwards → `onclick` / `onkeypress` (lowercase = native).
- `<slot name="flex">` → `flex` snippet prop.
- `checked` / `group` / `value` are `$bindable`.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3009