### PR TITLE
Migrate split-button to runes button (part 5)

### DIFF
--- a/src/lib/components/schedule/schedule-view/schedule-view.svelte
+++ b/src/lib/components/schedule/schedule-view/schedule-view.svelte
@@ -80,7 +80,7 @@
       menuLabel={translate('schedules.schedule-actions')}
       id="schedule-actions"
       disabled={editDisabled}
-      on:click={() => openConfirmationModal('pause')}
+      onclick={() => openConfirmationModal('pause')}
     >
       <MenuItem
         data-testid="trigger-schedule"

--- a/src/lib/holocene/split-button.stories.svelte
+++ b/src/lib/holocene/split-button.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import type { IconName } from '$lib/holocene/icon';
   import { iconNames } from '$lib/holocene/icon';
@@ -42,7 +43,7 @@
         control: 'boolean',
       },
     },
-  } satisfies Meta<SplitButton>;
+  } satisfies Meta<ComponentProps<typeof SplitButton>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/split-button.svelte
+++ b/src/lib/holocene/split-button.svelte
@@ -1,21 +1,43 @@
 <script lang="ts">
-  import Button from '$lib/holocene/button.svelte';
+  import type { Snippet } from 'svelte';
+
+  import Button from '$lib/holocene/button-runes.svelte';
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
   import { Menu, MenuButton, MenuContainer } from '$lib/holocene/menu';
 
-  export let label: string;
-  export let menuLabel: string;
-  export let icon: IconName | undefined = undefined;
-  export let id: string;
-  export let disabled = false;
-  export let position: 'left' | 'right' = 'left';
-  export let primaryActionDisabled = false;
-  export let href: string | undefined = undefined;
-  export let menuClass: string | undefined = undefined;
+  interface Props {
+    label: string;
+    menuLabel: string;
+    icon?: IconName;
+    id: string;
+    disabled?: boolean;
+    position?: 'left' | 'right';
+    primaryActionDisabled?: boolean;
+    href?: string;
+    menuClass?: string;
+    class?: string;
+    onclick?: (event: MouseEvent) => void;
+    children?: Snippet;
+  }
+
+  let {
+    label,
+    menuLabel,
+    icon,
+    id,
+    disabled = false,
+    position = 'left',
+    primaryActionDisabled = false,
+    href,
+    menuClass,
+    class: className,
+    onclick,
+    children,
+  }: Props = $props();
 </script>
 
-<MenuContainer class={$$props.class}>
+<MenuContainer class={className}>
   <div class="button-group flex h-10 cursor-pointer flex-row gap-[1px]">
     <Button
       disabled={disabled || primaryActionDisabled}
@@ -25,7 +47,7 @@
       data-track-name="split-button"
       data-track-intent="primary"
       data-track-text={label}
-      on:click
+      {onclick}
     >
       {#if icon}
         <Icon name={icon} />
@@ -44,6 +66,6 @@
   </div>
 
   <Menu id="{id}-menu" {position} class={menuClass}>
-    <slot />
+    {@render children?.()}
   </Menu>
 </MenuContainer>


### PR DESCRIPTION
Part 5 of the button strangler migration (stacked on #3730) — second wrapper.

Migrates `split-button.svelte` to runes: `export let`→`$props()`, `$$props.class`→`class` prop, bare `on:click` forward → `onclick` prop into `button-runes`, `<slot />`→`{@render children?.()}`, import→`button-runes`. Updates its 2 ui consumers (`schedule-view`, story). No `{...rest}` spread here, so no union cast needed. button-runes itself unchanged.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3015

`pnpm check` 0 errors, eslint clean, 2548 tests pass. Base is #3730.