### PR TITLE
Add memo support to Start Workflow

### DIFF
--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -324,6 +324,9 @@ export const Strings = {
   'view-running-workflow': 'View the running workflow',
   encoding: 'Encoding',
   'message-type': 'Message Type',
+  'memo-description':
+    'Non-indexed information stored with the Workflow Execution. Enter memo fields as a JSON object.',
+  'memo-valid-json-object': 'Memo must be a valid JSON object',
   'user-metadata': 'User Metadata',
   'markdown-supported': 'Markdown Supported',
   'markdown-description':

--- a/src/lib/pages/start-workflow.svelte
+++ b/src/lib/pages/start-workflow.svelte
@@ -22,6 +22,7 @@
   import Label from '$lib/holocene/label.svelte';
   import Link from '$lib/holocene/link.svelte';
   import MarkdownEditor from '$lib/holocene/markdown-editor/markdown-editor.svelte';
+  import Textarea from '$lib/holocene/textarea.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
   import { translate } from '$lib/i18n/translate';
   import type { PayloadInputEncoding } from '$lib/models/payload-encoding';
@@ -55,6 +56,7 @@
   let taskQueue = '';
   let workflowType = '';
   let input = '';
+  let memo = '';
   let summary = '';
   let details = '';
   let encoding: Writable<PayloadInputEncoding> = writable('json/plain');
@@ -121,6 +123,7 @@
         taskQueue,
         workflowType,
         input,
+        memo,
         summary,
         details,
         encoding: $encoding,
@@ -182,6 +185,7 @@
       workflowType,
     });
     input = initialValues.input;
+    memo = initialValues.memo;
     encoding.set(initialValues.encoding);
     messageType = initialValues.messageType;
     summary = initialValues.summary;
