### PR TITLE
fix(timeline): recolor a group when a later event extends it

### DIFF
--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -1896,3 +1896,67 @@ describe('appendLiveEvent — livePendingFollowers (unified bidirectional patter
     expect(g?.eventList).toHaveLength(2); // not 3
   });
 });
+
+// ---------------------------------------------------------------------------
+// Group reference identity
+//
+// The timeline row pool reuses a row while its group reference is unchanged, so
+// every path that adds an event to an already-rendered group must publish a
+// fresh reference. Regression: a running activity's bar and label stayed
+// "in progress" after it completed, until reload.
+// ---------------------------------------------------------------------------
+
+describe('group reference identity', () => {
+  beforeEach(() => {
+    reset(10);
+    resetLive();
+  });
+
+  it('publishes a fresh reference when a live completion extends a fetched group', () => {
+    const [scheduled, started, completed] = makeActivityGroup(1);
+    processEvent(scheduled, true);
+    processEvent(started, true);
+
+    const before = getGroupArray().find((g) => g.id === '1');
+    expect(before?.eventList).toHaveLength(2);
+    expect(before?.finalClassification).toBe('Started');
+
+    expect(appendLiveEvent(completed)).toBe(true);
+
+    const after = getGroupArray().find((g) => g.id === '1');
+    expect(after).not.toBe(before);
+    expect(after?.eventList).toHaveLength(3);
+    expect(after?.finalClassification).toBe('Completed');
+  });
+
+  it('publishes a fresh reference when a live follower extends a live group', () => {
+    const [scheduled, started] = makeActivityGroup(1);
+    appendLiveEvent(scheduled);
+
+    const before = getGroupArray().find((g) => g.id === '1');
+    expect(before?.eventList).toHaveLength(1);
+
+    expect(appendLiveEvent(started)).toBe(true);
+
+    const after = getGroupArray().find((g) => g.id === '1');
+    expect(after).not.toBe(before);
+    expect(after?.eventList).toHaveLength(2);
+  });
+
+  it('publishes a fresh reference when a follower arrives in a later fetch page', () => {
+    const [scheduled, started, completed] = makeActivityGroup(1);
+    processEvent(scheduled, true);
+    processEvent(started, true);
+
+    const before = getGroupArray().find((g) => g.id === '1');
+    expect(before?.eventList).toHaveLength(2);
+
+    // A group's terminal event can land in the next 1000-event page.
+    processEvent(completed, true);
+
+    const after = getGroupArray().find((g) => g.id === '1');
+    expect(after).not.toBe(before);
+    expect(after?.eventList).toHaveLength(3);
+    expect(after?.finalClassification).toBe('Completed');
+  });
+});

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -35,6 +35,7 @@ import {
   makeActivityGroup,
   makeActivityScheduled,
   makeActivityStarted,
+  makeActivityTimedOut,
   makeActivityTimeoutGroup,
   makeChildWorkflowGroup,
   makeNexusOperationGroup,
@@ -1958,5 +1959,23 @@ describe('group reference identity', () => {
     expect(after).not.toBe(before);
     expect(after?.eventList).toHaveLength(3);
     expect(after?.finalClassification).toBe('Completed');
+  });
+  it('flushes live followers into the group the fetch just published', () => {
+    reset(10);
+
+    // A follower parked by the fetch is flushed when the head registers, which
+    // replaces meta.group with the copy. A follower parked by the live poll is
+    // flushed straight after, and must land on that copy rather than on the
+    // reference processEvent started with.
+    processEvent(makeActivityStarted(2, 1), false);
+    expect(appendLiveEvent(makeActivityTimedOut(3, 1))).toBe(true);
+
+    processEvent(makeActivityScheduled(1), true);
+
+    const group = getGroupArray().find((g) => g.id === '1');
+    expect(group?.eventList.map((e) => e.id)).toEqual(['1', '2', '3']);
+    // Set by addEventToGroup, which writes to the group it is handed — unlike
+    // eventList, this is not shared with the pre-copy reference.
+    expect(group?.isFailureOrTimedOut).toBe(true);
   });
 });

