### PR TITLE
Update holocene link to runes syntax

### DIFF
--- a/src/lib/components/workflow/workflow-filters.svelte
+++ b/src/lib/components/workflow/workflow-filters.svelte
@@ -82,14 +82,14 @@
     {#if searchType === 'advanced'}
       <Link
         href="{$page.url.pathname}?search=basic"
-        on:click={updateSearchType('basic')}
+        onclick={updateSearchType('basic')}
       >
         {translate('workflows.basic-search')}
       </Link>
     {:else}
       <Link
         href="{$page.url.pathname}?search=advanced"
-        on:click={updateSearchType('advanced')}
+        onclick={updateSearchType('advanced')}
       >
         {translate('workflows.advanced-search')}
       </Link>

--- a/src/lib/holocene/link.stories.svelte
+++ b/src/lib/holocene/link.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import type { IconName } from './icon';
   import { iconNames } from './icon';
@@ -22,7 +23,7 @@
       href: { control: 'text' },
       icon: { control: 'select', options: iconNames },
     },
-  } satisfies Meta<Link>;
+  } satisfies Meta<ComponentProps<typeof Link>>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/link.svelte
+++ b/src/lib/holocene/link.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { HTMLAnchorAttributes } from 'svelte/elements';
 
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import { goto } from '$app/navigation';
@@ -9,7 +10,7 @@
 
   import Icon from './icon/icon.svelte';
 
-  type $$Props = HTMLAnchorAttributes & {
+  interface Props extends Omit<HTMLAnchorAttributes, 'class' | 'onclick'> {
     href: string;
     active?: boolean;
     interactive?: boolean;
@@ -23,23 +24,29 @@
     light?: boolean;
     gotoParams?: Parameters<typeof goto>[1];
     'data-testid'?: string;
-  };
+    children?: Snippet;
+    onclick?: (event: MouseEvent) => void;
+  }
 
-  let className = '';
-  export { className as class };
-  export let href: string;
-  export let active = false;
-  export let interactive = false;
-  export let newTab = false;
-  export let icon: IconName | undefined = undefined;
-  export let leadingIcon: IconName | undefined = undefined;
-  export let trailingIcon: IconName | undefined = undefined;
-  export let text: string = '';
-  export let light = false;
-  export let gotoParams = {};
+  let {
+    class: className = '',
+    href,
+    active = false,
+    interactive = false,
+    newTab = false,
+    icon,
+    leadingIcon,
+    trailingIcon,
+    text = '',
+    light = false,
+    gotoParams = {},
+    children,
+    onclick,
+    ...rest
+  }: Props = $props();
 
-  $: effectiveLeading = leadingIcon ?? icon;
-  $: hasIcon = !!(effectiveLeading || trailingIcon);
+  const effectiveLeading = $derived(leadingIcon ?? icon);
+  const hasIcon = $derived(!!(effectiveLeading || trailingIcon));
 
   const onLinkClick = (e: MouseEvent) => {
     if (e.button === 1 || newTab || e.metaKey || e.ctrlKey || e.shiftKey)
@@ -47,6 +54,12 @@
 
     e.preventDefault();
     goto(href, gotoParams);
+  };
+
+  const handleClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    onLinkClick(event);
+    onclick?.(event);
   };
 </script>
 
@@ -61,13 +74,13 @@
   data-track-name="link"
   data-track-intent="navigate"
   data-track-text={text || '*textContent*'}
-  on:click|stopPropagation={onLinkClick}
   tabindex={href ? null : 0}
-  {...$$restProps}
+  {...rest}
+  onclick={handleClick}
 >
   {#if effectiveLeading}
     <Icon class="mt-0.5" name={effectiveLeading} />
-  {/if}{#if text}{text}{/if}<slot />{#if trailingIcon}
+  {/if}{#if text}{text}{/if}{@render children?.()}{#if trailingIcon}
     <Icon class="mt-0.5" name={trailingIcon} />
   {/if}
 </a>


### PR DESCRIPTION
Migrates `link.svelte` to Svelte 5 runes. Independent of the button migration — off `main`.

- `export let` → `$props()`; `$$props.class` → `class` prop; `$:` → `$derived`; `$$restProps` → `...rest`; default slot → `children`.
- `on:click|stopPropagation={onLinkClick}` → an `onclick` handler that stops propagation, runs the internal nav (`goto`), then forwards a consumer `onclick` (the legacy component never forwarded consumer clicks; this now does).
- Only **1 ui consumer** needed changes (`workflow-filters`, whose `on:click={updateSearchType(…)}` was a dead handler on the old Link — now correctly wired) + the story. All other ~81 ui consumers use `href`/props/default content and are unchanged.

Consumer follow-up in cloud-ui: temporalio/cloud-ui#3027

`pnpm check` 0 errors, eslint clean, tests pass.