### PR TITLE
VLN-1585: remediate claude-code-action-unhardened

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,20 +27,21 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2 # v1.0.112
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          show_full_output: false
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -65,4 +66,6 @@ jobs:
           assignee_trigger: 'claude-bot'
           # These overrides ensure claude can reply inline and not only post top-level feedback.
           claude_args: |
-            --allowedTools "Read,Write,Bash,Edit,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*)"
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(pnpm install --frozen-lockfile:*),Bash(pnpm lint:*),Bash(pnpm lint:ci:*),Bash(pnpm check:*),Bash(pnpm test:*),Bash(pnpm test:coverage:*),Bash(pnpm test:e2e:*),Bash(pnpm test:integration:*),Bash(pnpm build:local:*),Bash(pnpm stories:build:*),Bash(pnpm stories:test:*),Bash(pnpm validate:versions:*)"
+            --disallowedTools WebFetch,WebSearch
+            --max-turns 10

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,11 +28,12 @@ jobs:
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required: the action mints its GitHub token via OIDC
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
+          # Keep credentials: the action's own `git fetch` runs before it configures git auth.
           fetch-depth: 1
 
       - name: Run Claude Code

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,6 +67,6 @@ jobs:
           assignee_trigger: 'claude-bot'
           # These overrides ensure claude can reply inline and not only post top-level feedback.
           claude_args: |
-            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(pnpm install --frozen-lockfile:*),Bash(pnpm lint:*),Bash(pnpm lint:ci:*),Bash(pnpm check:*),Bash(pnpm test:*),Bash(pnpm test:coverage:*),Bash(pnpm test:e2e:*),Bash(pnpm test:integration:*),Bash(pnpm build:local:*),Bash(pnpm stories:build:*),Bash(pnpm stories:test:*),Bash(pnpm validate:versions:*)"
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*)"
             --disallowedTools WebFetch,WebSearch
             --max-turns 10


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>claude-code-action-unhardened</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>HIGH</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/ui</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1585">VLN-1585</a></td></tr>
</table>

## Summary

- `.github/workflows/claude.yml`: Pinned `anthropics/claude-code-action` to the vetted `v1.0.183` commit; retained job-level `id-token: write` for action token minting and retained checkout credentials for the action pre-authentication fetch; disabled full output and the `WebFetch`/`WebSearch` tools; capped execution at 10 turns; restricted allowed tools to read, inline comments, `gh pr comment`, and `gh pr diff`; and removed every package-executing `pnpm` command from the Bash allowlist.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base