### PR TITLE
fix(auth): decouple refresh token cookie lifetime from access token expiry

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -40,6 +40,7 @@ auth:
 | `enabled`            | boolean  | Enable or disable authentication                                                                                               |
 | `redirectToProvider` | boolean  | Skip the Temporal UI login page and redirect unauthenticated users directly to the configured OIDC provider                    |
 | `maxSessionDuration` | duration | Maximum session duration before forced re-login (e.g., `8h`, `24h`, `168h`). Set to `0` or omit for unlimited session duration |
+| `refreshTokenLifetime` | duration | Lifetime of the refresh token cookie (e.g., `24h`, `168h`). Should match your IdP's refresh token or SSO session policy. Defaults to 7 days; capped at 30 days |
 | `providers`          | array    | List of auth providers (currently only the first is used)                                                                      |
 
 #### Provider Settings
@@ -66,6 +67,8 @@ Temporal UI supports two mechanisms for session management:
 1. **Token Refresh**: When access tokens expire, the UI automatically refreshes them using the refresh token. Users stay logged in seamlessly.
 
 2. **Max Session Duration**: Forces users to re-authenticate after a specified time, regardless of token validity.
+
+The refresh token is stored in an HttpOnly cookie whose lifetime is controlled by `refreshTokenLifetime` (default 7 days). OAuth2 token responses only communicate the access token's lifetime, not the refresh token's, so set `refreshTokenLifetime` to match your IdP's refresh token or SSO session policy.
 
 ### Configuring Max Session Duration
 
