### PR TITLE
Migrate start-workflow-button and workflow-detail to runes syntax

### DIFF
--- a/src/lib/components/lines-and-dots/workflow-detail.svelte
+++ b/src/lib/components/lines-and-dots/workflow-detail.svelte
@@ -7,18 +7,33 @@
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
 
-  export let title = '';
-  export let content: string;
-  export let copyable = false;
-  export let filterable = false;
-  export let href: string | undefined = undefined;
-  export let icon: IconName | undefined = undefined;
-  export let tooltip: string = '';
-  export let badge: BadgeType | undefined = undefined;
+  interface Props {
+    title?: string;
+    content: string;
+    copyable?: boolean;
+    filterable?: boolean;
+    href?: string;
+    icon?: IconName;
+    tooltip?: string;
+    badge?: BadgeType;
+    class?: string;
+  }
+
+  let {
+    title = '',
+    content,
+    copyable = false,
+    filterable = false,
+    href,
+    icon,
+    tooltip = '',
+    badge,
+    class: className = '',
+  }: Props = $props();
 </script>
 
 <p
-  class="flex items-center justify-between gap-16 truncate whitespace-nowrap {$$restProps.class}"
+  class="flex items-center justify-between gap-16 truncate whitespace-nowrap {className}"
 >
   {#if title}
     {title}

--- a/src/lib/components/workflow/start-workflow-button.svelte
+++ b/src/lib/components/workflow/start-workflow-button.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import type { ComponentProps } from 'svelte';
+
   import { goto } from '$app/navigation';
 
   import Button from '$lib/holocene/button.svelte';
@@ -6,19 +8,32 @@
   import { translate } from '$lib/i18n/translate';
   import { routeForWorkflowStart } from '$lib/utilities/route-for';
 
-  export let namespace: string;
-  export let workflowId: string;
-  export let runId: string;
-  export let taskQueue: string | undefined;
-  export let workflowType: string;
+  type Props = ComponentProps<typeof Button> & {
+    namespace: string;
+    workflowId: string;
+    runId: string;
+    taskQueue: string | undefined;
+    workflowType: string;
+  };
 
-  $: href = routeForWorkflowStart({
+  let {
     namespace,
     workflowId,
     runId,
     taskQueue,
     workflowType,
-  });
+    ...rest
+  }: Props = $props();
+
+  const href = $derived(
+    routeForWorkflowStart({
+      namespace,
+      workflowId,
+      runId,
+      taskQueue,
+      workflowType,
+    }),
+  );
 </script>
 
 <Tooltip
@@ -33,6 +48,6 @@
     leadingIcon="lightning-bolt"
     aria-label={translate('workflows.start-workflow-like-this-one')}
     onclick={() => goto(href)}
-    {...$$restProps}
+    {...rest}
   ></Button>
 </Tooltip>


### PR DESCRIPTION
Migrates `start-workflow-button.svelte` and `lines-and-dots/workflow-detail.svelte` to Svelte 5 runes.

- `export let` → `$props()`; `$:` → `$derived`.
- `start-workflow-button`: `{...$$restProps}` → `...rest` typed as `ComponentProps<typeof Button> & {...}` (forwarded to `Button`).
- `workflow-detail`: `$$restProps.class` → declared `class` prop.

Public prop APIs are unchanged, so no consumer edits. No cloud-ui consumers.
