### PR TITLE
Update holocene copyable to runes syntax

### DIFF
--- a/src/lib/holocene/copyable/index.svelte
+++ b/src/lib/holocene/copyable/index.svelte
@@ -1,13 +1,31 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import { copyToClipboard } from '$lib/utilities/copy-to-clipboard';
 
   import CopyButton from './button.svelte';
 
-  export let content: string;
-  export let visible = false;
-  export let clickAllToCopy = false;
-  export let copyIconTitle: string;
-  export let copySuccessIconTitle: string;
+  interface Props {
+    content: string;
+    visible?: boolean;
+    clickAllToCopy?: boolean;
+    copyIconTitle: string;
+    copySuccessIconTitle: string;
+    class?: string;
+    'container-class'?: string;
+    children?: Snippet;
+  }
+
+  let {
+    content,
+    visible = false,
+    clickAllToCopy = false,
+    copyIconTitle,
+    copySuccessIconTitle,
+    class: className = '',
+    'container-class': containerClass = '',
+    children,
+  }: Props = $props();
 
   const { copy, copied } = copyToClipboard();
 
@@ -16,26 +34,24 @@
   }
 </script>
 
-<div class="group flex items-center gap-1 {$$props['container-class']}">
+<div class="group flex items-center gap-1 {containerClass}">
   {#if clickAllToCopy}
     <button
       type="button"
       class="break-all text-left"
-      on:click={handleOnClick}
-      aria-label={$$slots.default ? undefined : `Copy ${content}`}
+      onclick={handleOnClick}
+      aria-label={children ? undefined : `Copy ${content}`}
     >
-      <slot>
-        <span class={$$props.class} class:select-all={!$$slots.default}
-          >{content}</span
-        >
-      </slot>
+      {#if children}
+        {@render children()}
+      {:else}
+        <span class={['select-all', className]}>{content}</span>
+      {/if}
     </button>
+  {:else if children}
+    {@render children()}
   {:else}
-    <slot>
-      <span class={$$props.class} class:select-all={!$$slots.default}
-        >{content}</span
-      >
-    </slot>
+    <span class={['select-all', className]}>{content}</span>
   {/if}
   <CopyButton
     {copyIconTitle}


### PR DESCRIPTION
Migrates `copyable/index.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `$$props['container-class']`/`$$props.class` → declared `container-class`/`class` props (same names).
- Default slot → `children` (fallback `<span>` when no content); `$$slots.default` checks → `children`.
- `select-all` on the fallback span (always applied) now uses Svelte 5 array-class merging instead of a `class:select-all` directive.

No consumer changes in either repo — prop names and default-slot usage are unchanged.
