### PR TITLE
Only pass start delay on activity update if value changes

### DIFF
--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -170,13 +170,20 @@
         await onSave(toActivityOptions(form.data));
         toaster.push({
           variant: 'success',
-          message: `Options for Activity ${activityId} have been updated.`,
+          message: translate('activities.update-options-success', {
+            activityId,
+          }),
         });
       } catch (error) {
         console.error('Error updating activity options:', error);
         toaster.push({
           variant: 'error',
-          message: `Options for Activity ${activityId} have been failed to update: ${has(error, 'message') ? error.message : translate('common.unknown-error')}`,
+          message: translate('activities.update-options-error', {
+            activityId,
+            error: has(error, 'message')
+              ? String(error.message)
+              : translate('common.unknown-error'),
+          }),
           duration: 5000,
         });
       } finally {

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -4,6 +4,7 @@
   import { zodClient } from 'sveltekit-superforms/adapters';
   import z from 'zod/v3';
 
+  import Message from '$lib/components/form/message.svelte';
   import Button from '$lib/holocene/button.svelte';
   import DrawerContent from '$lib/holocene/drawer-content.svelte';
   import Drawer from '$lib/holocene/drawer.svelte';
@@ -156,13 +157,13 @@
     open = false;
   };
 
-  const { form, errors, enhance } = superForm(initialData, {
+  const { form, errors, message, enhance } = superForm(initialData, {
     SPA: true,
     dataType: 'json',
     resetForm: false,
     invalidateAll: false,
     validators: zodClient(schema),
-    onUpdate: async ({ form }) => {
+    onUpdate: async ({ form, cancel }) => {
       if (!form.valid) return;
 
       try {
@@ -173,20 +174,19 @@
             activityId,
           }),
         });
+        closeCustomizationDrawer();
       } catch (error) {
-        console.error('Error updating activity options:', error);
-        toaster.push({
-          variant: 'error',
-          message: translate('activities.update-options-error', {
+        message.set({
+          intent: 'error',
+          title: translate('common.error-occurred'),
+          text: translate('activities.update-options-error', {
             activityId,
             error: has(error, 'message')
               ? String(error.message)
               : translate('common.unknown-error'),
           }),
-          duration: 5000,
         });
-      } finally {
-        closeCustomizationDrawer();
+        cancel();
       }
     },
   });
@@ -218,7 +218,7 @@
           labelHidden
           bind:value={$form.maximumAttempts}
           min={0}
-          error={!!$errors.maximumAttempts}
+          error={!!$errors.maximumAttempts?.[0]}
           hintText={$errors.maximumAttempts?.[0] ?? ''}
           class="w-24"
         />
@@ -239,7 +239,7 @@
           bind:value={$form.backoffCoefficient}
           step={0.01}
           min={1}
-          error={!!$errors.backoffCoefficient}
+          error={!!$errors.backoffCoefficient?.[0]}
           hintText={$errors.backoffCoefficient?.[0] ?? ''}
           class="w-24"
         />
@@ -282,7 +282,7 @@
         initialUnit={initialTimeoutUnit(initialData.scheduleToCloseTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
-        error={!!$errors.scheduleToCloseTimeout}
+        error={!!$errors.scheduleToCloseTimeout?.[0]}
         hintText={$errors.scheduleToCloseTimeout?.[0] ?? ''}
         class="max-w-80"
       />
@@ -298,7 +298,7 @@
         initialUnit={initialTimeoutUnit(initialData.startToCloseTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
-        error={!!$errors.startToCloseTimeout}
+        error={!!$errors.startToCloseTimeout?.[0]}
         hintText={$errors.startToCloseTimeout?.[0] ?? ''}
         class="max-w-80"
       />
@@ -340,11 +340,12 @@
           label={translate('activities.task-queue-name')}
           required
           bind:value={$form.taskQueue}
-          error={!!$errors.taskQueue}
+          error={!!$errors.taskQueue?.[0]}
           hintText={$errors.taskQueue?.[0] ?? ''}
           class="w-full"
         />
       </div>
+      <Message value={$message} />
       <div class="flex items-center justify-end gap-4">
         <Button
           type="button"

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -15,6 +15,7 @@
     SECONDS,
   } from '$lib/holocene/duration-input/duration-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
+  import NumberInput from '$lib/holocene/input/number-input.svelte';
   import Label from '$lib/holocene/label.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
@@ -45,15 +46,6 @@
     delayed = false,
   }: Props = $props();
 
-  const toStringValue = (value: unknown): string =>
-    value === null || value === undefined ? '' : String(value);
-
-  const isWholeNumber = (value: string): boolean =>
-    value.trim() !== '' &&
-    Number.isInteger(Number(value)) &&
-    Number(value) >= 0;
-  const isBackoffCoefficient = (value: string): boolean =>
-    value.trim() !== '' && Number(value) >= 1;
   const isPositiveDuration = (value: string | undefined): boolean => {
     const seconds = Number(parseDuration(value ?? ''));
     return !isNaN(seconds) && seconds > 0;
@@ -67,25 +59,26 @@
         .min(1, {
           message: translate('standalone-activities.form-task-queue-required'),
         }),
-      scheduleToCloseTimeout: z.string().default(''),
-      scheduleToStartTimeout: z.string().default(''),
-      startToCloseTimeout: z.string().default(''),
-      heartbeatTimeout: z.string().default(''),
-      initialInterval: z.string().default(''),
-      maximumInterval: z.string().default(''),
-      startDelay: z.string().default(''),
-      maximumAttempts: z.preprocess(
-        toStringValue,
-        z.string().refine(isWholeNumber, {
-          message: translate('activities.retry-max-attempts-error'),
-        }),
-      ),
-      backoffCoefficient: z.preprocess(
-        toStringValue,
-        z.string().refine(isBackoffCoefficient, {
-          message: translate('activities.retry-backoff-coefficient-error'),
-        }),
-      ),
+      scheduleToCloseTimeout: z.string(),
+      scheduleToStartTimeout: z.string(),
+      startToCloseTimeout: z.string(),
+      heartbeatTimeout: z.string(),
+      initialInterval: z.string(),
+      maximumInterval: z.string(),
+      startDelay: z.string(),
+      maximumAttempts: z
+        .number({
+          invalid_type_error: translate('activities.retry-max-attempts-error'),
+        })
+        .int(translate('activities.retry-max-attempts-error'))
+        .min(0, translate('activities.retry-max-attempts-error')),
+      backoffCoefficient: z
+        .number({
+          invalid_type_error: translate(
+            'activities.retry-backoff-coefficient-error',
+          ),
+        })
+        .min(1, translate('activities.retry-backoff-coefficient-error')),
     })
     .superRefine((data, context) => {
       if (
@@ -121,10 +114,8 @@
     initialInterval: String(initialOptions?.retryPolicy?.initialInterval ?? ''),
     maximumInterval: String(initialOptions?.retryPolicy?.maximumInterval ?? ''),
     startDelay: String(initialOptions?.startDelay ?? ''),
-    maximumAttempts: String(initialOptions?.retryPolicy?.maximumAttempts ?? 0),
-    backoffCoefficient: String(
-      initialOptions?.retryPolicy?.backoffCoefficient || 2,
-    ),
+    maximumAttempts: initialOptions?.retryPolicy?.maximumAttempts ?? 0,
+    backoffCoefficient: initialOptions?.retryPolicy?.backoffCoefficient || 2,
   }));
 
   const toActivityOptions = (data: z.infer<typeof schema>) =>
@@ -146,8 +137,8 @@
         startDelay: data.startDelay || '0s',
       }),
       retryPolicy: {
-        maximumAttempts: Number(data.maximumAttempts),
-        backoffCoefficient: Number(data.backoffCoefficient),
+        maximumAttempts: data.maximumAttempts,
+        backoffCoefficient: data.backoffCoefficient,
         ...(data.initialInterval && { initialInterval: data.initialInterval }),
         ...(data.maximumInterval && { maximumInterval: data.maximumInterval }),
       },
@@ -211,14 +202,13 @@
         <p class="mb-1 text-xs text-secondary">
           {translate('activities.retry-max-attempts-description')}
         </p>
-        <Input
+        <NumberInput
           id="maximum-attempts"
-          type="number"
           label={translate('activities.retry-max-attempts')}
           labelHidden
           bind:value={$form.maximumAttempts}
           min={0}
-          error={!!$errors.maximumAttempts?.[0]}
+          invalid={!!$errors.maximumAttempts?.[0]}
           hintText={$errors.maximumAttempts?.[0] ?? ''}
           class="w-24"
         />
@@ -231,15 +221,14 @@
         <p class="mb-1 text-xs text-secondary">
           {translate('activities.retry-backoff-coefficient-description')}
         </p>
-        <Input
+        <NumberInput
           id="retry-backoff-coefficient"
-          type="number"
           label={translate('activities.retry-backoff-coefficient')}
           labelHidden
           bind:value={$form.backoffCoefficient}
           step={0.01}
           min={1}
-          error={!!$errors.backoffCoefficient?.[0]}
+          invalid={!!$errors.backoffCoefficient?.[0]}
           hintText={$errors.backoffCoefficient?.[0] ?? ''}
           class="w-24"
         />

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -69,8 +69,13 @@
   let maximumInterval = $state(
     untrack(() => String(initialOptions?.retryPolicy?.maximumInterval ?? '')),
   );
-  let startDelay = $state(
-    untrack(() => String(initialOptions?.startDelay ?? '')),
+  const initialStartDelay = untrack(() =>
+    String(initialOptions?.startDelay ?? ''),
+  );
+  let startDelay = $state(initialStartDelay);
+
+  const startDelayChanged = $derived(
+    Boolean(startDelay) && startDelay !== initialStartDelay,
   );
 
   const activityOptions = $derived({
@@ -79,7 +84,7 @@
     scheduleToStartTimeout: scheduleToStartTimeout || undefined,
     startToCloseTimeout: startToCloseTimeout || undefined,
     heartbeatTimeout: heartbeatTimeout || undefined,
-    startDelay: startDelay || undefined,
+    ...(startDelayChanged && { startDelay }),
     retryPolicy: {
       maximumAttempts,
       backoffCoefficient,

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
   import { untrack } from 'svelte';
+  import { superForm } from 'sveltekit-superforms';
+  import { zodClient } from 'sveltekit-superforms/adapters';
+  import z from 'zod/v3';
 
   import Button from '$lib/holocene/button.svelte';
   import DrawerContent from '$lib/holocene/drawer-content.svelte';
@@ -7,10 +10,10 @@
   import DurationInput, {
     DAYS,
     DEFAULT_UNITS,
+    parseDuration,
     SECONDS,
   } from '$lib/holocene/duration-input/duration-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
-  import NumberInput from '$lib/holocene/input/number-input.svelte';
   import Label from '$lib/holocene/label.svelte';
   import { translate } from '$lib/i18n/translate';
   import {
@@ -41,82 +44,146 @@
     delayed = false,
   }: Props = $props();
 
-  // Form fields are seeded from activity.activityOptions once when the drawer
-  // opens. They must NOT reset reactively if the activity prop changes while
-  // the user is mid-edit — untrack() captures the initial value intentionally.
-  let taskQueue = $state(untrack(() => initialOptions?.taskQueue?.name ?? ''));
-  let scheduleToCloseTimeout = $state(
-    untrack(() => String(initialOptions?.scheduleToCloseTimeout ?? '')),
-  );
-  let scheduleToStartTimeout = $state(
-    untrack(() => String(initialOptions?.scheduleToStartTimeout ?? '')),
-  );
-  let startToCloseTimeout = $state(
-    untrack(() => String(initialOptions?.startToCloseTimeout ?? '')),
-  );
-  let heartbeatTimeout = $state(
-    untrack(() => String(initialOptions?.heartbeatTimeout ?? '')),
-  );
-  let maximumAttempts = $state(
-    untrack(() => initialOptions?.retryPolicy?.maximumAttempts ?? 0),
-  );
-  let backoffCoefficient = $state(
-    untrack(() => initialOptions?.retryPolicy?.backoffCoefficient ?? 0),
-  );
-  let initialInterval = $state(
-    untrack(() => String(initialOptions?.retryPolicy?.initialInterval ?? '')),
-  );
-  let maximumInterval = $state(
-    untrack(() => String(initialOptions?.retryPolicy?.maximumInterval ?? '')),
-  );
-  const initialStartDelay = untrack(() =>
-    String(initialOptions?.startDelay ?? ''),
-  );
-  let startDelay = $state(initialStartDelay);
+  const toStringValue = (value: unknown): string =>
+    value === null || value === undefined ? '' : String(value);
 
-  const startDelayChanged = $derived(
-    Boolean(startDelay) && startDelay !== initialStartDelay,
-  );
+  const isWholeNumber = (value: string): boolean =>
+    value.trim() !== '' &&
+    Number.isInteger(Number(value)) &&
+    Number(value) >= 0;
+  const isBackoffCoefficient = (value: string): boolean =>
+    value.trim() !== '' && Number(value) >= 1;
+  const isPositiveDuration = (value: string | undefined): boolean => {
+    const seconds = Number(parseDuration(value ?? ''));
+    return !isNaN(seconds) && seconds > 0;
+  };
 
-  const activityOptions = $derived({
-    taskQueue: { name: taskQueue },
-    scheduleToCloseTimeout: scheduleToCloseTimeout || undefined,
-    scheduleToStartTimeout: scheduleToStartTimeout || undefined,
-    startToCloseTimeout: startToCloseTimeout || undefined,
-    heartbeatTimeout: heartbeatTimeout || undefined,
-    ...(startDelayChanged && { startDelay }),
-    retryPolicy: {
-      maximumAttempts,
-      backoffCoefficient,
-      initialInterval: initialInterval || undefined,
-      maximumInterval: maximumInterval || undefined,
-    },
-  }) as unknown as ActivityOptions;
+  const schema = z
+    .object({
+      taskQueue: z
+        .string()
+        .trim()
+        .min(1, {
+          message: translate('standalone-activities.form-task-queue-required'),
+        }),
+      scheduleToCloseTimeout: z.string().default(''),
+      scheduleToStartTimeout: z.string().default(''),
+      startToCloseTimeout: z.string().default(''),
+      heartbeatTimeout: z.string().default(''),
+      initialInterval: z.string().default(''),
+      maximumInterval: z.string().default(''),
+      startDelay: z.string().default(''),
+      maximumAttempts: z.preprocess(
+        toStringValue,
+        z.string().refine(isWholeNumber, {
+          message: translate('activities.retry-max-attempts-error'),
+        }),
+      ),
+      backoffCoefficient: z.preprocess(
+        toStringValue,
+        z.string().refine(isBackoffCoefficient, {
+          message: translate('activities.retry-backoff-coefficient-error'),
+        }),
+      ),
+    })
+    .superRefine((data, context) => {
+      if (
+        !isPositiveDuration(data.startToCloseTimeout) &&
+        !isPositiveDuration(data.scheduleToCloseTimeout)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['startToCloseTimeout'],
+          message: translate('standalone-activities.form-timeout-required'),
+        });
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['scheduleToCloseTimeout'],
+          message: translate('standalone-activities.form-timeout-required'),
+        });
+      }
+    });
+
+  // Seeded from activity.activityOptions once when the drawer opens. These must
+  // NOT reset reactively if the activity prop changes while the user is
+  // mid-edit — untrack() captures the initial values intentionally.
+  const initialData: z.infer<typeof schema> = untrack(() => ({
+    taskQueue: initialOptions?.taskQueue?.name ?? '',
+    scheduleToCloseTimeout: String(
+      initialOptions?.scheduleToCloseTimeout ?? '',
+    ),
+    scheduleToStartTimeout: String(
+      initialOptions?.scheduleToStartTimeout ?? '',
+    ),
+    startToCloseTimeout: String(initialOptions?.startToCloseTimeout ?? ''),
+    heartbeatTimeout: String(initialOptions?.heartbeatTimeout ?? ''),
+    initialInterval: String(initialOptions?.retryPolicy?.initialInterval ?? ''),
+    maximumInterval: String(initialOptions?.retryPolicy?.maximumInterval ?? ''),
+    startDelay: String(initialOptions?.startDelay ?? ''),
+    maximumAttempts: String(initialOptions?.retryPolicy?.maximumAttempts ?? 0),
+    backoffCoefficient: String(
+      initialOptions?.retryPolicy?.backoffCoefficient || 2,
+    ),
+  }));
+
+  const toActivityOptions = (data: z.infer<typeof schema>) =>
+    ({
+      taskQueue: { name: data.taskQueue },
+      ...(data.scheduleToCloseTimeout && {
+        scheduleToCloseTimeout: data.scheduleToCloseTimeout,
+      }),
+      ...(data.scheduleToStartTimeout && {
+        scheduleToStartTimeout: data.scheduleToStartTimeout,
+      }),
+      ...(data.startToCloseTimeout && {
+        startToCloseTimeout: data.startToCloseTimeout,
+      }),
+      ...(data.heartbeatTimeout && {
+        heartbeatTimeout: data.heartbeatTimeout,
+      }),
+      ...(data.startDelay &&
+        data.startDelay !== initialData.startDelay && {
+          startDelay: data.startDelay,
+        }),
+      retryPolicy: {
+        maximumAttempts: Number(data.maximumAttempts),
+        backoffCoefficient: Number(data.backoffCoefficient),
+        ...(data.initialInterval && { initialInterval: data.initialInterval }),
+        ...(data.maximumInterval && { maximumInterval: data.maximumInterval }),
+      },
+    }) as unknown as ActivityOptions;
 
   const closeCustomizationDrawer = () => {
     open = false;
   };
 
-  const onUpdate = async (e: SubmitEvent) => {
-    e.preventDefault();
+  const { form, errors, enhance } = superForm(initialData, {
+    SPA: true,
+    dataType: 'json',
+    resetForm: false,
+    invalidateAll: false,
+    validators: zodClient(schema),
+    onUpdate: async ({ form }) => {
+      if (!form.valid) return;
 
-    try {
-      await onSave(activityOptions);
-      toaster.push({
-        variant: 'success',
-        message: `Options for Activity ${activityId} have been updated.`,
-      });
-    } catch (error) {
-      console.error('Error updating activity options:', error);
-      toaster.push({
-        variant: 'error',
-        message: `Options for Activity ${activityId} have been failed to update: ${has(error, 'message') ? error.message : translate('common.unknown-error')}`,
-        duration: 5000,
-      });
-    } finally {
-      closeCustomizationDrawer();
-    }
-  };
+      try {
+        await onSave(toActivityOptions(form.data));
+        toaster.push({
+          variant: 'success',
+          message: `Options for Activity ${activityId} have been updated.`,
+        });
+      } catch (error) {
+        console.error('Error updating activity options:', error);
+        toaster.push({
+          variant: 'error',
+          message: `Options for Activity ${activityId} have been failed to update: ${has(error, 'message') ? error.message : translate('common.unknown-error')}`,
+          duration: 5000,
+        });
+      } finally {
+        closeCustomizationDrawer();
+      }
+    },
+  });
 </script>
 
 <Drawer
@@ -129,7 +196,7 @@
   class="w-screen sm:w-[480px]"
 >
   <DrawerContent title="Update Activity {activityId}">
-    <form onsubmit={onUpdate} class="flex flex-col gap-4">
+    <form use:enhance novalidate class="flex flex-col gap-4">
       <div>
         <Label
           for="maximum-attempts"
@@ -138,11 +205,15 @@
         <p class="mb-1 text-xs text-secondary">
           {translate('activities.retry-max-attempts-description')}
         </p>
-        <NumberInput
+        <Input
           id="maximum-attempts"
+          type="number"
           label={translate('activities.retry-max-attempts')}
           labelHidden
-          bind:value={maximumAttempts}
+          bind:value={$form.maximumAttempts}
+          min={0}
+          error={!!$errors.maximumAttempts}
+          hintText={$errors.maximumAttempts?.[0] ?? ''}
           class="w-24"
         />
       </div>
@@ -154,13 +225,16 @@
         <p class="mb-1 text-xs text-secondary">
           {translate('activities.retry-backoff-coefficient-description')}
         </p>
-        <NumberInput
+        <Input
           id="retry-backoff-coefficient"
+          type="number"
           label={translate('activities.retry-backoff-coefficient')}
           labelHidden
-          bind:value={backoffCoefficient}
+          bind:value={$form.backoffCoefficient}
           step={0.01}
           min={1}
+          error={!!$errors.backoffCoefficient}
+          hintText={$errors.backoffCoefficient?.[0] ?? ''}
           class="w-24"
         />
       </div>
@@ -171,8 +245,8 @@
           'activities.retry-initial-interval-duration-description',
         )}
         inputmode="numeric"