--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -1903,8 +1903,9 @@ describe('appendLiveEvent — livePendingFollowers (unified bidirectional patter
 //
 // The timeline row pool reuses a row while its group reference is unchanged, so
 // every path that adds an event to an already-rendered group must publish a
-// fresh reference. Regression: a running activity's bar and label stayed
-// "in progress" after it completed, until reload.
+// fresh one. Each test below names the symptom; the assertion is the reference
+// change that prevents it, since the colour and label live in components while
+// the invariant that drives them lives here.
 // ---------------------------------------------------------------------------
 
 describe('group reference identity', () => {
@@ -1913,7 +1914,8 @@ describe('group reference identity', () => {
     resetLive();
   });
 
-  it('publishes a fresh reference when a live completion extends a fetched group', () => {
+  // Without a fresh reference the row keeps its in-progress colour and label.
+  it('a fetched group stops showing as in progress once the live poll completes it', () => {
     const [scheduled, started, completed] = makeActivityGroup(1);
     processEvent(scheduled, true);
     processEvent(started, true);
@@ -1930,7 +1932,8 @@ describe('group reference identity', () => {
     expect(after?.finalClassification).toBe('Completed');
   });
 
-  it('publishes a fresh reference when a live follower extends a live group', () => {
+  // Same symptom for a group the live poll created rather than the fetch.
+  it('a live group stops showing as in progress once the live poll completes it', () => {
     const [scheduled, started] = makeActivityGroup(1);
     appendLiveEvent(scheduled);
 
@@ -1944,7 +1947,9 @@ describe('group reference identity', () => {
     expect(after?.eventList).toHaveLength(2);
   });
 
-  it('publishes a fresh reference when a follower arrives in a later fetch page', () => {
+  // Same symptom on histories over 1000 events, where a group can straddle a
+  // page boundary — no live poll involved.
+  it('a group stops showing as in progress when its completion is a page later', () => {
     const [scheduled, started, completed] = makeActivityGroup(1);
     processEvent(scheduled, true);
     processEvent(started, true);
@@ -1960,7 +1965,12 @@ describe('group reference identity', () => {
     expect(after?.eventList).toHaveLength(3);
     expect(after?.finalClassification).toBe('Completed');
   });
-  it('flushes live followers into the group the fetch just published', () => {
+  // Both producers can park a follower before the head exists. Draining the
+  // first queue swaps in the copy, so the second drain must not write to the
+  // reference processEvent captured before it. When it does, addEventToGroup's
+  // flags land on the abandoned object and the activity renders as if it
+  // succeeded — eventList is shared, so the events themselves still appear.
+  it('a timed-out activity keeps its failure state when its head arrives last', () => {
     reset(10);
 
     // A follower parked by the fetch is flushed when the head registers, which

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -267,6 +267,26 @@ function clearResolvedPendingState(group: EventGroup): void {
   }
 }
 
+/**
+ * Returns a copy of `group` with `event` added. Callers must store the returned
+ * reference back over the old one: the timeline row pool reuses a row when its
+ * group reference is unchanged (timeline-graph.svelte), so extending a rendered
+ * group in place leaves the row showing its old classification — a completed
+ * activity keeps rendering as in-progress until reload.
+ *
+ * The copy is shallow and shares `eventList` and `links` with the original, so
+ * the pre-copy reference is left inconsistent and must be treated as dead once
+ * the caller has stored the new one.
+ */
+function withAddedEvent(group: EventGroup, event: WorkflowEvent): EventGroup {
+  const next = cloneEventGroup(group);
+  insertEventById(next.eventList, event);
+  next.timestamp = event.timestamp;
+  addEventToGroup(next, event);
+  clearResolvedPendingState(next);
+  return next;
+}
+
 function growArrays(newSize: number): void {
   if (newSize <= eventSlots.length) return;
   eventSlots.length = newSize;
@@ -293,13 +313,9 @@ function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
   if (!raw || !meta.group) return;
 
   const event = toWorkflowEvent(raw, false);
-  insertEventById(meta.group.eventList, event);
-  meta.group.timestamp = event.timestamp;
-  addEventToGroup(meta.group, event);
+  meta.group = withAddedEvent(meta.group, event);
 
   eventToGroup[followerSlotIdx] = poolIdx + 1;
-
-  clearResolvedPendingState(meta.group);
 
   const followerMs = toMs(event.eventTime);
   if (followerMs > meta.endMs) meta.endMs = followerMs;
@@ -483,7 +499,7 @@ export function processEvent(
   }
 
   // Try both group dispatchers — createWorkflowTaskGroup handles WFT events
-  const group =
+  let group =
     createEventGroup(event as CommonHistoryEvent) ??
     createWorkflowTaskGroup(event as CommonHistoryEvent);
 
@@ -547,6 +563,9 @@ export function processEvent(
       attachFollowerToPool(poolIdx, followerSlotIdx);
     }
     pendingFollowers.delete(slotIdx);
+    // attachFollowerToPool replaced meta.group — re-sync the local ref so the
+    // flushes below, and the group this call publishes, aren't stale.
+    group = meta.group ?? group;
   }
 
   // Flush any followers that arrived before this head via the live poll.
@@ -1001,12 +1020,9 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
 
   if (!isHead) {
     // Option A: head already in a live group — extend it directly.
-    const existing = liveGroups.find((g) => g.id === gid);
-    if (existing) {
-      insertEventById(existing.eventList, event);
-      existing.timestamp = event.timestamp;
-      addEventToGroup(existing, event);
-      clearResolvedPendingState(existing);
+    const existingIdx = liveGroups.findIndex((g) => g.id === gid);
+    if (existingIdx !== -1) {
+      liveGroups[existingIdx] = withAddedEvent(liveGroups[existingIdx], event);
       _liveVersion++;
       invalidateGroupArrayCaches();
       return true;
@@ -1021,10 +1037,7 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
     ) {
       const meta = groupPool[eventToGroup[headSlotIdx] - 1];
       if (meta?.group) {
-        insertEventById(meta.group.eventList, event);
-        meta.group.timestamp = event.timestamp;
-        addEventToGroup(meta.group, event);
-        clearResolvedPendingState(meta.group);
+        meta.group = withAddedEvent(meta.group, event);
         growArraysFor(slotIdx);
         eventToGroup[slotIdx] = eventToGroup[headSlotIdx];
         const followerMs = toMs(event.eventTime);

--- a/tests/integration/timeline-live-completion.spec.ts
+++ b/tests/integration/timeline-live-completion.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  makeActivityCompleted,
+  makeActivityScheduled,
+  makeActivityStarted,
+  makeWorkflowStarted,
+} from '$src/lib/services/test-helpers/synthetic-events';
+import { mockWorkflowApis } from '~/test-utilities/mock-apis';
+import {
+  EVENT_HISTORY_API,
+  EVENT_HISTORY_API_REVERSE,
+} from '~/test-utilities/mocks/event-history';
+import { mockWorkflow } from '~/test-utilities/mocks/workflow';
+
+// Regression for: a running group's timeline bar/label stayed "in progress"
+// after it completed, until reload. The completion arrives via the live poll,
+// which used to extend the group in place — the row pool keys on group identity,
+// so a stable reference meant no re-render. The buffer now copy-on-writes the
+// group, handing the row a fresh reference. The accessible name
+// ("Event <type>: <classification>") is the robust, non-brittle proxy for the
+// recolor — with the bug it stays non-Completed.
+
+const { workflowId, runId } = mockWorkflow.workflowExecutionInfo.execution;
+const timelineUrl = `/namespaces/default/workflows/${workflowId}/${runId}/timeline`;
+
+// Activity scheduled + started, not yet completed.
+const inProgress = [
+  makeWorkflowStarted(1),
+  makeActivityScheduled(2, 'DeployNetwork'),
+  makeActivityStarted(3, 2),
+];
+const completion = makeActivityCompleted(4, 2, 3);
+
+const historyPage = (events: unknown[]) => ({
+  history: { events },
+  rawHistory: [],
+  nextPageToken: null,
+  archived: false,
+});
+
+const runningWorkflow = {
+  ...mockWorkflow,
+  workflowExecutionInfo: {
+    ...mockWorkflow.workflowExecutionInfo,
+    status: 'Running',
+    closeTime: null,
+  },
+  // Keep the activity out of pendingActivities so its in-progress state comes
+  // purely from its classification (Started), isolating the recolor path.
+  pendingActivities: [],
+  pendingChildren: [],
+};
+
+test.describe('Timeline live completion', () => {
+  test('recolors/relabels a group to Completed when the completion arrives live', async ({
+    page,
+  }) => {
+    await mockWorkflowApis(page, runningWorkflow);
+
+    // The stale-color bug only shows once the in-progress bar is already on
+    // screen and the completion then lands on the rendered group. The live poll
+    // starts before the initial fetch, so the completion is held until the test
+    // has observed that state — a fixed delay would race initial render.
+    let releaseCompletion: () => void;
+    const completionHeld = new Promise<void>((resolve) => {
+      releaseCompletion = resolve;
+    });
+
+    // The live poll long-polls the ascending history route with
+    // waitNewEvent=true; deliver the completion on the first such request and
+    // nothing thereafter. The initial (non-waitNewEvent) fetch stays in-progress.
+    let completionDelivered = false;
+    await page.route(EVENT_HISTORY_API, async (route) => {
+      if (route.request().url().includes('waitNewEvent=true')) {
+        if (!completionDelivered) {
+          completionDelivered = true;
+          await completionHeld;
+          return route.fulfill({ json: historyPage([completion]) });
+        }
+        return route.fulfill({ json: historyPage([]) });
+      }
+      return route.fulfill({ json: historyPage(inProgress) });
+    });
+    await page.route(EVENT_HISTORY_API_REVERSE, (route) =>
+      route.fulfill({ json: historyPage([...inProgress].reverse()) }),
+    );
+
+    await page.goto(timelineUrl);
+
+    // Row renders in progress first (Started, not Completed)...
+    const completedButton = page.getByRole('button', {
+      name: 'Event DeployNetwork: Completed',
+    });
+    await expect(
+      page.getByRole('button', { name: /^Event DeployNetwork:/ }),
+    ).toBeVisible();
+    await expect(completedButton).toHaveCount(0);
+
+    // ...then flips to Completed once the live completion arrives — no reload.
+    releaseCompletion();
+    await expect(completedButton).toBeVisible();
+  });
+});


### PR DESCRIPTION
A group's timeline bar and label kept their in-progress color and text after the group completed, until reload.

The row pool reuses a row while its group reference is unchanged (`timeline-graph.svelte:427`), and the buffer extended already-rendered groups in place. The `eventCount` prop still changes, so the new dot gets drawn — but `lineColor` and `accessibleName` derive from `group` alone and never re-derive. When testing by hand, the dot appearing is not evidence the bug is gone.

Three paths now copy the group and publish the new reference:

- the live poll extending a group loaded by the fetch
- the live poll extending a group the poll itself created
- the fetch attaching a follower whose head arrived in an earlier page (histories over 1000 events)

`processEvent` re-syncs its local reference after the pending-follower flush, which can now swap `meta.group`. Unit tests cover each path, plus an integration test asserting the label flips without a reload.

The copy is shallow and shares `eventList`, so a superseded reference must be treated as dead; #3790 removes that sharp edge by deriving groups on read.

https://github.com/user-attachments/assets/c3c6495b-156b-46bc-a943-de6cade30f3c

