### PR TITLE
Migrate batch-operations header to runes syntax

### DIFF
--- a/src/lib/components/batch-operations/header.svelte
+++ b/src/lib/components/batch-operations/header.svelte
@@ -9,7 +9,7 @@
 
   interface Props {
     operation: BatchOperation;
-    onToggleAutoRefresh?: (detail: { checked: boolean }) => void;
+    onToggleAutoRefresh?: (checked: boolean) => void;
   }
 
   let { operation, onToggleAutoRefresh }: Props = $props();
@@ -20,7 +20,7 @@
     }
 
     const { checked } = event.currentTarget;
-    onToggleAutoRefresh?.({ checked });
+    onToggleAutoRefresh?.(checked);
     $autoRefresh = checked;
   };
 

--- a/src/lib/components/batch-operations/header.svelte
+++ b/src/lib/components/batch-operations/header.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-
   import Badge, { type BadgeType } from '$lib/holocene/badge.svelte';
   import Copyable from '$lib/holocene/copyable/index.svelte';
   import ToggleSwitch from '$lib/holocene/toggle-switch.svelte';
@@ -11,13 +9,10 @@
 
   interface Props {
     operation: BatchOperation;
+    onToggleAutoRefresh?: (detail: { checked: boolean }) => void;
   }
 
-  let { operation }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    toggleAutoRefresh: { checked: boolean };
-  }>();
+  let { operation, onToggleAutoRefresh }: Props = $props();
 
   const handleToggleAutoRefresh = (event: Event) => {
     if (!(event.currentTarget instanceof HTMLInputElement)) {
@@ -25,7 +20,7 @@
     }
 
     const { checked } = event.currentTarget;
-    dispatch('toggleAutoRefresh', { checked });
+    onToggleAutoRefresh?.({ checked });
     $autoRefresh = checked;
   };
 

--- a/src/lib/components/batch-operations/header.svelte
+++ b/src/lib/components/batch-operations/header.svelte
@@ -20,8 +20,8 @@
     }
 
     const { checked } = event.currentTarget;
-    onToggleAutoRefresh?.(checked);
     $autoRefresh = checked;
+    onToggleAutoRefresh?.(checked);
   };
 
   const jobStateToBadgeType: Record<BatchOperationState, BadgeType> = {

--- a/src/lib/pages/batch-operation.svelte
+++ b/src/lib/pages/batch-operation.svelte
@@ -20,7 +20,7 @@
   let fetchKey = $state(0);
   let timeout: number;
 
-  const handleToggleAutoRefresh = ({ checked }: { checked: boolean }) => {
+  const handleToggleAutoRefresh = (checked: boolean) => {
     if (checked) {
       fetchKey += 1;
     } else if (timeout) {

--- a/src/lib/pages/batch-operation.svelte
+++ b/src/lib/pages/batch-operation.svelte
@@ -20,10 +20,8 @@
   let fetchKey = $state(0);
   let timeout: number;
 
-  const handleToggleAutoRefresh = (
-    event: CustomEvent<{ checked: boolean }>,
-  ) => {
-    if (event.detail.checked) {
+  const handleToggleAutoRefresh = ({ checked }: { checked: boolean }) => {
+    if (checked) {
       fetchKey += 1;
     } else if (timeout) {
       window.clearTimeout(timeout);
@@ -53,7 +51,7 @@
       <BatchOperationSkeleton />
     {:then operation}
       <BatchOperationHeader
-        on:toggleAutoRefresh={handleToggleAutoRefresh}
+        onToggleAutoRefresh={handleToggleAutoRefresh}
         {operation}
       />
       <Card>


### PR DESCRIPTION
Migrates `batch-operations/header.svelte` to Svelte 5 runes.

- Removes `createEventDispatcher`; `toggleAutoRefresh` event → `onToggleAutoRefresh` callback prop.
- Updates its one consumer (`pages/batch-operation.svelte`): `on:toggleAutoRefresh` → `onToggleAutoRefresh`, handler takes `{ checked }` instead of a `CustomEvent`.

No cloud-ui consumers.
