### PR TITLE
Fix worker deployment actions for self-hosted deployments

### DIFF
--- a/src/lib/components/deployments/deployment-client-test-runner-entry.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner-entry.ts
@@ -79,6 +79,15 @@ export function expandDetails(target: HTMLElement) {
   );
 }
 
+export function openMenu(controls: string) {
+  const trigger = document.querySelector<HTMLButtonElement>(
+    `[aria-controls="${controls}"]`,
+  );
+  trigger?.click();
+  flushSync();
+  return document.getElementById(controls);
+}
+
 export function renderRows({
   computeStatuses,
   showConnectionStatus = false,

--- a/src/lib/components/deployments/deployment-header.svelte
+++ b/src/lib/components/deployments/deployment-header.svelte
@@ -16,6 +16,7 @@
   interface Props {
     namespace: string;
     deploymentName: string;
+    hasComputeConfig: boolean;
     showInstancesLink?: boolean;
     onDeleteClick: () => void;
     onRampToUnversioned: () => void;
@@ -24,6 +25,7 @@
   let {
     namespace,
     deploymentName,
+    hasComputeConfig,
     showInstancesLink = true,
     onDeleteClick,
     onRampToUnversioned,
@@ -60,14 +62,16 @@
   <div class="flex w-full items-center justify-between">
     <h1>{deploymentName}</h1>
     <div class="flex items-center gap-4">
-      <Button
-        href={routeForWorkerDeploymentVersionCreate({
-          namespace,
-          deployment: deploymentName,
-        })}
-      >
-        {translate('deployments.create-new-version')}
-      </Button>
+      {#if hasComputeConfig}
+        <Button
+          href={routeForWorkerDeploymentVersionCreate({
+            namespace,
+            deployment: deploymentName,
+          })}
+        >
+          {translate('deployments.create-new-version')}
+        </Button>
+      {/if}
       <MenuContainer>
         <MenuButton
           controls="deployment-header-actions"
@@ -80,9 +84,11 @@
           <MenuItem href={workflowHref}>
             {translate('deployments.view-workflows')}
           </MenuItem>
-          <MenuItem onclick={onRampToUnversioned}>
-            {translate('deployments.ramp-to-unversioned')}
-          </MenuItem>
+          {#if hasComputeConfig}
+            <MenuItem onclick={onRampToUnversioned}>
+              {translate('deployments.ramp-to-unversioned')}
+            </MenuItem>
+          {/if}
           <MenuItem onclick={onDeleteClick} destructive>
             {translate('deployments.delete-deployment')}
           </MenuItem>

--- a/src/lib/components/deployments/version-actions-menu.svelte
+++ b/src/lib/components/deployments/version-actions-menu.svelte
@@ -47,24 +47,26 @@
       <Icon name="vertical-ellipsis" class="h-4 w-4" />
     </MenuButton>
     <Menu id="version-actions-{buildId}" position="right" usePortal>
-      <MenuItem href={editHref}>
-        {translate('deployments.edit')}
+      {#if hasComputeConfig}
+        <MenuItem href={editHref}>
+          {translate('deployments.edit')}
+        </MenuItem>
+      {/if}
+      {#if isCurrent}
+        <MenuItem onclick={onUnsetCurrent}>
+          {translate('deployments.unset-current')}
+        </MenuItem>
+      {:else}
+        <MenuItem onclick={onSetCurrent}>
+          {translate('deployments.set-as-current')}
+        </MenuItem>
+      {/if}
+      <MenuItem onclick={onSetRamping} disabled={isCurrent}>
+        {isRamping
+          ? translate('deployments.edit-ramping-percentage')
+          : translate('deployments.set-ramping-version')}
       </MenuItem>
       {#if hasComputeConfig}
-        {#if isCurrent}
-          <MenuItem onclick={onUnsetCurrent}>
-            {translate('deployments.unset-current')}
-          </MenuItem>
-        {:else}
-          <MenuItem onclick={onSetCurrent}>
-            {translate('deployments.set-as-current')}
-          </MenuItem>
-        {/if}
-        <MenuItem onclick={onSetRamping} disabled={isCurrent}>
-          {isRamping
-            ? translate('deployments.edit-ramping-percentage')
-            : translate('deployments.set-ramping-version')}
-        </MenuItem>
         <MenuItem onclick={onValidate}>
           {translate('deployments.validate-connection')}
         </MenuItem>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -387,8 +387,8 @@
     {workflowHref}
     {isCurrent}
     hasComputeConfig={isVersionSummaryNew(version)
-      ? !!version.computeConfig
-      : true}
+      ? Object.keys(version.computeConfig?.scalingGroups ?? {}).length > 0
+      : false}
     {isRamping}
     onSetCurrent={() => (showSetCurrentModal = true)}
     onSetRamping={openSetRamping}

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -18,6 +18,7 @@
     setRampingUnversionedWorkers,
   } from '$lib/services/deployments-service';
   import type { WorkerDeploymentResponse } from '$lib/types/deployments';
+  import { deploymentHasComputeConfig } from '$lib/utilities/deployment-has-compute-config';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
 
@@ -129,6 +130,7 @@
     <Error error={refreshError.error} />
   {/if}
   {@const info = deployment.workerDeploymentInfo}
+  {@const hasComputeConfig = deploymentHasComputeConfig(info)}
   {@const unversionedRampingPercentage =
     !info.routingConfig?.rampingDeploymentVersion &&
     info.routingConfig?.rampingVersionPercentage != null
@@ -138,6 +140,7 @@
   <DeploymentHeader
     {namespace}
     {deploymentName}
+    {hasComputeConfig}
     {showInstancesLink}
     onDeleteClick={() => (showDeleteModal = true)}
     onRampToUnversioned={() => {

--- a/src/lib/pages/deployment.svelte.test.ts
+++ b/src/lib/pages/deployment.svelte.test.ts
@@ -27,6 +27,9 @@ const deployment = {
     },
     currentVersionSummary: {
       version: 'deployment.build-id',
+      computeConfig: {
+        scalingGroups: { default: { providerType: 'aws-lambda' } },
+      },
     },
     lastModifierIdentity: 'test',
     versionSummaries: [
@@ -49,6 +52,37 @@ const deployment = {
     ],
   },
 } as unknown as WorkerDeploymentResponse;
+
+const selfHostedDeployment = {
+  ...deployment,
+  workerDeploymentInfo: {
+    ...deployment.workerDeploymentInfo,
+    versionSummaries: [
+      {
+        ...deployment.workerDeploymentInfo.versionSummaries[0],
+        computeConfig: undefined,
+      },
+      {
+        version: 'deployment.build-id-2',
+        deploymentVersion: {
+          deploymentName: 'deployment',
+          buildId: 'build-id-2',
+        },
+        status: 'WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE',
+        computeConfig: { scalingGroups: {} },
+      },
+    ],
+    currentVersionSummary: {
+      version: 'deployment.build-id',
+    },
+  },
+} as unknown as WorkerDeploymentResponse;
+
+function menuItems(menu: Element | null) {
+  return Array.from(menu?.querySelectorAll('[role="menuitem"]') ?? []).map(
+    (item) => item.textContent?.trim(),
+  );
+}
 
 describe('deployment connection status visibility', () => {
   let client: Awaited<ReturnType<typeof getDeploymentClientTestRunner>>;
@@ -133,5 +167,58 @@ describe('deployment connection status visibility', () => {
     const details = client.expandDetails(target);
     expect(details).not.toBeNull();
     expect(details?.getAttribute('colspan')).toBe('6');
+  });
+
+  test('shows compute-only deployment and version actions for deployments with compute config', async () => {
+    const target = await client.renderDeployment({
+      fetchDeployment: deployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+      showConnectionStatus: false,
+    });
+
+    expect(target.textContent).toContain('Create New Version');
+    expect(client.openMenu('deployment-header-actions')?.textContent).toContain(
+      'Ramp to Unversioned Workers',
+    );
+
+    const versionMenu = client.openMenu('version-actions-build-id');
+    expect(menuItems(versionMenu)).toEqual([
+      'Edit',
+      'Unset Current',
+      'Set Ramping Version',
+      'Validate Connection',
+      'View Workflows',
+      'Delete',
+    ]);
+  });
+
+  test('hides compute-only actions but retains routing actions for self-hosted deployments', async () => {
+    const target = await client.renderDeployment({
+      fetchDeployment: selfHostedDeployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+      showConnectionStatus: false,
+    });
+
+    expect(target.textContent).not.toContain('Create New Version');
+    const headerMenu = client.openMenu('deployment-header-actions');
+    expect(headerMenu?.textContent).not.toContain(
+      'Ramp to Unversioned Workers',
+    );
+
+    const versionMenu = client.openMenu('version-actions-build-id');
+    expect(menuItems(versionMenu)).toEqual([
+      'Unset Current',
+      'Set Ramping Version',
+      'View Workflows',
+      'Delete',
+    ]);
+
+    const inactiveVersionMenu = client.openMenu('version-actions-build-id-2');
+    expect(menuItems(inactiveVersionMenu)).toEqual([
+      'Set Current Version',
+      'Set Ramping Version',
+      'View Workflows',
+      'Delete',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Self-hosted deployments regain Set/Unset Current and ramping actions.
- Compute-only Create/Edit/Validate/Ramp-to-Unversioned actions remain gated by compute config.
- Regression tests cover both cases.

## Test plan

- `pnpm test --run src/lib/pages/deployment.svelte.test.ts` (4 passed)
- `pnpm check` (0 errors, 62 pre-existing warnings)
- Prettier and git diff check clean