-        bind:value={initialInterval}
-        initialUnit={initialTimeoutUnit(initialInterval)}
+        bind:value={$form.initialInterval}
+        initialUnit={initialTimeoutUnit(initialData.initialInterval)}
         units={TIMEOUT_UNITS}
         min={0}
         class="max-w-80"
@@ -184,8 +258,8 @@
           'activities.schedule-to-start-timeout-duration-description',
         )}
         inputmode="numeric"
-        bind:value={scheduleToStartTimeout}
-        initialUnit={initialTimeoutUnit(scheduleToStartTimeout)}
+        bind:value={$form.scheduleToStartTimeout}
+        initialUnit={initialTimeoutUnit(initialData.scheduleToStartTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
         class="max-w-80"
@@ -197,10 +271,13 @@
           'activities.schedule-to-close-timeout-duration-description',
         )}
         inputmode="numeric"
-        bind:value={scheduleToCloseTimeout}
-        initialUnit={initialTimeoutUnit(scheduleToCloseTimeout)}
+        required={!isPositiveDuration($form.startToCloseTimeout)}
+        bind:value={$form.scheduleToCloseTimeout}
+        initialUnit={initialTimeoutUnit(initialData.scheduleToCloseTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
+        error={!!$errors.scheduleToCloseTimeout}
+        hintText={$errors.scheduleToCloseTimeout?.[0] ?? ''}
         class="max-w-80"
       />
       <DurationInput
@@ -210,10 +287,13 @@
           'activities.start-to-close-timeout-duration-description',
         )}
         inputmode="numeric"
