### PR TITLE
Update holocene number-input to runes syntax

### DIFF
--- a/src/lib/components/workflow/search-attribute-input/index.svelte
+++ b/src/lib/components/workflow/search-attribute-input/index.svelte
@@ -107,7 +107,6 @@
       <NumberInput
         label={translate('common.value')}
         id="attribute-value-{id}"
-        valid={value < Number.MAX_SAFE_INTEGER}
         hintText="Number is too large"
         bind:value
         max={Number.MAX_SAFE_INTEGER}

--- a/src/lib/holocene/input/number-input.stories.svelte
+++ b/src/lib/holocene/input/number-input.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import { iconNames } from '$lib/holocene/icon';
   import NumberInput from '$lib/holocene/input/number-input.svelte';
@@ -36,7 +37,7 @@
       min: { name: 'Maximum Value', control: { type: 'number', min: 0 } },
       search: { name: 'Search', control: 'boolean' },
     },
-  } satisfies Meta<NumberInput>;
+  } satisfies Meta<ComponentProps<typeof NumberInput>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/input/number-input.svelte
+++ b/src/lib/holocene/input/number-input.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FullAutoFill } from 'svelte/elements';
+  import type { FullAutoFill, HTMLInputAttributes } from 'svelte/elements';
 
   import { twMerge as merge } from 'tailwind-merge';
 
@@ -7,41 +7,55 @@
   import Icon from '$lib/holocene/icon/icon.svelte';
   import Label from '$lib/holocene/label.svelte';
 
-  export let icon: IconName | undefined = undefined;
-  export let id: string;
-  export let value: number;
-  export let label: string;
-  export let labelHidden = false;
-  export let units = '';
-  export let placeholder = '';
-  export let name = id;
-  export let disabled = false;
-  export let required = false;
-  export let hintText = '';
-  export let max: number | undefined = undefined;
-  export let min: number | undefined = undefined;
-  export let step: number = 1;
-  export let search = false;
-  export let autocomplete: FullAutoFill = 'off';
-
-  let valid = true;
-
-  const validate = (val: number) => {
-    if ((min !== undefined && val < min) || (max !== undefined && val > max)) {
-      valid = false;
-    } else {
-      valid = true;
-    }
-  };
-
-  $: {
-    validate(value);
+  interface Props extends Omit<HTMLInputAttributes, 'value' | 'class'> {
+    icon?: IconName;
+    id: string;
+    value: number;
+    label: string;
+    labelHidden?: boolean;
+    units?: string;
+    placeholder?: string;
+    name?: string;
+    disabled?: boolean;
+    required?: boolean;
+    hintText?: string;
+    max?: number;
+    min?: number;
+    step?: number;
+    search?: boolean;
+    autocomplete?: FullAutoFill;
+    class?: string;
   }
 
-  $: errorId = `${id}-error`;
+  let {
+    icon,
+    id,
+    value = $bindable(),
+    label,
+    labelHidden = false,
+    units = '',
+    placeholder = '',
+    name,
+    disabled = false,
+    required = false,
+    hintText = '',
+    max,
+    min,
+    step = 1,
+    search = false,
+    autocomplete = 'off',
+    class: className,
+    ...rest
+  }: Props = $props();
+
+  const resolvedName = $derived(name ?? id);
+  const valid = $derived(
+    !((min !== undefined && value < min) || (max !== undefined && value > max)),
+  );
+  const errorId = $derived(`${id}-error`);
 </script>
 
-<div class={merge('flex flex-col gap-1', $$props.class)}>
+<div class={merge('flex flex-col gap-1', className)}>
   <Label {required} {label} hidden={labelHidden} for={id} />
   <div class="flex items-center">
     <div
@@ -65,7 +79,7 @@
         data-1p-ignore="true"
         {placeholder}
         {id}
-        {name}
+        name={resolvedName}
         {step}
         {required}
         aria-invalid={!valid ? 'true' : undefined}
@@ -73,11 +87,7 @@
         {autocomplete}
         spellcheck="false"
         bind:value
-        on:input
-        on:change
-        on:focus
-        on:blur
-        on:keydown
+        {...rest}
       />
     </div>
     {#if units}


### PR DESCRIPTION
Migrates `input/number-input.svelte` to Svelte 5 runes. Independent of the button migration — branches off `main`.

- `export let` → `$props()` (`Props extends Omit<HTMLInputAttributes, 'value' | 'class'>`); `value = $bindable()`; `$$props.class` → `class` prop.
- `$:` validation + `let valid` state → a single `$derived`; `errorId` → `$derived`; the `name = id` default → a `$derived` fallback.
- Native event forwards (`on:input/change/focus/blur/keydown`) now flow through `{...rest}` (typed via `HTMLInputAttributes`).
- Removed a dead `valid={…}` prop from `search-attribute-input` — `valid` was never a real prop (computed internally from min/max); the adjacent `max={Number.MAX_SAFE_INTEGER}` already drives that validation.

No consumer event/prop changes needed (no ui or cloud-ui consumer forwarded events or used the dead prop). `pnpm check` 0 errors, eslint clean, 2548 tests pass.

Paired cloud-ui PR (removes an unused `error` prop from the retention form): temporalio/cloud-ui#3039