### PR TITLE
Update holocene orderable-list to runes syntax

### DIFF
--- a/src/lib/components/workflow/configurable-table-headers-drawer/orderable-list.svelte
+++ b/src/lib/components/workflow/configurable-table-headers-drawer/orderable-list.svelte
@@ -37,9 +37,9 @@
 
 <div class="flex flex-col gap-4">
   <OrderableList>
-    <svelte:fragment slot="heading">
+    {#snippet heading()}
       {type} <span class="font-normal">(in view)</span>
-    </svelte:fragment>
+    {/snippet}
     {#each columnsInUse as { label }, index (`${label}:${index}`)}
       <OrderableListItem
         {index}
@@ -69,9 +69,9 @@
     {/each}
   </OrderableList>
   <OrderableList>
-    <svelte:fragment slot="heading">
+    {#snippet heading()}
       Available Columns <span class="font-normal">(not in view)</span>
-    </svelte:fragment>
+    {/snippet}
     {#each $availableColumns as { label } (label)}
       <OrderableListItem
         static
@@ -90,10 +90,10 @@
   </OrderableList>
   {#if table !== TABLE_TYPE.DEPLOYMENTS}
     <OrderableList>
-      <svelte:fragment slot="heading">
+      {#snippet heading()}
         {translate('events.custom-search-attributes')}
         <span class="font-normal">(not in view)</span>
-      </svelte:fragment>
+      {/snippet}
       {#each $availableCustomColumns as { label } (label)}
         <OrderableListItem
           static

--- a/src/lib/holocene/orderable-list/orderable-list.stories.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import OrderableListItem from './orderable-list-item.svelte';
   import OrderableList from './orderable-list.svelte';
@@ -19,13 +20,7 @@
     title: 'Orderable List',
     component: OrderableList,
     subcomponents: { OrderableListItem },
-    argTypes: {
-      items: {
-        name: 'Items',
-        control: { type: 'object' },
-      },
-    },
-  } satisfies Meta<OrderableList>;
+  } satisfies Meta<ComponentProps<typeof OrderableList>>;
 </script>
 
 <script lang="ts">
@@ -39,13 +34,13 @@
 
 <Story name="Heading" let:context>
   <OrderableList>
-    <span slot="heading">{context.name}</span>
+    {#snippet heading()}<span>{context.name}</span>{/snippet}
   </OrderableList>
 </Story>
 
 <Story name="With Items" let:context>
   <OrderableList>
-    <span slot="heading">{context.name}</span>
+    {#snippet heading()}<span>{context.name}</span>{/snippet}
     {#each items as item, index (item.label)}
       <OrderableListItem
         on:moveItem={action('moveItem')}

--- a/src/lib/holocene/orderable-list/orderable-list.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list.svelte
@@ -1,15 +1,26 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import OrderableListItem from './orderable-list-item.svelte';
+
+  interface Props {
+    heading?: Snippet;
+    children?: Snippet;
+  }
+
+  let { heading, children }: Props = $props();
 </script>
 
 <div class="orderable-section">
   <h5>
-    <slot name="heading">Items</slot>
+    {#if heading}{@render heading()}{:else}Items{/if}
   </h5>
   <ol class="orderable-list">
-    <slot>
+    {#if children}
+      {@render children()}
+    {:else}
       <OrderableListItem readonly label="No Items" />
-    </slot>
+    {/if}
   </ol>
 </div>
 


### PR DESCRIPTION
Migrates `orderable-list/orderable-list.svelte` to Svelte 5 runes. Independent of the button migration — off `main`.

- Adds a runes `$props()` with `heading`/`children` snippet props (the component previously had only slots, no props).
- Named `slot="heading"` → `heading` snippet (fallback "Items"); default slot → `children` (fallback `<OrderableListItem readonly label="No Items" />`).
- 1 ui consumer updated (`configurable-table-headers-drawer/orderable-list` — 3 `svelte:fragment slot="heading"` → `{#snippet heading()}`) + story. Dropped a dead `items` argType from the story (never a prop).

No cloud-ui consumers. `orderable-list-item` (which uses icon-button) stays legacy — rendered fine as a legacy child. `pnpm check` 0 errors, eslint clean, tests pass.