### PR TITLE
Update holocene drawer-content to runes syntax

### DIFF
--- a/src/lib/components/workflow/configurable-table-headers-drawer/index.svelte
+++ b/src/lib/components/workflow/configurable-table-headers-drawer/index.svelte
@@ -44,13 +44,13 @@
   class="w-[35vw] min-w-min max-w-fit"
 >
   <DrawerContent title={translate('workflows.configure-headers', { title })}>
-    <svelte:fragment slot="subtitle">
+    {#snippet subtitle()}
       Add (<Icon class="inline" name="add" />), re-arrange (<Icon
         class="inline"
         name="chevron-selector-vertical"
       />), and remove (<Icon class="inline" name="hyphen" />), {type} to personalize
       the {title}.
-    </svelte:fragment>
+    {/snippet}
 
     <OrderableList {availableColumns} {table} {type} />
   </DrawerContent>

--- a/src/lib/holocene/drawer-content.svelte
+++ b/src/lib/holocene/drawer-content.svelte
@@ -1,12 +1,25 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { getContext } from 'svelte';
   import { twMerge } from 'tailwind-merge';
 
-  export let title: string = '';
+  interface Props {
+    title?: string;
+    class?: string;
+    subtitle?: Snippet;
+    children?: Snippet;
+  }
 
-  let position: 'bottom' | 'right' = getContext('drawer-pos');
+  let {
+    title = '',
+    class: className = '',
+    subtitle,
+    children,
+  }: Props = $props();
 
-  $: hasHeader = Boolean(title) || $$slots['subtitle'];
+  const position: 'bottom' | 'right' = getContext('drawer-pos');
+
+  const hasHeader = $derived(Boolean(title) || Boolean(subtitle));
 </script>
 
 {#if hasHeader}
@@ -14,16 +27,16 @@
     {#if title}
       <h2>{title}</h2>
     {/if}
-    {#if $$slots['subtitle']}
+    {#if subtitle}
       <p class="text-xs font-normal">
-        <slot name="subtitle" />
+        {@render subtitle()}
       </p>
     {/if}
   </div>
 {/if}
 
-<div class={twMerge('content', position, !hasHeader && 'pt-6', $$props.class)}>
-  <slot />
+<div class={twMerge('content', position, !hasHeader && 'pt-6', className)}>
+  {@render children?.()}
 </div>
 
 <style lang="postcss">

--- a/src/lib/holocene/drawer.stories.svelte
+++ b/src/lib/holocene/drawer.stories.svelte
@@ -77,7 +77,9 @@
   <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent title="Drawer Title">
-      <span slot="subtitle">A supporting subtitle line</span>
+      {#snippet subtitle()}
+        <span>A supporting subtitle line</span>
+      {/snippet}
       <p class={merge(args.position === 'right' && 'max-w-80')}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
       </p>
@@ -89,7 +91,9 @@
   <Button on:click={() => (open = !open)}>Toggle Drawer</Button>
   <Drawer bind:open {...args} onClick={action('click')}>
     <DrawerContent>
-      <span slot="subtitle">Subtitle rendered without a title</span>
+      {#snippet subtitle()}
+        <span>Subtitle rendered without a title</span>
+      {/snippet}
       <p class={merge(args.position === 'right' && 'max-w-80')}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus.
       </p>


### PR DESCRIPTION
Migrates `drawer-content.svelte` to Svelte 5 runes. Independent of the button migration — off `main`.

- `export let` → `$props()`; `$$props.class` → `class` prop; `$:` → `$derived`; `getContext('drawer-pos')` unchanged.
- Named `slot="subtitle"` → `subtitle` snippet prop; default slot → `children`.
- 2 ui consumers updated (`configurable-table-headers-drawer`, drawer story).

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3026

`pnpm check` 0 errors, eslint clean, tests pass.