### PR TITLE
Update holocene time-picker to runes syntax

### DIFF
--- a/src/lib/components/workflow/search-attribute-input/datetime-input.svelte
+++ b/src/lib/components/workflow/search-attribute-input/datetime-input.svelte
@@ -52,6 +52,6 @@
     bind:minute
     bind:second
     twelveHourClock={false}
-    on:timechange={updateDatetime}
+    onTimeChange={updateDatetime}
   />
 </div>

--- a/src/lib/holocene/time-picker.svelte
+++ b/src/lib/holocene/time-picker.svelte
@@ -1,25 +1,37 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
   import Input from '$lib/holocene/input/input.svelte';
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
 
-  export let hour = '';
-  export let minute = '';
-  export let second = '';
-  export let half: 'AM' | 'PM' = 'AM';
-  export let twelveHourClock = true;
-  export let includeSeconds = true;
-  export let disabled = false;
-  export let error = false;
-  export let idPrefix = '';
+  interface Props {
+    hour?: string;
+    minute?: string;
+    second?: string;
+    half?: 'AM' | 'PM';
+    twelveHourClock?: boolean;
+    includeSeconds?: boolean;
+    disabled?: boolean;
+    error?: boolean;
+    idPrefix?: string;
+    onTimeChange?: (value: string) => void;
+  }
 
-  const dispatch = createEventDispatcher();
+  let {
+    hour = $bindable(''),
+    minute = $bindable(''),
+    second = $bindable(''),
+    half = $bindable('AM'),
+    twelveHourClock = true,
+    includeSeconds = true,
+    disabled = false,
+    error = false,
+    idPrefix = '',
+    onTimeChange,
+  }: Props = $props();
 
   const onInput = (e: Event) => {
     const target = e.target as HTMLInputElement;
-    dispatch('timechange', target.value);
+    onTimeChange?.(target.value);
   };
 </script>
 


### PR DESCRIPTION
Migrates `time-picker.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `hour`/`minute`/`second`/`half` are `$bindable`.
- `timechange` event → `onTimeChange` callback prop.
- Updated the one consumer that used the event, `datetime-input.svelte`.

No cloud-ui consumers.
