### PR TITLE
Split worker deployment API response types

### DIFF
--- a/src/lib/components/deployments/deployment-client-test-runner-entry.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner-entry.ts
@@ -9,7 +9,7 @@ import resources from '$lib/i18n/locales';
 import Deployment from '$lib/pages/deployment.svelte';
 import type {
   ComputeStatus,
-  WorkerDeploymentSummary,
+  ListWorkerDeployment,
 } from '$lib/types/deployments';
 
 import { resetDeploymentsServiceMock } from './deployments-service-client-test-double';
@@ -118,7 +118,7 @@ export function renderRows({
 function deployment(
   name: string,
   computeStatus: ComputeStatus,
-): WorkerDeploymentSummary {
+): ListWorkerDeployment {
   return {
     name,
     createTime: msNumberToTs(1_000),

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -15,7 +15,7 @@
     fetchDeployment,
   } from '$lib/services/deployments-service';
   import type { ConfigurableTableHeader } from '$lib/stores/configurable-table-columns';
-  import type { WorkerDeploymentSummary } from '$lib/types/deployments';
+  import type { ListWorkerDeployment } from '$lib/types/deployments';
   import { parseVersionStatus } from '$lib/utilities/deployments';
   import {
     routeForWorkerDeployment,
@@ -27,7 +27,7 @@
   import DeploymentStatus from './deployment-status.svelte';
 
   interface Props {
-    deployment: WorkerDeploymentSummary;
+    deployment: ListWorkerDeployment;
     columns: ConfigurableTableHeader[];
     showConnectionStatus?: boolean;
     onChange?: () => void;

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -17,7 +17,7 @@
     removeRampingUnversionedWorkers,
     setRampingUnversionedWorkers,
   } from '$lib/services/deployments-service';
-  import type { WorkerDeploymentResponse } from '$lib/types/deployments';
+  import type { DescribeWorkerDeploymentResponse } from '$lib/types/deployments';
   import { deploymentHasComputeConfig } from '$lib/utilities/deployment-has-compute-config';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
@@ -45,7 +45,7 @@
   });
   let refreshedDeployment = $state.raw<{
     route: typeof deploymentRoute;
-    deployment: WorkerDeploymentResponse;
+    deployment: DescribeWorkerDeploymentResponse;
   }>();
   let refreshError = $state.raw<{
     route: typeof deploymentRoute;

--- a/src/lib/pages/deployment.svelte.test.ts
+++ b/src/lib/pages/deployment.svelte.test.ts
@@ -13,28 +13,24 @@ import {
   closeDeploymentClientTestRunner,
   getDeploymentClientTestRunner,
 } from '$lib/components/deployments/deployment-client-test-runner';
-import type { WorkerDeploymentResponse } from '$lib/types/deployments';
+import type { DescribeWorkerDeploymentResponse } from '$lib/types/deployments';
 
 const deployment = {
   conflictToken: 'token',
   workerDeploymentInfo: {
     name: 'deployment',
+    createTime: '',
     routingConfig: {
       currentDeploymentVersion: {
         deploymentName: 'deployment',
         buildId: 'build-id',
       },
     },
-    currentVersionSummary: {
-      version: 'deployment.build-id',
-      computeConfig: {
-        scalingGroups: { default: { providerType: 'aws-lambda' } },
-      },
-    },
     lastModifierIdentity: 'test',
     versionSummaries: [
       {
         version: 'deployment.build-id',
+        createTime: '',
         deploymentVersion: {
           deploymentName: 'deployment',
           buildId: 'build-id',
@@ -45,25 +41,44 @@ const deployment = {
         },
         computeStatus: {
           providerValidation: {
-            lastCheckTime: { seconds: 1, nanos: 0 },
+            lastCheckTime: '2026-08-04T18:54:10.136859273Z',
           },
         },
       },
     ],
   },
-} as unknown as WorkerDeploymentResponse;
+} satisfies DescribeWorkerDeploymentResponse;
 
 const selfHostedDeployment = {
-  ...deployment,
+  conflictToken: 'token',
   workerDeploymentInfo: {
-    ...deployment.workerDeploymentInfo,
+    name: 'deployment',
+    createTime: '',
+    routingConfig: {
+      currentDeploymentVersion: {
+        deploymentName: 'deployment',
+        buildId: 'build-id',
+      },
+    },
+    lastModifierIdentity: 'test',
     versionSummaries: [
       {
-        ...deployment.workerDeploymentInfo.versionSummaries[0],
-        computeConfig: undefined,
+        version: 'deployment.build-id',
+        createTime: '',
+        deploymentVersion: {
+          deploymentName: 'deployment',
+          buildId: 'build-id',
+        },
+        status: 'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+        computeStatus: {
+          providerValidation: {
+            lastCheckTime: '2026-08-04T18:54:10.136859273Z',
+          },
+        },
       },
       {
         version: 'deployment.build-id-2',
+        createTime: '',
         deploymentVersion: {
           deploymentName: 'deployment',
           buildId: 'build-id-2',
@@ -72,11 +87,8 @@ const selfHostedDeployment = {
         computeConfig: { scalingGroups: {} },
       },
     ],
-    currentVersionSummary: {
-      version: 'deployment.build-id',
-    },
   },
-} as unknown as WorkerDeploymentResponse;
+} satisfies DescribeWorkerDeploymentResponse;
 
 function menuItems(menu: Element | null) {
   return Array.from(menu?.querySelectorAll('[role="menuitem"]') ?? []).map(

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -6,9 +6,9 @@ import type {
   CreateWorkerDeploymentVersionRequest,
   DeploymentParameters,
   DeploymentVersionParameters,
+  DescribeWorkerDeploymentResponse,
+  ListWorkerDeployment,
   ListWorkerDeploymentsResponse,
-  WorkerDeploymentResponse,
-  WorkerDeploymentSummary,
   WorkerDeploymentVersionResponse,
 } from '$lib/types/deployments';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
@@ -19,21 +19,18 @@ import { routeForApi } from '$lib/utilities/route-for-api';
 type PaginatedDeploymentsPromise = (
   pageSize: number,
   token: string,
-) => Promise<{ items: WorkerDeploymentSummary[]; nextPageToken: string }>;
+) => Promise<{ items: ListWorkerDeployment[]; nextPageToken: string }>;
 
-const emptyVersionSummary = { version: '', createTime: {} };
-
-const emptyWorkerDeploymentResponse: WorkerDeploymentResponse = {
+const emptyWorkerDeploymentResponse = {
   conflictToken: '',
   workerDeploymentInfo: {
     name: '',
     createTime: {},
     routingConfig: {},
-    currentVersionSummary: emptyVersionSummary,
     lastModifierIdentity: '',
     versionSummaries: [],
   },
-};
+} satisfies DescribeWorkerDeploymentResponse;
 
 const emptyWorkerDeploymentVersionResponse: WorkerDeploymentVersionResponse = {
   workerDeploymentVersionInfo: {
@@ -108,9 +105,9 @@ export const fetchDeployment = async (
   onError?: ErrorCallback,
   notifyOnError = true,
   signal?: AbortSignal,
-): Promise<WorkerDeploymentResponse> => {
+): Promise<DescribeWorkerDeploymentResponse> => {
   const route = routeForApi('worker-deployment', parameters);
-  return requestFromAPI<WorkerDeploymentResponse>(route, {
+  return requestFromAPI<DescribeWorkerDeploymentResponse>(route, {
     request,
     onError,
     notifyOnError,

--- a/src/lib/types/deployments.ts
+++ b/src/lib/types/deployments.ts
@@ -1,5 +1,7 @@
 import type { Timestamp } from '@temporalio/common';
 
+type ApiTimestamp = Timestamp | string;
+
 export interface DeploymentParameters {
   namespace: string;
   deploymentName: string;
@@ -20,23 +22,25 @@ export interface RoutingConfig {
   rampingVersion?: string;
   rampingDeploymentVersion?: WorkerDeploymentVersion;
   rampingVersionPercentage?: number;
-  currentVersionChangedTime?: Timestamp;
-  rampingVersionChangedTime?: Timestamp;
-  rampingVersionPercentageChangedTime?: Timestamp;
+  currentVersionChangedTime?: ApiTimestamp;
+  rampingVersionChangedTime?: ApiTimestamp;
+  rampingVersionPercentageChangedTime?: ApiTimestamp;
+  revisionNumber?: string;
 }
 
-export interface WorkerDeploymentSummary {
+/** A deployment returned by ListWorkerDeployments. */
+export interface ListWorkerDeployment {
   name: string;
-  createTime: Timestamp;
+  createTime: ApiTimestamp;
   routingConfig: RoutingConfig;
   latestVersionSummary?: VersionSummaryNew;
-  currentVersionSummary: VersionSummaryNew;
+  currentVersionSummary?: VersionSummaryNew;
   rampingVersionSummary?: VersionSummaryNew;
 }
 
 export interface ListWorkerDeploymentsResponse {
   nextPageToken: string;
-  workerDeployments: WorkerDeploymentSummary[];
+  workerDeployments: ListWorkerDeployment[];
 }
 
 export function isVersionSummaryNew(
@@ -52,13 +56,13 @@ export function isVersionSummaryNew(
 export type VersionSummary = VersionSummaryOld | VersionSummaryNew;
 export interface VersionSummaryOld {
   version: string;
-  createTime: Timestamp;
+  createTime: ApiTimestamp;
   drainageStatus: string;
 }
 
 export interface ProviderValidation {
   errorMessage?: string;
-  lastCheckTime?: Timestamp;
+  lastCheckTime?: ApiTimestamp;
 }
 
 export interface ComputeStatus {
@@ -70,29 +74,34 @@ export interface VersionSummaryNew {
   status?: string;
   drainageStatus?: string;
   deploymentVersion?: WorkerDeploymentVersion;
-  createTime: Timestamp;
+  createTime: ApiTimestamp;
   drainageInfo?: {
-    lastChangedTime?: Timestamp;
-    lastCheckedTime?: Timestamp;
+    lastChangedTime?: ApiTimestamp;
+    lastCheckedTime?: ApiTimestamp;
   };
-  currentSinceTime?: Timestamp;
-  rampingSinceTime?: Timestamp;
-  routingUpdateTime?: Timestamp;
-  firstActivationTime?: Timestamp;
-  lastDeactivationTime?: Timestamp;
+  currentSinceTime?: ApiTimestamp;
+  rampingSinceTime?: ApiTimestamp;
+  routingUpdateTime?: ApiTimestamp;
+  firstActivationTime?: ApiTimestamp;
+  lastDeactivationTime?: ApiTimestamp;
+  lastCurrentTime?: ApiTimestamp;
   computeConfig?: ComputeConfig;
   computeStatus?: ComputeStatus;
 }
 
-export interface WorkerDeploymentInfo extends WorkerDeploymentSummary {
-  lastModifierIdentity: string;
+/** A deployment returned by DescribeWorkerDeployment. */
+export interface DescribeWorkerDeployment {
+  name: string;
+  createTime: ApiTimestamp;
+  routingConfig: RoutingConfig;
+  lastModifierIdentity?: string;
   versionSummaries: VersionSummary[];
-  computeConfig?: ComputeConfig;
+  routingConfigUpdateState?: string;
 }
 
-export interface WorkerDeploymentResponse {
+export interface DescribeWorkerDeploymentResponse {
   conflictToken: string;
-  workerDeploymentInfo: WorkerDeploymentInfo;
+  workerDeploymentInfo: DescribeWorkerDeployment;
 }
 
 export interface TaskQueueInfo {

--- a/src/lib/utilities/deployment-has-compute-config.test.ts
+++ b/src/lib/utilities/deployment-has-compute-config.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import type {
   ComputeConfig,
-  WorkerDeploymentInfo,
+  DescribeWorkerDeployment,
+  ListWorkerDeployment,
 } from '$lib/types/deployments';
 
 import { deploymentHasComputeConfig } from './deployment-has-compute-config';
@@ -16,17 +17,22 @@ const computeConfig: ComputeConfig = {
   },
 };
 
-const baseDeployment = {
+const baseDescribe = {
   name: 'loan-underwriting-app',
-  createTime: undefined,
+  createTime: '',
   routingConfig: {},
-  lastModifierIdentity: 'test',
   versionSummaries: [],
+} satisfies DescribeWorkerDeployment;
+
+const baseList = {
+  name: 'loan-underwriting-app',
+  createTime: '',
+  routingConfig: {},
   currentVersionSummary: {
     version: 'loan-underwriting-app.build-1',
-    createTime: undefined,
+    createTime: '',
   },
-} as unknown as WorkerDeploymentInfo;
+} satisfies ListWorkerDeployment;
 
 describe('deploymentHasComputeConfig', () => {
   it('returns false for undefined deployment', () => {
@@ -34,62 +40,52 @@ describe('deploymentHasComputeConfig', () => {
   });
 
   it('returns false when no compute config exists', () => {
-    expect(deploymentHasComputeConfig(baseDeployment)).toBe(false);
+    expect(deploymentHasComputeConfig(baseDescribe)).toBe(false);
   });
 
-  it('returns false when compute config has no scaling groups', () => {
+  it('returns false when a list response has no version summaries', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
-        computeConfig: { scalingGroups: {} },
+        name: 'loan-underwriting-app',
+        createTime: '',
+        routingConfig: {},
       }),
     ).toBe(false);
   });
 
-  it('returns true when the deployment has a compute config', () => {
-    expect(
-      deploymentHasComputeConfig({ ...baseDeployment, computeConfig }),
-    ).toBe(true);
-  });
-
-  it('returns true when the current version summary has a compute config', () => {
+  it('returns true when a list current version summary has a compute config', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
+        ...baseList,
         currentVersionSummary: {
-          ...baseDeployment.currentVersionSummary,
+          ...baseList.currentVersionSummary,
           computeConfig,
         },
       }),
     ).toBe(true);
   });
 
-  it('returns true when the ramping version summary has a compute config', () => {
+  it('returns true when a list ramping version summary has a compute config', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
+        ...baseList,
         rampingVersionSummary: {
           version: 'loan-underwriting-app.build-2',
-          createTime: undefined,
+          createTime: '',
           computeConfig,
         },
       }),
     ).toBe(true);
   });
 
-  it('ignores compute configs on inactive versions', () => {
+  it('ignores compute configs on describe versions that are not routed to', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
-        latestVersionSummary: {
-          version: 'loan-underwriting-app.build-2',
-          createTime: undefined,
-          computeConfig,
-        },
+        ...baseDescribe,
         versionSummaries: [
           {
             version: 'loan-underwriting-app.build-0',
-            createTime: undefined,
+            createTime: '',
             computeConfig,
           },
         ],
@@ -97,12 +93,10 @@ describe('deploymentHasComputeConfig', () => {
     ).toBe(false);
   });
 
-  // DescribeWorkerDeployment only returns versionSummaries + routingConfig.
   it('returns true when the routed current version summary has a compute config', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
-        currentVersionSummary: undefined,
+        ...baseDescribe,
         routingConfig: {
           currentDeploymentVersion: {
             deploymentName: 'loan-underwriting-app',
@@ -116,19 +110,18 @@ describe('deploymentHasComputeConfig', () => {
               deploymentName: 'loan-underwriting-app',
               buildId: 'build-1',
             },
-            createTime: undefined,
+            createTime: '',
             computeConfig,
           },
         ],
-      } as unknown as WorkerDeploymentInfo),
+      }),
     ).toBe(true);
   });
 
   it('returns true when the routed ramping version summary has a compute config', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
-        currentVersionSummary: undefined,
+        ...baseDescribe,
         routingConfig: {
           rampingDeploymentVersion: {
             deploymentName: 'loan-underwriting-app',
@@ -142,17 +135,16 @@ describe('deploymentHasComputeConfig', () => {
               deploymentName: 'loan-underwriting-app',
               buildId: 'build-2',
             },
-            createTime: undefined,
+            createTime: '',
             computeConfig,
           },
         ],
-      } as unknown as WorkerDeploymentInfo),
+      }),
     ).toBe(true);
   });
 
-  // Verbatim DescribeWorkerDeployment payload from Temporal Cloud. Note that it
-  // carries no currentVersionSummary at all — compute config only ever arrives
-  // on versionSummaries, linked by routingConfig.currentDeploymentVersion.
+  // Verbatim DescribeWorkerDeployment payload from Temporal Cloud. Compute
+  // config is only exposed on versionSummaries and linked by routingConfig.
   it('returns true for a real cloud describe response', () => {
     const cloudResponse = {
       name: 'test',
@@ -198,17 +190,15 @@ describe('deploymentHasComputeConfig', () => {
         revisionNumber: '1',
       },
       routingConfigUpdateState: 'ROUTING_CONFIG_UPDATE_STATE_IN_PROGRESS',
-    } as unknown as WorkerDeploymentInfo;
+    } satisfies DescribeWorkerDeployment;
 
-    expect(cloudResponse.currentVersionSummary).toBeUndefined();
     expect(deploymentHasComputeConfig(cloudResponse)).toBe(true);
   });
 
-  it('ignores compute configs on version summaries that are not routed to', () => {
+  it('ignores compute configs on describe versions that are not routed to', () => {
     expect(
       deploymentHasComputeConfig({
-        ...baseDeployment,
-        currentVersionSummary: undefined,
+        ...baseDescribe,
         routingConfig: {
           currentDeploymentVersion: {
             deploymentName: 'loan-underwriting-app',
@@ -222,7 +212,7 @@ describe('deploymentHasComputeConfig', () => {
               deploymentName: 'loan-underwriting-app',
               buildId: 'build-1',
             },
-            createTime: undefined,
+            createTime: '',
           },
           {
             version: 'loan-underwriting-app.build-0',
@@ -230,11 +220,11 @@ describe('deploymentHasComputeConfig', () => {
               deploymentName: 'loan-underwriting-app',
               buildId: 'build-0',
             },
-            createTime: undefined,
+            createTime: '',
             computeConfig,
           },
         ],
-      } as unknown as WorkerDeploymentInfo),
+      }),
     ).toBe(false);
   });
 });

--- a/src/lib/utilities/deployment-has-compute-config.ts
+++ b/src/lib/utilities/deployment-has-compute-config.ts
@@ -1,9 +1,10 @@
 import {
   type ComputeConfig,
+  type DescribeWorkerDeployment,
   isVersionSummaryNew,
+  type ListWorkerDeployment,
   type RoutingConfig,
   type VersionSummary,
-  type WorkerDeploymentInfo,
   type WorkerDeploymentVersion,
 } from '$lib/types/deployments';
 
@@ -51,17 +52,19 @@ const activeVersionComputeConfigs = (
     );
 
 export const deploymentHasComputeConfig = (
-  deployment?: WorkerDeploymentInfo,
+  deployment?: ListWorkerDeployment | DescribeWorkerDeployment,
 ): boolean => {
   if (!deployment) return false;
 
-  return [
-    deployment.computeConfig,
-    deployment.currentVersionSummary?.computeConfig,
-    deployment.rampingVersionSummary?.computeConfig,
-    ...activeVersionComputeConfigs(
+  if ('versionSummaries' in deployment) {
+    return activeVersionComputeConfigs(
       deployment.versionSummaries,
       deployment.routingConfig,
-    ),
+    ).some(hasScalingGroups);
+  }
+
+  return [
+    deployment.currentVersionSummary?.computeConfig,
+    deployment.rampingVersionSummary?.computeConfig,
   ].some(hasScalingGroups);
 };

--- a/src/lib/utilities/lock-compute-provider.test.ts
+++ b/src/lib/utilities/lock-compute-provider.test.ts
@@ -1,19 +1,23 @@
 import { describe, expect, it } from 'vitest';
 
-import type { WorkerDeploymentInfo } from '$lib/types/deployments';
+import type { DescribeWorkerDeployment } from '$lib/types/deployments';
 
 import { lockComputeProvider } from './lock-compute-provider';
 
-const deployment = (types: (string | undefined)[]): WorkerDeploymentInfo =>
+const deployment = (types: (string | undefined)[]): DescribeWorkerDeployment =>
   ({
+    name: 'test-deployment',
+    createTime: '',
+    routingConfig: {},
+    lastModifierIdentity: '',
     versionSummaries: types.map((type, index) => ({
       version: `build-${index}`,
-      createTime: undefined,
+      createTime: '',
       computeConfig: {
         scalingGroups: { default: { provider: { type } } },
       },
     })),
-  }) as unknown as WorkerDeploymentInfo;
+  }) satisfies DescribeWorkerDeployment;
 
 describe('lockComputeProvider', () => {
   it('does not lock deployments without versions', () => {
@@ -81,8 +85,11 @@ describe('lockComputeProvider', () => {
 
   it('supports providerType', () => {
     const info = deployment(['aws-lambda']);
+    const version = info.versionSummaries[0];
     const group =
-      info.versionSummaries[0].computeConfig?.scalingGroups?.default;
+      'computeConfig' in version
+        ? version.computeConfig?.scalingGroups?.default
+        : undefined;
     if (group) {
       group.providerType = 'gcp-cloud-run';
       group.provider = undefined;
@@ -98,42 +105,5 @@ describe('lockComputeProvider', () => {
     ['gcp-cloud-run', 'cloud-run'],
   ] as const)('maps the %s provider type to %s', (type, provider) => {
     expect(lockComputeProvider(deployment([type]))?.provider).toBe(provider);
-  });
-
-  it.each([
-    'computeConfig',
-    'latestVersionSummary',
-    'currentVersionSummary',
-    'rampingVersionSummary',
-  ] as const)('resolves the provider from %s', (source) => {
-    const info = deployment(['aws-lambda']);
-    const computeConfig = {
-      scalingGroups: {
-        default: { provider: { type: 'gcp-cloud-run' } },
-      },
-    };
-
-    info.versionSummaries = info.versionSummaries.map((summary) => {
-      if ('computeConfig' in summary) summary.computeConfig = undefined;
-      return summary;
-    });
-    if (source === 'computeConfig') {
-      info.computeConfig = computeConfig;
-    } else {
-      Object.assign(info, { [source]: { computeConfig } });
-    }
-
-    expect(lockComputeProvider(info)?.provider).toBe('cloud-run');
-  });
-
-  it('fails closed when top-level and summary providers are mixed', () => {
-    const info = deployment(['aws-lambda']);
-    info.computeConfig = {
-      scalingGroups: {
-        default: { providerType: 'gcp-cloud-run' },
-      },
-    };
-
-    expect(lockComputeProvider(info)).toBeUndefined();
   });
 });

--- a/src/lib/utilities/lock-compute-provider.ts
+++ b/src/lib/utilities/lock-compute-provider.ts
@@ -4,7 +4,7 @@ import type {
 } from '$lib/components/workers/serverless-worker-form/shared';
 import type {
   ComputeConfig,
-  WorkerDeploymentInfo,
+  DescribeWorkerDeployment,
 } from '$lib/types/deployments';
 
 export type LockedComputeProvider = {
@@ -34,21 +34,17 @@ const providersInConfig = (
 };
 
 export const lockComputeProvider = (
-  deployment: WorkerDeploymentInfo,
+  deployment: DescribeWorkerDeployment,
   configuredProviders?: readonly ComputeProviderOption[],
 ): LockedComputeProvider | undefined => {
   const versionSummaries = deployment.versionSummaries ?? [];
   if (!versionSummaries.length) return;
 
-  const configs = [
-    deployment.computeConfig,
-    computeConfigOf(deployment.latestVersionSummary),
-    computeConfigOf(deployment.currentVersionSummary),
-    computeConfigOf(deployment.rampingVersionSummary),
-    ...versionSummaries.map((version) =>
+  const configs = versionSummaries
+    .map((version) =>
       'computeConfig' in version ? computeConfigOf(version) : undefined,
-    ),
-  ].filter((config): config is ComputeConfig => Boolean(config));
+    )
+    .filter((config): config is ComputeConfig => Boolean(config));
 
   if (!configs.length) return;
 


### PR DESCRIPTION
## Summary

Separates the ListWorkerDeployments and DescribeWorkerDeployment response models so each matches its API shape. Updates deployment consumers and compute-provider helpers to use endpoint-specific fields, and replaces unsafe fixture casts with shape-checked fixtures.

## Test plan

- [x] Full Vitest suite: 184 files passed
- [x] Type checking: 0 errors
- [x] Prettier, ESLint, and Stylelint passed for touched files
- [x] Independent architecture and code reviews approved