### PR TITLE
[DT-4313] Extend SAA detail Nexus Callback banner to link back to the caller SANO

### DIFF
--- a/src/lib/utilities/event-link.test.ts
+++ b/src/lib/utilities/event-link.test.ts
@@ -137,6 +137,31 @@ describe('toEventLinkView', () => {
     });
   });
 
+  it('uses caller labels for a Nexus operation in the caller perspective', () => {
+    const view = toEventLinkView(
+      {
+        nexusOperation: {
+          namespace: 'caller-ns',
+          operationId: 'operation-1',
+          runId: 'run-1',
+        },
+      },
+      { perspective: 'caller' },
+    );
+
+    expect(view).toMatchObject({
+      variant: 'nexusOperation',
+      label: 'Caller Event',
+      value: 'operation-1',
+      href: `${base}/namespaces/caller-ns/nexus-operations/operation-1/run-1/details`,
+      namespace: {
+        label: 'Caller Namespace',
+        value: 'caller-ns',
+        href: `${base}/namespaces/caller-ns`,
+      },
+    });
+  });
+
   it('returns a standalone activity route', () => {
     const view = toEventLinkView({
       activity: {

--- a/src/lib/utilities/event-link.ts
+++ b/src/lib/utilities/event-link.ts
@@ -48,7 +48,9 @@ const workflowValueFromHref = (href: string, fallback: string): string => {
 
 const namespaceDisplay = (
   namespace: string | null | undefined,
-  labelKey: 'nexus.namespace-link' | 'nexus.caller-namespace' = 'nexus.namespace-link',
+  labelKey:
+    | 'nexus.namespace-link'
+    | 'nexus.caller-namespace' = 'nexus.namespace-link',
 ): EventLinkDisplay | undefined => {
   if (!isPresent(namespace)) return undefined;
 
@@ -64,7 +66,9 @@ const eventDisplay = (
   eventType: unknown,
   eventId?: unknown,
   requestId?: string | null,
-  labelKey: 'nexus.handler-event' | 'nexus.caller-event' = 'nexus.handler-event',
+  labelKey:
+    | 'nexus.handler-event'
+    | 'nexus.caller-event' = 'nexus.handler-event',
 ): EventLinkDisplay | undefined => {
   if (eventId === undefined && !requestId && !eventType) {
     return undefined;
@@ -172,7 +176,9 @@ export const toEventLinkView = (
     return {
       variant: 'workflowEvent',
       key: `workflowEvent:${namespace ?? ''}:${workflow ?? ''}:${run ?? ''}:${workflowEvent.eventRef?.eventId ?? workflowEvent.requestIdRef?.requestId ?? index ?? ''}`,
-      label: translate(caller ? 'nexus.caller-workflow' : 'nexus.workflow-link'),
+      label: translate(
+        caller ? 'nexus.caller-workflow' : 'nexus.workflow-link',
+      ),
       value,
       href,
       namespace: namespaceDisplay(
@@ -235,14 +241,21 @@ export const toEventLinkView = (
         })
       : undefined;
 
+    const caller = context.perspective === 'caller';
+
     return {
       variant: 'nexusOperation',
       key: `nexusOperation:${namespace ?? ''}:${operationId ?? ''}:${runId ?? ''}:${index ?? ''}`,
-      label: translate('nexus.standalone-nexus-operation-link'),
+      label: translate(
+        caller ? 'nexus.caller-event' : 'nexus.standalone-nexus-operation-link',
+      ),
       value:
         operationId || runId || namespace || translate('nexus.nexus-operation'),
       href,
-      namespace: namespaceDisplay(namespace),
+      namespace: namespaceDisplay(
+        namespace,
+        caller ? 'nexus.caller-namespace' : 'nexus.namespace-link',
+      ),
     };
   }
 


### PR DESCRIPTION
## Summary

Extends the SAA-detail Nexus Callback banner (from DT-4311) so that when the Standalone Activity was invoked by a Standalone Nexus Operation rather than an in-workflow operation, the caller-perspective link resolves to the caller SANO: `Caller Event` links to the caller SANO detail page and `Caller Namespace` to its namespace. The only change is in the `nexusOperation` branch of `toEventLinkView`, which becomes caller-perspective-aware (Caller Event / Caller Namespace labels); its `href` already targets the SANO detail page and the banner's existing caller fallback renders it, so no banner or SAA-page change is needed. The workflow-invoked case (`workflowEvent` link) is untouched and still resolves to the workflow event child page. The correct caller primitive follows from which `EventLink` union branch fires, so no explicit source-type switch is required.

## Jira

https://temporalio.atlassian.net/browse/DT-4313

## Test plan

- [ ] SANO-invoked SAA: Caller Event links to the caller SANO detail page, Caller Namespace to its namespace
- [ ] Workflow-invoked SAA still resolves Caller Event to the workflow event child page (no regression)
- [ ] Verify describe-activity callback links carry a nexusOperation link for a SANO-invoked SAA
