### PR TITLE
Add runes button component (strangler migration, part 1)

### DIFF
--- a/src/lib/components/event/event-shortcut-keys.svelte
+++ b/src/lib/components/event/event-shortcut-keys.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import DrawerContent from '$lib/holocene/drawer-content.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
   import Shortcut from '$lib/holocene/keyboard-shortcut/shortcut.svelte';
@@ -19,7 +19,7 @@
     size="sm"
     variant="secondary"
     leadingIcon="keyboard"
-    on:click={onOpen}
+    onclick={onOpen}
   />
 </div>
 <Drawer

--- a/src/lib/components/form/form-error.svelte
+++ b/src/lib/components/form/form-error.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
 
@@ -48,7 +48,7 @@
             <Button
               variant="secondary"
               size="sm"
-              on:click={handleRetry}
+              onclick={handleRetry}
               disabled={isRetrying}
             >
               <Icon name="retry" />

--- a/src/lib/components/news-feed/news-feed-widget.svelte
+++ b/src/lib/components/news-feed/news-feed-widget.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import NavigationButton from '$lib/holocene/navigation/navigation-button.svelte';
   import { translate } from '$lib/i18n/translate';
   import { createNewsFeedStore } from '$lib/stores/news-feed';
@@ -53,7 +53,7 @@
     class="h-9 w-9 shrink-0 p-0"
     data-testid="news-feed-trigger"
     size="sm"
-    on:click={openNewsFeed}
+    onclick={openNewsFeed}
   />
 {/if}
 

--- a/src/lib/components/payload/payload-code-block.svelte
+++ b/src/lib/components/payload/payload-code-block.svelte
@@ -11,7 +11,7 @@
 <script lang="ts">
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import IconButton from '$lib/holocene/icon-button.svelte';
@@ -144,7 +144,7 @@
                     leadingIcon="download"
                     disabled={!getCodecEndpoint(page.data.settings)}
                     loading={downloadLoading}
