### PR TITLE
Update holocene tabs and tab-button to runes syntax

### DIFF
--- a/src/lib/components/event/event-summary.svelte
+++ b/src/lib/components/event/event-summary.svelte
@@ -72,21 +72,21 @@
         data-testid="feed"
         icon="feed"
         class="h-10"
-        on:click={onAllClick}>All</TabButton
+        onclick={onAllClick}>All</TabButton
       >
       <TabButton
         active={$eventViewType === 'compact'}
         data-testid="compact"
         icon="compact"
         class="h-10"
-        on:click={onCompactClick}>Compact</TabButton
+        onclick={onCompactClick}>Compact</TabButton
       >
       <TabButton
         active={$eventViewType === 'json'}
         data-testid="json"
         icon="json"
         class="h-10"
-        on:click={onJSONClick}>JSON</TabButton
+        onclick={onJSONClick}>JSON</TabButton
       >
     </TabButtons>
   </div>

--- a/src/lib/holocene/markdown-editor/markdown-editor.svelte
+++ b/src/lib/holocene/markdown-editor/markdown-editor.svelte
@@ -21,11 +21,11 @@
 <div>
   <TabButtons>
     <TabButton
-      on:click={() => setActiveTab('edit')}
+      onclick={() => setActiveTab('edit')}
       active={activeTab === 'edit'}>Edit</TabButton
     >
     <TabButton
-      on:click={() => setActiveTab('preview')}
+      onclick={() => setActiveTab('preview')}
       active={activeTab === 'preview'}>Preview</TabButton
     >
   </TabButtons>

--- a/src/lib/holocene/tab-buttons/tab-button.stories.svelte
+++ b/src/lib/holocene/tab-buttons/tab-button.stories.svelte
@@ -3,6 +3,7 @@
 <script lang="ts" module>
   import type { Meta, StoryContext } from '@storybook/svelte';
   import { expect, userEvent, within } from '@storybook/test';
+  import type { ComponentProps } from 'svelte';
 
   import { iconNames } from '$lib/holocene/icon';
 
@@ -20,7 +21,7 @@
       href: { table: { disable: true } },
       active: { table: { disable: true } },
     },
-  } satisfies Meta<TabButton>;
+  } satisfies Meta<ComponentProps<typeof TabButton>>;
 </script>
 
 <script lang="ts">
@@ -80,7 +81,7 @@
         {...args}
         data-testid={`toggle-button-${index}`}
         active={$selected === index}
-        on:click={() => select(index)}
+        onclick={() => select(index)}
       >
         {name}
       </TabButton>

--- a/src/lib/holocene/tab-buttons/tab-button.svelte
+++ b/src/lib/holocene/tab-buttons/tab-button.svelte
@@ -4,9 +4,10 @@
     HTMLButtonAttributes,
   } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import type { IconName } from '$lib/holocene/icon';
   import Icon from '$lib/holocene/icon/icon.svelte';
@@ -18,61 +19,72 @@
     icon?: IconName;
     group?: boolean;
     active?: boolean;
+    disabled?: boolean;
     'data-testid'?: string;
     tooltip?: string;
     class?: string;
+    onclick?: (event: MouseEvent) => void;
+    children?: Snippet;
   };
 
   type AnchorProps = BaseProps &
