### PR TITLE
Standalone Activity fixes

### DIFF
--- a/src/lib/components/activity/activity-reset-confirmation-modal.svelte
+++ b/src/lib/components/activity/activity-reset-confirmation-modal.svelte
@@ -7,10 +7,16 @@
   type Props = {
     open: boolean;
     activityId: string;
+    hideResetHeartbeatOption?: boolean;
     onConfirm: (resetHeartbeat: boolean) => Promise<void>;
   };
 
-  let { open = $bindable(), activityId, onConfirm }: Props = $props();
+  let {
+    hideResetHeartbeatOption = false,
+    open = $bindable(),
+    activityId,
+    onConfirm,
+  }: Props = $props();
 
   let error = $state('');
   let loading = $state(false);
@@ -59,11 +65,13 @@
   {#snippet content()}
     <div class="flex flex-col gap-4">
       <p>{translate('activities.reset-modal-description')}</p>
-      <Checkbox
-        bind:checked={resetHeartbeat}
-        label={translate('activities.reset-heartbeat-details')}
-        data-testid="reset-heartbeat-details"
-      />
+      {#if !hideResetHeartbeatOption}
+        <Checkbox
+          bind:checked={resetHeartbeat}
+          label={translate('activities.reset-heartbeat-details')}
+          data-testid="reset-heartbeat-details"
+        />
+      {/if}
     </div>
   {/snippet}
 </Modal>

--- a/src/lib/components/execution-status.svelte
+++ b/src/lib/components/execution-status.svelte
@@ -89,7 +89,7 @@
       'relative flex items-center gap-0 text-center text-xs leading-4',
       big && 'text-lg',
     )}
-    data-testid={testId || 'workflow-status'}
+    data-testid={testId || 'execution-status'}
   >
     <span
       role={announce ? 'status' : undefined}

--- a/src/lib/components/standalone-activities/activity-actions.svelte
+++ b/src/lib/components/standalone-activities/activity-actions.svelte
@@ -209,6 +209,7 @@
     bind:open={resetConfirmationModalOpen}
     {activityId}
     onConfirm={onConfirmReset}
