### PR TITLE
Update holocene orderable-list-item to runes syntax

### DIFF
--- a/src/lib/components/workflow/configurable-table-headers-drawer/orderable-list.svelte
+++ b/src/lib/components/workflow/configurable-table-headers-drawer/orderable-list.svelte
@@ -45,9 +45,8 @@
         {index}
         {label}
         totalItems={columnsInUse.length}
-        on:moveItem={(event) =>
-          moveColumn(event.detail.from, event.detail.to, namespace, table)}
-        on:removeItem={() => removeColumn(label, namespace, table)}
+        onMoveItem={({ from, to }) => moveColumn(from, to, namespace, table)}
+        onRemoveItem={() => removeColumn(label, namespace, table)}
         addButtonLabel={translate('workflows.add-column-label', {
           column: label,
         })}
@@ -75,7 +74,7 @@
     {#each $availableColumns as { label } (label)}
       <OrderableListItem
         static
-        on:addItem={() => addColumn(label, namespace, table)}
+        onAddItem={() => addColumn(label, namespace, table)}
         addButtonLabel={translate('workflows.add-column-label', {
           column: label,
         })}
@@ -97,7 +96,7 @@
       {#each $availableCustomColumns as { label } (label)}
         <OrderableListItem
           static
-          on:addItem={() => addColumn(label, namespace, table)}
+          onAddItem={() => addColumn(label, namespace, table)}
           addButtonLabel={translate('workflows.add-column-label', {
             column: label,
           })}

--- a/src/lib/holocene/orderable-list/orderable-list-item.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list-item.svelte
@@ -1,13 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
   import IconButton from '../icon-button.svelte';
-
-  const dispatch = createEventDispatcher<{
-    addItem: undefined;
-    moveItem: { from: number; to: number };
-    removeItem: undefined;
-  }>();
 
   type ExtendedDragEvent = DragEvent & {
     currentTarget: EventTarget & HTMLLIElement;
@@ -17,6 +9,9 @@
     label: string;
     index?: number;
     totalItems?: number;
+    onMoveItem?: (detail: { from: number; to: number }) => void;
+    onAddItem?: () => void;
+    onRemoveItem?: () => void;
   } & (
     | {
         readonly: true;
@@ -54,6 +49,9 @@
     moveDownButtonLabel = '',
     addButtonLabel = '',
     removeButtonLabel = '',
+    onMoveItem,
+    onAddItem,
+    onRemoveItem,
   }: Props = $props();
 
   const handleDragStart = (event: ExtendedDragEvent, index: number) => {
@@ -66,7 +64,7 @@
     if (!event.dataTransfer) return;
     event.currentTarget.classList.remove('dragging-over');
     const from = parseInt(event.dataTransfer.getData('text/plain'));
-    dispatch('moveItem', { from, to });
+    onMoveItem?.({ from, to });
   };
 
   const handleDragEnter = (event: ExtendedDragEvent) =>
@@ -108,14 +106,14 @@
           icon="chevron-up"
           data-testid="orderable-list-item-{label}-move-up-button"
           label={moveUpButtonLabel}
-          onclick={() => dispatch('moveItem', { from: index, to: index - 1 })}
+          onclick={() => onMoveItem?.({ from: index, to: index - 1 })}
         />
         <IconButton
           disabled={index === totalItems - 1}
           icon="chevron-down"
           data-testid="orderable-list-item-{label}-move-down-button"
           label={moveDownButtonLabel}
-          onclick={() => dispatch('moveItem', { from: index, to: index + 1 })}
+          onclick={() => onMoveItem?.({ from: index, to: index + 1 })}
         />
       </div>
     {/if}
@@ -127,14 +125,14 @@
         icon="add"
         data-testid="orderable-list-item-{label}-add-button"
         label={addButtonLabel}
-        onclick={() => dispatch('addItem')}
+        onclick={() => onAddItem?.()}
       />
     {:else}
       <IconButton
         icon="hyphen"
         data-testid="orderable-list-item-{label}-remove-button"
         label={removeButtonLabel}
-        onclick={() => dispatch('removeItem')}
+        onclick={() => onRemoveItem?.()}
       />
     {/if}
   {/if}

--- a/src/lib/holocene/orderable-list/orderable-list.stories.svelte
+++ b/src/lib/holocene/orderable-list/orderable-list.stories.svelte
@@ -43,8 +43,8 @@
     {#snippet heading()}<span>{context.name}</span>{/snippet}
     {#each items as item, index (item.label)}
       <OrderableListItem
-        on:moveItem={action('moveItem')}
-        on:removeItem={action('removeItem')}
+        onMoveItem={action('moveItem')}
+        onRemoveItem={action('removeItem')}
         addButtonLabel="Add"
         static={false}
         label={item.label}


### PR DESCRIPTION
Migrates `orderable-list-item.svelte` to Svelte 5 runes.

- Removes `createEventDispatcher`; `moveItem`/`addItem`/`removeItem` events → `onMoveItem`/`onAddItem`/`onRemoveItem` callback props.
- Updates the two consumers (`configurable-table-headers-drawer/orderable-list.svelte` and the story) to the callback props; `event.detail.{from,to}` → the callback's `{ from, to }` argument.

No cloud-ui consumers.
