### PR TITLE
Update holocene drawer to runes syntax

### DIFF
--- a/src/lib/holocene/drawer.stories.svelte
+++ b/src/lib/holocene/drawer.stories.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts" module>
   import type { Meta } from '@storybook/svelte';
+  import type { ComponentProps } from 'svelte';
 
   import Drawer from './drawer.svelte';
 
@@ -36,7 +37,7 @@
 
       open: { table: { disable: true } },
     },
-  } satisfies Meta<Drawer['$$prop_def'] & { title: string }>;
+  } satisfies Meta<ComponentProps<typeof Drawer> & { title: string }>;
 </script>
 
 <script lang="ts">

--- a/src/lib/holocene/drawer.svelte
+++ b/src/lib/holocene/drawer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { fly } from 'svelte/transition';
 
+  import type { Snippet } from 'svelte';
   import { onDestroy, onMount, setContext } from 'svelte';
   import { twMerge as merge } from 'tailwind-merge';
 
@@ -9,32 +10,44 @@
 
   import IconButton from './icon-button.svelte';
 
-  export let open = false;
-  export let position: 'bottom' | 'right' = 'bottom';
-  export let dark = true;
-  export let onClick: (e: MouseEvent | CustomEvent) => void;
-  export let id = 'navigation-drawer';
-  export let closeButtonLabel: string;
-  export let closePadding: boolean = true;
+  interface Props {
+    open?: boolean;
+    position?: 'bottom' | 'right';
+    dark?: boolean;
+    onClick: (e: MouseEvent) => void;
+    id?: string;
+    closeButtonLabel: string;
+    closePadding?: boolean;
+    class?: string;
+    children?: Snippet;
+  }
 
-  let portalElement: HTMLElement | null = null;
+  let {
+    open = $bindable(false),
+    position = 'bottom',
+    dark = true,
+    onClick,
+    id = 'navigation-drawer',
+    closeButtonLabel,
+    closePadding = true,
+    class: className = '',
+    children,
+  }: Props = $props();
 
-  let className = '';
-  export { className as class };
+  let portalElement = $state<HTMLElement | null>(null);
 
-  $: flyParamsIn = {
+  const flyParamsIn = $derived({
     duration: 250,
     ...(position === 'bottom' ? { y: 200 } : { x: 100 }),
-  };
+  });
 
-  $: flyParamsOut = {
+  const flyParamsOut = $derived({
     duration: 150,
     ...(position === 'bottom' ? { y: 200 } : { x: 100 }),
-  };
+  });
 
-  $: {
-    setContext('drawer-pos', position);
-  }
+  // svelte-ignore state_referenced_locally
+  setContext('drawer-pos', position);
 
   onMount(() => {
     portalElement = document.createElement('div');
@@ -88,22 +101,20 @@
   >
     <div class="relative h-full" class:pt-10={closePadding}>
       <div class="absolute right-2 top-2">
-        <slot name="close-button">
-          <IconButton
-            data-testid="drawer-close-button"
-            label={closeButtonLabel}
-            class={merge(
-              dark ? 'text-white' : 'text-primary',
-              'hover:text-primary',
-            )}
-            icon="close"
-            aria-expanded={open}
-            aria-controls="navigation-drawer"
-            onclick={onClick}
-          />
-        </slot>
+        <IconButton
+          data-testid="drawer-close-button"
+          label={closeButtonLabel}
+          class={merge(
+            dark ? 'text-white' : 'text-primary',
+            'hover:text-primary',
+          )}
+          icon="close"
+          aria-expanded={open}
+          aria-controls="navigation-drawer"
+          onclick={onClick}
+        />
       </div>
-      <slot />
+      {@render children?.()}
     </div>
   </aside>
 {/if}


### PR DESCRIPTION
Migrates `drawer.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `$:` → `$derived`; `open` is `$bindable`.
- Default slot → `children`. Removed the `close-button` slot (unused in ui and cloud-ui).
- `onClick` narrowed to `(e: MouseEvent) => void` — the `CustomEvent` in the old type was vestigial (both `clickoutside` and `IconButton` only ever pass a `MouseEvent`).
- `setContext('drawer-pos', …)` runs once at init; `svelte-ignore` marks the intentional initial-value read.
- Story `Meta` type updated to `ComponentProps`.

No consumer changes in either repo — all props keep the same usage and nothing used the removed slot.
