### PR TITLE
Migrate event-link components to runes syntax

### DIFF
--- a/src/lib/components/event/event-details-link.svelte
+++ b/src/lib/components/event/event-details-link.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import Link from '$lib/holocene/link.svelte';
   import type { CombinedAttributes } from '$lib/utilities/format-event-attributes';
@@ -10,11 +10,17 @@
     routeForWorkflow,
   } from '$lib/utilities/route-for';
 
-  export let value: string;
-  export let attributes: CombinedAttributes;
-  export let type: EventLinkType;
+  interface Props {
+    value: string;
+    attributes: CombinedAttributes;
+    type: EventLinkType;
+    class?: string;
+  }
 
-  $: ({ workflow, namespace } = $page.params);
+  let { value, attributes, type, class: className = '' }: Props = $props();
+
+  const namespace = $derived(page.params.namespace);
+  const workflow = $derived(page.params.workflow);
 
   function getHref(
     ns: string,
@@ -40,9 +46,9 @@
     }
   }
 
-  $: href = getHref(namespace, workflow, attributes, value, type);
+  const href = $derived(getHref(namespace, workflow, attributes, value, type));
 </script>
 
-<Link class={$$restProps.class} {href}>
+<Link class={className} {href}>
   {value}
 </Link>

--- a/src/lib/components/event/event-link.svelte
+++ b/src/lib/components/event/event-link.svelte
@@ -8,26 +8,47 @@
     toEventLinkView,
   } from '$lib/utilities/event-link';
 
-  export let link: EventLink | undefined = undefined;
-  export let view: EventLinkDisplay | undefined = undefined;
-  export let context: EventLinkContext = {};
-  export let value: string | undefined = undefined;
-  export let label: string | undefined = undefined;
-  export let href: string | undefined = undefined;
+  interface Props {
+    link?: EventLink;
+    view?: EventLinkDisplay;
+    context?: EventLinkContext;
+    value?: string;
+    label?: string;
+    href?: string;
+    class?: string;
+    linkClass?: string;
+  }
 
-  $: linkView = view ?? (link ? toEventLinkView(link, context) : undefined);
-  $: resolvedHref = href ?? linkView?.href;
-  $: resolvedValue = value ?? linkView?.value ?? resolvedHref ?? '';
-  $: resolvedLabel = label ?? linkView?.label ?? translate('nexus.link');
+  let {
+    link,
+    view,
+    context = {},
+    value,
+    label,
+    href,
+    class: className = '',
+    linkClass = '',
+  }: Props = $props();
+
+  const linkView = $derived(
+    view ?? (link ? toEventLinkView(link, context) : undefined),
+  );
+  const resolvedHref = $derived(href ?? linkView?.href);
+  const resolvedValue = $derived(
+    value ?? linkView?.value ?? resolvedHref ?? '',
+  );
+  const resolvedLabel = $derived(
+    label ?? linkView?.label ?? translate('nexus.link'),
+  );
 </script>
 
 <div
-  class="flex flex-row items-center gap-2 overflow-hidden first:pt-0 last:border-b-0 {$$props.class}"
+  class="flex flex-row items-center gap-2 overflow-hidden first:pt-0 last:border-b-0 {className}"
 >
   <p class="max-w-fit whitespace-nowrap text-right text-sm">
     {resolvedLabel}
   </p>
-  <div class="overflow-hidden {$$props.linkClass}">
+  <div class="overflow-hidden {linkClass}">
     {#if resolvedHref}
       <Link href={resolvedHref}>
         {resolvedValue}


### PR DESCRIPTION
Migrates `event-link.svelte` and `event-details-link.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `$:` → `$derived`.
- `$$props.class`/`$$props.linkClass` (event-link) and `$$restProps.class` (event-details-link) → declared `class`/`linkClass` props.
- `event-details-link`: `$app/stores` → `$app/state` for `page.params`.

Prop names are unchanged, so non-breaking. These are importable by cloud-ui via `@temporalio/ui/components/event/...`, but no cloud-ui file currently imports either (verified) — no paired PR needed.
