### PR TITLE
Update holocene skeleton table to runes syntax

### DIFF
--- a/src/lib/holocene/skeleton/skeleton-table.stories.svelte
+++ b/src/lib/holocene/skeleton/skeleton-table.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import SkeletonTable from './table.svelte';
 
@@ -16,7 +17,7 @@
       rows: { name: 'Rows', control: 'number' },
       columns: { name: 'Columns', control: 'number' },
     },
-  } satisfies Meta<SkeletonTable>;
+  } satisfies Meta<ComponentProps<typeof SkeletonTable>>;
 </script>
 
 <script lang="ts">
@@ -28,11 +29,11 @@
     100 / args.columns,
   )}
   <SkeletonTable {columnWidths} {...args}>
-    <svelte:fragment slot="headers">
+    {#snippet headers()}
       {#each Array(args.columns) as _, index}
         <th>Heading {index + 1}</th>
       {/each}
-    </svelte:fragment>
+    {/snippet}
   </SkeletonTable>
 </Template>
 

--- a/src/lib/holocene/skeleton/table.svelte
+++ b/src/lib/holocene/skeleton/table.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import Table from '$lib/holocene/table/table.svelte';
 
   import TableHeaderRow from '../table/table-header-row.svelte';
@@ -6,20 +8,37 @@
 
   import Skeleton from './index.svelte';
 
-  export let rows = 10;
-  export let columns = 4;
-  export let columnWidths: number[] = new Array(columns).fill(100 / columns);
-  export let bordered: boolean = true;
+  interface Props {
+    rows?: number;
+    columns?: number;
+    columnWidths?: number[];
+    bordered?: boolean;
+    headers?: Snippet;
+  }
+
+  let {
+    rows = 10,
+    columns = 4,
+    columnWidths,
+    bordered = true,
+    headers: headersSnippet,
+  }: Props = $props();
+
+  const widths = $derived(
+    columnWidths ?? new Array(columns).fill(100 / columns),
+  );
 </script>
 
 <Table class="w-full" fixed {bordered}>
   {#snippet headers()}
     <TableHeaderRow class="h-8">
-      <slot name="headers">
+      {#if headersSnippet}
+        {@render headersSnippet()}
+      {:else}
         {#each Array.from(new Array(columns)) as _column, index}
-          <th style="width: {columnWidths[index]}%;"></th>
+          <th style="width: {widths[index]}%;"></th>
         {/each}
-      </slot>
+      {/if}
     </TableHeaderRow>
   {/snippet}
   {#each Array.from(Array(rows).keys()) as _row}


### PR DESCRIPTION
Migrates `skeleton/table.svelte` to Svelte 5 runes. Independent of the button migration — branches off `main`.

- `export let` → `$props()`; the `columnWidths` default (which referenced `columns`) becomes a `$derived`.
- Named `<slot name="headers">` → a `headers` snippet prop (aliased locally to `headersSnippet` to avoid colliding with the `Table` `headers` snippet it renders).
- Story updated (`{#snippet headers()}`, `Meta<ComponentProps<typeof …>>`).

No consumer changes needed: no ui or cloud-ui consumer used the `headers` slot (verified — the `slot="headers"` usages nearby are on `Table`/`PaginatedTable`). `pnpm check` 0 errors, eslint clean, 2548 tests pass.