-                    on:click={() =>
+                    onclick={() =>
                       downloadExternalPayload(result.originalValue)}
                   >
                     {size}

--- a/src/lib/holocene/button-runes.svelte
+++ b/src/lib/holocene/button-runes.svelte
@@ -1,0 +1,238 @@
+<script module lang="ts">
+  import { cva, type VariantProps } from 'class-variance-authority';
+
+  const buttonStyles = cva(
+    [
+      'relative',
+      'flex',
+      'w-fit',
+      'items-center',
+      'justify-center',
+      'border',
+      'gap-2',
+      'disabled:opacity-50',
+      'disabled:cursor-not-allowed',
+      'border-box',
+      'transition-colors',
+      'transition-shadow',
+      'focus-visible:outline-none',
+      'focus-visible:border-inverse',
+      'focus-visible:ring-2',
+      'whitespace-nowrap',
+      'no-underline',
+      'active:scale-[0.98]',
+      'transition-all duration-200',
+    ],
+    {
+      variants: {
+        variant: {
+          primary:
+            'surface-interactive border-transparent text-white focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary data-[active=true]:bg-subtle data-[active=true]:text-primary',
+          secondary:
+            'surface-primary border-subtle focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary hover:surface-interactive-secondary focus-visible:surface-interactive-secondary data-[active=true]:bg-subtle',
+          destructive:
+            'surface-interactive-danger border-transparent focus-visible:ring-danger focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary data-[active=true]:surface-interactive-danger',
+          ghost:
+            'bg-transparent border-transparent text-primary hover:surface-interactive-ghost focus-visible:surface-interactive-ghost focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary data-[active=true]:bg-subtle',
+          'table-header':
+            'bg-transparent border-transparent focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface-primary focus-visible:border-transparent',
+        },
+        size: {
+          xs: 'h-8 text-xs px-2 py-1',
+          sm: 'h-9 text-sm px-4 py-1.5',
+          md: 'h-10 text-base px-4 py-2',
+          lg: 'h-11 text-lg px-5 py-2.5',
+        },
+      },
+      defaultVariants: {
+        variant: 'primary',
+        size: 'md',
+      },
+    },
+  );
+
+  export type ButtonStyles = VariantProps<typeof buttonStyles>;
+</script>
+
+<script lang="ts">
+  import type {
+    HTMLAnchorAttributes,
+    HTMLButtonAttributes,
+  } from 'svelte/elements';
+
+  import type { Snippet } from 'svelte';
+  import { twMerge as merge } from 'tailwind-merge';
+
+  import { goto } from '$app/navigation';
+
+  import Badge from '$lib/holocene/badge.svelte';
+  import type { IconName } from '$lib/holocene/icon';
+  import Icon from '$lib/holocene/icon/icon.svelte';
+
+  interface BaseProps {
+    variant?: ButtonStyles['variant'];
+    size?: ButtonStyles['size'];
+    disabled?: boolean;
+    loading?: boolean;
+    active?: boolean;
+    leadingIcon?: IconName;
+    trailingIcon?: IconName;
+    count?: number;
+    id?: string;
+    disableTracking?: boolean;
+    class?: string;
+    'data-testid'?: string;
+    children?: Snippet;
+    onclick?: (event: MouseEvent) => void;
+    onkeydown?: (event: KeyboardEvent) => void;
+  }
+
+  type ButtonWithoutHrefProps = BaseProps &
+    Omit<HTMLButtonAttributes, 'class' | 'onclick' | 'onkeydown'> & {
+      href?: never;
+      target?: never;
+    };
+
+  type ButtonWithHrefProps = BaseProps &
+    Omit<HTMLAnchorAttributes, 'class' | 'onclick' | 'onkeydown'> & {
+      href: string;
+      target?: HTMLAnchorAttributes['target'];
+    };
+
+  type Props = ButtonWithoutHrefProps | ButtonWithHrefProps;
+
+  let {
+    variant = 'primary',
+    size = 'md',
+    disabled = false,
+    loading = false,
+    active = false,
+    leadingIcon,
+    trailingIcon,
+    count = 0,
+    id,
+    href,
+    target,
+    disableTracking = false,
+    class: className = '',
+    children,
+    onclick,
+    onkeydown,
+    ...rest
+  }: Props = $props();
+
+  let element = $state<HTMLElement>();
+
+  export function focus() {
+    element?.focus();
+  }
+
+  const onLinkClick = (event: MouseEvent) => {
+    // Skip if middle mouse click or new tab
+    if (event.button === 1 || target || event.metaKey) return;
+    if (!href) return;
+    event.preventDefault();
+    goto(href);
+  };
+
+  const handleLinkClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    onLinkClick(event);
+    onclick?.(event);
+  };
+
+  const handleClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    onclick?.(event);
+  };
+
+  const handleKeydown = (event: KeyboardEvent) => {
+    event.stopPropagation();
+    onkeydown?.(event);
+  };
+
+  const dataTrackObj = $derived(
+    disableTracking
+      ? {}
+      : {
+          'data-track-name': 'button',
+          'data-track-intent': variant,
+          'data-track-text': '*textContent*',
+        },
+  );
+</script>
+
+{#if href && !disabled}
+  <a
+    bind:this={element}
+    {href}
+    {id}
+    role="button"
+    target={target ? '_blank' : null}
+    rel={target ? 'noreferrer' : null}
+    data-variant={variant}
+    data-active={active}
+    {...dataTrackObj}
+    class={merge(buttonStyles({ variant, size }), className)}
+    tabindex={href ? null : 0}
+    {...rest as HTMLAnchorAttributes}
+    onclick={handleLinkClick}
+  >
+    {#if leadingIcon || (loading && !trailingIcon)}
+      <span class:animate-spin={loading}>
+        <Icon name={loading ? 'spinner' : leadingIcon!} />
+      </span>
+    {/if}
+    {@render children?.()}
+    {#if trailingIcon}
+      <span
+        class:animate-spin={loading && !leadingIcon}
+        class:invisible={loading && leadingIcon}
+      >
+        <Icon name={loading && !leadingIcon ? 'spinner' : trailingIcon} />
+      </span>
+    {/if}
+    {#if count > 0}
+      <Badge
+        class="badge absolute right-0 top-0 origin-bottom-left translate-x-[10px] translate-y-[-10px]"
+        type="count">{count}</Badge
+      >
+    {/if}
+  </a>
+{:else}
+  <button
+    bind:this={element}
+    {disabled}
+    {id}
+    type="button"
+    data-variant={variant}
+    data-active={active}
+    {...dataTrackObj}
+    class={merge(buttonStyles({ variant, size }), className)}
+    {...rest as HTMLButtonAttributes}
+    onclick={handleClick}
+    onkeydown={handleKeydown}
+  >
+    {#if leadingIcon || (loading && !trailingIcon)}
+      <span class:animate-spin={loading}>
+        <Icon name={loading ? 'spinner' : leadingIcon!} />
+      </span>
+    {/if}
+    {@render children?.()}
+
+    {#if trailingIcon}
+      <span
+        class:animate-spin={loading && !leadingIcon}
+        class:invisible={loading && leadingIcon}
+      >
+        <Icon name={loading && !leadingIcon ? 'spinner' : trailingIcon} />
+      </span>
+    {/if}
+    {#if count > 0}
+      <Badge
+        class="badge absolute right-0 top-0 origin-bottom-left translate-x-[10px] translate-y-[-10px]"
+        type="count">{count}</Badge
+      >
+    {/if}
+  </button>
+{/if}

--- a/src/lib/holocene/button-runes.svelte
+++ b/src/lib/holocene/button-runes.svelte
@@ -177,6 +177,7 @@
     tabindex={href ? null : 0}
     {...rest as HTMLAnchorAttributes}
     onclick={handleLinkClick}
+    onkeydown={handleKeydown}
   >
     {#if leadingIcon || (loading && !trailingIcon)}
       <span class:animate-spin={loading}>


### PR DESCRIPTION
First step of migrating `button` to Svelte 5 runes using a strangler-fig approach, since `button` can't be migrated atomically — Svelte 5 has no interop between the legacy `on:click` directive and the `onclick` prop, so a single-PR swap would force ~150 ui + ~190 cloud-ui files to change at once (and drag in icon-button/split-button).

**This PR:**
- Adds `button-runes.svelte` — a runes version with real `onclick`/`onkeydown` callback props (wrapped to preserve the legacy `stopPropagation` behavior), alongside the untouched legacy `button.svelte`. Styles are duplicated deliberately so the hot legacy component (87 consumers) carries zero risk.
- Migrates 4 initial consumers (`form-error`, `event-shortcut-keys`, `news-feed-widget`, `payload-code-block`) to prove the pattern: import swap + `on:click` → `onclick`.

**Plan:**
- Subsequent PRs move consumers over in small batches (ui + cloud-ui).
- Final PR: once legacy `button.svelte` has no consumers, delete it and rename `button-runes.svelte` → `button.svelte`.

No consumer behavior changes; `pnpm check` clean, all tests pass.