### PR TITLE
Update holocene tooltip to runes syntax

### DIFF
--- a/src/lib/components/lines-and-dots/event-history-legend.svelte
+++ b/src/lib/components/lines-and-dots/event-history-legend.svelte
@@ -112,27 +112,26 @@
   tooltipClass="!surface-primary border border-subtle"
   usePortal
 >
-  <div
-    slot="content"
-    class="flex gap-6 whitespace-normal p-2 text-xs max-sm:flex-col"
-  >
-    {#if !eventTypesOnly}
+  {#snippet content()}
+    <div class="flex gap-6 whitespace-normal p-2 text-xs max-sm:flex-col">
+      {#if !eventTypesOnly}
+        <dl>
+          {@render term(translate('common.status'))}
+          {#each statuses as { status, label, style } (status)}
+            {@render statusKey({ label, status, style })}
+          {/each}
+          {#each pendingStatuses as status (status.label)}
+            {@render pendingStatusKey(status)}
+          {/each}
+        </dl>
+      {/if}
       <dl>
-        {@render term(translate('common.status'))}
-        {#each statuses as { status, label, style } (status)}
-          {@render statusKey({ label, status, style })}
-        {/each}
-        {#each pendingStatuses as status (status.label)}
-          {@render pendingStatusKey(status)}
+        {@render term(translate('events.event-types'))}
+        {#each categories as category (category)}
+          {@render eventCategoryKey(category)}
         {/each}
       </dl>
-    {/if}
-    <dl>
-      {@render term(translate('events.event-types'))}
-      {#each categories as category (category)}
-        {@render eventCategoryKey(category)}
-      {/each}
-    </dl>
-  </div>
+    </div>
+  {/snippet}
   <Icon name="info" class="text-secondary" />
 </Tooltip>

--- a/src/lib/holocene/tooltip.stories.svelte
+++ b/src/lib/holocene/tooltip.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import Button from '$lib/holocene/button.svelte';
   import { iconNames } from '$lib/holocene/icon';
@@ -70,7 +71,7 @@
         table: { category: 'Positioning' },
       },
     },
-  } satisfies Meta<Tooltip>;
+  } satisfies Meta<ComponentProps<typeof Tooltip>>;
 </script>
 
 <script lang="ts">
@@ -125,11 +126,13 @@
 
 <Story name="With Content instead of text">
   <Tooltip bottomRight show>
-    <div slot="content">
-      <div>whadup</div>
-      <div>whadup</div>
-      <div>whadup</div>
-    </div>
+    {#snippet content()}
+      <div>
+        <div>whadup</div>
+        <div>whadup</div>
+        <div>whadup</div>
+      </div>
+    {/snippet}
     <Button>Tooltip</Button>
   </Tooltip>
 </Story>

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { onDestroy } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
@@ -16,14 +17,16 @@
   type BaseProps = {
     text?: string;
     icon?: IconName;
-    hide?: boolean;
-    width?: number;
+    hide?: boolean | null;
+    width?: number | null;
     class?: string;
     tooltipClass?: string;
     show?: boolean;
     usePortal?: boolean;
     portalOffset?: PortalOffset;
     scrollContainer?: string;
+    children?: Snippet;
+    content?: Snippet;
   };
 
   type BasePositionProps = {
@@ -56,48 +59,46 @@
     | OnlyLeft
     | OnlyTopLeft;
 
-  type $$Props = BaseProps & AllUniquePositionProps;
+  type Props = BaseProps & AllUniquePositionProps;
 
-  let className = '';
-  export { className as class };
-  export let text = '';
-  export let icon: IconName | undefined = undefined;
-  /** bottom center of the tooltip aligned to the top center of the wrapper */
-  export let top = false;
-  /** bottom right of the tooltip aligned to the top right of the wrapper */
-  export let topRight = false;
-  /** left center of the tooltip aligned to the right center of the wrapper */
-  export let right = false;
-  /** top center of the tooltip aligned to the bottom center of the wrapper */
-  export let bottom = false;
-  /** top left of the tooltip aligned to the bottom left of the wrapper */
-  export let bottomLeft = false;
-  /** top right of the tooltip aligned to the bottom right of the wrapper */
-  export let bottomRight = false;
-  /** right center of the tooltip aligned to the left center of the wrapper */
-  export let left = false;
-  /** bottom left of the tooltip aligned to the top left of the wrapper   */
-  export let topLeft = false;
-  export let hide: boolean | null = false;
-  export let width: number | null = null;
-  export let tooltipClass = '';
-  export let show = false;
-  export let usePortal = false;
-  export let portalOffset: PortalOffset | undefined = undefined;
-  export let scrollContainer: string | undefined = undefined;
+  let {
+    class: className = '',
+    text = '',
+    icon,
+    top,
+    topRight,
+    right,
+    bottom,
+    bottomLeft,
+    bottomRight,
+    left,
+    topLeft,
+    hide = false,
+    width = null,
+    tooltipClass = '',
+    show = false,
+    usePortal = false,
+    portalOffset,
+    scrollContainer,
+    children,
+    content,
+  }: Props = $props();
 
-  let wrapperElement: HTMLElement | null = null;
-  let isHovered = false;
-  let isFocused = false;
-  let dismissed = false;
+  let wrapperElement = $state<HTMLElement | null>(null);
+  let isHovered = $state(false);
+  let isFocused = $state(false);
+  let dismissed = $state(false);
   let hoverHideTimer: ReturnType<typeof setTimeout> | null = null;
-  const tooltipId = `tooltip-${crypto.randomUUID()}`;
+  const uid = $props.id();
+  const tooltipId = `tooltip-${uid}`;
 
-  $: isOpen = (show || isHovered || isFocused) && !dismissed;
+  const isOpen = $derived((show || isHovered || isFocused) && !dismissed);
 
-  $: if (!isHovered && !isFocused && dismissed) {
-    dismissed = false;
-  }
+  $effect(() => {
+    if (!isHovered && !isFocused && dismissed) {
+      dismissed = false;
+    }
+  });
 
   function cancelHide() {
     if (hoverHideTimer) {
@@ -139,7 +140,7 @@
     cancelHide();
   });
 
-  $: portalPosition = ((): PortalPosition => {
+  const portalPosition = $derived.by((): PortalPosition => {
     if (top) return 'top';
     if (topRight) return 'top-right';
     if (right) return 'right';
@@ -149,25 +150,34 @@
     if (left) return 'left';
     if (topLeft) return 'top-left';
     return 'top';
-  })();
+  });
 </script>
 
-<svelte:window on:keydown|capture={handleWindowKeydown} />
+<svelte:window onkeydowncapture={handleWindowKeydown} />
+
+{#snippet tooltipContent()}
+  {#if content}
+    {@render content()}
+  {:else}
+    {#if icon}<Icon name={icon} class="inline h-4" />{/if}
+    <span>{text}</span>
+  {/if}
+{/snippet}
 
 {#if hide}
-  <slot />
+  {@render children?.()}
 {:else}
-  <!-- svelte-ignore a11y-no-static-element-interactions -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
     bind:this={wrapperElement}
     class={merge('wrapper relative inline-block', className)}
     aria-describedby={isOpen ? tooltipId : undefined}
-    on:mouseenter={handleHoverEnter}
-    on:mouseleave={handleHoverLeave}
-    on:focusin={handleFocusIn}
-    on:focusout={handleFocusOut}
+    onmouseenter={handleHoverEnter}
+    onmouseleave={handleHoverLeave}
+    onfocusin={handleFocusIn}
+    onfocusout={handleFocusOut}
   >
-    <slot />
+    {@render children?.()}
 
     {#if usePortal && wrapperElement}
       <Portal
@@ -184,15 +194,12 @@
             'inline-block rounded-md bg-slate-800 px-2 py-2 text-xs text-slate-50',
             tooltipClass,
           )}
-          on:mouseenter={handleHoverEnter}
-          on:mouseleave={handleHoverLeave}
+          onmouseenter={handleHoverEnter}
+          onmouseleave={handleHoverLeave}
           style={width ? `white-space: pre-wrap; width: ${width}px;` : null}
         >
           <div class="flex gap-2">
-            <slot name="content">
-              {#if icon}<Icon name={icon} class="inline h-4" />{/if}
-              <span>{text}</span>
-            </slot>
+            {@render tooltipContent()}
           </div>
         </div>
       </Portal>
@@ -204,8 +211,8 @@
           'tooltip absolute left-0 top-0 z-50 translate-x-12 whitespace-nowrap text-xs transition-all',
           isOpen ? 'inline-block opacity-95' : 'hidden opacity-0',
         )}
-        on:mouseenter={handleHoverEnter}
-        on:mouseleave={handleHoverLeave}
+        onmouseenter={handleHoverEnter}
+        onmouseleave={handleHoverLeave}
         class:left
         class:right
         class:bottom
@@ -223,10 +230,7 @@
           )}
         >
           <div class="flex gap-2">
-            <slot name="content">
-              {#if icon}<Icon name={icon} class="inline h-4" />{/if}
-              <span>{text}</span>
-            </slot>
+            {@render tooltipContent()}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Migrates `tooltip.svelte` to Svelte 5 runes. Independent of the button migration — off `main`.

## Changes
- `export let` → `$props()`; `$:` → `$derived`/`$derived.by`/`$effect`; `crypto.randomUUID()` → `$props.id()`.
- Slots → snippets: default slot → `children`; named `slot="content"` → `content` snippet (same `{icon}`/`{text}` fallback).
- `on:mouseenter`/`focusin`/`focusout` → `on*` props; `<svelte:window on:keydown|capture>` → `onkeydowncapture`.
- Position props (`top`/`bottom`/…) keep their discriminated-union (`Only<>`) public type; internally they lose the `= false` defaults (the union types each as `true`), which is behavior-equivalent — they're only read in truthiness checks and `portalPosition` still falls back to `'top'`.

## Consumers
- 1 ui consumer updated: `lines-and-dots/event-history-legend` (`slot="content"` → `{#snippet content()}`). All other ui consumers pass only default children + props (unaffected).
- **cloud-ui:** 4 consumers use `slot="content"` → paired PR below.

`pnpm check` 0 errors, eslint clean, 2556 tests pass. cloud-ui verified 0 errors via dist overlay.

Paired cloud-ui PR: temporalio/cloud-ui#3028
