### PR TITLE
server: accept standard envconfig TLS env var names

### DIFF
--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -38,13 +38,16 @@ cors:
     - "http://localhost:8080"
     {{- end }}
 tls:
-  caFile: {{ env "TEMPORAL_TLS_CA" | default "" }}
-  certFile: {{ env "TEMPORAL_TLS_CERT" | default "" }}
-  keyFile: {{ env "TEMPORAL_TLS_KEY" | default "" }}
-  caData: {{ env "TEMPORAL_TLS_CA_DATA" | default "" }}
-  certData: {{ env "TEMPORAL_TLS_CERT_DATA" | default "" }}
-  keyData: {{ env "TEMPORAL_TLS_KEY_DATA" | default "" }}
-  enableHostVerification: {{ env "TEMPORAL_TLS_ENABLE_HOST_VERIFICATION" | default "false" }}
+  # The standard envconfig names shared by the temporal CLI and SDKs are resolved first.
+  # TEMPORAL_TLS_CA/CERT/KEY (and their _DATA variants) and TEMPORAL_TLS_ENABLE_HOST_VERIFICATION
+  # are ui-server-specific names kept as a fallback for backwards compatibility.
+  caFile: {{ env "TEMPORAL_TLS_SERVER_CA_CERT_PATH" | default (env "TEMPORAL_TLS_CA") }}
+  certFile: {{ env "TEMPORAL_TLS_CLIENT_CERT_PATH" | default (env "TEMPORAL_TLS_CERT") }}
+  keyFile: {{ env "TEMPORAL_TLS_CLIENT_KEY_PATH" | default (env "TEMPORAL_TLS_KEY") }}
+  caData: {{ env "TEMPORAL_TLS_SERVER_CA_CERT_DATA" | default (env "TEMPORAL_TLS_CA_DATA") }}
+  certData: {{ env "TEMPORAL_TLS_CLIENT_CERT_DATA" | default (env "TEMPORAL_TLS_CERT_DATA") }}
+  keyData: {{ env "TEMPORAL_TLS_CLIENT_KEY_DATA" | default (env "TEMPORAL_TLS_KEY_DATA") }}
+  enableHostVerification: {{ if env "TEMPORAL_TLS_DISABLE_HOST_VERIFICATION" }}{{ eq (env "TEMPORAL_TLS_DISABLE_HOST_VERIFICATION") "false" }}{{ else if env "TEMPORAL_TLS_ENABLE_HOST_VERIFICATION" }}{{ env "TEMPORAL_TLS_ENABLE_HOST_VERIFICATION" }}{{ else }}false{{ end }}
   serverName: {{ env "TEMPORAL_TLS_SERVER_NAME" | default "" }}
 uiServerTLS:
   certFile: {{ env "TEMPORAL_UI_SERVER_TLS_CERT" | default "" }}

--- a/server/docker/README.md
+++ b/server/docker/README.md
@@ -20,10 +20,10 @@ docker run \
     -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx \
     -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback \
     -e TEMPORAL_AUTH_SCOPES=openid,email,profile \
