### PR TITLE
Resolve deployment compute config from routed version summaries

### DIFF
--- a/src/lib/utilities/deployment-has-compute-config.test.ts
+++ b/src/lib/utilities/deployment-has-compute-config.test.ts
@@ -96,4 +96,145 @@ describe('deploymentHasComputeConfig', () => {
       }),
     ).toBe(false);
   });
+
+  // DescribeWorkerDeployment only returns versionSummaries + routingConfig.
+  it('returns true when the routed current version summary has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        currentVersionSummary: undefined,
+        routingConfig: {
+          currentDeploymentVersion: {
+            deploymentName: 'loan-underwriting-app',
+            buildId: 'build-1',
+          },
+        },
+        versionSummaries: [
+          {
+            version: 'loan-underwriting-app.build-1',
+            deploymentVersion: {
+              deploymentName: 'loan-underwriting-app',
+              buildId: 'build-1',
+            },
+            createTime: undefined,
+            computeConfig,
+          },
+        ],
+      } as unknown as WorkerDeploymentInfo),
+    ).toBe(true);
+  });
+
+  it('returns true when the routed ramping version summary has a compute config', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        currentVersionSummary: undefined,
+        routingConfig: {
+          rampingDeploymentVersion: {
+            deploymentName: 'loan-underwriting-app',
+            buildId: 'build-2',
+          },
+        },
+        versionSummaries: [
+          {
+            version: 'loan-underwriting-app.build-2',
+            deploymentVersion: {
+              deploymentName: 'loan-underwriting-app',
+              buildId: 'build-2',
+            },
+            createTime: undefined,
+            computeConfig,
+          },
+        ],
+      } as unknown as WorkerDeploymentInfo),
+    ).toBe(true);
+  });
+
+  // Verbatim DescribeWorkerDeployment payload from Temporal Cloud. Note that it
+  // carries no currentVersionSummary at all — compute config only ever arrives
+  // on versionSummaries, linked by routingConfig.currentDeploymentVersion.
+  it('returns true for a real cloud describe response', () => {
+    const cloudResponse = {
+      name: 'test',
+      versionSummaries: [
+        {
+          version: 'test.62a8974f-86fe-4a77-a308-148beed6a67d',
+          status: 'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+          deploymentVersion: {
+            buildId: '62a8974f-86fe-4a77-a308-148beed6a67d',
+            deploymentName: 'test',
+          },
+          createTime: '2026-07-08T15:36:00.023495719Z',
+          currentSinceTime: '2026-07-08T15:36:01.475175109Z',
+          routingUpdateTime: '2026-07-08T15:36:01.475175109Z',
+          firstActivationTime: '2026-07-08T15:36:01.475175109Z',
+          lastCurrentTime: '2026-07-08T15:36:01.475175109Z',
+          computeConfig: {
+            scalingGroups: {
+              default: {
+                taskQueueTypes: [
+                  'TASK_QUEUE_TYPE_WORKFLOW',
+                  'TASK_QUEUE_TYPE_ACTIVITY',
+                ],
+                providerType: 'aws-lambda',
+              },
+            },
+          },
+          computeStatus: {
+            providerValidation: {
+              lastCheckTime: '2026-08-04T18:54:10.136859273Z',
+            },
+          },
+        },
+      ],
+      createTime: '2026-07-08T15:35:58.120242067Z',
+      routingConfig: {
+        currentDeploymentVersion: {
+          buildId: '62a8974f-86fe-4a77-a308-148beed6a67d',
+          deploymentName: 'test',
+        },
+        currentVersion: 'test.62a8974f-86fe-4a77-a308-148beed6a67d',
+        currentVersionChangedTime: '2026-07-08T15:36:01.475175109Z',
+        revisionNumber: '1',
+      },
+      routingConfigUpdateState: 'ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS',
+    } as unknown as WorkerDeploymentInfo;
+
+    expect(cloudResponse.currentVersionSummary).toBeUndefined();
+    expect(deploymentHasComputeConfig(cloudResponse)).toBe(true);
+  });
+
+  it('ignores compute configs on version summaries that are not routed to', () => {
+    expect(
+      deploymentHasComputeConfig({
+        ...baseDeployment,
+        currentVersionSummary: undefined,
+        routingConfig: {
+          currentDeploymentVersion: {
+            deploymentName: 'loan-underwriting-app',
+            buildId: 'build-1',
+          },
+        },
+        versionSummaries: [
+          {
+            version: 'loan-underwriting-app.build-1',
+            deploymentVersion: {
+              deploymentName: 'loan-underwriting-app',
+              buildId: 'build-1',
+            },
+            createTime: undefined,
+          },
+          {
+            version: 'loan-underwriting-app.build-0',
+            deploymentVersion: {
+              deploymentName: 'loan-underwriting-app',
+              buildId: 'build-0',
+            },
+            createTime: undefined,
+            computeConfig,
+          },
+        ],
+      } as unknown as WorkerDeploymentInfo),
+    ).toBe(false);
+  });
 });