-        bind:value={startToCloseTimeout}
-        initialUnit={initialTimeoutUnit(startToCloseTimeout)}
+        required={!isPositiveDuration($form.scheduleToCloseTimeout)}
+        bind:value={$form.startToCloseTimeout}
+        initialUnit={initialTimeoutUnit(initialData.startToCloseTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
+        error={!!$errors.startToCloseTimeout}
+        hintText={$errors.startToCloseTimeout?.[0] ?? ''}
         class="max-w-80"
       />
       <DurationInput
@@ -223,8 +303,8 @@
           'activities.heartbeat-timeout-duration-description',
         )}
         inputmode="numeric"
-        bind:value={heartbeatTimeout}
-        initialUnit={initialTimeoutUnit(heartbeatTimeout)}
+        bind:value={$form.heartbeatTimeout}
+        initialUnit={initialTimeoutUnit(initialData.heartbeatTimeout)}
         units={TIMEOUT_UNITS}
         min={0}
         class="max-w-80"
@@ -239,7 +319,7 @@
                 'standalone-activities.form-start-delay-hint',
               )}
               inputmode="numeric"
-              bind:value={startDelay}
+              bind:value={$form.startDelay}
               initialUnit={SECONDS.label}
               units={[...DEFAULT_UNITS, DAYS]}
               min={0}
