### PR TITLE
Pluralize batch operation execution type

### DIFF
--- a/src/lib/components/batch-operations/operation-type.svelte
+++ b/src/lib/components/batch-operations/operation-type.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import Badge, { type BadgeType } from '$lib/holocene/badge.svelte';
   import Icon from '$lib/holocene/icon/icon.svelte';
-  import type {
-    BatchOperationActionType,
+  import { translate } from '$lib/i18n/translate';
+  import {
+    type BatchOperationActionType,
     BatchOperationExecutionType,
-    BatchOperationType,
+    type BatchOperationType,
   } from '$lib/types/batch';
   import { toBatchOperationTypeReadable } from '$lib/utilities/screaming-enums';
 
@@ -26,8 +27,9 @@
         rawOperationType.endsWith('_UNSPECIFIED')
       )
         return undefined;
-      if (/ACTIVITY/.test(rawOperationType)) return 'Activity';
-      return 'Workflow';
+      if (/ACTIVITY/.test(rawOperationType))
+        return BatchOperationExecutionType.Activity;
+      return BatchOperationExecutionType.Workflow;
     },
   );
 
@@ -58,8 +60,14 @@
     </Badge>
     {#if executionType}
       <span class="flex items-center gap-1">
-        <Icon name={executionType === 'Activity' ? 'activity' : 'workflow'} />
-        {executionType}
+        <Icon
+          name={executionType === BatchOperationExecutionType.Activity
+            ? 'activity'
+            : 'workflow'}
+        />
+        {executionType === BatchOperationExecutionType.Activity
+          ? translate('common.activities-plural', { count: 2 })
+          : translate('common.workflows-plural', { count: 2 })}
       </span>
     {/if}
   {:else}

--- a/src/lib/types/batch.ts
+++ b/src/lib/types/batch.ts
@@ -11,7 +11,10 @@ export type BatchOperationActionType =
   | 'Delete'
   | 'Unspecified';
 
-export type BatchOperationExecutionType = 'Workflow' | 'Activity';
+export enum BatchOperationExecutionType {
+  Workflow = 'Workflow',
+  Activity = 'Activity',
+}
 
 export type BatchOperationState =
   | 'Running'


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
