### PR TITLE
[DT-4312] Link Standalone Nexus Operation handler target to the target Standalone Activity

### DIFF
--- a/src/lib/i18n/locales/en/standalone-nexus-operations.ts
+++ b/src/lib/i18n/locales/en/standalone-nexus-operations.ts
@@ -76,8 +76,6 @@ export const Strings = {
   'endpoint-name': 'Endpoint Name',
   'service-name': 'Service Name',
   'operation-name': 'Operation Name',
-  'handler-namespace': 'Handler Namespace',
-  'handler-operation-link': 'Handler Operation Link',
   'handler-namespace-note':
     'Note: Links will only work if your account has access permissions to the handler namespace.',
   'request-cancellation': 'Request Cancellation',

--- a/src/lib/pages/standalone-nexus-operation-details.svelte
+++ b/src/lib/pages/standalone-nexus-operation-details.svelte
@@ -10,7 +10,10 @@
   import Card from '$lib/holocene/card.svelte';
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { toEventLinkView } from '$lib/utilities/event-link';
+  import {
+    eventLinkTargetTypeLabel,
+    toEventLinkView,
+  } from '$lib/utilities/event-link';
   import { formatDurationAbbreviated } from '$lib/utilities/format-time';
   import { routeForStandaloneNexusOperationsWithQuery } from '$lib/utilities/route-for';
   import { toNexusOperationCancellationStateReadable } from '$lib/utilities/screaming-enums';
@@ -37,6 +40,16 @@
       : null,
   );
   const handlerNamespace = $derived(handlerLink?.namespace ?? null);
+  const handlerTargetType = $derived(
+    handlerLink ? eventLinkTargetTypeLabel(handlerLink.variant) : undefined,
+  );
+  const operationDetailsRowCount = $derived(
+    4 +
+      (info?.blockedReason ? 1 : 0) +
+      (handlerLink ? 1 : 0) +
+      (handlerTargetType ? 1 : 0) +
+      (handlerNamespace ? 1 : 0),
+  );
 
   const endpointFilterLink = $derived(
     info
@@ -146,7 +159,7 @@
         </p>
       {/if}
       <DetailList
-        rowCount={6}
+        rowCount={operationDetailsRowCount}
         aria-label={translate(
           'standalone-nexus-operations.operation-details-section',
         )}
@@ -211,27 +224,8 @@
           >
           <DetailListTextValue text={info.blockedReason} />
         {/if}
-        {#if handlerNamespace}
-          <DetailListLabel
-            >{translate(
-              'standalone-nexus-operations.handler-namespace',
-            )}</DetailListLabel
-          >
-          {#if handlerNamespace.href}
-            <DetailListLinkValue
-              text={handlerNamespace.value}
-              href={handlerNamespace.href}
-            />
-          {:else}
-            <DetailListTextValue text={handlerNamespace.value} />
-          {/if}
-        {/if}
         {#if handlerLink}
-          <DetailListLabel
-            >{translate(
-              'standalone-nexus-operations.handler-operation-link',
-            )}</DetailListLabel
-          >
+          <DetailListLabel>{translate('nexus.handler-target')}</DetailListLabel>
           {#if handlerLink.href}
             <DetailListLinkValue
               text={handlerLink.value}
@@ -239,6 +233,25 @@
             />
           {:else}
             <DetailListTextValue text={handlerLink.value} />
+          {/if}
+          {#if handlerTargetType}
+            <DetailListLabel
+              >{translate('nexus.handler-target-type')}</DetailListLabel
+            >
+            <DetailListTextValue text={handlerTargetType} />
+          {/if}
+          {#if handlerNamespace}
+            <DetailListLabel
+              >{translate('nexus.handler-namespace')}</DetailListLabel
+            >
+            {#if handlerNamespace.href}
+              <DetailListLinkValue
+                text={handlerNamespace.value}
+                href={handlerNamespace.href}
+              />
+            {:else}
+              <DetailListTextValue text={handlerNamespace.value} />
+            {/if}
           {/if}
         {/if}
       </DetailList>

--- a/src/lib/utilities/event-link.test.ts
+++ b/src/lib/utilities/event-link.test.ts
@@ -151,7 +151,13 @@ describe('toEventLinkView', () => {
       label: 'Standalone Activity Link',
       value: 'activity-1',
       href: `${base}/namespaces/test-ns/activities/activity-1/run-1/details`,
+      namespace: {
+        label: 'Namespace Link',
+        value: 'test-ns',
+        href: `${base}/namespaces/test-ns`,
+      },
     });
+    expect(eventLinkTargetTypeLabel(view.variant)).toBe('Standalone Activity');
   });
 
   it('returns a batch operation route when namespace context is available', () => {


### PR DESCRIPTION
## Summary

On the Standalone Nexus Operation detail page, the handler section now deep-links to the Standalone Activity started by the operation when the handler target is an SAA. This mirrors the DT-4310 handler-target pattern: the two hardcoded handler rows (Handler Namespace / Handler Operation Link) are replaced with Handler Target / Handler Target Type / Handler Namespace, derived from the operation's first link via the shared event-link utility and `eventLinkTargetTypeLabel`. Applied uniformly, so workflow-target operations render the same structured rows with Target Type "Workflow". Reuses the shared `nexus.*` i18n added by DT-4310; the two now-orphaned `standalone-nexus-operations` keys are removed.

## Jira

https://temporalio.atlassian.net/browse/DT-4312

## Test plan

- [ ] SANO detail page Handler Target deep-links to the target SAA when target type is Standalone Activity
- [ ] Handler Target Type reads "Standalone Activity"; labels use "Standalone Activity Link" / "Namespace Link"
- [ ] Workflow-target SANO still renders correctly (Handler Target Type: Workflow)
