### PR TITLE
Fix event id param

### DIFF
--- a/src/lib/pages/workflow-history-event.svelte
+++ b/src/lib/pages/workflow-history-event.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  import { page } from '$app/state';
-
   import EventSummaryRow from '$lib/components/event/event-summary-row.svelte';
   import Button from '$lib/holocene/button.svelte';
   import { buildGroupIndex, groupEvents } from '$lib/models/event-groups';
@@ -12,12 +10,14 @@
   import { fullEventHistory } from '$lib/stores/events';
   import { workflowRun } from '$lib/stores/workflow-run';
 
-  const {
-    eventId,
-    namespace,
-    workflow: workflowId,
-    run: runId,
-  } = $derived(page.params);
+  interface Props {
+    eventId: string;
+    namespace: string;
+    workflowId: string;
+    runId: string;
+  }
+
+  const { eventId, namespace, workflowId, runId }: Props = $props();
 
   let ids = $derived([eventId]);
 

--- a/src/lib/pages/workflow-history-event.svelte
+++ b/src/lib/pages/workflow-history-event.svelte
@@ -13,7 +13,7 @@
   import { workflowRun } from '$lib/stores/workflow-run';
 
   const {
-    id: eventId,
+    eventId,
     namespace,
     workflow: workflowId,
     run: runId,

--- a/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/[run]/history/events/[eventId]/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/[run]/history/events/[eventId]/+page.svelte
@@ -6,13 +6,13 @@
   import WorkflowHistoryEvent from '$lib/pages/workflow-history-event.svelte';
 
   const workflow = $derived(page.params.workflow);
-  const id = $derived(page.params.id);
+  const eventId = $derived(page.params.eventId);
 </script>
 
 <PageTitle
   title={`${translate(
     'workflows.workflow-history',
-  )} | ${workflow} | Event ${id}`}
+  )} | ${workflow} | Event ${eventId}`}
   url={page.url.href}
 />
 <WorkflowHistoryEvent />

--- a/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/[run]/history/events/[eventId]/+page.svelte
+++ b/src/routes/(app)/namespaces/[namespace]/workflows/[workflow]/[run]/history/events/[eventId]/+page.svelte
@@ -1,18 +1,24 @@
-<script>
+<script lang="ts">
   import { page } from '$app/state';
+
+  import type { PageProps } from './$types';
 
   import PageTitle from '$lib/components/page-title.svelte';
   import { translate } from '$lib/i18n/translate';
   import WorkflowHistoryEvent from '$lib/pages/workflow-history-event.svelte';
 
-  const workflow = $derived(page.params.workflow);
-  const eventId = $derived(page.params.eventId);
+  let { params }: PageProps = $props();
 </script>
 
 <PageTitle
   title={`${translate(
     'workflows.workflow-history',
-  )} | ${workflow} | Event ${eventId}`}
+  )} | ${params.workflow} | Event ${params.eventId}`}
   url={page.url.href}
 />
-<WorkflowHistoryEvent />
+<WorkflowHistoryEvent
+  eventId={params.eventId}
+  namespace={params.namespace}
+  workflowId={params.workflow}
+  runId={params.run}
+/>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

With the addition of projects, the route has two params named `id`. This PR moves `/events/[id]` to `/events/[eventId]` (so it doesn't conflict with `/projects/[id]/...`) and passes the params from the page component as props to the `<WorkflowHistoryEvent />` component. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
