### PR TITLE
[DT-4311] Add Nexus Callback banner to the Standalone Activity detail page

### DIFF
--- a/src/lib/components/workflow/workflow-callback.svelte
+++ b/src/lib/components/workflow/workflow-callback.svelte
@@ -21,8 +21,14 @@
   let {
     callback,
     link,
+    perspective = 'handler',
     children,
-  }: { callback: Callback; link?: Link; children?: Snippet } = $props();
+  }: {
+    callback: Callback;
+    link?: Link;
+    perspective?: 'caller' | 'handler';
+    children?: Snippet;
+  } = $props();
 
   const completedTime = $derived($timestamp(callback.lastAttemptCompleteTime));
   const nextTime = $derived($timestamp(callback.nextAttemptScheduleTime));
@@ -47,11 +53,20 @@
   const showCallbackUrl = $derived(!links.length && !link && callbackUrl);
   const namespace = $derived(page.params.namespace);
   const callbackLinks = $derived(links.length ? links : link ? [link] : []);
-  const linkViews = $derived(toEventLinkViews(callbackLinks, { namespace }));
+  const linkViews = $derived(
+    toEventLinkViews(callbackLinks, {
+      namespace,
+      perspective: perspective === 'caller' ? 'caller' : undefined,
+    }),
+  );
 </script>
 
 {#snippet callbackLink(view: EventLinkView)}
-  <EventLink {view} />
+  {#if perspective === 'caller' && view.event}
+    <EventLink view={view.event} />
+  {:else}
+    <EventLink {view} />
+  {/if}
   {#if view.namespace}
     <EventLink view={view.namespace} />
   {/if}

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -9,6 +9,7 @@
   import DetailListValue from '$lib/components/detail-list/detail-list-value.svelte';
   import PayloadCodeBlock from '$lib/components/payload/payload-code-block.svelte';
   import ActivityExecutionInputAndOutcome from '$lib/components/standalone-activities/activity-input-and-outcome.svelte';
+  import WorkflowCallback from '$lib/components/workflow/workflow-callback.svelte';
   import Badge from '$lib/holocene/badge.svelte';
   import Card from '$lib/holocene/card.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
@@ -76,6 +77,12 @@
 {/snippet}
 
 {#if $activityExecution}
+  {#if $activityExecution.callbacks?.length}
+    <WorkflowCallback
+      callback={$activityExecution.callbacks[0]}
+      perspective="caller"
+    />
+  {/if}
   <ActivityExecutionInputAndOutcome
     input={$activityExecution.input}
     outcome={$activityExecution.outcome}

--- a/src/lib/services/standalone-activities.test.ts
+++ b/src/lib/services/standalone-activities.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { StandaloneActivityFormData } from '$lib/components/standalone-activities/start-standalone-activity-form/types';
 
-import { toStartActivityExecutionRequest } from './standalone-activities';
+import {
+  toActivityCallbacks,
+  toStartActivityExecutionRequest,
+} from './standalone-activities';
 
 const baseFormData: StandaloneActivityFormData = {
   identity: 'test',
@@ -55,5 +58,48 @@ describe('toStartActivityExecutionRequest', () => {
     });
 
     expect(provided.startToCloseTimeout).toBe('30s');
+  });
+});
+
+describe('toActivityCallbacks', () => {
+  const activityCallbacks = [
+    {
+      trigger: {},
+      info: {
+        callback: {
+          nexus: { url: 'http://callback' },
+          links: [
+            {
+              workflowEvent: {
+                namespace: 'caller-ns',
+                workflowId: 'caller-wf',
+                runId: 'caller-run',
+                eventRef: { eventId: '7' },
+              },
+            },
+          ],
+        },
+        state: 'CALLBACK_STATE_SUCCEEDED',
+        attempt: 2,
+      },
+    },
+  ] as unknown as Parameters<typeof toActivityCallbacks>[0];
+
+  it('extracts nested info and makes state readable', () => {
+    const [callback] = toActivityCallbacks(activityCallbacks);
+
+    expect(callback.state).toBe('Succeeded');
+    expect(callback.attempt).toBe(2);
+    expect(callback.callback?.links).toHaveLength(1);
+    expect(callback.callback?.nexus?.url).toBe('http://callback');
+  });
+
+  it('skips callbacks without info and handles empty input', () => {
+    expect(toActivityCallbacks(undefined)).toEqual([]);
+    expect(
+      toActivityCallbacks([
+        {},
+      ] as unknown as Parameters<typeof toActivityCallbacks>[0]),
+    ).toEqual([]);
   });
 });

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -1,3 +1,5 @@
+import type { temporal } from '@temporalio/proto';
+
 import type { StandaloneActivityFormData } from '$lib/components/standalone-activities/start-standalone-activity-form/types';
 import {
   type DefaultUnits,
@@ -20,14 +22,17 @@ import type {
   ActivityExecutionInfo,
   StartActivityExecutionRequest,
 } from '$lib/types/activity-execution';
+import type { Callback } from '$lib/types/nexus';
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
 import { encodePayloads } from '$lib/utilities/encode-payload';
+import { isEmptyObject } from '$lib/utilities/is';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import {
   type ErrorCallback,
   requestFromAPI,
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
+import { toCallbackStateReadable } from '$lib/utilities/screaming-enums';
 
 import { ACTIVITY_OPTIONS_UPDATE_MASK } from './workflow-activities-service';
 import { setSearchAttributes } from './workflow-service';
@@ -65,6 +70,26 @@ const emptyActivityExecutionInfo: ActivityExecutionInfo = {
 const emptyActivityExecution: ActivityExecution = {
   runId: '',
   info: emptyActivityExecutionInfo,
+};
+
+type DescribeActivityExecutionResponse = Omit<ActivityExecution, 'callbacks'> & {
+  callbacks?: temporal.api.activity.v1.ICallbackInfo[] | null;
+};
+
+export const toActivityCallbacks = (
+  callbacks?: temporal.api.activity.v1.ICallbackInfo[] | null,
+): Callback[] => {
+  if (!callbacks) return [];
+  return callbacks.reduce<Callback[]>((acc, { info }) => {
+    if (!info) return acc;
+    acc.push({
+      ...info,
+      blockedReason: info.blockedReason ?? undefined,
+      callback: (info.callback ?? undefined) as Callback['callback'],
+      state: toCallbackStateReadable(info.state ?? undefined),
+    });
+    return acc;
+  }, []);
 };
 
 export interface StartStandaloneActivityResponse {
@@ -348,9 +373,13 @@ export const getActivityExecution = (
     runId,
   });
 
-  return requestFromAPI<ActivityExecution>(route, {
+  return requestFromAPI<DescribeActivityExecutionResponse>(route, {
     params,
-  }).then((response) => response ?? emptyActivityExecution);
+  }).then((response) => {
+    if (!response) return emptyActivityExecution;
+    const { callbacks, ...rest } = response;
+    return { ...rest, callbacks: toActivityCallbacks(callbacks) };
+  });
 };
 
 export const pollActivityExecution = (
@@ -374,10 +403,14 @@ export const pollActivityExecution = (
     longPollToken: token,
   });
 
-  return requestFromAPI<ActivityExecution>(route, {
+  return requestFromAPI<DescribeActivityExecutionResponse>(route, {
     params,
     notifyOnError: false,
     options: { signal },
+  }).then((response) => {
+    if (!response || isEmptyObject(response)) return undefined;
+    const { callbacks, ...rest } = response;
+    return { ...rest, callbacks: toActivityCallbacks(callbacks) };
   });
 };
 

--- a/src/lib/types/activity-execution.ts
+++ b/src/lib/types/activity-execution.ts
@@ -1,5 +1,7 @@
 import type { temporal } from '@temporalio/proto';
 
+import type { Callback } from '$lib/types/nexus';
+
 import type { Failure, Payloads } from '.';
 import type { WorkflowSearchAttributes } from './workflows';
 
@@ -85,6 +87,7 @@ export interface ActivityExecution {
   info: ActivityExecutionInfo;
   input?: Payloads;
   outcome?: ActivityExecutionOutcome;
+  callbacks?: Callback[];
   longPollToken?: string;
 }
 

--- a/src/lib/utilities/event-link.test.ts
+++ b/src/lib/utilities/event-link.test.ts
@@ -36,6 +36,30 @@ describe('toEventLinkView', () => {
     });
   });
 
+  it('uses caller labels for workflow events in the caller perspective', () => {
+    const view = toEventLinkView(
+      {
+        workflowEvent: {
+          namespace: 'caller-ns',
+          workflowId: 'caller-wf',
+          runId: 'caller-run',
+          eventRef: {
+            eventId: '7',
+            eventType: 'EVENT_TYPE_NEXUS_OPERATION_SCHEDULED',
+          },
+        },
+      },
+      { perspective: 'caller' },
+    );
+
+    expect(view.label).toBe('Caller Workflow');
+    expect(view.namespace?.label).toBe('Caller Namespace');
+    expect(view.event?.label).toBe('Caller Event');
+    expect(view.event?.href).toBe(
+      `${base}/namespaces/caller-ns/workflows/caller-wf/caller-run/history/events/7`,
+    );
+  });
+
   it('returns a workflow event route for request ID references', () => {
     const view = toEventLinkView({
       workflowEvent: {

--- a/src/lib/utilities/event-link.ts
+++ b/src/lib/utilities/event-link.ts
@@ -33,6 +33,7 @@ export type EventLinkView = EventLinkDisplay & {
 
 export type EventLinkContext = {
   namespace?: string;
+  perspective?: 'caller';
 };
 
 const workflowExecutionStarted = 'EVENT_TYPE_WORKFLOW_EXECUTION_STARTED';
@@ -47,11 +48,12 @@ const workflowValueFromHref = (href: string, fallback: string): string => {
 
 const namespaceDisplay = (
   namespace: string | null | undefined,
+  labelKey: 'nexus.namespace-link' | 'nexus.caller-namespace' = 'nexus.namespace-link',
 ): EventLinkDisplay | undefined => {
   if (!isPresent(namespace)) return undefined;
 
   return {
-    label: translate('nexus.namespace-link'),
+    label: translate(labelKey),
     value: namespace,
     href: routeForNamespace({ namespace }),
   };
@@ -62,6 +64,7 @@ const eventDisplay = (
   eventType: unknown,
   eventId?: unknown,
   requestId?: string | null,
+  labelKey: 'nexus.handler-event' | 'nexus.caller-event' = 'nexus.handler-event',
 ): EventLinkDisplay | undefined => {
   if (eventId === undefined && !requestId && !eventType) {
     return undefined;
@@ -78,7 +81,7 @@ const eventDisplay = (
     .join(' ');
 
   return {
-    label: translate('nexus.handler-event'),
+    label: translate(labelKey),
     value: value || translate('nexus.link'),
     href,
   };
@@ -164,19 +167,25 @@ export const toEventLinkView = (
       ? workflowValueFromHref(href, fallbackValue)
       : fallbackValue;
 
+    const caller = context.perspective === 'caller';
+
     return {
       variant: 'workflowEvent',
       key: `workflowEvent:${namespace ?? ''}:${workflow ?? ''}:${run ?? ''}:${workflowEvent.eventRef?.eventId ?? workflowEvent.requestIdRef?.requestId ?? index ?? ''}`,
-      label: translate('nexus.workflow-link'),
+      label: translate(caller ? 'nexus.caller-workflow' : 'nexus.workflow-link'),
       value,
       href,
-      namespace: namespaceDisplay(namespace),
+      namespace: namespaceDisplay(
+        namespace,
+        caller ? 'nexus.caller-namespace' : 'nexus.namespace-link',
+      ),
       event: eventDisplay(
         href,
         workflowEvent.eventRef?.eventType ??
           workflowEvent.requestIdRef?.eventType,
         workflowEvent.eventRef?.eventId,
         workflowEvent.requestIdRef?.requestId,
+        caller ? 'nexus.caller-event' : 'nexus.handler-event',
       ),
     };
   }


### PR DESCRIPTION
## Summary

On the handler side, a Standalone Activity started by an in-workflow Nexus operation now surfaces a Nexus Callback banner on its detail page, reusing the workflow callback banner. Exposes the describe-activity `callbacks` on `ActivityExecution`, normalizes the activity-specific nested callback shape, and adds a "caller" perspective to event links so the banner renders **Caller Event** and **Caller Namespace**. The banner only appears for Nexus-invoked activities.

## Jira

https://temporalio.atlassian.net/browse/DT-4311

## Test plan

- [ ] Nexus-invoked SAA detail page shows the callback banner with Caller Event / Caller Namespace links (manual, against a live server)
- [ ] Non-Nexus standalone activity shows no banner
- [x] Unit tests: `toActivityCallbacks` mapping + caller-perspective labels
- [x] Full unit suite passes (2578 tests)