### PR TITLE
fix(schedules): tolerate duplicate schedule IDs

### DIFF
--- a/src/lib/pages/schedules.svelte
+++ b/src/lib/pages/schedules.svelte
@@ -174,7 +174,7 @@
           <th>{label}</th>
         {/each}
       </tr>
-      {#each visibleItems as schedule (schedule.scheduleId)}
+      {#each visibleItems as schedule}
         <SchedulesTableRow {schedule} {columns} />
       {/each}
 

--- a/tests/integration/schedules-list.spec.ts
+++ b/tests/integration/schedules-list.spec.ts
@@ -4,6 +4,10 @@ import {
   mockSchedulesApis,
   SCHEDULES_COUNT_API,
 } from '~/test-utilities/mock-apis';
+import {
+  mockListSchedule,
+  SCHEDULES_API,
+} from '~/test-utilities/mocks/schedules';
 
 const schedulesUrl = '/namespaces/default/schedules';
 
@@ -66,5 +70,21 @@ test.describe('Schedules List with schedules', () => {
 
     const workflowType = page.getByText('run-regularly');
     await expect(workflowType).toBeVisible();
+  });
+
+  test('it remains rendered when schedules share an ID', async ({ page }) => {
+    await page.route(SCHEDULES_API, (route) =>
+      route.fulfill({
+        json: {
+          schedules: [mockListSchedule, mockListSchedule],
+          nextPageToken: null,
+        },
+      }),
+    );
+
+    await page.goto(schedulesUrl);
+
+    await page.waitForResponse(SCHEDULES_COUNT_API);
+    await expect(page.locator('table tbody tr')).toHaveCount(2);
   });
 });


### PR DESCRIPTION
## Summary

- remove the schedule-row key so duplicate IDs remain renderable
- keep the schedules list available when the API returns duplicate schedule IDs
- add a Playwright regression test covering the INC-1849 response shape

## Incident

INC-1849 exposed three records with the same `murmur-usage-rollup` schedule ID in one response page. The schedule list keyed rows by schedule ID alone, causing Svelte to throw `each_key_duplicate` and blank the page. Schedule rows do not retain editable local state, so the list can safely use Svelte's unkeyed reconciliation.

## Test plan

- [x] Confirmed the regression test fails before the fix with `each_key_duplicate`
- [x] Targeted Playwright regression test passes on desktop and mobile
- [x] `pnpm lint:ci`
- [x] `pnpm check`
- [x] `pnpm build:local`

## Release path

After this merges, the downstream UI pack workflow will open the Cloud UI release PR for the merged UI commit.
