### PR TITLE
Migrate holocene-internal button renderers to runes button (part 3)

### DIFF
--- a/src/lib/holocene/banner/banner.svelte
+++ b/src/lib/holocene/banner/banner.svelte
@@ -40,7 +40,7 @@
   import { onDestroy } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
 
   import type { IconName } from '../icon';
@@ -112,7 +112,7 @@
     </span>
     {#if dismissable}
       <Button
-        on:click={dismissBanner}
+        onclick={dismissBanner}
         leadingIcon="close"
         variant="ghost"
         size="xs"

--- a/src/lib/holocene/button-radio-group.stories.svelte
+++ b/src/lib/holocene/button-radio-group.stories.svelte
@@ -28,7 +28,7 @@
     ButtonRadioItem,
     ButtonRadioOption,
   } from '$lib/holocene/button-radio-group.svelte';
-  import Button, { type ButtonStyles } from '$lib/holocene/button.svelte';
+  import Button, { type ButtonStyles } from '$lib/holocene/button-runes.svelte';
 
   type StoryArgs = ComponentProps<
     typeof ButtonRadioGroup<ButtonRadioOption<string>>
@@ -67,8 +67,8 @@
     {size}
     active={checked}
     {...attrs}
-    on:click={onSelect}
-    on:keydown={onKeydown}
+    onclick={onSelect}
+    onkeydown={onKeydown}
   >
     {option.label}
   </Button>

--- a/src/lib/holocene/button.stories.svelte
+++ b/src/lib/holocene/button.stories.svelte
@@ -2,8 +2,9 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { iconNames } from '$lib/holocene/icon';
 
   export const meta = {
@@ -74,7 +75,7 @@
         },
       },
     },
-  } satisfies Meta<Button>;
+  } satisfies Meta<ComponentProps<typeof Button>>;
 </script>
 
 <script lang="ts">
@@ -87,22 +88,22 @@
 </script>
 
 <Template let:args>
-  <Button {...args} on:click={action('click')}>Click Me</Button>
+  <Button {...args} onclick={action('click')}>Click Me</Button>
 </Template>
 
 <Story name="Primary" args={{}} />
 
 <Story name="With Long Title" let:args>
   <div class="max-w-16">
-    <Button {...args} on:click={action('click')}>Request Cancellation</Button>
+    <Button {...args} onclick={action('click')}>Request Cancellation</Button>
   </div>
 </Story>
 
 <Story name="Button Group" let:args>
   <div class="button-group flex">
-    <Button {...args} on:click={action('click')}>First</Button>
-    <Button {...args} on:click={action('click')}>Middle</Button>
-    <Button {...args} on:click={action('click')}>Last</Button>
+    <Button {...args} onclick={action('click')}>First</Button>
+    <Button {...args} onclick={action('click')}>Middle</Button>
+    <Button {...args} onclick={action('click')}>Last</Button>
   </div>
 </Story>
 
@@ -141,7 +142,7 @@
     {...args}
     leadingIcon="temporal-logo"
     {loading}
