### PR TITLE
Use WorkflowTaskFailedCause enum

### DIFF
--- a/src/lib/i18n/locales/en/typed-errors.ts
+++ b/src/lib/i18n/locales/en/typed-errors.ts
@@ -51,7 +51,7 @@ export const Strings = {
     description:
       'The Workflow Task failed because of an unset attribute on CancelWorkflowExecution.',
   },
-  BadRequestCancelExternalAttributes: {
+  BadRequestCancelExternalWorkflowExecutionAttributes: {
     title: 'Bad Request Cancel External Attributes',
     description:
       'The Workflow Task failed due to an invalid attribute on a request to cancel an external Workflow. Check the Failure Message for more details.',
@@ -189,6 +189,11 @@ export const Strings = {
     title: 'gRPC Message Too Large',
     description:
       'A Workflow Task failed because the gRPC message exceeded the maximum allowed size.',
+  },
+  PayloadsTooLarge: {
+    title: 'Payloads Too Large',
+    description:
+      'A Workflow Task failed because its payloads exceeded the maximum allowed size.',
   },
   WorkflowTaskTimedOut: {
     title: 'Workflow Task Timed Out',

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -224,6 +224,8 @@ export type NexusOperationIdConflictPolicy =
   keyof typeof temporal.api.enums.v1.NexusOperationIdConflictPolicy;
 export type NexusOperationIdReusePolicy =
   keyof typeof temporal.api.enums.v1.NexusOperationIdReusePolicy;
+export type WorkflowTaskFailedCause =
+  keyof typeof temporal.api.enums.v1.WorkflowTaskFailedCause;
 
 // temporal.api.enums.v1.ResetReapplyExcludeType
 export enum ResetReapplyExcludeType {

--- a/src/lib/types/workflows.ts
+++ b/src/lib/types/workflows.ts
@@ -3,6 +3,7 @@ import type {
   Payload,
   PendingWorkflowTaskInfo,
   Priority,
+  WorkflowTaskFailedCause as ScreamingWorkflowTaskFailedCause,
   WorkflowExecutionStatus,
   WorkflowExtendedInfo,
   WorkflowVersionTimpstamp,
@@ -17,6 +18,25 @@ import type {
   PendingNexusOperation,
 } from './events';
 import type { Optional, Replace } from './global';
+
+/**
+ * Type-level equivalent of `fromScreamingEnum`: converts a SCREAMING_SNAKE_CASE
+ * enum key to PascalCase and strips the given prefix.
+ */
+type ScreamingToPascalCase<S extends string> =
+  S extends `${infer Head}_${infer Tail}`
+    ? `${Capitalize<Lowercase<Head>>}${ScreamingToPascalCase<Tail>}`
+    : Capitalize<Lowercase<S>>;
+
+type StripPrefix<
+  S extends string,
+  Prefix extends string,
+> = S extends `${Prefix}${infer Rest}` ? Rest : S;
+
+export type FromScreamingEnum<
+  S extends string,
+  Prefix extends string,
+> = StripPrefix<ScreamingToPascalCase<S>, Prefix>;
 
 /**
  * Replace Longs, ITimestamps, UInt8Array's etc. with their corresponding http values
@@ -204,37 +224,9 @@ export type WorkflowExecution = {
 };
 
 export type WorkflowTaskFailedCause =
-  | 'Unspecified'
-  | 'UnhandledCommand'
-  | 'BadScheduleActivityAttributes'
-  | 'BadRequestCancelActivityAttributes'
-  | 'BadStartTimerAttributes'
-  | 'BadCancelTimerAttributes'
-  | 'BadRecordMarkerAttributes'
-  | 'BadCompleteWorkflowExecutionAttributes'
-  | 'BadFailWorkflowExecutionAttributes'
-  | 'BadCancelWorkflowExecutionAttributes' // correct ?
-  | 'BadRequestCancelExternalAttributes'
-  | 'BadContinueAsNewAttributes'
-  | 'StartTimerDuplicateId'
-  | 'ResetStickyTaskQueue'
-  | 'WorkflowWorkerUnhandledFailure'
-  | 'WorkflowTaskHeartbeatError'
-  | 'BadSignalWorkflowExecutionAttributes'
-  | 'BadStartChildExecutionAttributes'
-  | 'ForceCloseCommand'
-  | 'FailoverCloseCommand'
-  | 'BadSignalInputSize'
-  | 'ResetWorkflow'
-  | 'BadBinary'
-  | 'ScheduleActivityDuplicateId'
-  | 'BadSearchAttributes'
-  | 'NonDeterministicError'
-  | 'BadModifyWorkflowPropertiesAttributes'
-  | 'PendingChildWorkflowsLimitExceeded'
-  | 'PendingActivitiesLimitExceeded'
-  | 'PendingSignalsLimitExceeded'
-  | 'PendingRequestCancelLimitExceeded'
-  | 'BadUpdateWorkflowExecutionMessage'
-  | 'UnhandledUpdate'
-  | 'WorkflowTaskTimedOut';
+  | FromScreamingEnum<
+      ScreamingWorkflowTaskFailedCause,
+      'WorkflowTaskFailedCause'
+    >
+  | 'WorkflowTaskTimedOut'
+  | 'WorkflowTaskHeartbeatError';

--- a/src/lib/utilities/screaming-enums.ts
+++ b/src/lib/utilities/screaming-enums.ts
@@ -7,6 +7,7 @@ import type {
   PendingNexusOperationState,
   WorkerStatus,
   WorkflowExecutionStatus,
+  WorkflowTaskFailedCause,
 } from '$lib/types';
 import type {
   BatchOperationActionType,
@@ -15,9 +16,9 @@ import type {
 } from '$lib/types/batch';
 import type { PendingActivityState } from '$lib/types/events';
 import type {
+  WorkflowTaskFailedCause as ReadableWorkflowTaskFailedCause,
   SearchAttributeType,
   WorkflowStatus,
-  WorkflowTaskFailedCause,
 } from '$lib/types/workflows';
 
 import type { EventType } from './is-event-type';
@@ -83,9 +84,12 @@ export const toBatchOperationTypeReadable = (
 
 export const toWorkflowTaskFailureReadable = (
   cause?: WorkflowTaskFailedCause,
-): WorkflowTaskFailedCause => {
+): ReadableWorkflowTaskFailedCause => {
   if (!cause) return 'Unspecified';
-  return fromScreamingEnum(cause, 'WorkflowTaskFailedCause');
+  return fromScreamingEnum(
+    cause,
+    'WorkflowTaskFailedCause',
+  ) as unknown as ReadableWorkflowTaskFailedCause;
 };
 
 export const toPendingActivityStateReadable = (


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Uses `temporal.api.enums.v1.WorkflowTaskFailedCause` and adds a `FromScreamingEnum<S, Prefix>` type helper that mirrors `fromScreamingEnum` at the type level. Now `typed-errors.ts` has to match all the real enum names.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