-    -e TEMPORAL_TLS_CA=../ca.cert \
-    -e TEMPORAL_TLS_CERT=../cluster.pem \
-    -e TEMPORAL_TLS_KEY=../cluster.key \
-    -e TEMPORAL_TLS_ENABLE_HOST_VERIFICATION=true \
+    -e TEMPORAL_TLS_SERVER_CA_CERT_PATH=../ca.cert \
+    -e TEMPORAL_TLS_CLIENT_CERT_PATH=../cluster.pem \
+    -e TEMPORAL_TLS_CLIENT_KEY_PATH=../cluster.key \
+    -e TEMPORAL_TLS_DISABLE_HOST_VERIFICATION=false \
     -e TEMPORAL_TLS_SERVER_NAME=tls-server \
     temporalio/ui:latest
 ```

--- a/server/plugins/fs_config_provider/docker_tls_env_test.go
+++ b/server/plugins/fs_config_provider/docker_tls_env_test.go
@@ -1,0 +1,147 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fs_config_provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/temporalio/ui-server/v2/server/config"
+)
+
+const dockerConfigDir = "../../config"
+
+type (
+	DockerTLSEnvSuite struct {
+		*require.Assertions
+		suite.Suite
+	}
+)
+
+func TestDockerTLSEnvSuite(t *testing.T) {
+	suite.Run(t, new(DockerTLSEnvSuite))
+}
+
+func (s *DockerTLSEnvSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+// TestLegacyNames verifies the pre-existing, non-standard TEMPORAL_TLS_* env
+// vars still populate the TLS config (back-compat).
+func (s *DockerTLSEnvSuite) TestLegacyNames() {
+	s.T().Setenv("TEMPORAL_TLS_CA", "/legacy/ca.pem")
+	s.T().Setenv("TEMPORAL_TLS_CERT", "/legacy/cert.pem")
+	s.T().Setenv("TEMPORAL_TLS_KEY", "/legacy/key.pem")
+	s.T().Setenv("TEMPORAL_TLS_ENABLE_HOST_VERIFICATION", "true")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.Equal("/legacy/ca.pem", cfg.TLS.CaFile)
+	s.Equal("/legacy/cert.pem", cfg.TLS.CertFile)
+	s.Equal("/legacy/key.pem", cfg.TLS.KeyFile)
+	s.True(cfg.TLS.EnableHostVerification)
+}
+
+// TestStandardEnvconfigNames verifies the standard envconfig names shared by
+// the temporal CLI and SDKs are also accepted.
+func (s *DockerTLSEnvSuite) TestStandardEnvconfigNames() {
+	s.T().Setenv("TEMPORAL_TLS_SERVER_CA_CERT_PATH", "/standard/ca.pem")
+	s.T().Setenv("TEMPORAL_TLS_CLIENT_CERT_PATH", "/standard/cert.pem")
+	s.T().Setenv("TEMPORAL_TLS_CLIENT_KEY_PATH", "/standard/key.pem")
+	s.T().Setenv("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION", "false")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.Equal("/standard/ca.pem", cfg.TLS.CaFile)
+	s.Equal("/standard/cert.pem", cfg.TLS.CertFile)
+	s.Equal("/standard/key.pem", cfg.TLS.KeyFile)
+	s.True(cfg.TLS.EnableHostVerification)
+}
+
+// TestStandardEnvconfigDataNames verifies the standard *_DATA env vars are
+// accepted for the base64-encoded PEM variants.
+func (s *DockerTLSEnvSuite) TestStandardEnvconfigDataNames() {
+	s.T().Setenv("TEMPORAL_TLS_SERVER_CA_CERT_DATA", "ca-data")
+	s.T().Setenv("TEMPORAL_TLS_CLIENT_CERT_DATA", "cert-data")
+	s.T().Setenv("TEMPORAL_TLS_CLIENT_KEY_DATA", "key-data")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.Equal("ca-data", cfg.TLS.CaData)
+	s.Equal("cert-data", cfg.TLS.CertData)
+	s.Equal("key-data", cfg.TLS.KeyData)
+}
+
+// TestDisableHostVerificationInverted verifies TEMPORAL_TLS_DISABLE_HOST_VERIFICATION
+// is correctly inverted into EnableHostVerification in both directions.
+func (s *DockerTLSEnvSuite) TestDisableHostVerificationInverted() {
+	s.T().Setenv("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION", "true")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.False(cfg.TLS.EnableHostVerification)
+}
+
+func (s *DockerTLSEnvSuite) TestDisableHostVerificationFalseEnablesHostVerification() {
+	s.T().Setenv("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION", "false")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.True(cfg.TLS.EnableHostVerification)
+}
+
+// TestStandardNamesTakePrecedence verifies that when both the standard and
+// legacy names are set, the standard envconfig name wins.
+func (s *DockerTLSEnvSuite) TestStandardNamesTakePrecedence() {
+	s.T().Setenv("TEMPORAL_TLS_CA", "/legacy/ca.pem")
+	s.T().Setenv("TEMPORAL_TLS_SERVER_CA_CERT_PATH", "/standard/ca.pem")
+	s.T().Setenv("TEMPORAL_TLS_ENABLE_HOST_VERIFICATION", "true")
+	s.T().Setenv("TEMPORAL_TLS_DISABLE_HOST_VERIFICATION", "true")
+
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.Equal("/standard/ca.pem", cfg.TLS.CaFile)
+	s.False(cfg.TLS.EnableHostVerification)
+}
+
+// TestNoTLSEnvVarsSet verifies the default (no TLS configured) case is
+// unaffected.
+func (s *DockerTLSEnvSuite) TestNoTLSEnvVarsSet() {
+	var cfg config.Config
+	s.NoError(Load(dockerConfigDir, &cfg, "docker"))
+
+	s.Empty(cfg.TLS.CaFile)
+	s.Empty(cfg.TLS.CertFile)
+	s.Empty(cfg.TLS.KeyFile)
+	s.False(cfg.TLS.EnableHostVerification)
+}


### PR DESCRIPTION
## Description & motivation 💭

`ui-server`'s Docker config template only recognized its own TLS env var names (`TEMPORAL_TLS_CA`/`CERT`/`KEY`, plus `_DATA` variants, and `TEMPORAL_TLS_ENABLE_HOST_VERIFICATION`), unlike the `temporal` CLI and every SDK, which share a standardized `envconfig` naming convention for the same settings. Deployments running mTLS across the CLI, SDKs, and the Web UI had to maintain two parallel sets of TLS env vars pointing at the same certificate files, and a mismatch produced no error — it was silently ignored.

`server/config/docker.yaml` now resolves the standard `envconfig` names first (`TEMPORAL_TLS_SERVER_CA_CERT_PATH`/`_DATA`, `TEMPORAL_TLS_CLIENT_CERT_PATH`/`_DATA`, `TEMPORAL_TLS_CLIENT_KEY_PATH`/`_DATA`, `TEMPORAL_TLS_DISABLE_HOST_VERIFICATION`), falling back to the legacy ui-server-specific names for backwards compatibility. `TEMPORAL_TLS_SERVER_NAME` already matched the standard name, so it needed no change.

### Screenshots (if applicable) 📸

N/A — config/docs-only change.

### Design Considerations 🎨

N/A

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Added `server/plugins/fs_config_provider/docker_tls_env_test.go`, which renders the real `docker.yaml` template and covers: legacy names still work, standard path/data names now work, the inverted `DISABLE_HOST_VERIFICATION` boolean logic in both directions, standard-over-legacy precedence, and the no-env-vars-set default.

Ran `go test ./...` in `server/` — all packages pass except the pre-existing `ui/embed.go` failures caused by missing built frontend assets in this checkout, unrelated to this change.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Set e.g. `TEMPORAL_TLS_SERVER_CA_CERT_PATH`, `TEMPORAL_TLS_CLIENT_CERT_PATH`, `TEMPORAL_TLS_CLIENT_KEY_PATH` on the Docker image and confirm the UI picks up the TLS config (previously these were silently ignored).

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

Closes [#3766](https://github.com/temporalio/ui/issues/3766)

## Docs

### Any docs updates needed?

Updated `server/docker/README.md`'s example to use the standard env var names.