-    on:click={() => {
+    onclick={() => {
       loading = true;
       setTimeout(() => {
         loading = false;
@@ -157,7 +158,7 @@
     {...args}
     trailingIcon="temporal-logo"
     {loading}
-    on:click={() => {
+    onclick={() => {
       loading = true;
       setTimeout(() => {
         loading = false;
@@ -172,7 +173,7 @@
     trailingIcon="temporal-logo"
     leadingIcon="temporal-logo"
     {loading}
-    on:click={() => {
+    onclick={() => {
       loading = true;
       setTimeout(() => {
         loading = false;

--- a/src/lib/holocene/combobox/combobox.stories.svelte
+++ b/src/lib/holocene/combobox/combobox.stories.svelte
@@ -54,7 +54,7 @@
   import { action as logAction } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
-  import Button from '../button.svelte';
+  import Button from '../button-runes.svelte';
 
   import AsyncTest from './async-test.svelte';
 </script>
@@ -317,7 +317,7 @@
     >
       {#snippet action()}
         <Button
-          on:click={() => {}}
+          onclick={() => {}}
           variant="ghost"
           size="xs"
           leadingIcon="close"

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -55,7 +55,7 @@
   import { translate } from '$lib/i18n/translate';
 
   import Badge from '../badge.svelte';
-  import Button from '../button.svelte';
+  import Button from '../button-runes.svelte';
   import Chip from '../chip.svelte';
   import type { IconName } from '../icon';
   import Icon from '../icon/icon.svelte';

--- a/src/lib/holocene/drawer.stories.svelte
+++ b/src/lib/holocene/drawer.stories.svelte
@@ -44,14 +44,14 @@
   import { Story, Template } from '@storybook/addon-svelte-csf';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from './button.svelte';
+  import Button from './button-runes.svelte';
   import DrawerContent from './drawer-content.svelte';
 
   let open = $state(true);
 </script>
 
 <Template let:args>
-  <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
+  <Button onclick={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent title="Drawer Title">
       <p class={merge(args.position === 'right' && 'max-w-80')}>
@@ -74,7 +74,7 @@
 </Template>
 
 <Template id="with-subtitle" let:args>
-  <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
+  <Button onclick={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent title="Drawer Title">
       <span slot="subtitle">A supporting subtitle line</span>
@@ -86,7 +86,7 @@
 </Template>
 
 <Template id="subtitle-only" let:args>
-  <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
+  <Button onclick={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent>
       <span slot="subtitle">Subtitle rendered without a title</span>
@@ -98,7 +98,7 @@
 </Template>
 
 <Template id="no-header" let:args>
-  <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
+  <Button onclick={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent>
       <p class={merge(args.position === 'right' && 'max-w-80')}>

--- a/src/lib/holocene/input/input.stories.svelte
+++ b/src/lib/holocene/input/input.stories.svelte
@@ -75,7 +75,7 @@
 <script lang="ts">
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
-  import Button from '../button.svelte';
+  import Button from '../button-runes.svelte';
 </script>
 
 <Template let:args let:context>

--- a/src/lib/holocene/menu/menu-button.svelte
+++ b/src/lib/holocene/menu/menu-button.svelte
@@ -3,10 +3,10 @@
   import { twMerge as merge } from 'tailwind-merge';
 
   import Badge from '$lib/holocene/badge.svelte';
-  import type { ButtonStyles } from '$lib/holocene/button.svelte';
+  import type { ButtonStyles } from '$lib/holocene/button-runes.svelte';
   import Button, {
     type ButtonWithoutHrefProps,
-  } from '$lib/holocene/button.svelte';
+  } from '$lib/holocene/button-runes.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import {
     MENU_CONTEXT,
@@ -91,8 +91,8 @@
   {id}
   {disabled}
   type="button"
-  on:click={handleClick}
-  on:keydown={handleKeyDown}
+  onclick={handleClick}
+  onkeydown={handleKeyDown}
   aria-haspopup={!disabled}
   aria-controls={controls}
   aria-expanded={$open}

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -4,7 +4,7 @@
   import { type ComponentProps, createEventDispatcher } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
 
   import IconButton from './icon-button.svelte';
 
@@ -12,7 +12,7 @@
     cancelText: string;
     confirmDisabled?: boolean;
     confirmText: string;
-    confirmType?: ComponentProps<Button>['variant'];
+    confirmType?: ComponentProps<typeof Button>['variant'];
     hideCancel?: boolean;
     hideConfirm?: boolean;
     hightlightNav?: boolean;
@@ -29,7 +29,7 @@
   export let hideConfirm = false;
   export let confirmText: string;
   export let cancelText: string;
-  export let confirmType: ComponentProps<Button>['variant'] = 'primary';
+  export let confirmType: ComponentProps<typeof Button>['variant'] = 'primary';
   export let confirmDisabled = false;
   export let large = false;
   export let loading = false;
@@ -136,7 +136,7 @@
             data-testid="cancel-modal-button"
             variant="ghost"
             disabled={loading}
-            on:click={closeModal}>{cancelText}</Button
+            onclick={closeModal}>{cancelText}</Button
           >
         {/if}
         {#if !hideConfirm}

--- a/src/lib/holocene/portal/portal.stories.svelte
+++ b/src/lib/holocene/portal/portal.stories.svelte
@@ -59,12 +59,12 @@
 <script lang="ts">
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
-  import Button from '../button.svelte';
+  import Button from '../button-runes.svelte';
 </script>
 
 <Template let:args>
   <div class="flex min-h-screen items-center justify-center p-8">
-    <Button id="portal-button" on:click={() => (args.open = !args.open)}>
+    <Button id="portal-button" onclick={() => (args.open = !args.open)}>
       Toggle Portal
     </Button>
 
@@ -89,7 +89,7 @@
   <div class="relative min-h-screen p-4">
     <Button
       id="top-button"
-      on:click={() => (args.open = !args.open)}
+      onclick={() => (args.open = !args.open)}
       class="absolute left-1/2 top-4"
     >
       Top
@@ -116,7 +116,7 @@
   <div class="relative min-h-screen p-4">
     <Button
       id="bottom-button"
-      on:click={() => (args.open = !args.open)}
+      onclick={() => (args.open = !args.open)}
       class="absolute bottom-4 left-1/2"
     >
       Bottom
@@ -143,7 +143,7 @@
   <div class="relative min-h-screen p-4">
     <Button
       id="left-button"
-      on:click={() => (args.open = !args.open)}
+      onclick={() => (args.open = !args.open)}
       class="absolute left-4 top-1/2"
     >
       Left
@@ -170,7 +170,7 @@
   <div class="relative min-h-screen p-4">
     <Button
       id="right-button"
-      on:click={() => (args.open = !args.open)}
+      onclick={() => (args.open = !args.open)}
       class="absolute right-4 top-1/2"
     >
       Right
@@ -200,7 +200,7 @@
         when near edges.
       </p>
       <div class="ml-[200px] mt-[300px]">
-        <Button id="combined-button" on:click={() => (args.open = !args.open)}>
+        <Button id="combined-button" onclick={() => (args.open = !args.open)}>
           Toggle Portal
         </Button>
         <Portal

--- a/src/lib/holocene/table/paginated-table/paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/paginated.svelte
@@ -3,7 +3,7 @@
 
   import { page } from '$app/stores';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import IconButton from '$lib/holocene/icon-button.svelte';
   import FilterSelect from '$lib/holocene/select/filter-select.svelte';
   import {
@@ -132,7 +132,7 @@
             ? 'bg-interactive-secondary-active'
             : ''}
           aria-label={pageButtonLabel(page)}
-          on:click={() => handlePageChange(page)}>{page}</Button
+          onclick={() => handlePageChange(page)}>{page}</Button
         >
       {/if}
     {/each}

--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -4,7 +4,7 @@
   import { createEventDispatcher } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { translate } from '$lib/i18n/translate';
@@ -61,6 +61,6 @@
     aria-label={dismissLabel}
     class="text-inherit h-6 w-6 shrink-0 p-0"
     disableTracking
-    on:click={handleDismiss}
+    onclick={handleDismiss}
   />
 </div>

--- a/src/lib/holocene/toaster.stories.svelte
+++ b/src/lib/holocene/toaster.stories.svelte
@@ -5,7 +5,7 @@
 
   import { toaster } from '../stores/toaster';
 
-  import Button from './button.svelte';
+  import Button from './button-runes.svelte';
   import Toast from './toast.svelte';
   import Toaster from './toaster.svelte';
 
@@ -72,7 +72,7 @@
   <div class="flex max-w-60 flex-col gap-2">
     <Toast id={context.id} {variant} {closeButtonLabel}>{message}</Toast>
 
-    <Button on:click={() => toaster.push({ duration, message, variant })}>
+    <Button onclick={() => toaster.push({ duration, message, variant })}>
       <span class="capitalize">Trigger {variant} toast</span>
     </Button>
 

--- a/src/lib/holocene/tooltip.stories.svelte
+++ b/src/lib/holocene/tooltip.stories.svelte
@@ -3,7 +3,7 @@
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import { iconNames } from '$lib/holocene/icon';
   import Tooltip from '$lib/holocene/tooltip.svelte';
 

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import Button from './button.svelte';
+  import Button from './button-runes.svelte';
   import Tooltip from './tooltip.svelte';
 
   export let containerHeight = 600;
@@ -165,7 +165,7 @@
           size="sm"
           leadingIcon="chevron-up"
           aria-label="Pan up"
-          on:click={() => panBy(0, -PAN_STEP_RATIO)}
+          onclick={() => panBy(0, -PAN_STEP_RATIO)}
         />
       </Tooltip>
       <Tooltip text="Pan down" bottom>
@@ -174,7 +174,7 @@
           size="sm"
           leadingIcon="chevron-down"
           aria-label="Pan down"
-          on:click={() => panBy(0, PAN_STEP_RATIO)}
+          onclick={() => panBy(0, PAN_STEP_RATIO)}
         />
       </Tooltip>
       <Tooltip text="Pan left" bottom>
@@ -183,7 +183,7 @@
           size="sm"
           leadingIcon="chevron-left"
           aria-label="Pan left"
-          on:click={() => panBy(-PAN_STEP_RATIO, 0)}
+          onclick={() => panBy(-PAN_STEP_RATIO, 0)}
         />
       </Tooltip>
       <Tooltip text="Pan right" bottom>
@@ -192,7 +192,7 @@
           size="sm"
           leadingIcon="chevron-right"
           aria-label="Pan right"
-          on:click={() => panBy(PAN_STEP_RATIO, 0)}
+          onclick={() => panBy(PAN_STEP_RATIO, 0)}
         />
       </Tooltip>
     {/if}
@@ -204,7 +204,7 @@
           leadingIcon="add"
           aria-label="Zoom in"
           disabled={zoomLevel - ZOOM_STEP < maxZoomIn}
-          on:click={() => zoomBy(-ZOOM_STEP)}
+          onclick={() => zoomBy(-ZOOM_STEP)}
         />
       </Tooltip>
       <Tooltip text="Zoom out" bottom>
@@ -214,7 +214,7 @@
           leadingIcon="hyphen"
           aria-label="Zoom out"
           disabled={zoomLevel + ZOOM_STEP > maxZoomOut}
-          on:click={() => zoomBy(ZOOM_STEP)}
+          onclick={() => zoomBy(ZOOM_STEP)}
         />
       </Tooltip>
     {/if}
@@ -225,7 +225,7 @@
         size="sm"
         leadingIcon="target"
         aria-label="Center"
-        on:click={() => {
+        onclick={() => {
           onCenter();
         }}
       />

--- a/src/lib/utilities/form/superforms-example.svelte
+++ b/src/lib/utilities/form/superforms-example.svelte
@@ -4,7 +4,7 @@
   import { zodClient } from 'sveltekit-superforms/adapters';
   import { z } from 'zod/v3';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button from '$lib/holocene/button-runes.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
 


### PR DESCRIPTION
Part 3 of the button strangler migration (stacked on #3728).

Migrates the holocene-internal Button renderers + story files to `button-runes.svelte`: `modal`, `toast`, `banner`, `combobox`, `paginated`, `menu-button`, `zoom-svg`, `superforms-example`, and the `button`/`drawer`/`tooltip`/`toaster`/`portal`/`input`/`combobox`/`button-radio-group` stories. Same scoped codemod (import swap + `on:click`→`onclick` inside `<Button>` only).

Also fixed `modal.svelte` and `button.stories` to use `ComponentProps<typeof Button>` / `Meta<ComponentProps<typeof Button>>` (function-component type form), which cleared the ~22 downstream modal-consumer type errors.

Still on legacy button: `icon-button`/`split-button`/`toggle-button` (bare-forward wrappers — next batch) and 4 type-only importers (fold into final rename).

`pnpm check` 0 errors, eslint clean, 2548 tests pass. Base is #3728; retarget as the stack merges.