### PR TITLE
Migrate icon-button to runes button (part 4)

### DIFF
--- a/src/lib/components/command-palette/modal.svelte
+++ b/src/lib/components/command-palette/modal.svelte
@@ -78,7 +78,7 @@
       label={cancelText}
       icon="close"
       class="float-right m-4"
-      on:click={closeModal}
+      onclick={closeModal}
     />
   {/if}
   <div id="modal-content-{id}" class="content">

--- a/src/lib/components/data-encoder-status.svelte
+++ b/src/lib/components/data-encoder-status.svelte
@@ -31,7 +31,7 @@
           class="relative flex items-center"
           data-testid="data-encoder-status-configured"
           icon="transcoder-on"
-          on:click={onIconClick}
+          onclick={onIconClick}
         />
       </Tooltip>
     {:else if $dataEncoder.hasError}
@@ -42,7 +42,7 @@
           class="relative flex items-center"
           data-testid="data-encoder-status-error"
           icon="transcoder-error"
-          on:click={onIconClick}
+          onclick={onIconClick}
         />
       </Tooltip>
     {:else if $dataEncoder.hasSuccess}
@@ -56,7 +56,7 @@
           class="relative flex items-center"
           data-testid="data-encoder-status-success"
           icon="transcoder-on"
-          on:click={onIconClick}
+          onclick={onIconClick}
         />
       </Tooltip>
     {/if}
@@ -71,7 +71,7 @@
         class="relative flex items-center"
         data-testid="data-encoder-status"
         icon="transcoder-off"
-        on:click={onIconClick}
+        onclick={onIconClick}
       />
     </Tooltip>
   {/if}

--- a/src/lib/components/event/event-summary-row.svelte
+++ b/src/lib/components/event/event-summary-row.svelte
@@ -216,7 +216,7 @@
     aria-expanded={expanded}
     aria-controls={expanded ? detailsId : undefined}
     class="h-6 w-6"