-    HTMLAnchorAttributes & {
+    Omit<HTMLAnchorAttributes, 'class' | 'onclick' | 'children'> & {
       href: string;
       base?: string;
     };
 
   type ButtonProps = BaseProps &
-    HTMLButtonAttributes & {
+    Omit<HTMLButtonAttributes, 'class' | 'onclick' | 'children'> & {
       href?: never;
       base?: never;
     };
 
-  type $$Props = AnchorProps | ButtonProps;
+  type Props = AnchorProps | ButtonProps;
 
-  let className = '';
-  export { className as class };
-  export let icon: IconName | undefined = undefined;
-  export let group = getAppContext('group');
-  export let href = '';
-  export let base = href;
-  export let active = false;
-  export let tooltip = '';
+  let {
+    class: className = '',
+    icon,
+    group = getAppContext('group'),
+    href = '',
+    base,
+    active = false,
+    tooltip = '',
+    disabled,
+    onclick,
+    children,
+    ...rest
+  }: Props = $props();
+
+  const resolvedBase = $derived(base ?? href);
 </script>
 
 <svelte:element
   this={href ? 'a' : 'button'}
   class={merge('toggle-button', className)}
   class:group
-  class:active={href ? $page.url.pathname.includes(base) : active}
-  href={href ? href + $page.url.search : null}
-  class:disabled={$$restProps.disabled}
+  class:active={href ? page.url.pathname.includes(resolvedBase) : active}
+  href={href ? href + page.url.search : null}
+  class:disabled
   data-track-name="tab-button"
   data-track-intent="select"
   data-track-text="*textContent*"
-  on:click
+  {onclick}
   role="button"
   tabindex="0"
   type={href ? undefined : 'button'}
-  {...$$restProps}
+  {disabled}
+  {...rest}
 >
   <Tooltip hide={!tooltip} text={tooltip} top>
     {#if icon}
       <div class="flex items-center gap-2">
         <Icon name={icon} />
-        {#if $$slots.default}
-          <span class="hidden md:block"><slot /></span>
+        {#if children}
+          <span class="hidden md:block">{@render children()}</span>
         {/if}
       </div>
     {:else}
-      <slot />
+      {@render children?.()}
     {/if}
   </Tooltip>
 </svelte:element>

--- a/src/lib/holocene/tab/tab.stories.svelte
+++ b/src/lib/holocene/tab/tab.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import TabList from './tab-list.svelte';
   import TabPanel from './tab-panel.svelte';
@@ -12,15 +13,7 @@
     title: 'Tabs',
     component: Tabs,
     subcomponents: { TabList, TabPanel, Tab },
-    argTypes: {
-      TABS: {
-        name: 'Tabs',
-        table: {
-          disable: true,
-        },
-      },
-    },
-  } satisfies Meta<Omit<Tabs, 'TABS'>>;
+  } satisfies Meta<ComponentProps<typeof Tabs>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/tab/tabs.svelte
+++ b/src/lib/holocene/tab/tabs.svelte
@@ -1,4 +1,6 @@
-<script lang="ts" context="module">
+<script lang="ts" module>
+  import type { Writable } from 'svelte/store';
+
   export type TabContext = {
     activeTab: Writable<string>;
     activePanel: Writable<string>;
@@ -12,11 +14,16 @@
 
 <script lang="ts">
   import type { HTMLAttributes } from 'svelte/elements';
-  import { type Writable, writable } from 'svelte/store';
+  import { writable } from 'svelte/store';
 
+  import type { Snippet } from 'svelte';
   import { onDestroy, setContext } from 'svelte';
 
-  type $$Props = HTMLAttributes<HTMLDivElement>;
+  interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+    children?: Snippet;
+  }
+
+  let { children, ...rest }: Props = $props();
 
   const tabs: string[] = [];
   const panels: string[] = [];
@@ -61,6 +68,6 @@
   });
 </script>
 
-<div class="tabs" {...$$restProps}>
-  <slot />
+<div class="tabs" {...rest}>
+  {@render children?.()}
 </div>

--- a/src/lib/layouts/workflow-history-layout.svelte
+++ b/src/lib/layouts/workflow-history-layout.svelte
@@ -221,21 +221,21 @@
           data-testid="feed"
           icon="feed"
           class="h-10"
-          on:click={onAllClick}>All</TabButton
+          onclick={onAllClick}>All</TabButton
         >
         <TabButton
           active={$eventViewType === 'compact'}
           data-testid="compact"
           icon="compact"
           class="h-10"
-          on:click={onCompactClick}>Compact</TabButton
+          onclick={onCompactClick}>Compact</TabButton
         >
         <TabButton
           active={$eventViewType === 'json'}
           data-testid="json"
           icon="json"
           class="h-10"
-          on:click={onJSONClick}>JSON</TabButton
+          onclick={onJSONClick}>JSON</TabButton
         >
       </TabButtons>
     </div>

--- a/src/routes/(app)/common-errors/+page.svelte
+++ b/src/routes/(app)/common-errors/+page.svelte
@@ -35,28 +35,28 @@
   <TabButtons>
     <TabButton
       active={activeFilter === 'all'}
-      on:click={() => {
+      onclick={() => {
         activeFilter = 'all';
       }}>All ({COMMON_ERRORS.length})</TabButton
     >
     <TabButton
       active={activeFilter === 'error'}
       icon="error"
-      on:click={() => {
+      onclick={() => {
         activeFilter = 'error';
       }}>Errors ({errorCount})</TabButton
     >
     <TabButton
       active={activeFilter === 'warning'}
       icon="warning"
-      on:click={() => {
+      onclick={() => {
         activeFilter = 'warning';
       }}>Warnings ({warningCount})</TabButton
     >
     <TabButton
       active={activeFilter === 'info'}
       icon="info"
-      on:click={() => {
+      onclick={() => {
         activeFilter = 'info';
       }}>Info ({infoCount})</TabButton
     >


### PR DESCRIPTION
Migrates `tab/tabs.svelte` and `tab-buttons/tab-button.svelte` to Svelte 5 runes. Independent of the button migration — branches off `main`.

**tabs** (context provider): `context="module"` → `<script module>`, `export let`→`$props()`, default `<slot/>` → `children`, `$$restProps`→`...rest`. Keeps the `TABS` context export + register/select logic unchanged.

**tab-button**: kept the sound `AnchorProps | ButtonProps` discriminated union; `$app/stores` $page → `$app/state` page; `on:click` → `onclick`; `$$slots.default` → `children` check; `svelte:element` a/button preserved.

4 ui `TabButton` consumers updated (`on:click`→`onclick`) + both stories. **No cloud-ui changes**: all 20 cloud-ui `Tabs` consumers use default-slot content (auto-maps to `children`), and `tab-button` has no cloud-ui consumers — verified 0/0 against a pristine dist overlay.

`pnpm check` 0 errors, eslint clean, 2548 tests pass.