### PR TITLE
Migrate app-level button consumers to runes button (part 2)

### DIFF
--- a/src/lib/components/activity/activity-commands.svelte
+++ b/src/lib/components/activity/activity-commands.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { Action } from '$lib/models/activity-actions';
@@ -108,7 +108,7 @@
       variant="secondary"
       size="sm"
       leadingIcon={activity.paused ? 'play' : 'pause'}
-      on:click={onPause}
+      onclick={onPause}
     >
       {activity.paused
         ? translate('workflows.unpause')
@@ -120,18 +120,13 @@
       variant="secondary"
       size="sm"
       leadingIcon="pencil"
-      on:click={onUpdate}
+      onclick={onUpdate}
     >
       {translate('common.update')}
     </Button>
   </Tooltip>
   <Tooltip bottom width={200} text="Reset this Activity.">
-    <Button
-      variant="secondary"
-      size="sm"
-      leadingIcon="retry"
-      on:click={onReset}
-    >
+    <Button variant="secondary" size="sm" leadingIcon="retry" onclick={onReset}>
       {translate('workflows.reset')}
     </Button>
   </Tooltip>

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import DrawerContent from '$lib/holocene/drawer-content.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
   import DurationInput, {
@@ -259,7 +259,7 @@
       <div class="flex items-center justify-end gap-4">
         <Button
           type="button"
-          on:click={closeCustomizationDrawer}
+          onclick={closeCustomizationDrawer}
           variant="ghost"
           size="sm">{translate('common.cancel')}</Button
         >

--- a/src/lib/components/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav.svelte
@@ -7,7 +7,7 @@
   import { beforeNavigate } from '$app/navigation';
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Logo from '$lib/holocene/logo.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -208,7 +208,7 @@
           leadingIcon="namespace-switcher"
           size="xs"
           class="grow text-white"
-          on:click={onNamespaceClick}>{truncateNamespace(namespace)}</Button
+          onclick={onNamespaceClick}>{truncateNamespace(namespace)}</Button
         >
         <div class="ml-1 h-full w-1 border-l border-subtle"></div>
         <Button

--- a/src/lib/components/codec-server-form/codec-server-form-content.svelte
+++ b/src/lib/components/codec-server-form/codec-server-form-content.svelte
@@ -6,7 +6,7 @@
   import Message from '$lib/components/form/message.svelte';
   import TaintedBadge from '$lib/components/form/tainted-badge.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Input from '$lib/holocene/input/input.svelte';
@@ -222,7 +222,7 @@
                 type="button"
                 variant="secondary"
                 size="sm"
-                on:click={() => {
+                onclick={() => {
                   showCustomSection = false;
                   $form.customMessage = '';
                   $form.customLink = '';
@@ -241,7 +241,7 @@
           type="button"
           variant="secondary"
           size="sm"
-          on:click={() => (showCustomSection = true)}
+          onclick={() => (showCustomSection = true)}
           disabled={$submitting}
           leadingIcon="add"
         >
@@ -267,7 +267,7 @@
           type="button"
           size="sm"
           variant="secondary"
-          on:click={handleCancel}
+          onclick={handleCancel}
           disabled={$submitting}
         >
           {translate('common.cancel')}

--- a/src/lib/components/count-refresh-button.svelte
+++ b/src/lib/components/count-refresh-button.svelte
@@ -4,7 +4,7 @@
 
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
 
   interface Props {
@@ -22,7 +22,7 @@
   size="xs"
   variant="ghost"
   leadingIcon="retry"
-  on:click={() => {
+  onclick={() => {
     $refresh = Date.now();
     onRefresh?.();
   }}

--- a/src/lib/components/deployments/deployment-header.svelte
+++ b/src/lib/components/deployments/deployment-header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Link from '$lib/holocene/link.svelte';
   import MenuButton from '$lib/holocene/menu/menu-button.svelte';
   import MenuContainer from '$lib/holocene/menu/menu-container.svelte';

--- a/src/lib/components/deployments/deployments-empty-state.svelte
+++ b/src/lib/components/deployments/deployments-empty-state.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
 

--- a/src/lib/components/deployments/ramp-unversioned-modal.svelte
+++ b/src/lib/components/deployments/ramp-unversioned-modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -32,7 +32,7 @@
   on:cancelModal={() => onCancel?.()}
 >
   {#if onRemove}
-    <Button slot="footer" variant="destructive" size="sm" on:click={onRemove}>
+    <Button slot="footer" variant="destructive" size="sm" onclick={onRemove}>
       {translate('deployments.remove-unversioned-ramping')}
     </Button>
   {/if}

--- a/src/lib/components/deployments/set-ramping-version-modal.svelte
+++ b/src/lib/components/deployments/set-ramping-version-modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -100,7 +100,7 @@
     </div>
     <svelte:fragment slot="footer">
       {#if isRamping}
-        <Button variant="destructive" on:click={onRemove}>
+        <Button variant="destructive" onclick={onRemove}>
           {translate('deployments.remove-ramping')}
         </Button>
       {:else}

--- a/src/lib/components/deployments/validate-connection-modal.svelte
+++ b/src/lib/components/deployments/validate-connection-modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -39,10 +39,10 @@
   </h3>
   <svelte:fragment slot="footer">
     <div class="flex w-full items-center justify-end gap-2">
-      <Button variant="ghost" on:click={onRetry} disabled={loading}
+      <Button variant="ghost" onclick={onRetry} disabled={loading}
         >{translate('common.retry')}</Button
       >
-      <Button variant="primary" on:click={onClose}
+      <Button variant="primary" onclick={onClose}
         >{translate('common.close')}</Button
       >
     </div>

--- a/src/lib/components/download-json-button.svelte
+++ b/src/lib/components/download-json-button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -29,7 +29,7 @@
 
 <Tooltip text={translate('common.download-json')} top>
   <Button
-    on:click={onClick}
+    onclick={onClick}
     data-testid={testId}
     size="xs"
     variant="ghost"

--- a/src/lib/components/feedback-button.svelte
+++ b/src/lib/components/feedback-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
 
   const href = $derived(
     page.data?.settings?.feedbackURL ||

--- a/src/lib/components/import/event-history-file-import.svelte
+++ b/src/lib/components/import/event-history-file-import.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Label from '$lib/holocene/label.svelte';
   import { translate } from '$lib/i18n/translate';
   import { groupEvents } from '$lib/models/event-groups';
@@ -73,7 +73,7 @@
     accept=".json"
     onchange={onFileSelect}
   />
-  <Button leadingIcon="file-upload" on:click={onConfirm} disabled={!fileLoaded}
+  <Button leadingIcon="file-upload" onclick={onConfirm} disabled={!fileLoaded}
     >{translate('common.import')}</Button
   >
 </div>

--- a/src/lib/components/lines-and-dots/timeline-graph/group-details-row.svelte
+++ b/src/lib/components/lines-and-dots/timeline-graph/group-details-row.svelte
@@ -5,7 +5,7 @@
 
   import EventDetailsFull from '$lib/components/event/event-details-full.svelte';
   import WorkflowStatus from '$lib/components/execution-status.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { EventGroup } from '$lib/models/event-groups/event-groups';
@@ -98,7 +98,7 @@
         {/if}
       </div>
       <div class="flex items-center gap-4">
-        <Button variant="ghost" size="xs" on:click={() => setActiveGroup(group)}
+        <Button variant="ghost" size="xs" onclick={() => setActiveGroup(group)}
           >{translate('common.close')} <Icon name="close" /></Button
         >
       </div>

--- a/src/lib/components/news-feed/news-feed-modal.svelte
+++ b/src/lib/components/news-feed/news-feed-modal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Checkbox from '$lib/holocene/checkbox.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Markdown from '$lib/holocene/markdown-editor/preview.svelte';
@@ -105,7 +105,7 @@
         size="xs"
         leadingIcon="retry"
         loading={$newsFeed.isLoading}
-        on:click={() => newsFeed.refresh({ cache: 'reload' })}
+        onclick={() => newsFeed.refresh({ cache: 'reload' })}
       >
         {translate('common.refresh')}
       </Button>

--- a/src/lib/components/random-uuid-button.svelte
+++ b/src/lib/components/random-uuid-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Button, {
     type ButtonWithoutHrefProps,
-  } from '$lib/holocene/button.svelte';
+  } from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
 
   type Props = ButtonWithoutHrefProps & {
@@ -17,6 +17,6 @@
   };
 </script>
 
-<Button variant="secondary" leadingIcon="retry" on:click={generate} {...rest}>
+<Button variant="secondary" leadingIcon="retry" onclick={generate} {...rest}>
   {translate('common.random-uuid')}
 </Button>

--- a/src/lib/components/saved-query-views/saved-views.svelte
+++ b/src/lib/components/saved-query-views/saved-views.svelte
@@ -8,7 +8,7 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { setPaginatedTableMaxHeight } from '$lib/holocene/table/paginated-table/context';
@@ -357,7 +357,7 @@
           : 'user-query-button'}
         data-track-intent="action"
         data-track-text={view.name}
-        on:click={() => setActiveQueryView(view)}
+        onclick={() => setActiveQueryView(view)}
         class={merge(
           'flex w-full justify-start',
           (view.count ?? 0) > 0 && 'text-red-900 dark:text-red-300',
@@ -416,7 +416,7 @@
               data-track-name="save-view-button"
               data-track-intent="action"
               data-track-text="save"
-              on:click={() => {
+              onclick={() => {
                 onSaveView({
                   ...view,
                   query,
@@ -432,7 +432,7 @@
             data-track-name="edit-view-button"
             data-track-intent="action"
             data-track-text="edit"
-            on:click={() => {
+            onclick={() => {
               editViewModalOpen = true;
             }}>Edit</Button
           >
@@ -446,7 +446,7 @@
             data-track-name="share-view-button"
             data-track-intent="action"
             data-track-text="share"
-            on:click={handleCopy}
+            onclick={handleCopy}
             ><span class={merge('hidden', $savedQueryNavOpen && 'lg:inline')}
               >Share</span
             ></Button
@@ -466,7 +466,7 @@
             data-track-name="create-view-button"
             data-track-intent="action"
             data-track-text="create"
-            on:click={() => {
+            onclick={() => {
               saveViewModalOpen = true;
             }}
             ><span

--- a/src/lib/components/saved-query-views/view-modal.svelte
+++ b/src/lib/components/saved-query-views/view-modal.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
@@ -190,7 +190,7 @@
           variant="secondary"
           disabled={!nameValid || maxViewsReached}
           data-testid="create-as-new-button"
-          on:click={onCreateAsNew}
+          onclick={onCreateAsNew}
           size="sm">{name === view.name ? 'Create Copy' : 'Create New'}</Button
         >
       </div>
@@ -202,7 +202,7 @@
     class="flex items-center gap-1 text-sm underline {!onDeleteView
       ? 'invisible'
       : ''}"
-    on:click={onDelete}
+    onclick={onDelete}
   >
     <Icon name="trash" /> Delete this Saved View
   </Button>

--- a/src/lib/components/schedule/schedule-form/form.svelte
+++ b/src/lib/components/schedule/schedule-form/form.svelte
@@ -6,7 +6,7 @@
 
   import CodecServerErrorBanner from '$lib/components/codec-server-error-banner.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Link from '$lib/holocene/link.svelte';
   import Loading from '$lib/holocene/loading.svelte';
   import { formatList } from '$lib/i18n/format-list';
@@ -191,7 +191,7 @@
               data-testid="delete-schedule-button"
               leadingIcon="trash"
               class="ml-auto hidden sm:inline-flex"
-              on:click={() => openConfirmationModal('delete')}
+              onclick={() => openConfirmationModal('delete')}
             >
               {translate('schedules.delete')}
             </Button>

--- a/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-input-payload.svelte
@@ -5,7 +5,7 @@
     type DecodedPayloadResult,
   } from '$lib/components/payload/payload-decoder.svelte';
   import PayloadInputWithEncoding from '$lib/components/payload-input-with-encoding.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     isPayloadInputEncodingType,
@@ -107,7 +107,7 @@
         copyable={true}
       >
         <div slot="action" class:hidden={!showEditActions}>
-          <Button variant="secondary" on:click={handleEdit}>
+          <Button variant="secondary" onclick={handleEdit}>
             {editInput ? translate('common.cancel') : translate('common.edit')}
           </Button>
         </div>

--- a/src/lib/components/schedule/schedule-form/schedule-policies-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-card.svelte
@@ -2,7 +2,7 @@
   import { untrack } from 'svelte';
   import { type SuperForm } from 'sveltekit-superforms';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -127,7 +127,7 @@
       <Button
         bind:this={editPoliciesButton}
         variant="secondary"
-        on:click={() => (isEditingPolicies = true)}
+        onclick={() => (isEditingPolicies = true)}
         >{translate('schedules.policies-title')}</Button
       >
     </div>

--- a/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-policies-drawer.svelte
@@ -4,7 +4,7 @@
   import { fieldProxy, superForm, type SuperForm } from 'sveltekit-superforms';
   import { zodClient } from 'sveltekit-superforms/adapters';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Checkbox from '$lib/holocene/checkbox.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
   import DurationInput, {
@@ -314,7 +314,7 @@
     {/key}
 
     <div class="ml-auto mt-2 flex gap-4">
-      <Button variant="secondary" on:click={onCancel}
+      <Button variant="secondary" onclick={onCancel}
         >{translate('common.cancel')}</Button
       >
       <Button variant="primary" type="submit"

--- a/src/lib/components/schedule/schedule-form/schedule-spec-card.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-spec-card.svelte
@@ -4,7 +4,7 @@
   import { tick } from 'svelte';
   import type { SuperForm } from 'sveltekit-superforms';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -119,7 +119,7 @@
     </div>
 
     <div>
-      <Button variant="secondary" on:click={addSpec}>
+      <Button variant="secondary" onclick={addSpec}>
         {translate('schedules.add-another-spec')}
       </Button>
     </div>

--- a/src/lib/components/schedule/schedule-form/schedule-spec-item.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-spec-item.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { type SuperForm } from 'sveltekit-superforms';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import IconButton from '$lib/holocene/icon-button.svelte';
   import Option from '$lib/holocene/select/option.svelte';
   import Select from '$lib/holocene/select/select.svelte';
@@ -96,7 +96,7 @@
         {#if spec.kind === 'interval'}
           <Button
             variant="ghost"
-            on:click={() => (isIntervalExampleModalOpen = true)}
+            onclick={() => (isIntervalExampleModalOpen = true)}
           >
             {translate('schedules.explore-interval-examples')}
           </Button>

--- a/src/lib/components/schedule/schedule-form/spec-type-cron.svelte
+++ b/src/lib/components/schedule/schedule-form/spec-type-cron.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { SuperForm } from 'sveltekit-superforms';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Label from '$lib/holocene/label.svelte';
   import { getWeekdayLabel } from '$lib/i18n/format-date-names';
@@ -69,8 +69,7 @@
       {#each shortcuts as shortcut (shortcut.value)}
         <Button
           variant="secondary"
-          on:click={() => setCronString(shortcut.value)}
-          >{shortcut.label}</Button
+          onclick={() => setCronString(shortcut.value)}>{shortcut.label}</Button
         >
       {/each}
     </div>

--- a/src/lib/components/schedule/schedule-form/spec-type-month.svelte
+++ b/src/lib/components/schedule/schedule-form/spec-type-month.svelte
@@ -2,7 +2,7 @@
   import type { SuperForm } from 'sveltekit-superforms';
 
   import ButtonRadioGroup from '$lib/holocene/button-radio-group.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { getMonthLabel } from '$lib/i18n/format-date-names';
   import { translate } from '$lib/i18n/translate';
 
@@ -134,7 +134,7 @@
           variant="secondary"
           size="sm"
           class="aspect-square min-h-12 min-w-12"
-          on:click={() => toggleDay(day)}>{day}</Button
+          onclick={() => toggleDay(day)}>{day}</Button
         >
       {/each}
     </div>
@@ -160,8 +160,8 @@
         <Button
           active={checked}
           variant="secondary"
-          on:click={onSelect}
-          on:keydown={onKeydown}
+          onclick={onSelect}
+          onkeydown={onKeydown}
           {...attrs}
         >
           {option.label}
@@ -183,7 +183,7 @@
             variant="secondary"
             size="sm"
             class="w-full"
-            on:click={() => toggleCustomMonth(value)}
+            onclick={() => toggleCustomMonth(value)}
           >
             {getMonthLabel(Number(value) - 1)}
           </Button>

--- a/src/lib/components/schedule/schedule-form/spec-type-week.svelte
+++ b/src/lib/components/schedule/schedule-form/spec-type-week.svelte
@@ -2,7 +2,7 @@
   import type { SuperForm } from 'sveltekit-superforms';
 
   import ButtonRadioGroup from '$lib/holocene/button-radio-group.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { getWeekdayLabel } from '$lib/i18n/format-date-names';
   import { translate } from '$lib/i18n/translate';
 
@@ -123,8 +123,8 @@
         variant="secondary"
         active={checked}
         {...attrs}
-        on:click={onSelect}
-        on:keydown={onKeydown}
+        onclick={onSelect}
+        onkeydown={onKeydown}
       >
         {option.label}
       </Button>
@@ -144,7 +144,7 @@
           aria-pressed={isSelected}
           variant="secondary"
           active={isSelected}
-          on:click={() => toggleCustomDay(value)}
+          onclick={() => toggleCustomDay(value)}
         >
           {getWeekdayLabel(Number(value))}
         </Button>

--- a/src/lib/components/schedule/schedule-view/schedule-spec-card.svelte
+++ b/src/lib/components/schedule/schedule-view/schedule-spec-card.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Panel from '$lib/components/panel.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { DescribeFullSchedule } from '$lib/types/schedule';
@@ -33,7 +33,7 @@
       trailingIcon="code"
       aria-expanded={isFullSpecVisible}
       aria-controls={scheduleFullSpecId}
-      on:click={() => (isFullSpecVisible = !isFullSpecVisible)}
+      onclick={() => (isFullSpecVisible = !isFullSpecVisible)}
     >
       {isFullSpecVisible
         ? translate('schedules.hide-full-spec')

--- a/src/lib/components/schedule/schedule-view/workflow-runs-empty.svelte
+++ b/src/lib/components/schedule/schedule-view/workflow-runs-empty.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { twMerge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
   interface Props {
@@ -36,7 +36,7 @@
     <Button
       size="sm"
       leadingIcon="play"
-      on:click={openTriggerConfirmationModal}
+      onclick={openTriggerConfirmationModal}
       variant="ghost"
       class="border border-subtle"
     >
@@ -45,7 +45,7 @@
     <Button
       size="sm"
       leadingIcon="retry"
-      on:click={openBackfillConfirmationModal}
+      onclick={openBackfillConfirmationModal}
       variant="ghost"
       class="border border-subtle"
     >

--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -6,7 +6,7 @@
   import { getContext, untrack } from 'svelte';
 
   import { timestamp } from '$lib/components/timestamp.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import DatePicker from '$lib/holocene/date-picker.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import ChipInput from '$lib/holocene/input/chip-input.svelte';
@@ -576,7 +576,7 @@
             size="xs"
             data-testid="remove-filter-button"
             type="button"
-            on:click={onRemove}>Remove</Button
+            onclick={onRemove}>Remove</Button
           >
           <Button
             variant="primary"

--- a/src/lib/components/search-attribute-filter/filter-bar.svelte
+++ b/src/lib/components/search-attribute-filter/filter-bar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Writable } from 'svelte/store';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import type { SearchAttributeFilter } from '$lib/models/search-attribute-filters';
@@ -58,7 +58,7 @@
           leadingIcon="json"
           active={viewManualQuery}
           data-testid="toggle-manual-query"
-          on:click={() => (viewManualQuery = !viewManualQuery)}
+          onclick={() => (viewManualQuery = !viewManualQuery)}
         />
       </Tooltip>
     </div>

--- a/src/lib/components/search-attribute-filter/filter-list.svelte
+++ b/src/lib/components/search-attribute-filter/filter-list.svelte
@@ -5,7 +5,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { SearchAttributeFilter } from '$lib/models/search-attribute-filters';
   import { createFilter } from '$lib/utilities/query/to-list-workflow-filters';
@@ -123,7 +123,7 @@
     {/each}
 
     {#if hasMoreFilters}
-      <Button variant="secondary" size="xs" on:click={viewMoreFilters}>
+      <Button variant="secondary" size="xs" onclick={viewMoreFilters}>
         {translate('common.view-more')}
       </Button>
     {/if}

--- a/src/lib/components/search-attribute-filter/manual-query.svelte
+++ b/src/lib/components/search-attribute-filter/manual-query.svelte
@@ -4,7 +4,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { SearchAttributeFilter } from '$lib/models/search-attribute-filters';

--- a/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
+++ b/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
@@ -5,7 +5,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import {
     Menu,
@@ -159,7 +159,7 @@
   <Button
     variant="ghost"
     size="xs"
-    on:click={clearAllFilters}
+    onclick={clearAllFilters}
     data-testid="clear-all-filters-button"
   >
     {translate('common.clear-all')}

--- a/src/lib/components/search-attributes-form/search-attribute-row.svelte
+++ b/src/lib/components/search-attributes-form/search-attribute-row.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { FormEventHandler } from 'svelte/elements';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Option from '$lib/holocene/select/option.svelte';
   import Select from '$lib/holocene/select/select.svelte';
@@ -90,7 +90,7 @@
     <Button
       variant="ghost"
       size="xs"
-      on:click={onRemove}
+      onclick={onRemove}
       disabled={submitting}
       leadingIcon="close"
       class="rounded-full"
@@ -104,7 +104,7 @@
       <Button
         variant="ghost"
         size="xs"
-        on:click={onRemove}
+        onclick={onRemove}
         disabled={submitting || isCloud}
         leadingIcon="trash"
       />

--- a/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
+++ b/src/lib/components/search-attributes-form/search-attributes-form-content.svelte
@@ -6,7 +6,7 @@
 
   import Message from '$lib/components/form/message.svelte';
   import TaintedBadge from '$lib/components/form/tainted-badge.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -223,7 +223,7 @@
       <Button
         variant="secondary"
         size="sm"
-        on:click={addAttribute}
+        onclick={addAttribute}
         disabled={$submitting}
         type="button"
         leadingIcon="add"
@@ -239,7 +239,7 @@
         <Button
           variant="secondary"
           size="sm"
-          on:click={handleCancel}
+          onclick={handleCancel}
           disabled={$submitting}
           type="button"
         >

--- a/src/lib/components/search.svelte
+++ b/src/lib/components/search.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { kebabCase } from 'es-toolkit';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
 

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/state';
 
   import DownloadJsonButton from '$lib/components/download-json-button.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/api-paginated.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
@@ -145,7 +145,7 @@
       <DownloadJsonButton items={visibleItems} {page} filePrefix="activities" />
       <Tooltip text={translate('common.configure-columns')} top>
         <Button
-          on:click={onClickConfigure}
+          onclick={onClickConfigure}
           data-testid="activities-summary-table-configuration-button"
           size="xs"
           variant="ghost"

--- a/src/lib/components/standalone-activities/activities-summary-configurable-table/batch-actions.svelte
+++ b/src/lib/components/standalone-activities/activities-summary-configurable-table/batch-actions.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import {
@@ -74,7 +74,7 @@
       class="focus-visible:border-table"
       data-testid="bulk-cancel-button"
       disabled={!$cancelableActivities.length}
-      on:click={openBatchCancelConfirmationModal}
+      onclick={openBatchCancelConfirmationModal}
       >{translate('standalone-activities.request-cancellation')}</Button
     >
     <Button
@@ -83,7 +83,7 @@
       class="focus-visible:border-table"
       data-testid="bulk-terminate-button"
       disabled={!$terminableActivities.length}
-      on:click={openBatchTerminateConfirmationModal}
+      onclick={openBatchTerminateConfirmationModal}
       >{translate('standalone-activities.terminate')}</Button
     >
   {/if}

--- a/src/lib/components/standalone-activities/activity-actions.svelte
+++ b/src/lib/components/standalone-activities/activity-actions.svelte
@@ -5,7 +5,7 @@
   import ActivityPauseConfirmationModal from '$lib/components/activity/activity-pause-confirmation-modal.svelte';
   import ActivityResetConfirmationModal from '$lib/components/activity/activity-reset-confirmation-modal.svelte';
   import ActivityUnpauseConfirmationModal from '$lib/components/activity/activity-unpause-confirmation-modal.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { MenuDivider, MenuItem } from '$lib/holocene/menu';
   import MenuButton from '$lib/holocene/menu/menu-button.svelte';
   import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
@@ -113,14 +113,14 @@
   {#if isRunning}
     {#if commandsDisabled}
       <Button
-        on:click={() => (cancelConfirmationModalOpen = true)}
+        onclick={() => (cancelConfirmationModalOpen = true)}
         disabled={writeActionsDisabled}
         size="sm"
       >
         {translate('standalone-activities.request-cancellation')}
       </Button>
     {:else}
-      <Button on:click={onPause} size="sm">
+      <Button onclick={onPause} size="sm">
         {isPaused
           ? translate('standalone-activities.unpause-activity')
           : translate('standalone-activities.pause-activity')}

--- a/src/lib/components/standalone-activities/start-activity-button.svelte
+++ b/src/lib/components/standalone-activities/start-activity-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { routeForStartStandaloneActivity } from '$lib/utilities/route-for';
@@ -46,6 +46,6 @@
     class="start-button"
     leadingIcon="lightning-bolt"
     aria-label={translate('standalone-activities.start-activity-like-this-one')}
-    on:click={() => goto(href)}
+    onclick={() => goto(href)}
   ></Button>
 </Tooltip>

--- a/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
+++ b/src/lib/components/standalone-activities/start-standalone-activity-form/form.svelte
@@ -10,7 +10,7 @@
   import { page } from '$app/state';
 
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import DurationInput, {
     DAYS,
@@ -474,7 +474,7 @@
       variant="ghost"
       trailingIcon={advancedOptionsVisible ? 'chevron-up' : 'chevron-down'}
       data-testid="start-standalone-activity-more-options"
-      on:click={() => (advancedOptionsVisible = !advancedOptionsVisible)}
+      onclick={() => (advancedOptionsVisible = !advancedOptionsVisible)}
     >
       {translate('common.more-options')}
     </Button>

--- a/src/lib/components/standalone-nexus-operations/nexus-operation-actions.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operation-actions.svelte
@@ -2,7 +2,7 @@
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { MenuDivider, MenuItem } from '$lib/holocene/menu';
   import MenuButton from '$lib/holocene/menu/menu-button.svelte';
   import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
@@ -44,7 +44,7 @@
 
 <div class="flex items-center gap-2">
   <Button
-    on:click={() => (cancelConfirmationModalOpen = true)}
+    onclick={() => (cancelConfirmationModalOpen = true)}
     disabled={!isRunning || commandsDisabled}
     size="sm"
   >

--- a/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/api-paginated.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
@@ -77,7 +77,7 @@
     <svelte:fragment slot="actions-end-additional">
       <Tooltip text="Configure Columns" top>
         <Button
-          on:click={onClickConfigure}
+          onclick={onClickConfigure}
           data-testid="nexus-operations-summary-table-configuration-button"
           size="xs"
           variant="ghost"

--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
@@ -9,7 +9,7 @@
   import { page } from '$app/state';
 
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import { parseDuration } from '$lib/holocene/duration-input/duration-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
@@ -366,7 +366,7 @@
               <Button
                 class="ml-2.5"
                 variant="secondary"
-                on:click={generateRandomId}
+                onclick={generateRandomId}
                 leadingIcon="retry"
                 >{translate(
                   'standalone-nexus-operations.form-random-uuid',
@@ -480,7 +480,7 @@
           <Button
             type="button"
             variant="secondary"
-            on:click={() => (operationPoliciesModalOpen = true)}
+            onclick={() => (operationPoliciesModalOpen = true)}
           >
             {translate(
               'standalone-nexus-operations.form-edit-operation-policies',
@@ -589,11 +589,11 @@
               type="button"
               variant="ghost"
               leadingIcon="close"
-              on:click={() => removeNexusHeader(index)}
+              onclick={() => removeNexusHeader(index)}
             />
           </div>
         {/each}
-        <Button type="button" variant="secondary" on:click={addNexusHeader}>
+        <Button type="button" variant="secondary" onclick={addNexusHeader}>
           {translate('standalone-nexus-operations.form-add-nexus-header')}
         </Button>
       </Card>

--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/operation-policies-modal.svelte
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/operation-policies-modal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { writable } from 'svelte/store';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import DrawerContent from '$lib/holocene/drawer-content.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
   import DurationInput from '$lib/holocene/duration-input/duration-input.svelte';
@@ -205,14 +205,14 @@
         <Button
           type="button"
           variant="ghost"
-          on:click={() => {
+          onclick={() => {
             open = false;
           }}>{translate('common.cancel')}</Button
         >
         <Button
           type="button"
           variant="primary"
-          on:click={() => {
+          onclick={() => {
             open = false;
           }}
           >{translate(

--- a/src/lib/components/timezone-select.svelte
+++ b/src/lib/components/timezone-select.svelte
@@ -5,7 +5,7 @@
   import { onMount } from 'svelte';
 
   import Timestamp from '$lib/components/timestamp.svelte';
-  import type { ButtonStyles } from '$lib/holocene/button.svelte';
+  import type { ButtonStyles } from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import {

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Accordion from '$lib/holocene/accordion/accordion.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Combobox from '$lib/holocene/combobox/combobox.svelte';
   import Input from '$lib/holocene/input/input.svelte';
@@ -290,11 +290,7 @@
             >
               {translate('workers.launch-stack')}
             </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              on:click={downloadCfnTemplate}
-            >
+            <Button variant="secondary" size="sm" onclick={downloadCfnTemplate}>
               {translate('workers.download-template')}
             </Button>
           </div>
@@ -385,7 +381,7 @@
     size="sm"
     type="button"
     trailingIcon={showScaling ? 'chevron-up' : 'chevron-down'}
-    on:click={() => (showScaling = !showScaling)}
+    onclick={() => (showScaling = !showScaling)}
   >
     {showScaling
       ? translate('workers.hide-defaults')

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -4,7 +4,7 @@
   import { zodClient } from 'sveltekit-superforms/adapters';
 
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';

--- a/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/edit-version-form.svelte
@@ -4,7 +4,7 @@
   import { zodClient } from 'sveltekit-superforms/adapters';
 
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import { translate } from '$lib/i18n/translate';
 
@@ -147,7 +147,7 @@
           >{translate('common.cancel')}</Button
         >
       </div>
-      <Button variant="destructive" type="button" on:click={() => onDelete()}>
+      <Button variant="destructive" type="button" onclick={() => onDelete()}>
         {translate('common.delete')}
       </Button>
     </div>

--- a/src/lib/components/workers/serverless-worker-form/recent-versions.svelte
+++ b/src/lib/components/workers/serverless-worker-form/recent-versions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import DeploymentStatus from '$lib/components/deployments/deployment-status.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     isVersionSummaryNew,
@@ -71,7 +71,7 @@
       {/each}
     </ol>
     {#if hiddenCount > 0}
-      <Button variant="secondary" size="xs" on:click={loadMore}>
+      <Button variant="secondary" size="xs" onclick={loadMore}>
         {translate('workers.recent-versions-more', { count: hiddenCount })}
       </Button>
     {/if}

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
@@ -4,7 +4,7 @@
   import { zodClient } from 'sveltekit-superforms/adapters';
 
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';

--- a/src/lib/components/workflow-actions.svelte
+++ b/src/lib/components/workflow-actions.svelte
@@ -10,7 +10,7 @@
   import UnpauseConfirmationModal from '$lib/components/workflow/client-actions/unpause-confirmation-modal.svelte';
   import UpdateConfirmationModal from '$lib/components/workflow/client-actions/update-confirmation-modal.svelte';
   import { dismissedWorkflowCommonErrors } from '$lib/components/workflow/workflow-common-errors.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { MenuDivider, MenuItem } from '$lib/holocene/menu';
   import MenuButton from '$lib/holocene/menu/menu-button.svelte';
   import MenuContainer from '$lib/holocene/menu/menu-container.svelte';
@@ -194,7 +194,7 @@
 
 {#snippet pauseButton()}
   <Button
-    on:click={() => (pauseConfirmationModalOpen = true)}
+    onclick={() => (pauseConfirmationModalOpen = true)}
     disabled={!pauseAuthorized || isDelayed}
     size="sm"
   >
@@ -208,7 +208,7 @@
 
 {#snippet requestCancellationButton()}
   <Button
-    on:click={() => (cancelConfirmationModalOpen = true)}
+    onclick={() => (cancelConfirmationModalOpen = true)}
     disabled={!cancelEnabled || cancelInProgress}
     size="sm"
   >
@@ -218,7 +218,7 @@
 
 {#snippet resetButton()}
   <Button
-    on:click={() => (resetConfirmationModalOpen = true)}
+    onclick={() => (resetConfirmationModalOpen = true)}
     disabled={!resetEnabled}
     size="sm"
   >

--- a/src/lib/components/workflow/add-search-attributes.svelte
+++ b/src/lib/components/workflow/add-search-attributes.svelte
@@ -2,7 +2,7 @@
   import type { ComponentProps } from 'svelte';
   import { type ClassNameValue, twMerge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
     customSearchAttributes,
@@ -16,7 +16,7 @@
     class?: ClassNameValue;
     attributesToAdd: SearchAttributesSchema;
     buttonCopy?: string;
-    variant?: ComponentProps<Button>['variant'];
+    variant?: ComponentProps<typeof Button>['variant'];
   }
 
   let {
@@ -55,7 +55,7 @@
     leadingIcon="add"
     class="max-sm:w-full"
     data-testid="add-search-attribute-button"
-    on:click={addSearchAttribute}
+    onclick={addSearchAttribute}
     disabled={!searchAttributes.length ||
       attributes.length === searchAttributes.length}>{buttonCopy}</Button
   >

--- a/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
@@ -7,7 +7,7 @@
   import PayloadInput from '$lib/components/payload-input.svelte';
   import RandomUuidButton from '$lib/components/random-uuid-button.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
@@ -149,7 +149,7 @@
         />
         {#if customUpdate}
           <Button
-            on:click={() => {
+            onclick={() => {
               customUpdate = false;
               name = '';
             }}

--- a/src/lib/components/workflow/metadata/workflow-current-details.svelte
+++ b/src/lib/components/workflow/metadata/workflow-current-details.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/state';
 
   import Timestamp from '$lib/components/timestamp.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Markdown from '$lib/holocene/markdown-editor/preview.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -75,7 +75,7 @@
           <p>Press for freshness</p>
           <Button
             variant="ghost"
-            on:click={fetchCurrentDetails}
+            onclick={fetchCurrentDetails}
             disabled={loading}
             aria-label={translate('common.refresh')}
           >

--- a/src/lib/components/workflow/search-attribute-input/index.svelte
+++ b/src/lib/components/workflow/search-attribute-input/index.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import ChipInput from '$lib/holocene/input/chip-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
@@ -88,7 +88,7 @@
       leadingIcon="close"
       data-testid="search-attribute-close-button"
       class="mt-6 w-10 rounded-full sm:hidden"
-      on:click={() => onRemove(label)}
+      onclick={() => onRemove(label)}
     />
   </div>
   {#if type === SEARCH_ATTRIBUTE_TYPE.BOOL}
@@ -146,6 +146,6 @@
     leadingIcon="close"
     data-testid="search-attribute-close-button"
     class="mt-6 w-10 rounded-full max-sm:hidden"
-    on:click={() => onRemove(label)}
+    onclick={() => onRemove(label)}
   />
 </div>

--- a/src/lib/components/workflow/start-workflow-button.svelte
+++ b/src/lib/components/workflow/start-workflow-button.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { routeForWorkflowStart } from '$lib/utilities/route-for';
@@ -32,7 +32,7 @@
     class="start-button"
     leadingIcon="lightning-bolt"
     aria-label={translate('workflows.start-workflow-like-this-one')}
-    on:click={() => goto(href)}
+    onclick={() => goto(href)}
     {...$$restProps}
   ></Button>
 </Tooltip>

--- a/src/lib/components/workflow/workflow-advanced-search.svelte
+++ b/src/lib/components/workflow/workflow-advanced-search.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import { translate } from '$lib/i18n/translate';
   import { workflowFilters } from '$lib/stores/filters';

--- a/src/lib/components/workflow/workflow-common-errors.svelte
+++ b/src/lib/components/workflow/workflow-common-errors.svelte
@@ -10,7 +10,7 @@
 
 <script lang="ts">
   import CommonErrorList from '$lib/components/common-errors/common-error-list.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import { fullEventHistory } from '$lib/stores/events';
@@ -47,7 +47,7 @@
           leadingIcon="close"
           size="xs"
           variant="ghost"
-          on:click={dismissCommonErrors}
+          onclick={dismissCommonErrors}
         >
           <span class="sr-only">
             {translate('workflows.dismiss-common-errors')}

--- a/src/lib/components/workflow/workflows-summary-configurable-table.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table.svelte
@@ -7,7 +7,7 @@
 
   import DownloadJsonButton from '$lib/components/download-json-button.svelte';
   import TableEmptyState from '$lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import FeatureTag from '$lib/holocene/feature-tag.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/api-paginated.svelte';
@@ -271,7 +271,7 @@
       >
         <FeatureTag feature="tableDensity" />
         <Button
-          on:click={setTableDensity}
+          onclick={setTableDensity}
           data-testid="table-density-button"
           size="xs"
           variant="ghost"
@@ -289,7 +289,7 @@
       />
       <Tooltip text={translate('common.configure-columns')} top>
         <Button
-          on:click={onClickConfigure}
+          onclick={onClickConfigure}
           data-testid="workflows-summary-table-configuration-button"
           size="xs"
           variant="ghost"

--- a/src/lib/components/workflow/workflows-summary-configurable-table/batch-actions.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/batch-actions.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/state';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import {
@@ -98,7 +98,7 @@
       class="focus-visible:border-table"
       data-testid="bulk-cancel-button"
       disabled={!$cancelableWorkflows.length}
-      on:click={openBatchCancelConfirmationModal}
+      onclick={openBatchCancelConfirmationModal}
       >{translate('workflows.request-cancellation')}</Button
     >
   {/if}
@@ -108,7 +108,7 @@
       variant="ghost"
       class="focus-visible:border-table"
       data-testid="bulk-reset-button"
-      on:click={openBatchResetConfirmationModal}
+      onclick={openBatchResetConfirmationModal}
       >{translate('workflows.reset')}</Button
     >
   {/if}
@@ -118,7 +118,7 @@
       variant="destructive"
       class="focus-visible:border-table"
       data-testid="bulk-terminate-button"
-      on:click={openBatchTerminateConfirmationModal}
+      onclick={openBatchTerminateConfirmationModal}
       >{translate('workflows.terminate')}</Button
     >
   {/if}

--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-row.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/state';
 
   import IsTemporalServerVersionGuard from '$lib/components/is-temporal-server-version-guard.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Checkbox from '$lib/holocene/checkbox.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
@@ -104,7 +104,7 @@
           <Button
             size="xs"
             variant={childrenShown ? 'primary' : 'ghost'}
-            on:click={() => toggleChildrenVisibility(workflow)}
+            onclick={() => toggleChildrenVisibility(workflow)}
             class={$tableDensity === 'dense' ? 'mt-1 h-5 w-5' : ''}
           >
             <Tooltip

--- a/src/lib/holocene/button-runes.svelte
+++ b/src/lib/holocene/button-runes.svelte
@@ -1,5 +1,13 @@
 <script module lang="ts">
+  import type {
+    HTMLAnchorAttributes,
+    HTMLButtonAttributes,
+  } from 'svelte/elements';
+
   import { cva, type VariantProps } from 'class-variance-authority';
+  import type { Snippet } from 'svelte';
+
+  import type { IconName } from '$lib/holocene/icon';
 
   const buttonStyles = cva(
     [
@@ -52,22 +60,6 @@
   );
 
   export type ButtonStyles = VariantProps<typeof buttonStyles>;
-</script>
-
-<script lang="ts">
-  import type {
-    HTMLAnchorAttributes,
-    HTMLButtonAttributes,
-  } from 'svelte/elements';
-
-  import type { Snippet } from 'svelte';
-  import { twMerge as merge } from 'tailwind-merge';
-
-  import { goto } from '$app/navigation';
-
-  import Badge from '$lib/holocene/badge.svelte';
-  import type { IconName } from '$lib/holocene/icon';
-  import Icon from '$lib/holocene/icon/icon.svelte';
 
   interface BaseProps {
     variant?: ButtonStyles['variant'];
@@ -87,19 +79,28 @@
     onkeydown?: (event: KeyboardEvent) => void;
   }
 
-  type ButtonWithoutHrefProps = BaseProps &
+  export type ButtonWithoutHrefProps = BaseProps &
     Omit<HTMLButtonAttributes, 'class' | 'onclick' | 'onkeydown'> & {
       href?: never;
       target?: never;
     };
 
-  type ButtonWithHrefProps = BaseProps &
+  export type ButtonWithHrefProps = BaseProps &
     Omit<HTMLAnchorAttributes, 'class' | 'onclick' | 'onkeydown'> & {
       href: string;
       target?: HTMLAnchorAttributes['target'];
     };
 
-  type Props = ButtonWithoutHrefProps | ButtonWithHrefProps;
+  export type ButtonProps = ButtonWithoutHrefProps | ButtonWithHrefProps;
+</script>
+
+<script lang="ts">
+  import { twMerge as merge } from 'tailwind-merge';
+
+  import { goto } from '$app/navigation';
+
+  import Badge from '$lib/holocene/badge.svelte';
+  import Icon from '$lib/holocene/icon/icon.svelte';
 
   let {
     variant = 'primary',
@@ -119,7 +120,7 @@
     onclick,
     onkeydown,
     ...rest
-  }: Props = $props();
+  }: ButtonProps = $props();
 
   let element = $state<HTMLElement>();
 

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -4,7 +4,7 @@
   import DeploymentTableRow from '$lib/components/deployments/deployment-table-row.svelte';
   import DeploymentsEmptyState from '$lib/components/deployments/deployments-empty-state.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import PaginatedTable from '$lib/holocene/table/paginated-table/api-paginated.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
@@ -122,7 +122,7 @@
       <svelte:fragment slot="actions-end-additional">
         <Tooltip text="Configure Columns" top>
           <Button
-            on:click={openCustomizationDrawer}
+            onclick={openCustomizationDrawer}
             data-testid="deployments-table-configuration-button"
             size="xs"
             variant="ghost"

--- a/src/lib/pages/nexus-edit-endpoint.svelte
+++ b/src/lib/pages/nexus-edit-endpoint.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -64,7 +64,7 @@
           variant="destructive"
           disabled={submitting}
           class="max-sm:w-full"
-          on:click={() => (deleteConfirmationModalOpen = true)}
+          onclick={() => (deleteConfirmationModalOpen = true)}
           data-testid="delete-endpoint-button"
         >
           {translate('common.delete')}

--- a/src/lib/pages/nexus-form.svelte
+++ b/src/lib/pages/nexus-form.svelte
@@ -6,7 +6,7 @@
 
   import Message from '$lib/components/form/message.svelte';
   import IsOssGuard from '$lib/components/is-oss-guard.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Combobox from '$lib/holocene/combobox/combobox.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import MarkdownEditor from '$lib/holocene/markdown-editor/markdown-editor.svelte';

--- a/src/lib/pages/schedules.svelte
+++ b/src/lib/pages/schedules.svelte
@@ -10,7 +10,7 @@
   import { timestamp } from '$lib/components/timestamp.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import EmptyState from '$lib/holocene/empty-state.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Link from '$lib/holocene/link.svelte';
@@ -210,7 +210,7 @@
       <svelte:fragment slot="actions-end-additional">
         <Tooltip text={translate('common.configure-columns')} top>
           <Button
-            on:click={openCustomizationDrawer}
+            onclick={openCustomizationDrawer}
             data-testid="workflows-summary-table-configuration-button"
             size="xs"
             variant="ghost"

--- a/src/lib/pages/standalone-activities.svelte
+++ b/src/lib/pages/standalone-activities.svelte
@@ -42,7 +42,7 @@
   import StatusCounts from '$lib/components/status-counts.svelte';
   import { timestamp } from '$lib/components/timestamp.svelte';
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import { fetchActivityCountByStatus } from '$lib/services/activity-counts';

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -10,7 +10,7 @@
   import RandomUuidButton from '$lib/components/random-uuid-button.svelte';
   import AddSearchAttributes from '$lib/components/workflow/add-search-attributes.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import DurationInput, {
     DAYS,
@@ -383,12 +383,12 @@
         variant="ghost"
         class="max-sm:w-full"
         trailingIcon={viewAdvancedOptions ? 'chevron-up' : 'chevron-down'}
-        on:click={() => (viewAdvancedOptions = !viewAdvancedOptions)}
+        onclick={() => (viewAdvancedOptions = !viewAdvancedOptions)}
         >{translate('common.more-options')}</Button
       >
       <Button
         disabled={!enableStart}
-        on:click={onWorkflowStart}
+        onclick={onWorkflowStart}
         data-testid="start-workflow-button"
         class="max-sm:w-full">{translate('workflows.start-workflow')}</Button
       >

--- a/src/lib/pages/workflow-call-stack.svelte
+++ b/src/lib/pages/workflow-call-stack.svelte
@@ -5,7 +5,7 @@
 
   import { timestamp } from '$lib/components/timestamp.svelte';
   import Alert from '$lib/holocene/alert.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import EmptyState from '$lib/holocene/empty-state.svelte';
   import Link from '$lib/holocene/link.svelte';
@@ -62,11 +62,7 @@
           class="mb-4 w-fit"
         />
         <div class="flex items-center gap-2">
-          <Button
-            variant="primary"
-            leadingIcon="retry"
-            on:click={setStackTrace}
-          >
+          <Button variant="primary" leadingIcon="retry" onclick={setStackTrace}>
             {translate('workflows.refresh-call-stack')}
           </Button>
           <p>

--- a/src/lib/pages/workflow-history-event.svelte
+++ b/src/lib/pages/workflow-history-event.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
 
   import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { buildGroupIndex, groupEvents } from '$lib/models/event-groups';
   import { isEvent } from '$lib/models/event-history';
   import { fetchAllEvents } from '$lib/services/events-service';
@@ -118,7 +118,7 @@
     variant="secondary"
     size="xs"
     leadingIcon="arrow-up"
-    on:click={loadPrevious}
+    onclick={loadPrevious}
     disabled={ids[0] === '1' || loading}
     data-testid="load-previous">Show Previous 10</Button
   >
@@ -140,7 +140,7 @@
     variant="secondary"
     size="xs"
     leadingIcon="arrow-down"
-    on:click={loadNext}
+    onclick={loadNext}
     disabled={ids[ids.length - 1] === lastEventId || loading}
     data-testid="load-next">Show Next 10</Button
   >

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -4,7 +4,7 @@
   import { page } from '$app/stores';
 
   import PayloadInput from '$lib/components/payload-input.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Card from '$lib/holocene/card.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import EmptyState from '$lib/holocene/empty-state.svelte';
@@ -152,7 +152,7 @@
         </div>
         <div class="flex w-full flex-wrap items-end justify-end gap-4">
           <Button
-            on:click={() => query(queryType)}
+            onclick={() => query(queryType)}
             {loading}
             variant={edited ? 'primary' : 'secondary'}
             leadingIcon={edited ? undefined : 'retry'}

--- a/src/lib/pages/workflows-with-new-search.svelte
+++ b/src/lib/pages/workflows-with-new-search.svelte
@@ -38,7 +38,7 @@
   import ConfigurableTableHeadersDrawer from '$lib/components/workflow/configurable-table-headers-drawer/index.svelte';
   import FilterBar from '$lib/components/workflow/filter-bar/index.svelte';
   import WorkflowsSummaryConfigurableTable from '$lib/components/workflow/workflows-summary-configurable-table.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import Translate from '$lib/i18n/translate.svelte';
   import { fetchWorkflowTaskFailures } from '$lib/services/workflow-counts';

--- a/src/routes/(app)/namespaces/[namespace]/nexus-operations/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/nexus-operations/+page.svelte
@@ -3,7 +3,7 @@
 
   import PageTitle from '$lib/components/page-title.svelte';
   import Badge from '$lib/holocene/badge.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import StandaloneNexusOperations from '$lib/pages/standalone-nexus-operations.svelte';
   import { routeForStartStandaloneNexusOperation } from '$lib/utilities/route-for';

--- a/src/routes/(app)/namespaces/[namespace]/workers/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/workers/+page.svelte
@@ -3,7 +3,7 @@
 
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import WorkersLayout from '$lib/layouts/workers-layout.svelte';
   import Workers from '$lib/pages/workers.svelte';

--- a/src/routes/(app)/namespaces/[namespace]/workers/deployments/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/workers/deployments/+page.svelte
@@ -3,7 +3,7 @@
 
   import CapabilityGuard from '$lib/components/capability-guard.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { translate } from '$lib/i18n/translate';
   import WorkersLayout from '$lib/layouts/workers-layout.svelte';
   import WorkerDeployments from '$lib/pages/deployments.svelte';

--- a/src/routes/(app)/nexus/+page.svelte
+++ b/src/routes/(app)/nexus/+page.svelte
@@ -3,7 +3,7 @@
 
   import PageTitle from '$lib/components/page-title.svelte';
   import Timestamp from '$lib/components/timestamp.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Link from '$lib/holocene/link.svelte';
   import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';
   import TableRow from '$lib/holocene/table/table-row.svelte';

--- a/src/routes/(app)/nexus/[id]/+page.svelte
+++ b/src/routes/(app)/nexus/[id]/+page.svelte
@@ -7,7 +7,7 @@
 
   import PageTitle from '$lib/components/page-title.svelte';
   import TaskQueueStatus from '$lib/components/task-queue-status.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
   import NexusEndpoint from '$lib/pages/nexus-endpoint.svelte';

--- a/src/routes/(login)/login/+page.svelte
+++ b/src/routes/(login)/login/+page.svelte
@@ -7,7 +7,7 @@
 
   import FeedbackButton from '$lib/components/feedback-button.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { routeForAuthentication } from '$lib/utilities/route-for';
   import Logo from '$lib/vendor/logo.svg';
 
@@ -33,7 +33,7 @@
     <Button
       data-testid="login-button"
       leadingIcon="lock"
-      on:click={() => {
+      onclick={() => {
         if (BROWSER) {
           window.location.assign(
             routeForAuthentication({

--- a/src/routes/(login)/signin/+page.svelte
+++ b/src/routes/(login)/signin/+page.svelte
@@ -7,7 +7,7 @@
 
   import FeedbackButton from '$lib/components/feedback-button.svelte';
   import PageTitle from '$lib/components/page-title.svelte';
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { routeForAuthentication } from '$lib/utilities/route-for';
   import Logo from '$lib/vendor/logo.svg';
 
@@ -30,7 +30,7 @@
     <Button
       data-testid="login-button"
       leadingIcon="lock"
-      on:click={() => {
+      onclick={() => {
         if (BROWSER) {
           window.location.assign(
             routeForAuthentication({


### PR DESCRIPTION
Part 2 of the button strangler migration (stacked on #3727).

Migrates ~78 app-level consumers (`src/lib/components`, `src/lib/pages`, `src/routes`) from legacy `button.svelte` to `button-runes.svelte`: import swap + `on:click`/`on:keydown` → `onclick`/`onkeydown`. All mechanical, done via a scoped codemod that only touches `<Button>` tags (other components' `on:click` left intact).

Also exported the prop types (`ButtonWithoutHrefProps`/`ButtonWithHrefProps`/`ButtonProps`) from `button-runes.svelte` for wrapper consumers, and fixed `add-search-attributes` to use `ComponentProps<typeof Button>`.

Still on legacy button after this: holocene-internal renderers (modal, toast, banner, paginated, stories), the `icon-button`/`split-button` wrappers, and 2 type-only importers — follow-up batches.

`pnpm check` 0 errors, eslint clean, 2548 tests pass. Base is #3727; retarget to main once that merges.