@@ -172,7 +175,7 @@ auth:
       callbackUrl: https://temporal-ui.example.com/auth/sso/callback
 ```
 
-Note: Google does not support `offline_access` scope. Token refresh depends on Google's token policies.
+Note: Google does not support the `offline_access` scope. To receive refresh tokens from Google, add `access_type: offline` (and `prompt: consent` to force re-issuance) under the provider's `options`.
 
 ## Security Considerations
 
@@ -219,6 +222,7 @@ Ensure:
 - `offline_access` scope is included and enabled in your IdP
 - Refresh tokens are enabled in your IdP configuration
 - The refresh token hasn't expired (check IdP settings)
+- `refreshTokenLifetime` is not shorter than your access token lifetime; if the `refresh` cookie expires before the first 401-triggered refresh, every refresh fails with `missing_refresh_token`
 
 ### Redirect loop after login
 

--- a/server/config/docker.yaml
+++ b/server/config/docker.yaml
@@ -52,6 +52,7 @@ uiServerTLS:
 auth:
   enabled: {{ env "TEMPORAL_AUTH_ENABLED" | default "false" }}
   redirectToProvider: {{ env "TEMPORAL_AUTH_REDIRECT_TO_PROVIDER" | default "false" }}
+  refreshTokenLifetime: {{ env "TEMPORAL_AUTH_REFRESH_TOKEN_LIFETIME" | default "168h" }}
   providers:
   - label: {{ env "TEMPORAL_AUTH_LABEL" | default "sso" }}
     type: {{ env "TEMPORAL_AUTH_TYPE" | default "oidc" }}

--- a/server/config/with-auth.yaml
+++ b/server/config/with-auth.yaml
@@ -40,6 +40,7 @@ auth:
   enabled: true
   redirectToProvider: false
   maxSessionDuration: 2m # Max time before forced re-login (0 = unlimited)
+  refreshTokenLifetime: 168h # Refresh cookie lifetime; match your IdP's refresh token policy (default 7d, max 30d)
   providers:
     - label: Dummy OIDC
       type: oidc # for futureproofing; only oidc is supported today

--- a/server/server/auth/auth.go
+++ b/server/server/auth/auth.go
@@ -46,6 +46,12 @@ const (
 	AuthorizationExtrasHeader = "authorization-extras"
 	cookieLen                 = 4000
 	sessionStartCookie        = "session_start"
+
+	// DefaultRefreshTokenLifetime is used for the refresh token cookie when
+	// auth.refreshTokenLifetime is not configured.
+	DefaultRefreshTokenLifetime = 7 * 24 * time.Hour
+	// MaxRefreshTokenLifetime caps the refresh token cookie lifetime.
+	MaxRefreshTokenLifetime = 30 * 24 * time.Hour
 )
 
 var tokenVerifier *oidc.IDTokenVerifier
@@ -58,7 +64,7 @@ func stripBearerPrefix(token string) string {
 	return strings.TrimPrefix(token, "Bearer ")
 }
 
-func SetUser(c echo.Context, user *User) error {
+func SetUser(c echo.Context, user *User, refreshTokenLifetime time.Duration) error {
 	if user.OAuth2Token == nil {
 		return errors.New("no OAuth2Token")
 	}
@@ -100,32 +106,25 @@ func SetUser(c echo.Context, user *User) error {
 	if rt := user.OAuth2Token.RefreshToken; rt != "" {
 		log.Println("[Auth] Setting refresh token cookie")
 
-		// Calculate MaxAge from OAuth2 token expiry.
-		// IMPORTANT: When a refresh token is issued, oauth2.Token.Expiry typically
-		// reflects the refresh token's lifetime, not the access token's lifetime.
-		// This is standard behavior in OIDC flows with offline_access scope.
-		// See: https://pkg.go.dev/golang.org/x/oauth2#Token
-		var refreshMaxAge int
-		if user.OAuth2Token.Expiry.IsZero() {
-			// Fallback: if IdP doesn't provide expiry, use 7 days
-			refreshMaxAge = int((7 * 24 * time.Hour).Seconds())
-			log.Printf("[Auth] Warning: No refresh token expiry from IdP, using 7-day default")
-		} else {
-			// Use IdP's expiry, capped at 30 days for safety
-			maxAge := time.Until(user.OAuth2Token.Expiry)
-			if maxAge > 30*24*time.Hour {
-				maxAge = 30 * 24 * time.Hour
-				log.Printf("[Auth] Warning: IdP refresh token expiry > 30 days, capping at 30 days")
-			}
-			refreshMaxAge = int(maxAge.Seconds())
-			log.Printf("[Auth] Setting refresh cookie MaxAge to %d seconds (%.1f days) from IdP",
-				refreshMaxAge, maxAge.Hours()/24)
+		// The cookie lifetime cannot be derived from oauth2.Token.Expiry: that
+		// field is populated from the token response's expires_in, which per
+		// RFC 6749 section 5.1 is the ACCESS token's lifetime. OAuth2/OIDC does
+		// not communicate the refresh token's lifetime, so the cookie TTL comes
+		// from configuration (auth.refreshTokenLifetime) instead.
+		lifetime := refreshTokenLifetime
+		if lifetime <= 0 {
+			lifetime = DefaultRefreshTokenLifetime
+			log.Printf("[Auth] refreshTokenLifetime not configured, using %v default", DefaultRefreshTokenLifetime)
+		}
+		if lifetime > MaxRefreshTokenLifetime {
+			log.Printf("[Auth] Warning: refreshTokenLifetime %v exceeds maximum, capping at %v", lifetime, MaxRefreshTokenLifetime)
+			lifetime = MaxRefreshTokenLifetime
 		}
 
 		refreshCookie := &http.Cookie{
 			Name:     "refresh",
 			Value:    rt,
-			MaxAge:   refreshMaxAge,
+			MaxAge:   int(lifetime.Seconds()),
 			Secure:   c.Request().TLS != nil,
 			HttpOnly: true,
 			Path:     "/",

--- a/server/server/auth/auth_test.go
+++ b/server/server/auth/auth_test.go
@@ -24,8 +24,10 @@ package auth_test
 
 import (
 	_ "embed"
+	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
@@ -60,18 +62,24 @@ import (
 // }
 
 func TestSetUser(t *testing.T) {
-	e := echo.New()
-	req := httptest.NewRequest(echo.GET, "/", nil)
-	rec := httptest.NewRecorder()
+	idToken := &auth.IDToken{
+		RawToken: "MMM.JJJ.NNN",
+		Claims: &auth.Claims{
+			Email:         "test@email.com",
+			EmailVerified: true,
+			Name:          "test-name",
+			Picture:       "test-picture",
+		},
+	}
 
 	tests := map[string]struct {
-		user    auth.User
-		ctx     echo.Context
-		wantErr bool
+		user                 auth.User
+		refreshTokenLifetime time.Duration
+		wantErr              bool
+		wantRefreshMaxAge    int
 	}{
 		"user empty": {
 			user:    auth.User{},
-			ctx:     e.NewContext(req, rec),
 			wantErr: true,
 		},
 		"user set": {
@@ -79,36 +87,84 @@ func TestSetUser(t *testing.T) {
 				OAuth2Token: &oauth2.Token{
 					AccessToken: "XXX.YYY.ZZZ",
 				},
-				IDToken: &auth.IDToken{
-					RawToken: "MMM.JJJ.NNN",
-					Claims: &auth.Claims{
-						Email:         "test@email.com",
-						EmailVerified: true,
-						Name:          "test-name",
-						Picture:       "test-picture",
-					},
-				},
+				IDToken: idToken,
 			},
-			ctx: e.NewContext(req, rec),
+		},
+		"refresh token with default lifetime": {
+			user: auth.User{
+				OAuth2Token: &oauth2.Token{
+					AccessToken:  "XXX.YYY.ZZZ",
+					RefreshToken: "refresh-token",
+					// Expiry reflects the access token's lifetime (expires_in) and
+					// must not influence the refresh cookie's MaxAge.
+					Expiry: time.Now().Add(time.Hour),
+				},
+				IDToken: idToken,
+			},
+			wantRefreshMaxAge: int(auth.DefaultRefreshTokenLifetime.Seconds()),
+		},
+		"refresh token with configured lifetime": {
+			user: auth.User{
+				OAuth2Token: &oauth2.Token{
+					AccessToken:  "XXX.YYY.ZZZ",
+					RefreshToken: "refresh-token",
+					Expiry:       time.Now().Add(time.Hour),
+				},
+				IDToken: idToken,
+			},
+			refreshTokenLifetime: 24 * time.Hour,
+			wantRefreshMaxAge:    int((24 * time.Hour).Seconds()),
+		},
+		"refresh token lifetime capped": {
+			user: auth.User{
+				OAuth2Token: &oauth2.Token{
+					AccessToken:  "XXX.YYY.ZZZ",
+					RefreshToken: "refresh-token",
+				},
+				IDToken: idToken,
+			},
+			refreshTokenLifetime: 90 * 24 * time.Hour,
+			wantRefreshMaxAge:    int(auth.MaxRefreshTokenLifetime.Seconds()),
 		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := auth.SetUser(tt.ctx, &tt.user)
-			cookies := tt.ctx.Cookies()
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			err := auth.SetUser(ctx, &tt.user, tt.refreshTokenLifetime)
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Empty(t, cookies)
+				assert.Empty(t, rec.Result().Cookies())
 				return
-			} else {
-				assert.NoError(t, err)
-				setCookie := tt.ctx.Response().Header().Get(echo.HeaderSetCookie)
-				assert.Contains(t, setCookie, "user0")
+			}
+
+			assert.NoError(t, err)
+			assert.Contains(t, ctx.Response().Header().Get(echo.HeaderSetCookie), "user0")
+
+			refreshCookie := findCookie(rec.Result().Cookies(), "refresh")
+			if tt.wantRefreshMaxAge == 0 {
+				assert.Nil(t, refreshCookie)
+				return
+			}
+			if assert.NotNil(t, refreshCookie) {
+				assert.Equal(t, tt.wantRefreshMaxAge, refreshCookie.MaxAge)
 			}
 		})
 	}
+}
+
+func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
 }
 
 func TestValidateAuthHeaderExists(t *testing.T) {

--- a/server/server/config/config.go
+++ b/server/server/config/config.go
@@ -113,6 +113,13 @@ type (
 		// forced to re-login after this duration regardless of token validity.
 		// Example values: "8h", "24h", "168h" (1 week). If zero, no max duration is enforced.
 		MaxSessionDuration time.Duration `yaml:"maxSessionDuration"`
+		// RefreshTokenLifetime - optional lifetime of the refresh token cookie.
+		// OAuth2 token responses only communicate the access token's lifetime
+		// (expires_in, RFC 6749 section 5.1); the refresh token's lifetime is not
+		// disclosed, so it must be configured to match the IdP's refresh token or
+		// SSO session policy. Example values: "24h", "168h" (1 week).
+		// Defaults to 7 days if zero; capped at 30 days.
+		RefreshTokenLifetime time.Duration `yaml:"refreshTokenLifetime"`
 	}
 
 	AuthProvider struct {

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -110,9 +110,9 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 
 	api := e.Group("/auth")
 	api.GET("/sso", authenticate(&oauthCfg, providerCfg.Options, serverCfg.CORS.AllowOrigins))
-	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
-	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration)) // compatibility with UI v1
-	api.GET("/refresh", refreshTokens(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
+	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth))
+	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth)) // compatibility with UI v1
+	api.GET("/refresh", refreshTokens(ctx, &oauthCfg, provider, serverCfg.Auth))
 	api.GET("/logout", logout())
 }
 
@@ -154,20 +154,20 @@ func authenticate(config *oauth2.Config, options map[string]interface{}, allowed
 	}
 }
 
-func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration) func(echo.Context) error {
+func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, authCfg config.Auth) func(echo.Context) error {
 	return func(c echo.Context) error {
 		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
 			return err
 		}
 
-		err = auth.SetUser(c, user)
+		err = auth.SetUser(c, user, authCfg.RefreshTokenLifetime)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set user: "+err.Error())
 		}
 
 		// Set session start time for max session duration enforcement
-		auth.SetSessionStart(c, maxSessionDuration)
+		auth.SetSessionStart(c, authCfg.MaxSessionDuration)
 
 		nonceS, err := c.Request().Cookie("nonce")
 		if err != nil {
@@ -189,14 +189,14 @@ func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc
 
 // refreshTokens exchanges a refresh token (stored in an HttpOnly cookie) for a new access token
 // and optionally a new ID token. It resets the cookies using auth.SetUser and returns 200.
-func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration) func(echo.Context) error {
+func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, authCfg config.Auth) func(echo.Context) error {
 	return func(c echo.Context) error {
 		startTime := time.Now()
 		clientIP := c.RealIP()
 
 		log.Printf("token_refresh_attempt ip=%s", clientIP)
 
-		if err := auth.ValidateSessionDuration(c, maxSessionDuration); err != nil {
+		if err := auth.ValidateSessionDuration(c, authCfg.MaxSessionDuration); err != nil {
 			log.Printf("token_refresh_denied reason=session_expired ip=%s", clientIP)
 			return echo.NewHTTPError(http.StatusUnauthorized, err.Error())
 		}
@@ -239,7 +239,7 @@ func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.
 			}
 		}
 
-		if err := auth.SetUser(c, &user); err != nil {
+		if err := auth.SetUser(c, &user, authCfg.RefreshTokenLifetime); err != nil {
 			duration := time.Since(startTime).Milliseconds()
 			log.Printf("token_refresh_failed reason=set_user_failed ip=%s error=%q duration_ms=%d", clientIP, err.Error(), duration)
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set refreshed user: "+err.Error())


### PR DESCRIPTION
## Description & motivation 💭

Fixes #3210.

`SetUser` in `server/server/auth/auth.go` derives the `refresh` cookie's `MaxAge` from `oauth2.Token.Expiry`, with a comment claiming that field "typically reflects the refresh token's lifetime". It doesn't: `oauth2.Token.Expiry` is populated from the token response's `expires_in`, which per [RFC 6749 §5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1) is the **access** token's lifetime. OAuth2/OIDC never communicates the refresh token's lifetime in the token response.

The consequence is fatal for the refresh flow: the frontend only refreshes reactively on a 401 (`src/lib/utilities/oss-provider.svelte.ts` → `ossPostResponse`), and a 401 can only occur once the access token has expired — which is the exact moment the browser deletes the `refresh` cookie. So the cookie is always gone before the first `/auth/refresh` attempt, and every refresh fails with `token_refresh_failed reason=missing_refresh_token`. Refresh tokens are effectively unusable with Google OIDC (`expires_in` ≈ 3599s) and any other IdP that returns a standard `expires_in`.

This PR decouples the cookie TTL from the access-token expiry:

- New config option `auth.refreshTokenLifetime` (`TEMPORAL_AUTH_REFRESH_TOKEN_LIFETIME` in the Docker config), so operators can match their IdP's refresh-token/SSO-session policy.
- Defaults to 7 days when unset; the existing 30-day cap is kept.
- `authenticateCb`/`refreshTokens` now take `config.Auth` instead of a bare `maxSessionDuration`, threading the new value the same way `MaxSessionDuration` already flows.

We verified the defect in a production deployment (v2.49.1, Google OIDC with `access_type=offline` + `prompt=consent` options): Google issued refresh tokens, the server logged a cookie `MaxAge` of 3598s, and 100% of refresh attempts failed with `missing_refresh_token`. Running a binary patched to a fixed 7-day cookie TTL (the same behavior as this PR's default) resolved it — sessions now survive access-token expiry via `/auth/refresh`.

### Screenshots (if applicable) 📸

N/A (server-side change).

### Design Considerations 🎨

N/A.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Unit tests cover the three lifetime paths (unset → 7-day default, configured value, > 30 days → capped) and assert that `oauth2.Token.Expiry` no longer influences the cookie. The underlying approach (fixed cookie TTL instead of `Expiry`-derived) has been running in our production deployment against Google OIDC.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Configure OIDC auth against Google (`providerUrl: https://accounts.google.com/`, provider `options: { access_type: offline, prompt: consent }`).
2. Log in and inspect the `refresh` cookie: before this change its Max-Age is ~3599s (the access token lifetime); after, it is `refreshTokenLifetime` (7 days by default).
3. Wait for the access token to expire (~1h) and perform any action: before this change the UI logs `token_refresh_failed reason=missing_refresh_token` and the user is logged out; after, `/auth/refresh` succeeds.
4. `cd server && go test ./server/auth/...`

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

- #3210

## Docs

### Any docs updates needed?

`AUTHENTICATION.md` is updated in this PR (new config option, corrected Google note, troubleshooting entry).