--- a/src/lib/utilities/deployment-has-compute-config.ts
+++ b/src/lib/utilities/deployment-has-compute-config.ts
@@ -1,10 +1,54 @@
-import type {
-  ComputeConfig,
-  WorkerDeploymentInfo,
+import {
+  type ComputeConfig,
+  isVersionSummaryNew,
+  type RoutingConfig,
+  type VersionSummary,
+  type WorkerDeploymentInfo,
+  type WorkerDeploymentVersion,
 } from '$lib/types/deployments';
+
+import {
+  getBuildIdFromVersion,
+  getDeploymentFromVersion,
+} from './get-deployment-build-id';
 
 const hasScalingGroups = (config?: ComputeConfig): boolean =>
   Object.keys(config?.scalingGroups ?? {}).length > 0;
+
+const matchesVersion = (
+  summary: VersionSummary,
+  version: WorkerDeploymentVersion | undefined,
+): boolean => {
+  if (!version) return false;
+
+  const deploymentName = isVersionSummaryNew(summary)
+    ? summary.deploymentVersion.deploymentName
+    : getDeploymentFromVersion(summary.version);
+  const buildId = isVersionSummaryNew(summary)
+    ? summary.deploymentVersion.buildId
+    : getBuildIdFromVersion(summary.version);
+
+  return (
+    deploymentName === version.deploymentName && buildId === version.buildId
+  );
+};
+
+// DescribeWorkerDeployment does not return current/ramping version summaries —
+// those only exist on ListWorkerDeployments — so the active versions have to be
+// resolved out of versionSummaries using the routing config.
+const activeVersionComputeConfigs = (
+  versionSummaries: VersionSummary[] = [],
+  routingConfig: RoutingConfig = {},
+): (ComputeConfig | undefined)[] =>
+  versionSummaries
+    .filter(
+      (summary) =>
+        matchesVersion(summary, routingConfig.currentDeploymentVersion) ||
+        matchesVersion(summary, routingConfig.rampingDeploymentVersion),
+    )
+    .map((summary) =>
+      isVersionSummaryNew(summary) ? summary.computeConfig : undefined,
+    );
 
 export const deploymentHasComputeConfig = (
   deployment?: WorkerDeploymentInfo,
@@ -15,5 +59,9 @@ export const deploymentHasComputeConfig = (
     deployment.computeConfig,
     deployment.currentVersionSummary?.computeConfig,
     deployment.rampingVersionSummary?.computeConfig,
+    ...activeVersionComputeConfigs(
+      deployment.versionSummaries,
+      deployment.routingConfig,
+    ),
   ].some(hasScalingGroups);
 };


### PR DESCRIPTION
## Description & motivation 💭

Follow-up to #3779, which added `hasComputeConfig` wrappers to hide serverless-only actions on the deployment page. The value is always `false` in Cloud, so **"Create new version" and "Ramp to unversioned" are hidden for every deployment**, including ones that do have scaling groups.

`deploymentHasComputeConfig` checked three fields:

```ts
deployment.computeConfig
deployment.currentVersionSummary?.computeConfig
deployment.rampingVersionSummary?.computeConfig
```

None of them exist on the `DescribeWorkerDeployment` response. `WorkerDeploymentInfo` ([message.proto:184-212](https://github.com/temporalio/api/blob/master/temporal/api/deployment/v1/message.proto)) carries only `name`, `version_summaries`, `create_time`, `routing_config`, `last_modifier_identity`, `manager_identity`, `routing_config_update_state`.

`current_version_summary` / `ramping_version_summary` / `latest_version_summary` are fields on **`ListWorkerDeployments`**' `WorkerDeploymentSummary` (`request_response.proto:2333-2343`). They leak onto the describe type through `WorkerDeploymentInfo extends WorkerDeploymentSummary` (`types/deployments.ts:84`, in place since #2576), so they type-check against a payload the server never sends them in. The list page uses them correctly — `deployment-table-row.svelte:81` is a real list row.

An actual Cloud describe response — compute config is present, just on `versionSummaries`, with no `currentVersionSummary` key anywhere:

```json
{
  "workerDeploymentInfo": {
    "name": "test",
    "versionSummaries": [
      {
        "deploymentVersion": { "buildId": "62a8974f-…", "deploymentName": "test" },
        "status": "WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT",
        "computeConfig": { "scalingGroups": { "default": { "providerType": "aws-lambda" } } }
      }
    ],
    "routingConfig": {
      "currentDeploymentVersion": { "buildId": "62a8974f-…", "deploymentName": "test" }
    }
  }
}
```

### Fix

Resolve the current and ramping summaries out of `versionSummaries` via `routingConfig`, matching on `deploymentName` + `buildId` the same way `version-table-row.svelte:91-97` already does. `lock-compute-provider.ts:48` also walks `versionSummaries` — this brings the two helpers in line.

The three old summary fields stay in the check so list-shaped input keeps working, and #3779's "ignore inactive versions" intent is preserved: compute config on a version that isn't routed to still returns `false`.

## Testing 🧪

### How was this tested 👻

- [x] Unit tests added

The verbatim Cloud payload above is now a regression fixture. Verified it fails on the old helper (`expected false to be true`) and passes on the new one, so the test is doing real work.

- `deployment-has-compute-config.test.ts` — 11 pass (4 new: real Cloud payload, routed current, routed ramping, non-routed ignored)
- `deployment.svelte.test.ts` — 4 pass
- Deployments/workers component suites — 60 pass
- `pnpm check` — 38 errors, all pre-existing `Cannot find module 'storybook/test'` resolution failures, none in touched files

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Open a Cloud worker deployment whose current version has a compute config. "Create new version" should appear next to More Actions, and "Ramp to unversioned" should be in the menu. On a self-hosted deployment with no scaling groups, both stay hidden.

## Checklists

### Merge Checklist

- [ ] Needs a repack into cloud-ui to land there (`.ui-sha` is currently `96a06250`)

### Follow-up (not in this PR)

`WorkerDeploymentInfo extends WorkerDeploymentSummary` is what let this through — the describe type advertises three fields the endpoint never returns. Splitting them would prevent a repeat, but it ripples into `lock-compute-provider.ts` and `deployment-table-row.svelte`, so it felt wrong to bundle with a fix.

Also unverified: top-level `deployment.computeConfig` (`types/deployments.ts:86`) isn't on either OSS message. Left in place as harmless, but I found nothing that populates it.

## Docs

### Any docs updates needed?

No.


## Blast radius 🔍

`deploymentHasComputeConfig` has two consumers, and both read a describe response, so both were broken:

1. **`deployment.svelte:133`** — the deployment page. The reported bug.
2. **`no-workers-polling-alert.svelte:42`** — also fixed as a side effect, and this one is user-visible on **workflow** pages. `serverlessDeployment` was always `false` in Cloud, so it always fell through to the `{:else}` generic "no workers polling" warning. Cloud deployments with routed compute config now correctly get the serverless info alert with the "View worker deployment" link. Intended behavior for that component, but worth a look since it's outside #3779's stated scope. Note it has no test file.

**The deployments list page is not affected.** It never calls this helper — `deployment-table-row.svelte:80-82` reads `currentVersionSummary?.computeConfig?.scalingGroups` directly off a `WorkerDeploymentSummary` from `ListWorkerDeployments`, where that field really does exist.

The change is additive-only: entries appended to the existing `.some()` array, three original checks untouched and evaluated first. It can only flip `false → true`, so nothing that previously rendered can stop rendering.

Full suite: 2573 pass, 13 fail — all 13 are pre-existing timezone-dependent date/time tests that fail identically on `main` (verified), none deployment-related.
