### PR TITLE
feat(workers): add release stage badges to compute provider picker

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-provider-picker.stories.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-provider-picker.stories.svelte
@@ -86,11 +86,37 @@
   </div>
 </Story>
 
-<Story name="Both enabled (cross-cloud)">
+<Story
+  name="Both enabled (cross-cloud)"
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Public Preview')).toBeInTheDocument();
+    await expect(canvas.getByText('Pre-release')).toBeInTheDocument();
+  }}
+>
   <div class="max-w-[45rem] p-4">
     <ComputeProviderPicker
       provider="lambda"
       providers={[{ value: 'lambda' }, { value: 'cloud-run' }]}
+    />
+  </div>
+</Story>
+
+<Story
+  name="Release stage overridden by caller"
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Public Preview')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Pre-release')).toBeInTheDocument();
+  }}
+>
+  <div class="max-w-[45rem] p-4">
+    <ComputeProviderPicker
+      provider="lambda"
+      providers={[
+        { value: 'lambda', releaseStage: 'generally-available' },
+        { value: 'cloud-run', releaseStage: 'pre-release' },
+      ]}
     />
   </div>
 </Story>

--- a/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
@@ -50,6 +50,8 @@
     }
   };
 
+  const badgeClass = 'px-1.5 py-0 text-xs font-normal leading-5';
+
   const releaseStageLabel = (option: ComputeProviderOption): string => {
     switch (option.releaseStage ?? defaultReleaseStage[option.value]) {
       case 'public-preview':
@@ -106,9 +108,13 @@
       {#snippet labelBadge()}
         <span>
           {#if option.disabled && option.disabledReason}
-            <Badge type="secondary">{option.disabledReason}</Badge>
+            <Badge type="secondary" class={badgeClass}>
+              {option.disabledReason}
+            </Badge>
           {:else if releaseStageLabel(option)}
-            <Badge type="secondary">{releaseStageLabel(option)}</Badge>
+            <Badge type="secondary" class={badgeClass}>
+              {releaseStageLabel(option)}
+            </Badge>
           {/if}
         </span>
       {/snippet}

--- a/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-provider-picker.svelte
@@ -11,7 +11,11 @@
   import { translate } from '$lib/i18n/translate';
   import { hasCapability } from '$lib/utilities/has-capability.svelte';
 
-  import type { ComputeProviderOption, ComputeProviderValue } from './shared';
+  import {
+    type ComputeProviderOption,
+    type ComputeProviderValue,
+    defaultReleaseStage,
+  } from './shared';
 
   interface Props {
     provider?: string;
@@ -43,6 +47,17 @@
         return translate('workers.provider-lambda-description');
       case 'cloud-run':
         return translate('workers.provider-cloud-run-description');
+    }
+  };
+
+  const releaseStageLabel = (option: ComputeProviderOption): string => {
+    switch (option.releaseStage ?? defaultReleaseStage[option.value]) {
+      case 'public-preview':
+        return translate('workers.public-preview');
+      case 'pre-release':
+        return translate('workers.pre-release');
+      case 'generally-available':
+        return '';
     }
   };
 
@@ -92,6 +107,8 @@
         <span>
           {#if option.disabled && option.disabledReason}
             <Badge type="secondary">{option.disabledReason}</Badge>
+          {:else if releaseStageLabel(option)}
+            <Badge type="secondary">{releaseStageLabel(option)}</Badge>
           {/if}
         </span>
       {/snippet}

--- a/src/lib/components/workers/serverless-worker-form/shared.ts
+++ b/src/lib/components/workers/serverless-worker-form/shared.ts
@@ -142,11 +142,25 @@ export type EditVersionFormData = z.infer<typeof editVersionSchema>;
 
 export type ComputeProviderValue = 'lambda' | 'cloud-run';
 
+export type ComputeProviderReleaseStage =
+  | 'public-preview'
+  | 'pre-release'
+  | 'generally-available';
+
 export type ComputeProviderOption = {
   value: ComputeProviderValue;
   disabled?: boolean;
   disabledReason?: string;
   hidden?: boolean;
+  releaseStage?: ComputeProviderReleaseStage;
+};
+
+export const defaultReleaseStage: Record<
+  ComputeProviderValue,
+  ComputeProviderReleaseStage
+> = {
+  lambda: 'public-preview',
+  'cloud-run': 'pre-release',
 };
 
 interface InitialComputeProviderOptions {

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -202,6 +202,8 @@ export const Strings = {
   'provider-coming-soon-description':
     'Support for additional compute providers is planned.',
   'coming-soon': 'Coming Soon',
+  'public-preview': 'Public Preview',
+  'pre-release': 'Pre-release',
   'setup-guide-title': 'AWS Setup Guide',
   'setup-guide-intro':
     'Before creating a serverless worker, you need a Lambda function and an IAM role in your AWS account.',


### PR DESCRIPTION
## Description & motivation 💭

With AWS Lambda going Public Preview and GCP Cloud Run entering Pre-release, the Compute Provider section gave no indication of either provider's release stage. This differs from features like Standalone Activities, which show a `Public Preview` label. Since users follow the same worker deployment creation flow for both providers, the missing labels could create confusion about the maturity and availability of each option.

This adds a release stage badge next to each Compute Provider option:

- **AWS Lambda** → `Public Preview`
- **Google Cloud Run** → `Pre-release`

The badge uses the same `secondary` Holocene `Badge` that Nexus and SAA use for their pre-release/preview labels, rendered in the existing `labelBadge` snippet on `RadioCard`.

### Configurable by the caller

The stage is not hardcoded to the provider — `ComputeProviderOption` gains an optional `releaseStage`, so Cloud can drive it through the `computeProviders` prop it already passes into `serverless-worker-create`, `worker-deployment-version-create`, and `worker-deployment-version-edit`. No new prop to thread.

```ts
export type ComputeProviderReleaseStage =
  | 'public-preview'
  | 'pre-release'
  | 'generally-available';
```

- **Unset** → falls back to `defaultReleaseStage` in `shared.ts` (the two stages above), so OSS/self-hosted and any caller that doesn't set it still get correct labels, and Cloud picks up stage changes on its next UI bump with no Cloud-side change.
- **`'generally-available'`** → renders no badge. This is how a provider drops the label once it GAs. Note `undefined` means "use the default", never "no badge".
- A **disabled** option still shows its `disabledReason` badge ("Coming Soon", "Not supported in AWS namespaces") instead — that's the more relevant maturity signal, and it avoids stacking two badges.

An enum rather than a free-form string keeps the label text and its translation in this repo; Cloud picks a stage, not a string to display. `defaultReleaseStage` is exported so Cloud can read the defaults if it needs to reason about them.

### Screenshots (if applicable) 📸

<!-- TODO: add a screenshot of the Compute Provider section showing both badges -->

### Design Considerations 🎨

Matches the crude mockup from the thread — badge inline to the right of the provider name. Reused the existing `secondary` badge type rather than introducing a release-stage-specific style, for consistency with the `Pre-release` badge already on the Nexus Operations page.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Storybook stories in `compute-provider-picker.stories.svelte`:

- "Both enabled (cross-cloud)" now asserts both `Public Preview` and `Pre-release` render.
- New "Release stage overridden by caller" story asserts a caller-supplied `'generally-available'` on Lambda renders no badge while Cloud Run keeps `Pre-release`.

`pnpm lint` clean (0 errors), `pnpm test --run` 2573 passed / 183 files. `pnpm check` is unchanged from `main` — it reports one pre-existing error (`Cannot find module './$types'` in the history events route) unrelated to these files.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Go to **Create Worker Deployment** and look at the **Compute Provider** section.
2. AWS Lambda shows `Public Preview`; Google Cloud Run shows `Pre-release`.
3. In an environment without the `serverScaledProviderCloudRun` capability, Cloud Run stays disabled and shows `Coming Soon` rather than a stage badge.
4. In Storybook: `Workers/Compute Provider Picker` → the two stories above.

## Checklists

### Merge Checklist

- [ ] Add screenshot to the PR description

### Issue(s) closed

<!-- Slack thread: "Add Public Preview / Pre release labels in UI for Serverless Workers" -->

## Docs

### Any docs updates needed?

None.