@@ -249,15 +329,13 @@
         </StartDelayGuard>
       {/if}
       <div>
-        <Label
-          for="task-queue-name"
-          label={translate('activities.task-queue-name')}
-        />
         <Input
           id="task-queue-name"
           label={translate('activities.task-queue-name')}
-          labelHidden
-          bind:value={taskQueue}
+          required
+          bind:value={$form.taskQueue}
+          error={!!$errors.taskQueue}
+          hintText={$errors.taskQueue?.[0] ?? ''}
           class="w-full"
         />
       </div>

--- a/src/lib/components/activity/activity-options-form.svelte
+++ b/src/lib/components/activity/activity-options-form.svelte
@@ -141,10 +141,9 @@
       ...(data.heartbeatTimeout && {
         heartbeatTimeout: data.heartbeatTimeout,
       }),
-      ...(data.startDelay &&
-        data.startDelay !== initialData.startDelay && {
-          startDelay: data.startDelay,
-        }),
+      ...(data.startDelay !== initialData.startDelay && {
+        startDelay: data.startDelay || '0s',
+      }),
       retryPolicy: {
         maximumAttempts: Number(data.maximumAttempts),
         backoffCoefficient: Number(data.backoffCoefficient),

--- a/src/lib/components/schedule/utilities/get-request-body.ts
+++ b/src/lib/components/schedule/utilities/get-request-body.ts
@@ -1,7 +1,9 @@
 import { parseDuration } from '$lib/holocene/duration-input/duration-input.svelte';
-import { setSearchAttributes } from '$lib/services/workflow-service';
 import type { Payload } from '$lib/types';
-import { encodePayloads } from '$lib/utilities/encode-payload';
+import {
+  encodePayloads,
+  setSearchAttributes,
+} from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 
 import { isValidCronString } from './cron';

--- a/src/lib/holocene/input/number-input.svelte
+++ b/src/lib/holocene/input/number-input.svelte
@@ -18,6 +18,7 @@
     name?: string;
     disabled?: boolean;
     required?: boolean;
+    invalid?: boolean;
     hintText?: string;
     max?: number;
     min?: number;
@@ -38,6 +39,7 @@
     name,
     disabled = false,
     required = false,
+    invalid = false,
     hintText = '',
     max,
     min,
@@ -50,7 +52,11 @@
 
   const resolvedName = $derived(name ?? id);
   const valid = $derived(
-    !((min !== undefined && value < min) || (max !== undefined && value > max)),
+    !invalid &&
+      !(
+        (min !== undefined && value < min) ||
+        (max !== undefined && value > max)
+      ),
   );
   const errorId = $derived(`${id}-error`);
 </script>

--- a/src/lib/i18n/locales/en/activities.ts
+++ b/src/lib/i18n/locales/en/activities.ts
@@ -19,9 +19,11 @@ export const Strings = {
   'pause-tooltip':
     'Pauses this Activity before its next retry or heartbeat. Timeout deadlines continue while paused.',
   'retry-max-attempts': 'Retry Max Attempts',
+  'retry-max-attempts-error': 'Enter a whole number of 0 or more.',
   'retry-max-attempts-description':
     'Maximum number of attempts. When exceeded the retries stop even if not expired yet. 1 disables retries. 0 means unlimited (up to the timeouts).',
   'retry-backoff-coefficient': 'Retry Backoff Coefficient',
+  'retry-backoff-coefficient-error': 'Enter a number of 1 or more.',
   'retry-backoff-coefficient-description':
     'Coefficient used to calculate the next retry interval. The next retry interval is previous interval multiplied by the coefficient. Must be 1 or larger.',
   'retry-initial-interval-duration': 'Retry Initial Interval Duration',

--- a/src/lib/i18n/locales/en/activities.ts
+++ b/src/lib/i18n/locales/en/activities.ts
@@ -15,6 +15,10 @@ export const Strings = {
     'Reset the execution of this Activity back to the initial attempt.',
   'reset-heartbeat-details': 'Reset Heartbeat Details (optional)',
   'reset-success': 'Activity {{activityId}} has been reset successfully.',
+  'update-options-success':
+    'Options for Activity {{activityId}} have been updated.',
+  'update-options-error':
+    'Options for Activity {{activityId}} failed to update: {{error}}',
   'resume-tooltip': 'Resume this Activity',
   'pause-tooltip':
     'Pauses this Activity before its next retry or heartbeat. Timeout deadlines continue while paused.',

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -22,15 +22,16 @@ import type {
 } from '$lib/types/activity-execution';
 import { activityOptionsUpdateMask } from '$lib/utilities/activity-options-update-mask';
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
-import { encodePayloads } from '$lib/utilities/encode-payload';
+import {
+  encodePayloads,
+  setSearchAttributes,
+} from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import {
   type ErrorCallback,
   requestFromAPI,
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
-
-import { setSearchAttributes } from './workflow-service';
 
 // Timeout duration inputs on the activity forms; largest-first so
 // getFirstWholeNumberUnit resolves to the coarsest whole unit, defaulting to

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -20,6 +20,7 @@ import type {
   ActivityExecutionInfo,
   StartActivityExecutionRequest,
 } from '$lib/types/activity-execution';
+import { activityOptionsUpdateMask } from '$lib/utilities/activity-options-update-mask';
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
 import { encodePayloads } from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
@@ -29,7 +30,6 @@ import {
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
 
-import { ACTIVITY_OPTIONS_UPDATE_MASK } from './workflow-activities-service';
 import { setSearchAttributes } from './workflow-service';
 
 // Timeout duration inputs on the activity forms; largest-first so
@@ -536,7 +536,7 @@ export const updateActivityExecutionOptions = async (
         activityId,
         runId,
         activityOptions,
-        updateMask: ACTIVITY_OPTIONS_UPDATE_MASK,
+        updateMask: activityOptionsUpdateMask(activityOptions),
         ...(identity && { identity }),
       }),
     },

--- a/src/lib/services/standalone-nexus-operations.ts
+++ b/src/lib/services/standalone-nexus-operations.ts
@@ -18,15 +18,16 @@ import type {
   StartNexusOperationRequest,
 } from '$lib/types/nexus-operation-execution';
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
-import { encodePayloads } from '$lib/utilities/encode-payload';
+import {
+  encodePayloads,
+  setSearchAttributes,
+} from '$lib/utilities/encode-payload';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import {
   type ErrorCallback,
   requestFromAPI,
 } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
-
-import { setSearchAttributes } from './workflow-service';
 
 export type ListNexusOperationsResponse = {
   operations: NexusOperationExecutionListInfo[];

--- a/src/lib/services/workflow-activities-service.ts
+++ b/src/lib/services/workflow-activities-service.ts
@@ -10,6 +10,7 @@ import type {
   ActivityUpdateOptionsRequest,
   ActivityUpdateOptionsResponse,
 } from '$lib/types';
+import { activityOptionsUpdateMask } from '$lib/utilities/activity-options-update-mask';
 import { isNotFound, isNotImplemented } from '$lib/utilities/handle-error';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
@@ -128,9 +129,6 @@ export const resetActivity = async ({
   );
 };
 
-export const ACTIVITY_OPTIONS_UPDATE_MASK =
-  'taskQueue.name,scheduleToCloseTimeout,scheduleToStartTimeout,startToCloseTimeout,heartbeatTimeout,retryPolicy.initialInterval,retryPolicy.backoffCoefficient,retryPolicy.maximumInterval,retryPolicy.maximumAttempts,startDelay';
-
 export const updateActivityOptions = async ({
   namespace,
   execution,
@@ -152,7 +150,7 @@ export const updateActivityOptions = async ({
           id,
           type,
           activityOptions,
-          updateMask: ACTIVITY_OPTIONS_UPDATE_MASK,
+          updateMask: activityOptionsUpdateMask(activityOptions),
           ...(identity && { identity }),
         }),
       },

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -28,7 +28,6 @@ import {
   ResetReapplyExcludeType,
   ResetReapplyType,
   type ResetWorkflowRequest,
-  type SearchAttribute,
   type UnpauseWorkflowRequest,
   type UpdateWorkflowResponse,
 } from '$lib/types';
@@ -54,7 +53,7 @@ import type {
 import { decodePayloadAndParseDataToJSON } from '$lib/utilities/decode-payload';
 import {
   encodePayloads,
-  setBase64Payload,
+  setSearchAttributes,
 } from '$lib/utilities/encode-payload';
 import {
   handleUnauthorizedOrForbiddenError,
@@ -664,25 +663,6 @@ export async function fetchAllChildWorkflows(
     return [];
   }
 }
-
-export const setSearchAttributes = (
-  attributes: SearchAttributesSchema,
-): NonNullable<SearchAttribute['indexedFields']> => {
-  if (!attributes.length) return {};
-
-  const searchAttributes: Record<
-    string,
-    ReturnType<typeof setBase64Payload>
-  > = {};
-  attributes.forEach((attribute) => {
-    searchAttributes[attribute.label] = setBase64Payload(attribute.value);
-  });
-
-  // Payloads are base64 strings over REST; the proto type expects Uint8Array.
-  return searchAttributes as unknown as NonNullable<
-    SearchAttribute['indexedFields']
-  >;
-};
 
 export async function startWorkflow({
   namespace,

--- a/src/lib/utilities/activity-options-update-mask.test.ts
+++ b/src/lib/utilities/activity-options-update-mask.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+
+import type { ActivityOptions } from '$lib/types';
+
+import {
+  ACTIVITY_OPTIONS_UPDATE_PATHS,
+  activityOptionsUpdateMask,
+} from './activity-options-update-mask';
+
+const BASE_MASK = ACTIVITY_OPTIONS_UPDATE_PATHS.join(',');
+
+const options = (overrides: Partial<ActivityOptions> = {}) =>
+  ({
+    taskQueue: { name: 'queue' },
+    scheduleToCloseTimeout: '10s',
+    ...overrides,
+  }) as ActivityOptions;
+
+describe('activityOptionsUpdateMask', () => {
+  test('omits optional paths when no value is supplied', () => {
+    expect(activityOptionsUpdateMask(options())).toBe(BASE_MASK);
+    expect(activityOptionsUpdateMask(undefined)).toBe(BASE_MASK);
+    expect(activityOptionsUpdateMask(null)).toBe(BASE_MASK);
+  });
+
+  test('omits optional paths set to an empty value', () => {
+    expect(activityOptionsUpdateMask(options({ startDelay: '' }))).toBe(
+      BASE_MASK,
+    );
+  });
+
+  test('includes startDelay when supplied', () => {
+    expect(activityOptionsUpdateMask(options({ startDelay: '30s' }))).toBe(
+      `${BASE_MASK},startDelay`,
+    );
+  });
+
+  test('supports nested optional paths', () => {
+    expect(
+      activityOptionsUpdateMask(
+        options({ retryPolicy: { maximumAttempts: 3 } }),
+        ['retryPolicy.maximumAttempts', 'retryPolicy.nonRetryableErrorTypes'],
+      ),
+    ).toBe(`${BASE_MASK},retryPolicy.maximumAttempts`);
+  });
+});

--- a/src/lib/utilities/activity-options-update-mask.ts
+++ b/src/lib/utilities/activity-options-update-mask.ts
@@ -1,0 +1,40 @@
+import type { ActivityOptions } from '$lib/types';
+
+export const ACTIVITY_OPTIONS_UPDATE_PATHS = [
+  'taskQueue.name',
+  'scheduleToCloseTimeout',
+  'scheduleToStartTimeout',
+  'startToCloseTimeout',
+  'heartbeatTimeout',
+  'retryPolicy.initialInterval',
+  'retryPolicy.backoffCoefficient',
+  'retryPolicy.maximumInterval',
+  'retryPolicy.maximumAttempts',
+] as const;
+
+const OPTIONAL_ACTIVITY_OPTIONS_UPDATE_PATHS = ['startDelay'] as const;
+
+const valueAtPath = (source: unknown, path: string): unknown =>
+  path
+    .split('.')
+    .reduce(
+      (value, key) =>
+        value === null || value === undefined
+          ? undefined
+          : (value as Record<string, unknown>)[key],
+      source,
+    );
+
+const hasValue = (value: unknown): boolean =>
+  value !== null && value !== undefined && value !== '';
+
+export const activityOptionsUpdateMask = (
+  activityOptions: ActivityOptions | null | undefined,
+  optionalPaths: readonly string[] = OPTIONAL_ACTIVITY_OPTIONS_UPDATE_PATHS,
+): string =>
+  [
+    ...ACTIVITY_OPTIONS_UPDATE_PATHS,
+    ...optionalPaths.filter((path) =>
+      hasValue(valueAtPath(activityOptions, path)),
+    ),
+  ].join(',');

--- a/src/lib/utilities/encode-payload.ts
+++ b/src/lib/utilities/encode-payload.ts
@@ -3,7 +3,8 @@ import { get } from 'svelte/store';
 import type { PayloadInputEncoding } from '$lib/models/payload-encoding';
 import { encodePayloadsWithCodec } from '$lib/services/data-encoder';
 import { dataEncoder } from '$lib/stores/data-encoder';
-import type { Payload } from '$lib/types';
+import type { SearchAttributesSchema } from '$lib/stores/search-attributes';
+import type { Payload, SearchAttribute } from '$lib/types';
 import { atob } from '$lib/utilities/atob';
 import { btoa } from '$lib/utilities/btoa';
 import {
@@ -52,6 +53,24 @@ export const setBase64Payload = (
     },
     data: btoa(stringifyWithBigInt(payload)),
   };
+};
+
+export const setSearchAttributes = (
+  attributes: SearchAttributesSchema,
+): NonNullable<SearchAttribute['indexedFields']> => {
+  if (!attributes.length) return {};
+
+  const searchAttributes: Record<
+    string,
+    ReturnType<typeof setBase64Payload>
+  > = {};
+  attributes.forEach((attribute) => {
+    searchAttributes[attribute.label] = setBase64Payload(attribute.value);
+  });
+
+  return searchAttributes as unknown as NonNullable<
+    SearchAttribute['indexedFields']
+  >;
 };
 
 type EncodePayloads = {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The `<ActivityOptionsUpdateDrawer />` sent a fixed update mask on every save (`taskQueue.name,scheduleToCloseTimeout,…,retryPolicy.maximumAttempts,startDelay`). Because `startDelay` was permanently in that mask, every save wrote it.

This PR refactors to use superForm + zod for validation and the update mask is now derived from the payload so `startDelay` is only added if there is an updated value for it.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

#### Run temporal server from a local build
1. Ensure you have cloned the [temporal](https://github.com/temporalio/temporal) repo
1. Make sure [EnableStandaloneActivityOperatorCommands](https://github.com/temporalio/temporal/blob/91fa0ba8c8156ab4317f3ccb0920d16569c4f87a/chasm/lib/activity/config.go#L43) is set to `true`
1. Run `make bins` and `make start`
1. Running temporal server from a local build does not create the namespace, run `temporal operator namespace create --namespace default`

#### Run the UI against a local build of temporal server
1. Checkout the `fix/activity-paused` branch in the UI repo 
1. `cd server/ && make build` 
1. `cd .. && pnpm dev:local-temporal`

------

Start a Standalone Activity > add a start delay > go to Standalone Activity > select "Update" > change start delay to zero
  - [ ] Verify start delay is updated
  - [ ] Verify "Update" drawer no longer contains "Start Delay"

 Select "Update" > change another value > hit "Save"
   - [ ] Verify there is no error r.e. start delay

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