@@ -205,6 +209,7 @@
 
     if (
       Object.keys(initialValues?.searchAttributes ?? {}).length ||
+      initialValues?.memo ||
       initialValues?.summary ||
       initialValues?.details
     ) {
@@ -234,11 +239,29 @@
 
   $: inputValid = !input || inputIsJSON(input);
 
+  const memoIsJSONObject = (input: string) => {
+    if (!input) return true;
+
+    try {
+      const parsedMemo = JSON.parse(input);
+      return (
+        typeof parsedMemo === 'object' &&
+        parsedMemo !== null &&
+        !Array.isArray(parsedMemo)
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  $: memoValid = memoIsJSONObject(memo);
+
   $: enableStart =
     !!workflowId &&
     !!taskQueue &&
     !!workflowType &&
     !!inputValid &&
+    !!memoValid &&
     !workflowCreateDisabled($page);
 
   $: checkTaskQueue(taskQueueParam ?? '');
@@ -313,6 +336,19 @@
     />
     <PayloadInputWithEncoding bind:input bind:encoding bind:messageType />
     {#if viewAdvancedOptions}
+      <Card class="flex flex-col gap-2">
+        <Textarea
+          id="memo"
+          label={translate('common.memo')}
+          description={translate('workflows.memo-description')}
+          placeholder={'{\n  "key": "value"\n}'}
+          rows={8}
+          bind:value={memo}
+          isValid={memoValid}
+          error={translate('workflows.memo-valid-json-object')}
+          spellcheck={false}
+        />
+      </Card>
       <Card class="flex flex-col gap-2">
         <div>
           <h3>{translate('search-attributes.custom-search-attributes')}</h3>

--- a/src/lib/services/workflow-service.test.ts
+++ b/src/lib/services/workflow-service.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { base } from '$app/paths';
 
-import { fetchAllWorkflows, fetchWorkflowForRunId } from './workflow-service';
+import {
+  fetchAllWorkflows,
+  fetchInitialValuesForStartWorkflow,
+  fetchWorkflowForRunId,
+  startWorkflow,
+} from './workflow-service';
 import { getApiOrigin } from '../utilities/get-api-origin';
 import { requestFromAPI } from '../utilities/request-from-api';
 
@@ -16,6 +21,10 @@ vi.mock('../utilities/request-from-api', () => ({
         }),
       ),
   ),
+}));
+
+vi.mock('./events-service', () => ({
+  fetchInitialEvent: vi.fn().mockResolvedValue({ attributes: {} }),
 }));
 
 const origin = getApiOrigin();
@@ -62,6 +71,87 @@ describe('workflow service', () => {
           request: expect.any(Function),
         },
       );
+    });
+  });
+
+  describe('startWorkflow', () => {
+    test('encodes memo fields in the start request', async () => {
+      await startWorkflow({
+        namespace: 'test',
+        workflowId: 'workflow-id',
+        taskQueue: 'task-queue',
+        workflowType: 'workflow-type',
+        input: '',
+        memo: '{"customer":"acme","attempt":3}',
+        encoding: 'json/plain',
+        messageType: '',
+        summary: '',
+        details: '',
+        searchAttributes: [],
+      });
+
+      const requestOptions = vi.mocked(requestFromAPI).mock.calls[0]?.[1];
+      const body = JSON.parse(String(requestOptions?.options?.body));
+
+      expect(body.memo).toEqual({
+        fields: {
+          customer: {
+            metadata: { encoding: 'anNvbi9wbGFpbg==' },
+            data: 'ImFjbWUi',
+          },
+          attempt: {
+            metadata: { encoding: 'anNvbi9wbGFpbg==' },
+            data: 'Mw==',
+          },
+        },
+      });
+    });
+  });
+
+  describe('fetchInitialValuesForStartWorkflow', () => {
+    test('decodes memo fields from the existing workflow', async () => {
+      vi.mocked(requestFromAPI)
+        .mockResolvedValueOnce({
+          executions: [
+            {
+              execution: {
+                workflowId: 'source-workflow',
+                runId: 'source-run',
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          workflowExecutionInfo: {
+            execution: {
+              workflowId: 'source-workflow',
+              runId: 'source-run',
+            },
+            memo: {
+              fields: {
+                customer: {
+                  metadata: { encoding: 'anNvbi9wbGFpbg==' },
+                  data: 'ImFjbWUi',
+                },
+                attempt: {
+                  metadata: { encoding: 'anNvbi9wbGFpbg==' },
+                  data: 'Mw==',
+                },
+              },
+            },
+          },
+        });
+
+      const initialValues = await fetchInitialValuesForStartWorkflow({
+        namespace: 'test',
+        workflowId: 'source-workflow',
+        runId: 'source-run',
+      });
+
+      expect(JSON.parse(initialValues.memo)).toEqual({
+        customer: 'acme',
+        attempt: 3,
+      });
     });
   });
 });

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -62,7 +62,10 @@ import {
   isUnauthorized,
 } from '$lib/utilities/handle-error';
 import { paginated } from '$lib/utilities/paginated';
-import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
+import {
+  parseWithBigInt,
+  stringifyWithBigInt,
+} from '$lib/utilities/parse-with-big-int';
 import { toListWorkflowQuery } from '$lib/utilities/query/list-workflow-query';
 import type { ErrorCallback } from '$lib/utilities/request-from-api';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
@@ -123,6 +126,7 @@ type StartWorkflowOptions = {
   taskQueue: string;
   workflowType: string;
   input: string;
+  memo: string;
   encoding: PayloadInputEncoding;
   messageType: string;
   summary: string;
@@ -690,6 +694,7 @@ export async function startWorkflow({
   taskQueue,
   workflowType,
   input,
+  memo,
   summary,
   details,
   encoding,
@@ -703,6 +708,7 @@ export async function startWorkflow({
     workflowId,
   });
   let payloads;
+  let memoFields;
   let summaryPayload;
   let detailsPayload;
 
@@ -711,6 +717,32 @@ export async function startWorkflow({
       payloads = await encodePayloads({ input, encoding, messageType });
     } catch {
       throw new Error('Could not encode input for starting workflow');
+    }
+  }
+
+  if (memo) {
+    try {
+      const parsedMemo = parseWithBigInt(memo);
+      if (
+        typeof parsedMemo !== 'object' ||
+        parsedMemo === null ||
+        Array.isArray(parsedMemo)
+      ) {
+        throw new Error('Memo must be an object');
+      }
+
+      const encodedMemoEntries = await Promise.all(
+        Object.entries(parsedMemo).map(async ([key, value]) => {
+          const encodedValue = await encodePayloads({
+            input: stringifyWithBigInt(value),
+            encoding: 'json/plain',
+          });
+          return [key, encodedValue?.[0]] as const;
+        }),
+      );
+      memoFields = Object.fromEntries(encodedMemoEntries);
+    } catch {
+      throw new Error('Could not encode memo for starting workflow');
     }
   }
 
@@ -745,6 +777,7 @@ export async function startWorkflow({
       name: workflowType,
     },
     input: payloads ? { payloads } : null,
+    memo: memoFields ? { fields: memoFields } : null,
     userMetadata: {
       summary: summaryPayload,
       details: detailsPayload,
@@ -776,6 +809,7 @@ export async function startWorkflow({
 
 type InitialValuesForStartWorkflow = {
   input: string;
+  memo: string;
   encoding: PayloadInputEncoding;
   messageType: string;
   searchAttributes: Record<string, string | Payload> | undefined;
@@ -799,6 +833,7 @@ export const fetchInitialValuesForStartWorkflow = async ({
   };
   const emptyValues: InitialValuesForStartWorkflow = {
     input: '',
+    memo: '',
     encoding: 'json/plain' as PayloadInputEncoding,
     messageType: '',
     searchAttributes: undefined,
@@ -863,6 +898,24 @@ export const fetchInitialValuesForStartWorkflow = async ({
       }
     }
 
+    let memo = '';
+    if (
+      workflow?.memo?.fields &&
+      Object.keys(workflow.memo.fields).length > 0
+    ) {
+      const decodedMemoEntries = await Promise.all(
+        Object.entries(workflow.memo.fields).map(async ([key, value]) => [
+          key,
+          await decodePayloadAndParseDataToJSON(value),
+        ]),
+      );
+      memo = stringifyWithBigInt(
+        Object.fromEntries(decodedMemoEntries),
+        undefined,
+        2,
+      );
+    }
+
     let input = '';
     let encoding: PayloadInputEncoding = 'json/plain';
     let messageType = '';
@@ -888,6 +941,7 @@ export const fetchInitialValuesForStartWorkflow = async ({
 
     return {
       input,
+      memo,
       encoding,
       messageType,
       searchAttributes: workflow?.searchAttributes?.indexedFields,

--- a/tests/integration/start-a-workflow.spec.ts
+++ b/tests/integration/start-a-workflow.spec.ts
@@ -46,6 +46,14 @@ test.describe('Start a Workflow', () => {
       await expect(page.locator('#workflowId')).toBeEnabled();
       await expect(page.locator('#taskQueue')).toBeEnabled();
       await expect(page.locator('#workflowType')).toBeEnabled();
+      await page.getByText('More options').click();
+      const memo = page.locator('#memo');
+      await expect(memo).toBeEnabled();
+      await memo.fill('[]');
+      await expect(
+        page.getByText('Memo must be a valid JSON object'),
+      ).toBeVisible();
+      await memo.fill('{"key":"value"}');
       await page.locator('#workflowId').type('test-workflow-id');
       await page.locator('#taskQueue').type('task-queue');
       await mockTaskQueuesApi(page);


### PR DESCRIPTION
## Description & motivation 💭

Adds a JSON Memo field to the Start Workflow page so workflows that require memo metadata can be started from the UI. “Start Workflow Like This One” now decodes and prefills memo fields from the source execution.

### Screenshots (if applicable) 📸

N/A

### Design Considerations 🎨

Memo input is represented as a JSON object. Each top-level value is encoded as a Temporal payload before the start request is sent.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Validated with the focused workflow-service unit tests, ESLint, Prettier, and Svelte check (0 errors). Integration coverage was added for the memo field and validation; local Playwright execution was blocked in global setup by an unrelated `@temporalio/common` `encode is not a function` error before tests ran.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open Start Workflow and expand More options.
2. Enter a JSON object in Memo and start the workflow.
3. Verify the new execution contains those memo fields.
4. From an execution with memo fields, choose Start Workflow Like This One and verify Memo is prefilled.

## Checklists

### Draft Checklist

- [x] Implementation and automated coverage included

### Merge Checklist

- [ ] CI passes
- [ ] Review complete

### Issue(s) closed

Closes #2512

## Docs

### Any docs updates needed?

No documentation updates are required.