### PR TITLE
Migrate start-workflow and workflow-query pages to runes syntax

### DIFF
--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -3,7 +3,7 @@
 
   import { onMount } from 'svelte';
 
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import CodecServerErrorBanner from '$lib/components/codec-server-error-banner.svelte';
   import PayloadInputWithEncoding from '$lib/components/payload-input-with-encoding.svelte';
@@ -47,31 +47,31 @@
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
   import { workflowCreateDisabled } from '$lib/utilities/workflow-create-disabled';
 
-  $: ({ namespace } = $page.params);
+  const namespace = $derived(page.params.namespace);
 
   const identity = getIdentity();
 
-  let workflowId = '';
-  let taskQueue = '';
-  let workflowType = '';
-  let input = '';
-  let summary = '';
-  let details = '';
-  let encoding: Writable<PayloadInputEncoding> = writable('json/plain');
-  let messageType = '';
-  let workflowStartDelay = '';
+  let workflowId = $state('');
+  let taskQueue = $state('');
+  let workflowType = $state('');
+  let input = $state('');
+  let summary = $state('');
+  let details = $state('');
+  let encoding = $state<Writable<PayloadInputEncoding>>(writable('json/plain'));
+  let messageType = $state('');
+  let workflowStartDelay = $state('');
 
-  let initialRunId = '';
-  let initialWorkflowId = '';
-  let initialWorkflowType = '';
+  let initialRunId = $state('');
+  let initialWorkflowId = $state('');
+  let initialWorkflowType = $state('');
 
-  let error = '';
-  let pollerCount: undefined | number = undefined;
-  let viewAdvancedOptions = false;
+  let error = $state('');
+  let pollerCount = $state<undefined | number>(undefined);
+  let viewAdvancedOptions = $state(false);
 
-  let searchAttributes: SearchAttributesSchema = [];
+  let searchAttributes = $state<SearchAttributesSchema>([]);
 
-  $: errorWorkflowDetails = extractWorkflowFromError(error);
+  const errorWorkflowDetails = $derived(extractWorkflowFromError(error));
 
   function extractWorkflowFromError(errorMessage: string): {
     workflowId?: string;
@@ -93,15 +93,15 @@
     };
   }
 
