### PR TITLE
Update holocene toast to runes syntax

### DIFF
--- a/src/lib/holocene/toast.svelte
+++ b/src/lib/holocene/toast.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { fly } from 'svelte/transition';
 
-  import { createEventDispatcher } from 'svelte';
+  import type { Snippet } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
   import Button from '$lib/holocene/button.svelte';
@@ -10,7 +10,21 @@
   import { translate } from '$lib/i18n/translate';
   import type { ToastVariant } from '$lib/types/holocene';
 
-  const dispatch = createEventDispatcher<{ dismiss: { id: string } }>();
+  interface Props {
+    id: string;
+    variant: ToastVariant;
+    closeButtonLabel?: string;
+    onDismiss: (id: string) => void;
+    children: Snippet;
+  }
+
+  let {
+    id,
+    variant,
+    closeButtonLabel = '',
+    onDismiss,
+    children,
+  }: Props = $props();
 
   const variants: Readonly<Record<ToastVariant, string>> = {
     primary: 'bg-slate-800 text-white',
@@ -28,16 +42,12 @@
     warning: 'warning',
   };
 
-  export let id: string;
-  export let variant: keyof typeof variants;
-  export let closeButtonLabel: string = '';
-
-  $: dismissLabel = closeButtonLabel || translate('common.close');
-  $: icon = variantIcon[variant];
+  const dismissLabel = $derived(closeButtonLabel || translate('common.close'));
+  const icon = $derived(variantIcon[variant]);
 
   const handleDismiss = (e: Event) => {
     e.stopPropagation();
-    dispatch('dismiss', { id });
+    onDismiss(id);
   };
 </script>
 
@@ -53,7 +63,7 @@
     <Icon name={icon} class="shrink-0" />
   {/if}
   <p class="text-sm">
-    <slot />
+    {@render children()}
   </p>
   <Button
     variant="ghost"

--- a/src/lib/holocene/toaster.stories.svelte
+++ b/src/lib/holocene/toaster.stories.svelte
@@ -60,7 +60,13 @@
         },
       },
     },
-  } satisfies Meta<Toaster & Toast['variant']>;
+  } satisfies Meta<{
+    closeButtonLabel: string;
+    duration: number;
+    variant: string;
+    message: string;
+    position: string;
+  }>;
 </script>
 
 <script lang="ts">
@@ -70,7 +76,9 @@
 <Template let:args let:context>
   {@const { duration, message, variant, closeButtonLabel } = args}
   <div class="flex max-w-60 flex-col gap-2">
-    <Toast id={context.id} {variant} {closeButtonLabel}>{message}</Toast>
+    <Toast id={context.id} {variant} {closeButtonLabel} onDismiss={toaster.pop}
+      >{message}</Toast
+    >
 
     <Button onclick={() => toaster.push({ duration, message, variant })}>
       <span class="capitalize">Trigger {variant} toast</span>

--- a/src/lib/holocene/toaster.svelte
+++ b/src/lib/holocene/toaster.svelte
@@ -25,8 +25,8 @@
 
   const announcements = toasterStore.announcements;
 
-  const dismissToast = (event: CustomEvent<{ id: string }>) => {
-    pop(event.detail.id);
+  const dismissToast = (id: string) => {
+    pop(id);
   };
 
   const toast = cva(['fixed z-[99999] flex flex-col items-end gap-2'], {
@@ -59,7 +59,7 @@ inertBackground walk from re-inerting it as a body-level sibling. -->
       {closeButtonLabel}
       variant={variant ?? 'primary'}
       id={id ?? ''}
-      on:dismiss={dismissToast}
+      onDismiss={dismissToast}
     >
       {#if link}
         <Link href={link}>

--- a/src/lib/holocene/toaster.svelte
+++ b/src/lib/holocene/toaster.svelte
@@ -25,10 +25,6 @@
 
   const announcements = toasterStore.announcements;
 
-  const dismissToast = (id: string) => {
-    pop(id);
-  };
-
   const toast = cva(['fixed z-[99999] flex flex-col items-end gap-2'], {
     variants: {
       position: {
@@ -59,7 +55,7 @@ inertBackground walk from re-inerting it as a body-level sibling. -->
       {closeButtonLabel}
       variant={variant ?? 'primary'}
       id={id ?? ''}
-      onDismiss={dismissToast}
+      onDismiss={pop}
     >
       {#if link}
         <Link href={link}>


### PR DESCRIPTION
Migrates `toast.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `$:` → `$derived`.
- `dismiss` event → `onDismiss` callback prop; default slot → `children`.
- Updated its only consumer, `toaster.svelte`, and the story.

No cloud-ui changes (it only imports `Toaster`, whose props are unchanged).
