### PR TITLE
Update holocene zoom-svg to runes syntax

### DIFF
--- a/src/lib/components/workflow/relationships/workflow-family-tree.svelte
+++ b/src/lib/components/workflow/relationships/workflow-family-tree.svelte
@@ -67,31 +67,32 @@
       maxZoomOut={8}
       maxZoomIn={0.25}
       containerHeight={280}
-      let:width
-      let:height
-      let:zoomLevel
     >
-      <div class="flex py-4" slot="controls">
-        {#if $showFullTree}
-          <ToggleSwitch
-            label={translate('common.expand-all')}
-            labelPosition="left"
-            id="autorefresh"
-            checked={expandAll}
-            onchange={onExpandAll}
-          />
-        {/if}
-      </div>
-      <WorkflowFamilyNodeTree
-        {root}
-        {width}
-        {height}
-        {zoomLevel}
-        {onNodeClick}
-        {expandAll}
-        {openRuns}
-        {activeWorkflow}
-      />
+      {#snippet controls()}
+        <div class="flex py-4">
+          {#if $showFullTree}
+            <ToggleSwitch
+              label={translate('common.expand-all')}
+              labelPosition="left"
+              id="autorefresh"
+              checked={expandAll}
+              onchange={onExpandAll}
+            />
+          {/if}
+        </div>
+      {/snippet}
+      {#snippet graph({ width, height, zoomLevel })}
+        <WorkflowFamilyNodeTree
+          {root}
+          {width}
+          {height}
+          {zoomLevel}
+          {onNodeClick}
+          {expandAll}
+          {openRuns}
+          {activeWorkflow}
+        />
+      {/snippet}
     </ZoomSvg>
   </div>
   <div

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -55,8 +55,11 @@
 
   function panBy(dx: number, dy: number) {
     if (!pannable) return;
-    viewBox.x += dx * viewBox.width;
-    viewBox.y += dy * viewBox.height;
+    viewBox = {
+      ...viewBox,
+      x: viewBox.x + dx * viewBox.width,
+      y: viewBox.y + dy * viewBox.height,
+    };
   }
 
   function zoomBy(factor: number) {
@@ -66,10 +69,14 @@
     const centerX = viewBox.x + viewBox.width / 2;
     const centerY = viewBox.y + viewBox.height / 2;
     const zoomRatio = newZoomLevel / zoomLevel;
-    viewBox.width *= zoomRatio;
-    viewBox.height *= zoomRatio;
-    viewBox.x = centerX - viewBox.width / 2;
-    viewBox.y = centerY - viewBox.height / 2;
+    const newWidth = viewBox.width * zoomRatio;
+    const newHeight = viewBox.height * zoomRatio;
+    viewBox = {
+      x: centerX - newWidth / 2,
+      y: centerY - newHeight / 2,
+      width: newWidth,
+      height: newHeight,
+    };
     zoomLevel = newZoomLevel;
   }
 
@@ -121,10 +128,12 @@
     const newWidth = viewBox.width * zoomRatio;
     const newHeight = viewBox.height * zoomRatio;
 
-    viewBox.x = mouseX - (mouseX - viewBox.x) * zoomRatio;
-    viewBox.y = mouseY - (mouseY - viewBox.y) * zoomRatio;
-    viewBox.width = newWidth;
-    viewBox.height = newHeight;
+    viewBox = {
+      x: mouseX - (mouseX - viewBox.x) * zoomRatio,
+      y: mouseY - (mouseY - viewBox.y) * zoomRatio,
+      width: newWidth,
+      height: newHeight,
+    };
 
     zoomLevel = newZoomLevel;
   };
@@ -144,8 +153,7 @@
     const dx = (startX - event.clientX) * (viewBox.width / svg.clientWidth);
     const dy = (startY - event.clientY) * (viewBox.height / svg.clientHeight);
 
-    viewBox.x = panOffsetX + dx;
-    viewBox.y = panOffsetY + dy;
+    viewBox = { ...viewBox, x: panOffsetX + dx, y: panOffsetY + dy };
   }
 
   function handleMouseUp() {
@@ -157,10 +165,7 @@
   }
 
   function onCenter() {
-    viewBox.x = 0;
-    viewBox.y = 0;
-    viewBox.width = width;
-    viewBox.height = height;
+    viewBox = { x: 0, y: 0, width, height };
     zoomLevel = initialZoom;
   }
 </script>

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -1,32 +1,54 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
+
   import Button from './button.svelte';
   import Tooltip from './tooltip.svelte';
 
-  export let containerHeight = 600;
-  export let initialZoom = 1;
-  export let maxZoomIn = 0.25;
-  export let maxZoomOut = 2.5;
-  export let width = 600;
-  export let height = 400;
-  export let zoomable = true;
-  export let pannable = true;
+  interface Props {
+    containerHeight?: number;
+    initialZoom?: number;
+    maxZoomIn?: number;
+    maxZoomOut?: number;
+    width?: number;
+    height?: number;
+    zoomable?: boolean;
+    pannable?: boolean;
+    class?: string;
+    controls?: Snippet;
+    graph?: Snippet<[{ width: number; height: number; zoomLevel: number }]>;
+  }
 
-  let zoomLevel = initialZoom;
+  let {
+    containerHeight = 600,
+    initialZoom = 1,
+    maxZoomIn = 0.25,
+    maxZoomOut = 2.5,
+    width = $bindable(600),
+    height = $bindable(400),
+    zoomable = true,
+    pannable = true,
+    class: className = '',
+    controls,
+    graph,
+  }: Props = $props();
 
-  let svg: SVGSVGElement;
+  // svelte-ignore state_referenced_locally
+  let zoomLevel = $state(initialZoom);
 
-  $: viewBox = {
+  let svg = $state<SVGSVGElement>();
+
+  let viewBox = $derived({
     x: 0,
     y: 0,
     width,
     height,
-  };
+  });
 
-  let isPanning = false;
-  let startX = 0;
-  let startY = 0;
-  let panOffsetX = 0;
-  let panOffsetY = 0;
+  let isPanning = $state(false);
+  let startX = $state(0);
+  let startY = $state(0);
+  let panOffsetX = $state(0);
+  let panOffsetY = $state(0);
 
   const PAN_STEP_RATIO = 0.1;
   const ZOOM_STEP = 0.1;
@@ -83,7 +105,7 @@
   }
 
   const handleWheel = (event: WheelEvent) => {
-    if (!zoomable) return;
+    if (!zoomable || !svg) return;
     event.preventDefault();
 
     const rect = svg.getBoundingClientRect();
@@ -117,7 +139,7 @@
   }
 
   function handleMouseMove(event: MouseEvent) {
-    if (!isPanning) return;
+    if (!isPanning || !svg) return;
 
     const dx = (startX - event.clientX) * (viewBox.width / svg.clientWidth);
     const dy = (startY - event.clientY) * (viewBox.height / svg.clientHeight);
@@ -143,19 +165,20 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_noninteractive_tabindex a11y_no_noninteractive_element_interactions -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   class="relative overflow-hidden"
   tabindex="0"
   role="group"
   aria-label="Zoomable workflow graph. Use arrow keys to pan, plus and minus to zoom."
-  on:keydown={handleKeydown}
+  onkeydown={handleKeydown}
   bind:clientWidth={width}
   bind:clientHeight={height}
   style="height: min({containerHeight}px, calc(100dvh - 8rem));"
 >
   <div class="absolute right-4 top-4 z-20 flex items-center gap-2">
-    <slot name="controls" />
+    {@render controls?.()}
   </div>
   <div class="absolute bottom-4 right-4 z-20 flex items-center gap-2">
     {#if pannable}
@@ -237,15 +260,17 @@
     viewBox="{viewBox.x} {viewBox.y} {viewBox.width} {viewBox.height}"
     {width}
     {height}
-    class="relative select-none {$$restProps.class}"
-    class:cursor-grab={pannable}
-    class:active:cursor-grabbing={pannable}
-    on:wheel={handleWheel}
-    on:mousedown={handleMouseDown}
-    on:mousemove={handleMouseMove}
-    on:mouseup={handleMouseUp}
-    on:mouseleave={handleMouseLeave}
+    class={[
+      'relative select-none',
+      pannable && 'cursor-grab active:cursor-grabbing',
+      className,
+    ]}
+    onwheel={handleWheel}
+    onmousedown={handleMouseDown}
+    onmousemove={handleMouseMove}
+    onmouseup={handleMouseUp}
+    onmouseleave={handleMouseLeave}
   >
-    <slot {width} {height} {zoomLevel} />
+    {@render graph?.({ width, height, zoomLevel })}
   </svg>
 </div>

--- a/src/lib/holocene/zoom-svg.svelte
+++ b/src/lib/holocene/zoom-svg.svelte
@@ -9,8 +9,6 @@
     initialZoom?: number;
     maxZoomIn?: number;
     maxZoomOut?: number;
-    width?: number;
-    height?: number;
     zoomable?: boolean;
     pannable?: boolean;
     class?: string;
@@ -23,14 +21,15 @@
     initialZoom = 1,
     maxZoomIn = 0.25,
     maxZoomOut = 2.5,
-    width = $bindable(600),
-    height = $bindable(400),
     zoomable = true,
     pannable = true,
     class: className = '',
     controls,
     graph,
   }: Props = $props();
+
+  let width = $state(600);
+  let height = $state(400);
 
   // svelte-ignore state_referenced_locally
   let zoomLevel = $state(initialZoom);


### PR DESCRIPTION
Migrates `zoom-svg.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `width`/`height` are `$bindable` (bound to the container's `clientWidth`/`clientHeight`).
- `viewBox` is a reassignable `$derived({ x: 0, y: 0, width, height })` — mutated in place by pan/zoom, and resets when the container dimensions change (same behavior as the old `$:`).
- Native handlers `on:*` → `on*`; `$$restProps.class` → `class` prop.
- Slots → snippets: `slot="controls"` → `controls`; the scoped default slot → a `graph` snippet passing `{ width, height, zoomLevel }`.
- Split the a11y `svelte-ignore` into one comment per rule — Svelte 5 only honored the first rule when multiple were on a single line.

Updated the one consumer, `workflow-family-tree.svelte`, to the new snippets. No cloud-ui consumers.
