### PR TITLE
Sweep remaining on: directives to runes event syntax

### DIFF
--- a/src/lib/components/command-palette/modal.svelte
+++ b/src/lib/components/command-palette/modal.svelte
@@ -61,7 +61,7 @@
   });
 </script>
 
-<svelte:window on:click={handleClick} />
+<svelte:window onclick={handleClick} />
 
 <dialog
   {id}

--- a/src/lib/components/workflow/workflow-json-navigator.svelte
+++ b/src/lib/components/workflow/workflow-json-navigator.svelte
@@ -46,7 +46,7 @@
   }
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 <div class="flex gap-4 max-sm:flex-col">
   <div class="bg-gray-100 flex w-full gap-4">
     <RangeInput


### PR DESCRIPTION
Converts the last two deprecated `on:` event directives to runes syntax:
- `command-palette/modal.svelte`: `<svelte:window on:click>` → `onclick`
- `workflow-json-navigator.svelte`: `<svelte:window on:keydown>` → `onkeydown`

Both files are already runes; these were the only genuine leftovers (every other `on:` match was either a consumer of an already-migrated component, handled in its own PR, or a `transition:`/CSS false positive). Independent of the runes-mode flip (#3770) — mergeable anytime.

Verified with `svelte-check` (non-incremental) — 0 errors; lint clean; tests pass.
