### PR TITLE
Update holocene accordion to runes syntax

### DIFF
--- a/src/lib/components/lines-and-dots/workflow-error-stack-trace.svelte
+++ b/src/lib/components/lines-and-dots/workflow-error-stack-trace.svelte
@@ -15,9 +15,11 @@
 
 {#if failure}
   <Accordion title={translate('common.failure')} class="text-sm">
-    <div class="w-full text-right text-xs" slot="summary">
-      {failure?.message}
-    </div>
+    {#snippet summary()}
+      <div class="w-full text-right text-xs">
+        {failure?.message}
+      </div>
+    {/snippet}
     <div class="flex flex-col gap-2">
       <p>{translate('common.message')}</p>
       <CodeBlock

--- a/src/lib/components/workflow/pending-activities.svelte
+++ b/src/lib/components/workflow/pending-activities.svelte
@@ -41,17 +41,20 @@
       title={translate('workflows.pending-activities')}
       data-testid="pending-activities"
     >
-      <div slot="summary" class="flex items-center gap-2">
-        <Badge type="count">{pendingActivities.length}</Badge>
-        {#if canceled}
-          <Tooltip
-            bottom
-            text={translate('workflows.pending-activities-canceled')}
-          >
-            <Badge type="warning" class="py-0"><Icon name="canceled" /></Badge>
-          </Tooltip>
-        {/if}
-      </div>
+      {#snippet summary()}
+        <div class="flex items-center gap-2">
+          <Badge type="count">{pendingActivities.length}</Badge>
+          {#if canceled}
+            <Tooltip
+              bottom
+              text={translate('workflows.pending-activities-canceled')}
+            >
+              <Badge type="warning" class="py-0"><Icon name="canceled" /></Badge
+              >
+            </Tooltip>
+          {/if}
+        </div>
+      {/snippet}
       <div>
         {#each pendingActivities as { id, ...pendingActivity } (id)}
           {@const failed = (pendingActivity.attempt ?? 0) > 1}

--- a/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
+++ b/src/lib/components/workflow/pending-activity/pending-activity-card.svelte
@@ -224,11 +224,12 @@
     title={activity.lastFailure?.stackTrace
       ? translate('workflows.last-failure-with-stack-trace')
       : translate('workflows.last-failure')}
-    let:open
   >
-    {#if open}
-      {@render failuresCodeBlock()}
-    {/if}
+    {#snippet children(open)}
+      {#if open}
+        {@render failuresCodeBlock()}
+      {/if}
+    {/snippet}
   </Accordion>
 {/snippet}
 

--- a/src/lib/holocene/accordion/accordion.stories.svelte
+++ b/src/lib/holocene/accordion/accordion.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import { iconNames } from '$lib/holocene/icon';
 
@@ -29,11 +30,11 @@
         options: iconNames,
       },
     },
-  } satisfies Meta<Accordion>;
+  } satisfies Meta<ComponentProps<typeof Accordion>>;
 </script>
 
 <script lang="ts">
-  import { action } from '@storybook/addon-actions';
+  import { action as logAction } from '@storybook/addon-actions';
   import { Story, Template } from '@storybook/addon-svelte-csf';
 
   import Link from '../link.svelte';
@@ -43,17 +44,17 @@
 
 <Template let:args>
   <div class="flex flex-col gap-2">
-    <Accordion {...args} onToggle={action('onToggle')}>
+    <Accordion {...args} onToggle={logAction('onToggle')}>
       <p>Accordion Content</p>
     </Accordion>
     <AccordionGroup>
-      <Accordion {...args} onToggle={action('onToggle')}>
+      <Accordion {...args} onToggle={logAction('onToggle')}>
         <p>Accordion Content</p>
       </Accordion>
-      <Accordion {...args} onToggle={action('onToggle')}>
+      <Accordion {...args} onToggle={logAction('onToggle')}>
         <p>Accordion Content</p>
       </Accordion>
-      <Accordion {...args} onToggle={action('onToggle')}>
+      <Accordion {...args} onToggle={logAction('onToggle')}>
         <p>Accordion Content</p>
       </Accordion>
     </AccordionGroup>
@@ -77,17 +78,21 @@
     },
   }}
 >
-  <Accordion {...args} onToggle={action('onToggle')}>
+  <Accordion {...args} onToggle={logAction('onToggle')}>
     <p>Accordion Content</p>
-    <Link href="https://docs.temporal.io/" newTab slot="action" icon="book">
-      <span class="sr-only">docs</span>
-    </Link>
+    {#snippet action()}
+      <Link href="https://docs.temporal.io/" newTab icon="book">
+        <span class="sr-only">docs</span>
+      </Link>
+    {/snippet}
   </Accordion>
 </Story>
 
 <Story name="With Summary" let:args>
-  <Accordion {...args} onToggle={action('onToggle')}>
-    <p slot="summary">Accordion Summary</p>
+  <Accordion {...args} onToggle={logAction('onToggle')}>
+    {#snippet summary()}
+      <p>Accordion Summary</p>
+    {/snippet}
     <p>Accordion Content</p>
   </Accordion>
 </Story>

--- a/src/lib/holocene/accordion/accordion.svelte
+++ b/src/lib/holocene/accordion/accordion.svelte
@@ -1,13 +1,17 @@
 <script lang="ts">
   import type { HTMLAttributes } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import Badge from '$lib/holocene/badge.svelte';
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
 
-  interface $$Props extends HTMLAttributes<HTMLDivElement> {
+  interface Props extends Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'title' | 'children'
+  > {
     title: string;
     id?: string;
     subtitle?: string;
@@ -18,23 +22,32 @@
     onToggle?: () => void;
     'data-testid'?: string;
     class?: string;
+    summary?: Snippet;
+    action?: Snippet;
+    children?: Snippet<[boolean]>;
   }
 
-  export let title: string;
-  export let id: string = crypto.randomUUID();
-  export let subtitle = '';
-  export let icon: IconName | undefined = undefined;
-  export let open = false;
-  export let expandable = true;
-  export let error = '';
-  export let onToggle = () => {};
+  const generatedId = $props.id();
 
-  let className = '';
-  export { className as class };
+  let {
+    title,
+    id = generatedId,
+    subtitle = '',
+    icon,
+    open = $bindable(false),
+    expandable = true,
+    error = '',
+    onToggle,
+    class: className = '',
+    summary,
+    action,
+    children,
+    ...rest
+  }: Props = $props();
 
   const toggleAccordion = () => {
     open = !open;
-    onToggle();
+    onToggle?.();
   };
 </script>
 
@@ -42,7 +55,7 @@
   <div
     data-track-container={title}
     class={merge('surface-primary w-full border border-subtle', className)}
-    {...$$restProps}
+    {...rest}
   >
     <div class="flex w-full flex-row items-center">
       <button
@@ -54,7 +67,7 @@
         data-track-name="accordion"
         data-track-intent="toggle"
         data-track-text={title}
-        on:click={toggleAccordion}
+        onclick={toggleAccordion}
       >
         <div class="flex w-full flex-row items-center justify-between gap-2">
           <div class="flex w-full items-center gap-2">
@@ -63,13 +76,13 @@
               {title}
             </h3>
             <div class="text-secondary max-sm:hidden">
-              <slot name="summary" />
+              {@render summary?.()}
             </div>
           </div>
           <Icon class="shrink-0" name={open ? 'chevron-up' : 'chevron-down'} />
         </div>
         <div class="text-secondary sm:hidden">
-          <slot name="summary" />
+          {@render summary?.()}
         </div>
         <p class="flex items-center">
           {#if error}
@@ -79,7 +92,7 @@
         </p>
       </button>
       <div class="flex shrink-0 flex-row items-center gap-2 pr-2">
-        <slot name="action" />
+        {@render action?.()}
       </div>
     </div>
 
@@ -89,14 +102,14 @@
       class="mt-4 block w-full p-4"
       class:hidden={!open}
     >
-      <slot {open} />
+      {@render children?.(open)}
     </div>
   </div>
 {:else}
   <div
     class="surface-primary w-full border border-subtle p-4"
     data-track-container={title}
-    {...$$restProps}
+    {...rest}
   >
     <div class="flex w-full flex-col">
       <div class="flex w-full flex-row items-center justify-between gap-2">
@@ -106,15 +119,15 @@
             {title}
           </h3>
           <div class="text-secondary max-sm:hidden">
-            <slot name="summary" />
+            {@render summary?.()}
           </div>
         </div>
         <div class="flex flex-row items-center gap-2 pr-2">
-          <slot name="action" />
+          {@render action?.()}
         </div>
       </div>
       <div class="text-secondary sm:hidden">
-        <slot name="summary" />
+        {@render summary?.()}
       </div>
       <p class="flex items-center">
         {#if error}
@@ -125,7 +138,7 @@
     </div>
 
     <div class="mt-6 block w-full" class:hidden={!open}>
-      <slot {open} />
+      {@render children?.(open)}
     </div>
   </div>
 {/if}


### PR DESCRIPTION
Migrates `accordion/accordion.svelte` to Svelte 5 runes. Independent of the button migration — branches off `main`.

- `export let` → `$props()`; `open` → `$bindable`; internal `on:click` → `onclick`; `$$restProps` → `...rest`.
- Named slots `summary`/`action` → snippet props; scoped default `<slot {open}>` → `children?: Snippet<[boolean]>`.
- Generated-id fallback uses `$props.id()` (SSR-stable, per-instance) instead of `crypto.randomUUID()`.
- `Omit<HTMLAttributes, 'title' | 'children'>` to avoid the DOM `title`/`children` collisions.
- 3 ui consumers updated (`slot="summary"`→snippet, `let:open`→`{#snippet children(open)}`) + story.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3019

`pnpm check` 0 errors, eslint clean, 2548 tests pass.