### PR TITLE
Update holocene pagination to runes syntax

### DIFF
--- a/src/lib/components/workflow/child-workflows-table.svelte
+++ b/src/lib/components/workflow/child-workflows-table.svelte
@@ -47,57 +47,62 @@
 
 <Pagination
   items={formattedAll}
-  let:visibleItems
   aria-label={translate('workflows.child-workflows')}
   pageSizeSelectLabel={translate('common.per-page')}
   previousButtonLabel={translate('common.previous')}
   nextButtonLabel={translate('common.next')}
 >
-  <div slot="pagination-top"></div>
-  <Table class="w-full">
-    {#snippet caption()}
-      <caption class="sr-only">{translate('workflows.child-workflows')}</caption
-      >
-    {/snippet}
-    {#snippet headers()}
-      <TableHeaderRow>
-        <th scope="col" class="max-md:hidden">{translate('common.status')}</th>
-        <th scope="col" class="max-lg:hidden">{translate('common.type')}</th>
-        <th scope="col">{translate('workflows.child-id')}</th>
-        <th scope="col">{translate('workflows.child-run-id')}</th>
-      </TableHeaderRow>
-    {/snippet}
-    {#each visibleItems as child}
-      <TableRow>
-        <td class="max-md:hidden">
-          <WorkflowStatus status={child.status} />
-        </td>
-        <td class="max-lg:hidden">
-          {child.type}
-        </td>
-        <td class="hover:text-blue-700 hover:underline">
-          <Link
-            href={routeForWorkflow({
-              namespace: child.namespace,
-              workflow: child.workflowId,
-              run: child.runId,
-            })}
+  {#snippet paginationTop()}
+    <div></div>
+  {/snippet}
+  {#snippet children({ visibleItems })}
+    <Table class="w-full">
+      {#snippet caption()}
+        <caption class="sr-only"
+          >{translate('workflows.child-workflows')}</caption
+        >
+      {/snippet}
+      {#snippet headers()}
+        <TableHeaderRow>
+          <th scope="col" class="max-md:hidden">{translate('common.status')}</th
           >
-            {child.workflowId}
-          </Link>
-        </td>
-        <td class="hover:text-blue-700 hover:underline">
-          <Link
-            href={routeForWorkflow({
-              namespace: child.namespace,
-              workflow: child.workflowId,
-              run: child.runId,
-            })}
-          >
-            {child.runId}
-          </Link>
-        </td>
-      </TableRow>
-    {/each}
-  </Table>
+          <th scope="col" class="max-lg:hidden">{translate('common.type')}</th>
+          <th scope="col">{translate('workflows.child-id')}</th>
+          <th scope="col">{translate('workflows.child-run-id')}</th>
+        </TableHeaderRow>
+      {/snippet}
+      {#each visibleItems as child}
+        <TableRow>
+          <td class="max-md:hidden">
+            <WorkflowStatus status={child.status} />
+          </td>
+          <td class="max-lg:hidden">
+            {child.type}
+          </td>
+          <td class="hover:text-blue-700 hover:underline">
+            <Link
+              href={routeForWorkflow({
+                namespace: child.namespace,
+                workflow: child.workflowId,
+                run: child.runId,
+              })}
+            >
+              {child.workflowId}
+            </Link>
+          </td>
+          <td class="hover:text-blue-700 hover:underline">
+            <Link
+              href={routeForWorkflow({
+                namespace: child.namespace,
+                workflow: child.workflowId,
+                run: child.runId,
+              })}
+            >
+              {child.runId}
+            </Link>
+          </td>
+        </TableRow>
+      {/each}
+    </Table>
+  {/snippet}
 </Pagination>

--- a/src/lib/components/workflow/live-child-workflows-table.svelte
+++ b/src/lib/components/workflow/live-child-workflows-table.svelte
@@ -15,64 +15,69 @@
     children?: WorkflowExecution[];
   }
 
-  let { children = [] }: Props = $props();
+  let { children: childWorkflows = [] }: Props = $props();
 
   const namespace = $derived(page.params.namespace);
 </script>
 
 <Pagination
-  items={children}
-  let:visibleItems
+  items={childWorkflows}
   aria-label={translate('workflows.child-workflows')}
   pageSizeSelectLabel={translate('common.per-page')}
   previousButtonLabel={translate('common.previous')}
   nextButtonLabel={translate('common.next')}
 >
-  <div slot="pagination-top"></div>
-  <Table class="w-full">
-    {#snippet caption()}
-      <caption class="sr-only">{translate('workflows.child-workflows')}</caption
-      >
-    {/snippet}
-    {#snippet headers()}
-      <TableHeaderRow>
-        <th scope="col" class="max-md:hidden">{translate('common.status')}</th>
-        <th scope="col" class="max-lg:hidden">{translate('common.type')}</th>
-        <th scope="col">{translate('workflows.child-id')}</th>
-        <th scope="col">{translate('workflows.child-run-id')}</th>
-      </TableHeaderRow>
-    {/snippet}
-    {#each visibleItems as child}
-      <TableRow>
-        <td class="max-md:hidden">
-          <WorkflowStatus status={child.status} />
-        </td>
-        <td class="max-lg:hidden">
-          {child.name}
-        </td>
-        <td class="hover:text-blue-700 hover:underline">
-          <Link
-            href={routeForWorkflow({
-              namespace,
-              workflow: child.id,
-              run: child.runId,
-            })}
+  {#snippet paginationTop()}
+    <div></div>
+  {/snippet}
+  {#snippet children({ visibleItems })}
+    <Table class="w-full">
+      {#snippet caption()}
+        <caption class="sr-only"
+          >{translate('workflows.child-workflows')}</caption
+        >
+      {/snippet}
+      {#snippet headers()}
+        <TableHeaderRow>
+          <th scope="col" class="max-md:hidden">{translate('common.status')}</th
           >
-            {child.id}
-          </Link>
-        </td>
-        <td class="hover:text-blue-700 hover:underline">
-          <Link
-            href={routeForWorkflow({
-              namespace,
-              workflow: child.id,
-              run: child.runId,
-            })}
-          >
-            {child.runId}
-          </Link>
-        </td>
-      </TableRow>
-    {/each}
-  </Table>
+          <th scope="col" class="max-lg:hidden">{translate('common.type')}</th>
+          <th scope="col">{translate('workflows.child-id')}</th>
+          <th scope="col">{translate('workflows.child-run-id')}</th>
+        </TableHeaderRow>
+      {/snippet}
+      {#each visibleItems as child}
+        <TableRow>
+          <td class="max-md:hidden">
+            <WorkflowStatus status={child.status} />
+          </td>
+          <td class="max-lg:hidden">
+            {child.name}
+          </td>
+          <td class="hover:text-blue-700 hover:underline">
+            <Link
+              href={routeForWorkflow({
+                namespace,
+                workflow: child.id,
+                run: child.runId,
+              })}
+            >
+              {child.id}
+            </Link>
+          </td>
+          <td class="hover:text-blue-700 hover:underline">
+            <Link
+              href={routeForWorkflow({
+                namespace,
+                workflow: child.id,
+                run: child.runId,
+              })}
+            >
+              {child.runId}
+            </Link>
+          </td>
+        </TableRow>
+      {/each}
+    </Table>
+  {/snippet}
 </Pagination>

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -1,9 +1,10 @@
-<script lang="ts">
+<script lang="ts" generics="T">
   import type { HTMLAttributes } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
   import { onMount } from 'svelte';
 
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import FilterSelect from '$lib/holocene/select/filter-select.svelte';
   import Skeleton from '$lib/holocene/skeleton/index.svelte';
@@ -18,10 +19,16 @@
   import { getFloatStyle } from '$lib/utilities/get-float-style';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
 
-  type T = $$Generic;
-  interface $$Props extends HTMLAttributes<HTMLDivElement> {
+  type PaginationScope = {
+    visibleItems: T[];
+    initialItem: T;
+    activeRowIndex: number | undefined;
+    setActiveRowIndex: (index: number) => void;
+  };
+
+  interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
     items: T[];
-    floatId?: string | undefined;
+    floatId?: string;
     startingIndex?: string | number;
     currentPageKey?: string;
     itemsPerPage?: number | null;
@@ -29,50 +36,73 @@
     pageSizeSelectLabel: string;
     previousButtonLabel: string;
     nextButtonLabel: string;
+    actionTopLeft?: Snippet;
+    actionTopCenter?: Snippet;
+    actionTopRight?: Snippet;
+    actionBottomLeft?: Snippet;
+    actionBottomRight?: Snippet;
+    paginationTop?: Snippet;
+    children?: Snippet<[PaginationScope]>;
   }
 
-  export let items: T[];
-  export let floatId: string | undefined = undefined;
-  export let startingIndex: string | number = 0;
-  export let currentPageKey = 'page';
-  export let itemsPerPage: number | null = null;
-  export let updating = false;
-  export let pageSizeSelectLabel: string;
-  export let previousButtonLabel: string;
-  export let nextButtonLabel: string;
+  let {
+    items,
+    floatId,
+    startingIndex = 0,
+    currentPageKey = 'page',
+    itemsPerPage = null,
+    updating = false,
+    pageSizeSelectLabel,
+    previousButtonLabel,
+    nextButtonLabel,
+    actionTopLeft,
+    actionTopCenter,
+    actionTopRight,
+    actionBottomLeft,
+    actionBottomRight,
+    paginationTop,
+    children,
+    ...rest
+  }: Props = $props();
 
-  $: perPage =
+  const perPage = $derived(
     itemsPerPage !== null
       ? String(itemsPerPage)
       : String(
           perPageFromSearchParameter(
-            $page.url.searchParams.get(perPageKey) ?? undefined,
+            page.url.searchParams.get(perPageKey) ?? undefined,
           ),
-        ).toString();
+        ).toString(),
+  );
 
-  $: {
+  $effect(() => {
     if (parseInt(perPage, 10) > parseInt(MAX_PAGE_SIZE, 10)) {
       updateQueryParameters({
         parameter: perPageKey,
         value: MAX_PAGE_SIZE,
-        url: $page.url,
+        url: page.url,
       });
     } else if (!options.includes(perPage)) {
       updateQueryParameters({
         parameter: perPageKey,
         value: defaultItemsPerPage,
-        url: $page.url,
+        url: page.url,
       });
     }
-  }
-  $: store = pagination(items, perPage, startingIndex);
-  $: currentPage =
-    $page.url.searchParams.get(currentPageKey) ?? $store.currentPage;
-  $: store.jumpToPage(currentPage);
+  });
 
-  let screenWidth: number;
-  let width: number | undefined;
-  let height: number | undefined;
+  const store = $derived(pagination(items, perPage, startingIndex));
+  const currentPage = $derived(
+    page.url.searchParams.get(currentPageKey) ?? $store.currentPage,
+  );
+
+  $effect(() => {
+    store.jumpToPage(currentPage);
+  });
+
+  let screenWidth = $state<number>(0);
+  let width = $state<number>();
+  let height = $state<number>(0);
 
   onMount(() => {
     updateWidth();
@@ -86,7 +116,7 @@
     updateQueryParameters({
       parameter: currentPageKey,
       value: $store.currentPage,
-      url: $page.url,
+      url: page.url,
     });
   };
 
@@ -96,7 +126,7 @@
     }
   };
 
-  $: floatStyle = getFloatStyle({ width, height, screenWidth });
+  const floatStyle = $derived(getFloatStyle({ width, height, screenWidth }));
 
   async function handleKeydown(event: KeyboardEvent) {
     switch (event.code) {
@@ -130,8 +160,8 @@
 
 <svelte:window
   bind:innerWidth={screenWidth}
-  on:resize={updateWidth}
-  on:keydown={handleKeydown}
+  onresize={updateWidth}
+  onkeydown={handleKeydown}
 />
 
 <div class="pagination relative mb-8 flex flex-col gap-4">
@@ -139,15 +169,15 @@
     class="flex flex-col items-center justify-between gap-2 md:flex-row md:items-start"
   >
     <div class="w-full">
-      <slot name="action-top-left" />
+      {@render actionTopLeft?.()}
     </div>
     <nav
       style={floatStyle}
       bind:clientHeight={height}
       class="flex min-w-fit flex-col items-end gap-4 md:flex-row"
-      aria-label="{$$restProps['aria-label']} 1"
+      aria-label="{rest['aria-label']} 1"
     >
-      <slot name="action-top-center" />
+      {@render actionTopCenter?.()}
       <div class="flex gap-4">
         {#if !itemsPerPage}
           <FilterSelect
@@ -158,12 +188,14 @@
             position="top"
           />
         {/if}
-        <slot name="pagination-top">
+        {#if paginationTop}
+          {@render paginationTop()}
+        {:else}
           <div class="flex items-center justify-center gap-3">
             <button
               class="caret"
               disabled={!$store.hasPrevious}
-              on:click={() => {
+              onclick={() => {
                 store.previous();
                 handlePageChange();
               }}
@@ -183,7 +215,7 @@
             <button
               class="caret"
               disabled={!$store.hasNext}
-              on:click={() => {
+              onclick={() => {
                 store.next();
                 handlePageChange();
               }}
@@ -192,24 +224,22 @@
               <span class="arrow arrow-right"></span>
             </button>
           </div>
-        </slot>
+        {/if}
       </div>
-      <slot name="action-top-right" />
+      {@render actionTopRight?.()}
     </nav>
   </div>
-  <slot
-    visibleItems={$store.items}
-    initialItem={$store.initialItem}
-    activeRowIndex={$store.activeRowIndex}
-    setActiveRowIndex={store.setActiveRowIndex}
-  />
+  {@render children?.({
+    visibleItems: $store.items,
+    initialItem: $store.initialItem,
+    activeRowIndex: $store.activeRowIndex,
+    setActiveRowIndex: store.setActiveRowIndex,
+  })}
   <nav
-    class={`flex ${
-      $$slots['action-bottom-left'] ? 'justify-between' : 'justify-end'
-    }`}
-    aria-label="{$$restProps['aria-label']} 2"
+    class={`flex ${actionBottomLeft ? 'justify-between' : 'justify-end'}`}
+    aria-label="{rest['aria-label']} 2"
   >
-    <slot name="action-bottom-left" />
+    {@render actionBottomLeft?.()}
     <div class="flex gap-4">
       {#if !itemsPerPage}
         <FilterSelect
@@ -224,7 +254,7 @@
         <button
           class="caret"
           disabled={!$store.hasPrevious}
-          on:click={() => {
+          onclick={() => {
             store.previous();
             handlePageChange();
           }}
@@ -243,7 +273,7 @@
         <button
           class="caret"
           disabled={!$store.hasNext}
-          on:click={() => {
+          onclick={() => {
             store.next();
             handlePageChange();
           }}
@@ -252,7 +282,7 @@
           <span class="arrow arrow-right"></span>
         </button>
       </div>
-      <slot name="action-bottom-right" />
+      {@render actionBottomRight?.()}
     </div>
   </nav>
 </div>

--- a/src/lib/holocene/pagination.svelte
+++ b/src/lib/holocene/pagination.svelte
@@ -23,7 +23,7 @@
     visibleItems: T[];
     initialItem: T;
     activeRowIndex: number | undefined;
-    setActiveRowIndex: (index: number) => void;
+    setActiveRowIndex: (index: number | undefined) => void;
   };
 
   interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {

--- a/src/routes/(app)/namespaces/+page.svelte
+++ b/src/routes/(app)/namespaces/+page.svelte
@@ -22,33 +22,34 @@
 {#if $namespaces?.length > 0}
   <Pagination
     items={$namespaces}
-    let:visibleItems
     aria-label={translate('common.namespaces')}
     pageSizeSelectLabel={translate('common.per-page')}
     previousButtonLabel={translate('common.previous')}
     nextButtonLabel={translate('common.next')}
   >
-    <Table class="w-full">
-      {#snippet caption()}
-        <caption class="sr-only">{translate('common.namespaces')}</caption>
-      {/snippet}
-      {#snippet headers()}
-        <TableHeaderRow>
-          <th>{translate('common.name')}</th>
-        </TableHeaderRow>
-      {/snippet}
-      {#each visibleItems as namespace (namespace.namespaceInfo?.name)}
-        <TableRow>
-          <td>
-            <Link
-              href={routeForNamespace({
-                namespace: namespace.namespaceInfo?.name ?? '',
-              })}>{namespace.namespaceInfo?.name}</Link
-            >
-          </td>
-        </TableRow>
-      {/each}
-    </Table>
+    {#snippet children({ visibleItems })}
+      <Table class="w-full">
+        {#snippet caption()}
+          <caption class="sr-only">{translate('common.namespaces')}</caption>
+        {/snippet}
+        {#snippet headers()}
+          <TableHeaderRow>
+            <th>{translate('common.name')}</th>
+          </TableHeaderRow>
+        {/snippet}
+        {#each visibleItems as namespace (namespace.namespaceInfo?.name)}
+          <TableRow>
+            <td>
+              <Link
+                href={routeForNamespace({
+                  namespace: namespace.namespaceInfo?.name ?? '',
+                })}>{namespace.namespaceInfo?.name}</Link
+              >
+            </td>
+          </TableRow>
+        {/each}
+      </Table>
+    {/snippet}
   </Pagination>
 {:else}
   <EmptyState


### PR DESCRIPTION
Migrates `pagination.svelte` to Svelte 5 runes. Independent of the button migration — branches off `main`. (`api-pagination` is handled separately — it's deprecated; see follow-up.)

- `generics="T"`, `export let` → `$props()`, `$:` → `$derived`/`$effect`, `$app/stores` $page → `$app/state` page, `svelte:window` `on:resize`/`on:keydown` → `onresize`/`onkeydown`.
- Hyphenated named slots → camelCase snippet props (`action-top-left` → `actionTopLeft`, `pagination-top` → `paginationTop`, etc.); scoped default slot → `children({ visibleItems, initialItem, activeRowIndex, setActiveRowIndex })`.
- 3 ui consumers updated (`namespaces/+page`, `child-workflows-table`, `live-child-workflows-table`) — incl. aliasing a consumer's `children` prop to avoid shadowing the new `children` snippet.

No cloud-ui consumers. `pnpm check` 0 errors, eslint clean, 2556 tests pass.