+    hideResetHeartbeatOption // TODO: remove once API supports resetHeartbeat
   />
   {#key optionsUpdateDrawerOpen}
     <ActivityOptionsUpdateDrawer

--- a/src/lib/components/standalone-activities/activity-actions.svelte
+++ b/src/lib/components/standalone-activities/activity-actions.svelte
@@ -51,7 +51,7 @@
     activityExecutionInfo.status === 'ACTIVITY_EXECUTION_STATUS_RUNNING',
   );
   let isPaused = $derived(
-    activityExecutionInfo.runState === 'PENDING_ACTIVITY_STATE_PAUSED',
+    activityExecutionInfo.status === 'ACTIVITY_EXECUTION_STATUS_PAUSED',
   );
   const commandsDisabled = $derived(standaloneActivityCommandsDisabled(page));
   const writeActionsDisabled = $derived(
@@ -110,7 +110,7 @@
 </script>
 
 <div class="flex items-center gap-2">
-  {#if isRunning}
+  {#if isRunning || isPaused}
     {#if commandsDisabled}
       <Button
         onclick={() => (cancelConfirmationModalOpen = true)}
@@ -137,7 +137,7 @@
       {translate('workflows.more-actions')}
     </MenuButton>
     <Menu id="activity-execution-actions" position="right" class="w-[16rem]">
-      {#if isRunning}
+      {#if isRunning || isPaused}
         {#if !commandsDisabled}
           <MenuItem
             onclick={() => (cancelConfirmationModalOpen = true)}

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -507,7 +507,8 @@ export const resetActivityExecution = async (
         namespace,
         activityId,
         runId,
-        resetHeartbeat,
+        // TODO: re-enable once API supports resetHeartbeat
+        // resetHeartbeat,
         ...(identity && { identity }),
       }),
     },

--- a/src/lib/types/activity-execution.ts
+++ b/src/lib/types/activity-execution.ts
@@ -7,7 +7,8 @@ import type { WorkflowSearchAttributes } from './workflows';
 // string unions of the proto enum keys (not the numeric proto enum). Keying off
 // the generated proto enums ties them to the current API so they can't drift.
 export type ActivityExecutionStatus =
-  keyof typeof import('@temporalio/proto').temporal.api.enums.v1.ActivityExecutionStatus;
+  | keyof typeof import('@temporalio/proto').temporal.api.enums.v1.ActivityExecutionStatus
+  | 'ACTIVITY_EXECUTION_STATUS_PAUSED'; // TODO: Remove ACTIVITY_EXECUTION_STATUS_PAUSED once it is added to the proto enum
 
 export type ActivityIdReusePolicy =
   keyof typeof import('@temporalio/proto').temporal.api.enums.v1.ActivityIdReusePolicy;

--- a/src/lib/utilities/get-activity-status-and-count.ts
+++ b/src/lib/utilities/get-activity-status-and-count.ts
@@ -4,6 +4,7 @@ import { parseRawPayloadToJSON } from '$lib/utilities/decode-payload';
 
 export type ActivityStatus =
   | 'Running'
+  | 'Paused'
   | 'Completed'
   | 'Failed'
   | 'Canceled'
@@ -24,6 +25,7 @@ const executionStatusToActivityStatus: Record<
   ActivityStatus
 > = {
   ACTIVITY_EXECUTION_STATUS_UNSPECIFIED: 'Running',
+  ACTIVITY_EXECUTION_STATUS_PAUSED: 'Paused',
   ACTIVITY_EXECUTION_STATUS_RUNNING: 'Running',
   ACTIVITY_EXECUTION_STATUS_COMPLETED: 'Completed',
   ACTIVITY_EXECUTION_STATUS_FAILED: 'Failed',

--- a/tests/integration/standalone-activity-commands.spec.ts
+++ b/tests/integration/standalone-activity-commands.spec.ts
@@ -91,7 +91,7 @@ test.describe('Standalone Activity Commands', () => {
     await activityCommandsPage.resetMenuItem.click();
 
     await expect(activityCommandsPage.resetModal).toBeVisible();
-    await activityCommandsPage.resetHeartbeatCheckbox.click();
+    // await activityCommandsPage.resetHeartbeatCheckbox.click();
     await activityCommandsPage.resetConfirmButton.click();
 
     await expect(activityCommandsPage.resetModal).toBeHidden();

--- a/tests/integration/standalone-activity-commands.spec.ts
+++ b/tests/integration/standalone-activity-commands.spec.ts
@@ -46,6 +46,7 @@ test.describe('Standalone Activity Commands', () => {
     await activityCommandsPage.goto({ activityId, runId });
 
     await expect(activityCommandsPage.pauseButton).toBeVisible();
+    await expect(activityCommandsPage.activityStatus).toHaveText('Running');
 
     await activityCommandsPage.pauseButton.click();
     await expect(activityCommandsPage.pauseModal).toBeVisible();
@@ -53,6 +54,7 @@ test.describe('Standalone Activity Commands', () => {
     await activityCommandsPage.pauseConfirmButton.click();
 
     await expect(activityCommandsPage.unpauseButton).toBeVisible();
+    await expect(activityCommandsPage.activityStatus).toHaveText('Paused');
   });
 
   test('should unpause a paused activity', async ({ page }) => {
@@ -68,12 +70,14 @@ test.describe('Standalone Activity Commands', () => {
     await activityCommandsPage.goto({ activityId, runId });
 
     await expect(activityCommandsPage.unpauseButton).toBeVisible();
+    await expect(activityCommandsPage.activityStatus).toHaveText('Paused');
 
     await activityCommandsPage.unpauseButton.click();
     await expect(activityCommandsPage.unpauseModal).toBeVisible();
     await activityCommandsPage.unpauseConfirmButton.click();
 
     await expect(activityCommandsPage.pauseButton).toBeVisible();
+    await expect(activityCommandsPage.activityStatus).toHaveText('Running');
   });
 
   test('should reset a running activity', async ({ page }) => {

--- a/tests/integration/workflow-pause.spec.ts
+++ b/tests/integration/workflow-pause.spec.ts
@@ -94,8 +94,8 @@ test.describe('Workflow Pause', () => {
       await mockWorkflowApis(workflowPausePage.page, mockPausedWorkflow);
       await mockNamespaceWithPauseCapability(workflowPausePage.page);
 
-      await expect(workflowPausePage.pausedStatus).toBeVisible();
-      await expect(workflowPausePage.pausedStatus).toContainText('Paused');
+      await expect(workflowPausePage.workflowStatus).toBeVisible();
+      await expect(workflowPausePage.workflowStatus).toContainText('Paused');
     });
 
     test('should show unpause button when workflow is paused', async () => {

--- a/tests/pages/standalone-activity-commands.ts
+++ b/tests/pages/standalone-activity-commands.ts
@@ -2,6 +2,7 @@ import type { Locator, Page } from '@playwright/test';
 
 export class StandaloneActivityCommandsPage {
   readonly page: Page;
+  readonly activityStatus: Locator;
   readonly pauseButton: Locator;
   readonly unpauseButton: Locator;
   readonly moreActionsButton: Locator;
@@ -22,6 +23,7 @@ export class StandaloneActivityCommandsPage {
 
   constructor(page: Page) {
     this.page = page;
+    this.activityStatus = page.getByTestId('execution-status');
     this.pauseButton = page
       .getByRole('button', { name: 'Pause Activity', exact: true })
       .first();

--- a/tests/pages/workflow-pause.ts
+++ b/tests/pages/workflow-pause.ts
@@ -14,7 +14,7 @@ export class WorkflowPausePage {
   readonly unpauseCancelButton: Locator;
   readonly pausedAlert: Locator;
   readonly pausedAlertReason: Locator;
-  readonly pausedStatus: Locator;
+  readonly workflowStatus: Locator;
   readonly moreActionsButton: Locator;
   readonly updateMenuItem: Locator;
   readonly resetMenuItem: Locator;
@@ -56,7 +56,7 @@ export class WorkflowPausePage {
     this.pausedAlertReason = this.pausedAlert.getByText('Reason', {
       exact: true,
     });
-    this.pausedStatus = page.getByTestId('workflow-status');
+    this.workflowStatus = page.getByTestId('execution-status');
     this.moreActionsButton = page.getByRole('button', { name: 'More Actions' });
     this.updateMenuItem = page
       .getByTestId('update-button')

--- a/tests/test-utilities/mocks/activity-execution.ts
+++ b/tests/test-utilities/mocks/activity-execution.ts
@@ -68,6 +68,7 @@ export const mockPausedActivityExecution: ActivityExecution = {
   longPollToken: 'long-poll-token',
   info: {
     ...baseActivityExecutionInfo,
+    status: 'ACTIVITY_EXECUTION_STATUS_PAUSED',
     runState: 'PENDING_ACTIVITY_STATE_PAUSED',
     pauseInfo: {
       manual: {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

* Accounts for `ACTIVITY_EXECUTION_STATUS_PAUSED` status on a Standalone Activity
* Removes `resetHeartbeat` option from the reset modal for a Standalone Activity

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

#### Run temporal server from a local build
1. Ensure you have cloned the [temporal](https://github.com/temporalio/temporal) repo
1. Make sure [EnableStandaloneActivityOperatorCommands](https://github.com/temporalio/temporal/blob/91fa0ba8c8156ab4317f3ccb0920d16569c4f87a/chasm/lib/activity/config.go#L43) is set to `true`
1. Run `make bins` and `make start`
1. Running temporal server from a local build does not create the namespace, run `temporal operator namespace create --namespace default`

#### Run the UI against a local build of temporal server
1. Checkout the `fix/activity-paused` branch in the UI repo 
1. `cd server/ && make build` 
1. `cd .. && pnpm dev:local-temporal`

------

Go to a running Standalone Activity > select Pause Activity
   - [ ] Verify status is updated to "Paused"
   - [ ] Verify "Unpause Activity" button is visible
 
Select Unpause Activity
   - [ ] Verify status is updated to "Running"
   - [ ] Verify "Pause Activity" button is visible

Go to a running Standalone Activity > select Reset
   - [ ] Verify "Reset Heartbeat Details" is not visible
   - [ ] Verify reset works as expected

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
