### PR TITLE
Migrate toggle-button to runes button (part 6)

### DIFF
--- a/src/lib/components/dark-mode-menu.svelte
+++ b/src/lib/components/dark-mode-menu.svelte
@@ -25,7 +25,7 @@
   <ToggleButton
     aria-label={translate('common.system-default')}
     data-testid="system-mode"
-    on:click={() => setDarkModePreference('system')}
+    onclick={() => setDarkModePreference('system')}
     active={$useDarkModePreference === 'system'}
     size="xs"
   >
@@ -34,7 +34,7 @@
   <ToggleButton
     aria-label={translate('common.day')}
     data-testid="day-mode"
-    on:click={() => setDarkModePreference(false)}
+    onclick={() => setDarkModePreference(false)}
     active={$useDarkModePreference === false}
     size="xs"
   >
@@ -43,7 +43,7 @@
   <ToggleButton
     aria-label={translate('common.night')}
     data-testid="night-mode"
-    on:click={() => setDarkModePreference(true)}
+    onclick={() => setDarkModePreference(true)}
     active={$useDarkModePreference === true}
     size="xs"
   >

--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -331,7 +331,7 @@
       <ToggleButton
         variant="secondary"
         active={localFilter.conditional === option.value}
-        on:click={() => {
+        onclick={() => {
           if (isNullConditional(option.value)) {
             localFilter.value = '';
           } else if (isNullFilter) {
@@ -530,7 +530,7 @@
             <ToggleButtons>
               <ToggleButton
                 variant={localFilter.value === 'true' ? 'primary' : 'secondary'}
-                on:click={() => {
+                onclick={() => {
                   localFilter.conditional = '=';
                   localFilter.value = 'true';
                 }}
@@ -541,7 +541,7 @@
                 variant={localFilter.value === 'false'
                   ? 'primary'
                   : 'secondary'}
-                on:click={() => {
+                onclick={() => {
                   localFilter.conditional = '=';
                   localFilter.value = 'false';
                 }}

--- a/src/lib/components/timezone-select.svelte
+++ b/src/lib/components/timezone-select.svelte
@@ -181,22 +181,22 @@
           <ToggleButton
             size="xs"
             active={$timestampFormat === 'short'}
-            on:click={() => setTimestampFormat('short')}>Short</ToggleButton
+            onclick={() => setTimestampFormat('short')}>Short</ToggleButton
           >
           <ToggleButton
             size="xs"
             active={$timestampFormat === 'medium'}
-            on:click={() => setTimestampFormat('medium')}>Default</ToggleButton
+            onclick={() => setTimestampFormat('medium')}>Default</ToggleButton
           >
           <ToggleButton
             size="xs"
             active={$timestampFormat === 'long'}
-            on:click={() => setTimestampFormat('long')}>Long</ToggleButton
+            onclick={() => setTimestampFormat('long')}>Long</ToggleButton
           >
           <ToggleButton
             size="xs"
             active={$timestampFormat === 'iso'}
-            on:click={() => setTimestampFormat('iso')}>ISO</ToggleButton
+            onclick={() => setTimestampFormat('iso')}>ISO</ToggleButton
           >
         </ToggleButtons>
       </div>
@@ -210,19 +210,19 @@
             size="xs"
             active={$hourFormat === 'system'}
             disabled={$timestampFormat === 'iso'}
-            on:click={() => setHourFormat('system')}>System</ToggleButton
+            onclick={() => setHourFormat('system')}>System</ToggleButton
           >
           <ToggleButton
             size="xs"
             active={$hourFormat === '12'}
             disabled={$timestampFormat === 'iso'}
-            on:click={() => setHourFormat('12')}>12-hour</ToggleButton
+            onclick={() => setHourFormat('12')}>12-hour</ToggleButton
           >
           <ToggleButton
             size="xs"
             active={$hourFormat === '24'}
             disabled={$timestampFormat === 'iso'}
-            on:click={() => setHourFormat('24')}>24-hour</ToggleButton
+            onclick={() => setHourFormat('24')}>24-hour</ToggleButton
           >
         </ToggleButtons>
       </div>

--- a/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-fields.svelte
@@ -265,13 +265,13 @@
         <ToggleButtons>
           <ToggleButton
             active={activeRoleHelpTab === 'cloudformation'}
-            on:click={() => (activeRoleHelpTab = 'cloudformation')}
+            onclick={() => (activeRoleHelpTab = 'cloudformation')}
           >
             {translate('workers.cfn-tab')}
           </ToggleButton>
           <ToggleButton
             active={activeRoleHelpTab === 'terraform'}
-            on:click={() => (activeRoleHelpTab = 'terraform')}
+            onclick={() => (activeRoleHelpTab = 'terraform')}
           >
             {translate('workers.terraform-tab')}
           </ToggleButton>

--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -222,7 +222,7 @@
     <ToggleButtons>
       <ToggleButton
         size="xs"
-        on:click={() => {
+        onclick={() => {
           autoRefresh = !autoRefresh;
           if (autoRefresh) onrefresh();
         }}

--- a/src/lib/components/workers/workers-table/task-queue-workers-table.svelte
+++ b/src/lib/components/workers/workers-table/task-queue-workers-table.svelte
@@ -78,14 +78,14 @@
   <ToggleButtons>
     <ToggleButton
       active={selected === View.Workers}
-      on:click={() => (selected = View.Workers)}
+      onclick={() => (selected = View.Workers)}
     >
       {translate('workers.workers')}
     </ToggleButton>
     <ToggleButton
       class="!border-r"
       active={selected === View.Pollers}
-      on:click={() => (selected = View.Pollers)}
+      onclick={() => (selected = View.Pollers)}
     >
       {translate('workers.pollers')}
       {#await pollersPromise then workers}

--- a/src/lib/holocene/time-picker.svelte
+++ b/src/lib/holocene/time-picker.svelte
@@ -68,10 +68,10 @@
   {/if}
   {#if twelveHourClock}
     <ToggleButtons>
-      <ToggleButton active={half === 'AM'} on:click={() => (half = 'AM')}
+      <ToggleButton active={half === 'AM'} onclick={() => (half = 'AM')}
         >AM</ToggleButton
       >
-      <ToggleButton active={half === 'PM'} on:click={() => (half = 'PM')}
+      <ToggleButton active={half === 'PM'} onclick={() => (half = 'PM')}
         >PM</ToggleButton
       >
     </ToggleButtons>

--- a/src/lib/holocene/toggle-button/toggle-button.stories.svelte
+++ b/src/lib/holocene/toggle-button/toggle-button.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta, StoryContext } from '@storybook/svelte';
   import { expect, userEvent, within } from '@storybook/test';
+  import type { ComponentProps } from 'svelte';
 
   import ToggleButton from './toggle-button.svelte';
   import ToggleButtons from './toggle-buttons.svelte';
@@ -17,7 +18,7 @@
       href: { table: { disable: true } },
       active: { table: { disable: true } },
     },
-  } satisfies Meta<ToggleButton>;
+  } satisfies Meta<ComponentProps<typeof ToggleButton>>;
 </script>
 
 <script lang="ts">
@@ -71,7 +72,7 @@
         {...args}
         data-testid={`toggle-button-${index}`}
         active={$selected === index}
-        on:click={() => select(index)}
+        onclick={() => select(index)}
       >
         {name}
       </ToggleButton>

--- a/src/lib/holocene/toggle-button/toggle-button.svelte
+++ b/src/lib/holocene/toggle-button/toggle-button.svelte
@@ -1,61 +1,61 @@
 <script lang="ts">
-  import type { ComponentProps } from 'svelte';
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import { getAppContext } from '$lib/utilities/get-context';
 
   import type {
-    ButtonWithHrefProps,
+    ButtonProps,
     ButtonWithoutHrefProps,
-  } from '../button.svelte';
-  import Button from '../button.svelte';
+  } from '../button-runes.svelte';
+  import Button from '../button-runes.svelte';
 
-  type BaseProps = {
+  type Props = Omit<ButtonWithoutHrefProps, 'href' | 'target'> & {
     group?: boolean;
     active?: boolean;
+    href?: string | null;
+    base?: string | null;
   };
 
-  type AnchorProps = BaseProps &
-    ButtonWithHrefProps & {
-      base?: string;
-    };
+  let {
+    class: className = '',
+    group = getAppContext('group'),
+    href = null,
+    base = null,
+    active = false,
+    variant = 'secondary',
+    leadingIcon,
+    onclick,
+    children,
+    ...rest
+  }: Props = $props();
 
-  type ButtonProps = BaseProps &
-    ButtonWithoutHrefProps & {
-      base?: never;
-    };
+  const pressed = $derived(
+    href ? page.url.pathname.includes(base ?? href) : active,
+  );
 
-  type $$Props = AnchorProps | ButtonProps;
-
-  let className = '';
-  export { className as class };
-  export let group = getAppContext('group');
-  export let href: string | null = null;
-  export let base: string | null = href;
-  export let active = false;
-  export let variant: ComponentProps<Button>['variant'] = 'secondary';
-
-  $: pressed = href ? $page.url.pathname.includes(base ?? href) : active;
+  const buttonProps = $derived({
+    ...rest,
+    variant,
+    leadingIcon,
+    onclick,
+    'data-track-name': 'toggle-button',
+    'aria-pressed': pressed ? 'true' : 'false',
+    href: href ? href + page.url.search : undefined,
+    class: merge(
+      pressed && 'bg-interactive-secondary-active',
+      group && '[&:not(:last-child)]:border-r-0',
+      className,
+    ),
+  } as ButtonProps);
 </script>
 
-<Button
-  on:click
-  class={merge(
-    pressed && 'bg-interactive-secondary-active',
-    group && '[&:not(:last-child)]:border-r-0',
-    className,
-  )}
-  data-track-name="toggle-button"
-  {variant}
-  href={href ? href + $page.url.search : undefined}
-  aria-pressed={pressed ? 'true' : 'false'}
-  {...$$restProps}
->
-  {#if $$restProps.leadingIcon}
-    <span class="hidden md:block"><slot /></span>
+<Button {...buttonProps}>
+  {#if leadingIcon}
+    <span class="hidden md:block">{@render children?.()}</span>
   {:else}
-    <slot />
+    {@render children?.()}
   {/if}
 </Button>

--- a/src/lib/holocene/toggle-button/toggle-button.svelte
+++ b/src/lib/holocene/toggle-button/toggle-button.svelte
@@ -8,22 +8,33 @@
 
   import type {
     ButtonProps,
+    ButtonWithHrefProps,
     ButtonWithoutHrefProps,
   } from '../button-runes.svelte';
   import Button from '../button-runes.svelte';
 
-  type Props = Omit<ButtonWithoutHrefProps, 'href' | 'target'> & {
+  type ToggleBaseProps = {
     group?: boolean;
     active?: boolean;
-    href?: string | null;
-    base?: string | null;
   };
+
+  type AnchorProps = ToggleBaseProps &
+    ButtonWithHrefProps & {
+      base?: string;
+    };
+
+  type ButtonToggleProps = ToggleBaseProps &
+    ButtonWithoutHrefProps & {
+      base?: never;
+    };
+
+  type Props = AnchorProps | ButtonToggleProps;
 
   let {
     class: className = '',
     group = getAppContext('group'),
-    href = null,
-    base = null,
+    href,
+    base,
     active = false,
     variant = 'secondary',
     leadingIcon,

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -245,7 +245,7 @@
           <ToggleButton
             leadingIcon={reverseSort ? 'descending' : 'ascending'}
             data-testid="zoom-in"
-            on:click={onSort}
+            onclick={onSort}
             size="sm"
           >
             {reverseSort
@@ -259,7 +259,7 @@
           data-testid="pause"
           class="border-l-0"
           size="sm"
-          on:click={onAutoRefreshToggle}
+          onclick={onAutoRefreshToggle}
         >
           <span
             class="h-1.5 w-1.5 rounded-full {$pauseLiveUpdates || isNotPending
@@ -274,7 +274,7 @@
           data-testid="download"
           leadingIcon="download"
           size="sm"
-          on:click={() => (showDownloadPrompt = true)}
+          onclick={() => (showDownloadPrompt = true)}
         >
           {translate('common.download')}
         </ToggleButton>

--- a/src/lib/layouts/workflow-timeline-layout.svelte
+++ b/src/lib/layouts/workflow-timeline-layout.svelte
@@ -185,7 +185,7 @@
         <ToggleButton
           leadingIcon={reverseSort ? 'descending' : 'ascending'}
           data-testid="zoom-in"
-          on:click={onSort}
+          onclick={onSort}
           size="sm">{reverseSort ? 'Descending' : 'Ascending'}</ToggleButton
         >
         <ToggleButton
@@ -194,7 +194,7 @@
           loading={!historyCtx.fetchComplete}
           disabled={!historyCtx.fetchComplete ||
             !timeline?.hasCollapsibleSegments}
-          on:click={onToggleIdleTime}
+          onclick={onToggleIdleTime}
           size="sm"
         >
           {timeline?.allCollapsibleSegmentsCollapsed
@@ -207,7 +207,7 @@
           data-testid="pause"
           class="border-l-0"
           size="sm"
-          on:click={onAutoRefreshToggle}
+          onclick={onAutoRefreshToggle}
         >
           <span
             class="h-1.5 w-1.5 rounded-full {$pauseLiveUpdates || isNotPending
@@ -222,7 +222,7 @@
           data-testid="download"
           leadingIcon="download"
           size="sm"
-          on:click={() => (showDownloadPrompt = true)}
+          onclick={() => (showDownloadPrompt = true)}
         >
           {translate('common.download')}
         </ToggleButton>


### PR DESCRIPTION
Part 6 of the button strangler migration (stacked on #3731) — third/final wrapper.

Migrates `toggle-button.svelte` to runes: `export let`→`$props()`, `$app/stores`→`$app/state`, `$:`→`$derived`, bare `on:click` forward → `onclick` prop, `<slot/>`→`{@render children?.()}`, import→`button-runes`. Updates its 11 ui consumers.

Because toggle-button spreads a broad `rest` **and** passes a dynamic `href`, it trips the `ButtonProps` union's "too complex" distribution. Kept the **sound discriminated union** on button-runes (unchanged) and cast the merged props to `ButtonProps` at the single spread site — a localized cast in a generic passthrough wrapper; all consumer-facing types stay sound.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3016

`pnpm check` 0 errors, eslint clean, 2548 tests pass. Base is #3731.