-  $: taskQueueParam = $page.url.searchParams.get('taskQueue');
+  const taskQueueParam = $derived(page.url.searchParams.get('taskQueue'));
 
   onMount(() => {
-    workflowId = $page.url.searchParams.get('workflowId') || '';
-    taskQueue = $page.url.searchParams.get('taskQueue') || '';
-    workflowType = $page.url.searchParams.get('workflowType') || '';
-    initialRunId = $page.url.searchParams.get('runId') || '';
-    initialWorkflowId = $page.url.searchParams.get('workflowId') || '';
-    initialWorkflowType = $page.url.searchParams.get('workflowType') || '';
+    workflowId = page.url.searchParams.get('workflowId') || '';
+    taskQueue = page.url.searchParams.get('taskQueue') || '';
+    workflowType = page.url.searchParams.get('workflowType') || '';
+    initialRunId = page.url.searchParams.get('runId') || '';
+    initialWorkflowId = page.url.searchParams.get('workflowId') || '';
+    initialWorkflowType = page.url.searchParams.get('workflowType') || '';
 
     if (initialWorkflowId || initialWorkflowType || initialRunId) {
       getInitialValues({
@@ -153,7 +153,7 @@
     updateQueryParameters({
       parameter: 'workflowId',
       value,
-      url: $page.url,
+      url: page.url,
       allowEmpty: true,
       options: { keepFocus: true, noScroll: true, replaceState: true },
     });
@@ -217,7 +217,7 @@
     updateQueryParameters({
       parameter,
       value,
-      url: $page.url,
+      url: page.url,
       allowEmpty: true,
       options: { keepFocus: true, noScroll: true, replaceState: true },
     });
@@ -232,16 +232,19 @@
     }
   };
 
-  $: inputValid = !input || inputIsJSON(input);
+  const inputValid = $derived(!input || inputIsJSON(input));
 
-  $: enableStart =
+  const enableStart = $derived(
     !!workflowId &&
-    !!taskQueue &&
-    !!workflowType &&
-    !!inputValid &&
-    !workflowCreateDisabled($page);
+      !!taskQueue &&
+      !!workflowType &&
+      !!inputValid &&
+      !workflowCreateDisabled(page),
+  );
 
-  $: checkTaskQueue(taskQueueParam ?? '');
+  $effect(() => {
+    checkTaskQueue(taskQueueParam ?? '');
+  });
 </script>
 
 <div class="flex w-full flex-col gap-4 pb-20">

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -57,7 +57,7 @@
   let input = $state('');
   let summary = $state('');
   let details = $state('');
-  let encoding = $state<Writable<PayloadInputEncoding>>(writable('json/plain'));
+  const encoding: Writable<PayloadInputEncoding> = writable('json/plain');
   let messageType = $state('');
   let workflowStartDelay = $state('');
 
@@ -314,7 +314,7 @@
       label="Workflow Type"
       onblur={(e) => onInputChange(e, 'workflowType')}
     />
-    <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
+    <PayloadInputWithEncoding bind:input {encoding} bind:messageType />
     {#if viewAdvancedOptions}
       <Card class="flex flex-col gap-2">
         <div>

--- a/src/lib/pages/workflow-query.svelte
+++ b/src/lib/pages/workflow-query.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
 
-  import { page } from '$app/stores';
+  import { page } from '$app/state';
 
   import PayloadInput from '$lib/components/payload-input.svelte';
   import Button from '$lib/holocene/button.svelte';
@@ -24,33 +24,22 @@
   import { encodePayloads } from '$lib/utilities/encode-payload';
   import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
-  const { namespace, workflow: workflowId, run: runId } = $page.params;
+  const { namespace, workflow: workflowId, run: runId } = page.params;
 
   const params = {
     id: workflowId,
     runId,
   };
 
-  let queryType: string;
-  let initialQueryType: string;
-  let input = '';
-  let initialInput = '';
-  let loading = false;
-  let jsonFormatting = true;
+  let queryType = $state('');
+  let initialQueryType = $state('');
+  let input = $state('');
+  let initialInput = $state('');
+  let loading = $state(false);
+  let jsonFormatting = $state(true);
 
-  $: edited = initialQueryType !== queryType || input !== initialInput;
-
-  $: metadataError = $workflowRun.metadata?.error?.message;
-  $: queryTypes = sortByName(
-    $workflowRun?.metadata?.definition?.queryDefinitions?.filter((query) => {
-      return query?.name !== '__stack_trace';
-    }) || [],
-  );
-
-  $: queryType = queryType || queryTypes?.[0]?.name || '';
-
-  let queryResult: Promise<ParsedQuery>;
-  let encodePayloadResult: Promise<Payload[] | null>;
+  let queryResult = $state<Promise<ParsedQuery>>();
+  let encodePayloadResult = $state<Promise<Payload[] | null>>();
 
   const sortByName = (
     list: WorkflowInteractionDefinition[],
@@ -67,6 +56,24 @@
       return aName.localeCompare(bName);
     });
   };
+
+  const metadataError = $derived($workflowRun.metadata?.error?.message);
+  const queryTypes = $derived(
+    sortByName(
+      $workflowRun?.metadata?.definition?.queryDefinitions?.filter((query) => {
+        return query?.name !== '__stack_trace';
+      }) || [],
+    ),
+  );
+  const edited = $derived(
+    initialQueryType !== queryType || input !== initialInput,
+  );
+
+  $effect(() => {
+    if (!queryType) {
+      queryType = queryTypes?.[0]?.name || '';
+    }
+  });
 
   onMount(() => {
     if (!$workflowRun.metadata) {


### PR DESCRIPTION
Migrates the last two legacy pages to Svelte 5 runes — `pages/start-workflow.svelte` and `pages/workflow-query.svelte`. These slipped the earlier component sweep because they have no props (only `$:` reactive statements + `$page`).

- `let` locals → `$state`; `$:` → `$derived`; `$app/stores` `$page` → `$app/state` `page`.
- `workflow-query`: `queryType` (default-to-first, but `bind:`-bound and user-overridable) uses `$state` + an `$effect` for the default — it can't be a `$derived` because it's two-way bound.

No public prop API (both read `page.params`), so cloud-ui's `<StartWorkflow />` / `<WorkflowQuery />` usages are unaffected — verified, no paired PR.