-    on:click={(e) => {
+    onclick={(e) => {
       e.stopPropagation();
       onLinkClick(e);
     }}

--- a/src/lib/components/payload/payload-code-block.svelte
+++ b/src/lib/components/payload/payload-code-block.svelte
@@ -209,7 +209,7 @@
         {#snippet headerActions()}
           <IconButton
             icon="retry"
-            on:click={retry}
+            onclick={retry}
             label={translate('common.retry')}
           />
         {/snippet}

--- a/src/lib/components/payload/payload-inline.svelte
+++ b/src/lib/components/payload/payload-inline.svelte
@@ -61,7 +61,7 @@
     <IconButton
       class="h-8 w-8"
       icon="retry"
-      on:click={retry}
+      onclick={retry}
       label={translate('common.retry')}
     />
   {/snippet}

--- a/src/lib/components/schedule/schedule-form/schedule-spec-item.svelte
+++ b/src/lib/components/schedule/schedule-form/schedule-spec-item.svelte
@@ -110,7 +110,7 @@
           icon="trash"
           label={translate('common.delete')}
           class="mr-4 mt-[1.625rem] h-10"
-          on:click={onRemove}
+          onclick={onRemove}
         />
       {/if}
     </div>
@@ -148,7 +148,7 @@
         size="sm"
         icon="trash"
         label={translate('common.delete')}
-        on:click={(e) => {
+        onclick={(e) => {
           e.stopPropagation();
           onRemove();
         }}

--- a/src/lib/holocene/drawer.svelte
+++ b/src/lib/holocene/drawer.svelte
@@ -99,7 +99,7 @@
             icon="close"
             aria-expanded={open}
             aria-controls="navigation-drawer"
-            on:click={onClick}
+            onclick={onClick}
           />
         </slot>
       </div>

--- a/src/lib/holocene/icon-button.stories.svelte
+++ b/src/lib/holocene/icon-button.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import IconButton from '$lib/holocene/icon-button.svelte';
 
@@ -21,7 +22,7 @@
         options: iconNames,
       },
     },
-  } satisfies Meta<IconButton>;
+  } satisfies Meta<ComponentProps<typeof IconButton>>;
 </script>
 
 <script lang="ts">
@@ -30,7 +31,7 @@
 </script>
 
 <Template let:args>
-  <IconButton {...args} on:click={action('click')} />
+  <IconButton {...args} onclick={action('click')} />
 </Template>
 
 <Story name="Default" />

--- a/src/lib/holocene/icon-button.svelte
+++ b/src/lib/holocene/icon-button.svelte
@@ -4,23 +4,29 @@
   import type { ComponentProps } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import Button from '$lib/holocene/button.svelte';
+  import Button, {
+    type ButtonWithoutHrefProps,
+  } from '$lib/holocene/button-runes.svelte';
   import type { IconName } from '$lib/holocene/icon';
 
-  interface $$Props extends HTMLButtonAttributes {
+  interface Props extends Omit<HTMLButtonAttributes, 'onclick'> {
     icon: IconName;
     'data-testid'?: string;
     label: string;
     variant?: 'primary' | 'secondary' | 'ghost';
     class?: string;
     size?: ComponentProps<typeof Button>['size'];
+    onclick?: (event: MouseEvent) => void;
   }
 
-  let className = '';
-  export { className as class };
-  export let icon: IconName;
-  export let label: string;
-  export let variant: 'primary' | 'secondary' | 'ghost' = 'ghost';
+  let {
+    class: className = '',
+    icon,
+    label,
+    variant = 'ghost',
+    onclick,
+    ...rest
+  }: Props = $props();
 </script>
 
 <Button
@@ -32,6 +38,6 @@
   data-track-name="icon-button"
   data-track-intent="{variant}-{icon}"
   data-track-text={label}
-  on:click
-  {...$$restProps}
+  {onclick}
+  {...rest as ButtonWithoutHrefProps}
 />

--- a/src/lib/holocene/input/input.svelte
+++ b/src/lib/holocene/input/input.svelte
@@ -183,7 +183,7 @@
         <div class="clear-icon-container" data-testid="clear-input">
           <IconButton
             label={clearButtonLabel}
-            on:click={handleClear}
+            onclick={handleClear}
             icon="close"
           />
         </div>

--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -108,7 +108,7 @@
       label={cancelText}
       icon="close"
       class="float-right m-4"
-      on:click={closeModal}
+      onclick={closeModal}
     />
   {/if}
   <div id="modal-title-{id}" class="title">

--- a/src/lib/holocene/orderable-list/orderable-list-item.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list-item.svelte
@@ -108,14 +108,14 @@
           icon="chevron-up"
           data-testid="orderable-list-item-{label}-move-up-button"
           label={moveUpButtonLabel}
-          on:click={() => dispatch('moveItem', { from: index, to: index - 1 })}
+          onclick={() => dispatch('moveItem', { from: index, to: index - 1 })}
         />
         <IconButton
           disabled={index === totalItems - 1}
           icon="chevron-down"
           data-testid="orderable-list-item-{label}-move-down-button"
           label={moveDownButtonLabel}
-          on:click={() => dispatch('moveItem', { from: index, to: index + 1 })}
+          onclick={() => dispatch('moveItem', { from: index, to: index + 1 })}
         />
       </div>
     {/if}
@@ -127,14 +127,14 @@
         icon="add"
         data-testid="orderable-list-item-{label}-add-button"
         label={addButtonLabel}
-        on:click={() => dispatch('addItem')}
+        onclick={() => dispatch('addItem')}
       />
     {:else}
       <IconButton
         icon="hyphen"
         data-testid="orderable-list-item-{label}-remove-button"
         label={removeButtonLabel}
-        on:click={() => dispatch('removeItem')}
+        onclick={() => dispatch('removeItem')}
       />
     {/if}
   {/if}

--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -256,7 +256,7 @@
     <IconButton
       label={previousButtonLabel}
       disabled={!$store.hasPrevious}
-      on:click={handlePreviousPage}
+      onclick={handlePreviousPage}
       icon="arrow-left"
     />
     <div class="flex gap-1">
@@ -272,7 +272,7 @@
     <IconButton
       label={nextButtonLabel}
       disabled={!$store.hasNext || $store.updating}
-      on:click={fetchIndexData}
+      onclick={fetchIndexData}
       icon="arrow-right"
     />
   </nav>

--- a/src/lib/holocene/table/paginated-table/paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/paginated.svelte
@@ -148,12 +148,12 @@
       label={previousPageButtonLabel}
       disabled={!$store.hasPrevious}
       icon="arrow-left"
-      on:click={() => handlePageChange($store.currentPage - 1)}
+      onclick={() => handlePageChange($store.currentPage - 1)}
     />
     <IconButton
       label={nextPageButtonLabel}
       disabled={!$store.hasNext}
-      on:click={() => handlePageChange($store.currentPage + 1)}
+      onclick={() => handlePageChange($store.currentPage + 1)}
       icon="arrow-right"
     />
   </nav>


### PR DESCRIPTION
Part 4 of the button strangler migration (stacked on #3729) — first wrapper.

Migrates `icon-button.svelte` to runes: `export let`→`$props()`, bare `on:click` forward → an `onclick` prop passed to `button-runes`, import repointed to `button-runes.svelte`. Updates its 12 ui consumers (`on:click`→`onclick`, incl. relative-import ones the earlier grep missed: drawer/input/modal/orderable-list-item). Story → `Meta<ComponentProps<typeof IconButton>>`.

The wrapper spreads `{...rest}` into `Button`, which tripped the `ButtonProps` union's "too complex" distribution — fixed with a local `rest as ButtonWithoutHrefProps` cast (no change to the shared button-runes type; the union stays for direct consumers' href/anchor safety).

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3014

`pnpm check` 0 errors, eslint clean, 2548 tests pass. Base is #3729.