### PR TITLE
fix(schedules): resolve recent run statuses from visibility

### DIFF
--- a/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
+++ b/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
@@ -5,10 +5,15 @@
   import { timestamp } from '$lib/components/timestamp.svelte';
   import Link from '$lib/holocene/link.svelte';
   import { translate } from '$lib/i18n/translate';
-  import type { DescribeFullSchedule } from '$lib/types/schedule';
-  import { getEpochMilliseconds } from '$lib/utilities/format-time';
+  import {
+    fetchRecentScheduleRunStatuses,
+    toRecentScheduleRuns,
+  } from '$lib/services/schedule-service';
+  import type {
+    DescribeFullSchedule,
+    RecentScheduleRun,
+  } from '$lib/types/schedule';
   import { routeForWorkflow } from '$lib/utilities/route-for';
-  import { toWorkflowStatusReadable } from '$lib/utilities/screaming-enums';
 
   import WorkflowRunsEmpty from './workflow-runs-empty.svelte';
 
@@ -28,20 +33,19 @@
     openTriggerConfirmationModal,
   }: Props = $props();
 
-  const sortedRecentRuns = $derived.by(() => {
-    const runs = schedule?.info?.recentActions ?? [];
-    return runs
-      .filter(Boolean)
-      .sort(
-        (a, b) =>
-          getEpochMilliseconds(b.actualTime) -
-          getEpochMilliseconds(a.actualTime),
-      )
-      .slice(0, 5);
-  });
+  const recordedRuns = $derived(toRecentScheduleRuns(schedule));
+  const runsPromise = $derived(
+    recordedRuns.length
+      ? fetchRecentScheduleRunStatuses({
+          namespace,
+          scheduleId: schedule.schedule_id,
+          runs: recordedRuns,
+        })
+      : Promise.resolve(recordedRuns),
+  );
 </script>
 
-{#if !sortedRecentRuns.length}
+{#if !recordedRuns.length}
   <WorkflowRunsEmpty
     class={className}
     title={translate('schedules.workflow-runs-empty-state-recent-title')}
@@ -52,15 +56,23 @@
     {openTriggerConfirmationModal}
   />
 {:else}
+  {#await runsPromise}
+    {@render runList(recordedRuns)}
+  {:then runs}
+    {@render runList(runs)}
+  {:catch}
+    {@render runList(recordedRuns)}
+  {/await}
+{/if}
+
+{#snippet runList(runs: RecentScheduleRun[])}
   <ul class={twMerge('flex flex-col gap-2', className)}>
-    {#each sortedRecentRuns as run, i (run?.startWorkflowResult?.runId ?? i)}
+    {#each runs as run, i (run.runId || i)}
       <li
         class="grid grid-cols-[max-content_1fr] gap-x-2 gap-y-1 border-b border-subtle py-2 sm:grid-cols-[minmax(max-content,7rem)_1fr_max-content]"
       >
         <div class="col-start-1 row-start-1 flex items-center">
-          <WorkflowStatus
-            status={toWorkflowStatusReadable(run.startWorkflowStatus ?? null)}
-          />
+          <WorkflowStatus status={run.status} />
         </div>
 
         <div
@@ -68,12 +80,12 @@
         >
           <Link
             href={routeForWorkflow({
-              workflow: run.startWorkflowResult?.workflowId ?? '',
-              run: run.startWorkflowResult?.runId ?? '',
+              workflow: run.workflowId,
+              run: run.runId,
               namespace,
             })}
           >
-            {run.startWorkflowResult?.workflowId}
+            {run.workflowId}
           </Link>
         </div>
 
@@ -85,4 +97,4 @@
       </li>
     {/each}
   </ul>
-{/if}
+{/snippet}

--- a/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
+++ b/src/lib/components/schedule/schedule-view/workflow-runs-recent.svelte
@@ -35,13 +35,11 @@
 
   const recordedRuns = $derived(toRecentScheduleRuns(schedule));
   const runsPromise = $derived(
-    recordedRuns.length
-      ? fetchRecentScheduleRunStatuses({
-          namespace,
-          scheduleId: schedule.schedule_id,
-          runs: recordedRuns,
-        })
-      : Promise.resolve(recordedRuns),
+    fetchRecentScheduleRunStatuses({
+      namespace,
+      scheduleId: schedule.schedule_id,
+      runs: recordedRuns,
+    }),
   );
 </script>
 

--- a/src/lib/services/schedule-service.test.ts
+++ b/src/lib/services/schedule-service.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { DescribeFullSchedule } from '$lib/types/schedule';
+import type { WorkflowExecution } from '$lib/types/workflows';
+import { requestFromAPI } from '$lib/utilities/request-from-api';
+
+import {
+  fetchRecentScheduleRunStatuses,
+  toRecentScheduleRuns,
+  withLatestWorkflowStatuses,
+} from './schedule-service';
+
+vi.mock('$lib/utilities/request-from-api', () => ({
+  requestFromAPI: vi.fn(),
+}));
+
+const action = (
+  workflowId: string,
+  actualTime: string,
+  startWorkflowStatus?: string,
+) => ({
+  actualTime,
+  startWorkflowResult: { workflowId, runId: `${workflowId}-run` },
+  startWorkflowStatus,
+});
+
+const scheduleWith = (actions: unknown[]) =>
+  ({ info: { recentActions: actions } }) as unknown as DescribeFullSchedule;
+
+const execution = (id: string, startTime: string, status: string) =>
+  ({ id, startTime, status }) as unknown as WorkflowExecution;
+
+describe('toRecentScheduleRuns', () => {
+  test('sorts by actual time descending and caps the list', () => {
+    const schedule = scheduleWith([
+      action('a', '2026-08-01T00:00:00Z'),
+      action('c', '2026-08-03T00:00:00Z'),
+      action('b', '2026-08-02T00:00:00Z'),
+    ]);
+
+    expect(
+      toRecentScheduleRuns(schedule, 2).map((run) => run.workflowId),
+    ).toEqual(['c', 'b']);
+  });
+
+  test('defaults to five runs', () => {
+    const actions = Array.from({ length: 8 }, (_, index) =>
+      action(`wf-${index}`, `2026-08-0${index + 1}T00:00:00Z`),
+    );
+
+    expect(toRecentScheduleRuns(scheduleWith(actions))).toHaveLength(5);
+  });
+
+  test('converts the recorded status to its readable form', () => {
+    const schedule = scheduleWith([
+      action('a', '2026-08-01T00:00:00Z', 'WORKFLOW_EXECUTION_STATUS_RUNNING'),
+    ]);
+
+    expect(toRecentScheduleRuns(schedule)[0].status).toBe('Running');
+  });
+
+  test('does not mutate the schedule response', () => {
+    const actions = [
+      action('a', '2026-08-01T00:00:00Z'),
+      action('c', '2026-08-03T00:00:00Z'),
+    ];
+    const schedule = scheduleWith(actions);
+
+    toRecentScheduleRuns(schedule);
+
+    expect(schedule.info.recentActions[0].startWorkflowResult.workflowId).toBe(
+      'a',
+    );
+  });
+
+  test('returns an empty list when the schedule has no recent actions', () => {
+    expect(toRecentScheduleRuns({} as DescribeFullSchedule)).toEqual([]);
+  });
+});
+
+describe('withLatestWorkflowStatuses', () => {
+  const runs = toRecentScheduleRuns(
+    scheduleWith([
+      action('a', '2026-08-01T00:00:00Z', 'WORKFLOW_EXECUTION_STATUS_RUNNING'),
+      action('b', '2026-08-02T00:00:00Z', 'WORKFLOW_EXECUTION_STATUS_RUNNING'),
+    ]),
+  );
+
+  test('replaces the recorded status with the live one', () => {
+    const merged = withLatestWorkflowStatuses(runs, [
+      execution('a', '2026-08-01T00:00:00Z', 'Terminated'),
+      execution('b', '2026-08-02T00:00:00Z', 'Paused'),
+    ]);
+
+    expect(merged.map((run) => run.status)).toEqual(['Paused', 'Terminated']);
+  });
+
+  test('keeps the recorded status for runs visibility did not return', () => {
+    const merged = withLatestWorkflowStatuses(runs, [
+      execution('b', '2026-08-02T00:00:00Z', 'Completed'),
+    ]);
+
+    expect(merged.map((run) => run.status)).toEqual(['Completed', 'Running']);
+  });
+
+  test('uses the newest execution of a continue-as-new chain', () => {
+    const merged = withLatestWorkflowStatuses(runs, [
+      execution('a', '2026-08-01T00:00:00Z', 'ContinuedAsNew'),
+      execution('a', '2026-08-05T00:00:00Z', 'Failed'),
+      execution('a', '2026-08-03T00:00:00Z', 'ContinuedAsNew'),
+    ]);
+
+    expect(merged.find((run) => run.workflowId === 'a')?.status).toBe('Failed');
+  });
+
+  test('leaves runs untouched when visibility returns nothing', () => {
+    expect(withLatestWorkflowStatuses(runs, [])).toEqual(runs);
+  });
+});
+
+describe('fetchRecentScheduleRunStatuses', () => {
+  const twoRuns = toRecentScheduleRuns(
+    scheduleWith([
+      action('a', '2026-08-01T00:00:00Z', 'WORKFLOW_EXECUTION_STATUS_RUNNING'),
+      action('b', '2026-08-02T00:00:00Z', 'WORKFLOW_EXECUTION_STATUS_RUNNING'),
+    ]),
+  );
+
+  const queryFor = () =>
+    vi.mocked(requestFromAPI).mock.calls[0][1]?.params as Record<
+      string,
+      string
+    >;
+
+  beforeEach(() => {
+    vi.mocked(requestFromAPI).mockReset();
+    vi.mocked(requestFromAPI).mockResolvedValue({ executions: [] });
+  });
+
+  test('bounds the query to the runs on screen and to one execution each', async () => {
+    await fetchRecentScheduleRunStatuses({
+      namespace: 'default',
+      scheduleId: 'daily',
+      runs: twoRuns,
+    });
+
+    expect(queryFor().query).toBe(
+      'TemporalScheduledById="daily" AND WorkflowId in ("b", "a") AND ExecutionStatus != "ContinuedAsNew"',
+    );
+  });
+
+  test('escapes quotes in workflow ids', async () => {
+    await fetchRecentScheduleRunStatuses({
+      namespace: 'default',
+      scheduleId: 'daily',
+      runs: toRecentScheduleRuns(
+        scheduleWith([action('say "hi"', '2026-08-01T00:00:00Z')]),
+      ),
+    });
+
+    expect(queryFor().query).toContain('WorkflowId in ("say \\"hi\\"")');
+  });
+
+  test('does not call the API when there are no runs', async () => {
+    const result = await fetchRecentScheduleRunStatuses({
+      namespace: 'default',
+      scheduleId: 'daily',
+      runs: [],
+    });
+
+    expect(requestFromAPI).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/services/schedule-service.test.ts
+++ b/src/lib/services/schedule-service.test.ts
@@ -161,6 +161,30 @@ describe('fetchRecentScheduleRunStatuses', () => {
     expect(queryFor().query).toContain('WorkflowId in ("say \\"hi\\"")');
   });
 
+  test('escapes backslashes in workflow ids', async () => {
+    await fetchRecentScheduleRunStatuses({
+      namespace: 'default',
+      scheduleId: 'daily',
+      runs: toRecentScheduleRuns(
+        scheduleWith([action('back\\slash', '2026-08-01T00:00:00Z')]),
+      ),
+    });
+
+    expect(queryFor().query).toContain('WorkflowId in ("back\\\\slash")');
+  });
+
+  test('escapes a trailing backslash so it cannot escape the closing quote', async () => {
+    await fetchRecentScheduleRunStatuses({
+      namespace: 'default',
+      scheduleId: 'daily',
+      runs: toRecentScheduleRuns(
+        scheduleWith([action('trailing\\', '2026-08-01T00:00:00Z')]),
+      ),
+    });
+
+    expect(queryFor().query).toContain('WorkflowId in ("trailing\\\\")');
+  });
+
   test('does not call the API when there are no runs', async () => {
     const result = await fetchRecentScheduleRunStatuses({
       namespace: 'default',

--- a/src/lib/services/schedule-service.test.ts
+++ b/src/lib/services/schedule-service.test.ts
@@ -27,8 +27,12 @@ const action = (
 const scheduleWith = (actions: unknown[]) =>
   ({ info: { recentActions: actions } }) as unknown as DescribeFullSchedule;
 
-const execution = (id: string, startTime: string, status: string) =>
-  ({ id, startTime, status }) as unknown as WorkflowExecution;
+const execution = (
+  id: string,
+  startTime: string,
+  status: string,
+  runId = `${id}-run`,
+) => ({ id, runId, startTime, status }) as unknown as WorkflowExecution;
 
 describe('toRecentScheduleRuns', () => {
   test('sorts by actual time descending and caps the list', () => {
@@ -105,12 +109,26 @@ describe('withLatestWorkflowStatuses', () => {
 
   test('uses the newest execution of a continue-as-new chain', () => {
     const merged = withLatestWorkflowStatuses(runs, [
-      execution('a', '2026-08-01T00:00:00Z', 'ContinuedAsNew'),
-      execution('a', '2026-08-05T00:00:00Z', 'Failed'),
-      execution('a', '2026-08-03T00:00:00Z', 'ContinuedAsNew'),
+      execution('a', '2026-08-01T00:00:00Z', 'ContinuedAsNew', 'a-run-1'),
+      execution('a', '2026-08-05T00:00:00Z', 'Failed', 'a-run-3'),
+      execution('a', '2026-08-03T00:00:00Z', 'ContinuedAsNew', 'a-run-2'),
     ]);
 
-    expect(merged.find((run) => run.workflowId === 'a')?.status).toBe('Failed');
+    expect(merged.find((run) => run.workflowId === 'a')).toMatchObject({
+      status: 'Failed',
+      runId: 'a-run-3',
+    });
+  });
+
+  test('keeps the recorded run id when the execution has none', () => {
+    const merged = withLatestWorkflowStatuses(runs, [
+      execution('a', '2026-08-01T00:00:00Z', 'Completed', ''),
+    ]);
+
+    expect(merged.find((run) => run.workflowId === 'a')).toMatchObject({
+      status: 'Completed',
+      runId: 'a-run',
+    });
   });
 
   test('leaves runs untouched when visibility returns nothing', () => {

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -137,14 +137,15 @@ export const withLatestWorkflowStatuses = (
   }
 
   return runs.map((run) => {
-    const workflow = latest.get(run.workflowId);
-    if (!workflow) {
+    const latestWorkflow = latest.get(run.workflowId);
+    if (!latestWorkflow) {
       return run;
     }
     return {
-      ...run,
-      status: workflow.status,
-      runId: workflow.runId || run.runId,
+      actualTime: run.actualTime,
+      workflowId: latestWorkflow.id || run.workflowId,
+      status: latestWorkflow.status || run.status,
+      runId: latestWorkflow.runId || run.runId,
     };
   });
 };

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -141,7 +141,11 @@ export const withLatestWorkflowStatuses = (
     if (!workflow) {
       return run;
     }
-    return { ...run, status: workflow.status };
+    return {
+      ...run,
+      status: workflow.status,
+      runId: workflow.runId || run.runId,
+    };
   });
 };
 

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -3,12 +3,18 @@ import type { ListScheduleResponse, ScheduleListEntry } from '$lib/types';
 import type {
   DescribeFullSchedule,
   OverlapPolicy,
+  RecentScheduleRun,
   ScheduleRequestBody,
 } from '$lib/types/schedule';
+import type { WorkflowExecution } from '$lib/types/workflows';
+import { getEpochMilliseconds } from '$lib/utilities/format-time';
 import { stringifyWithBigInt } from '$lib/utilities/parse-with-big-int';
 import type { ErrorCallback } from '$lib/utilities/request-from-api';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
+import { toWorkflowStatusReadable } from '$lib/utilities/screaming-enums';
+
+import { fetchWorkflowsForQuery } from './workflow-service';
 
 type ScheduleParameters = {
   namespace: string;
@@ -93,6 +99,90 @@ export async function fetchSchedule(
   // DescribeFullSchedule says it should, since we know it we can attach it here.
   return { ...response, schedule_id: parameters.scheduleId };
 }
+
+const RECENT_RUN_COUNT = 5;
+
+export const toRecentScheduleRuns = (
+  schedule: DescribeFullSchedule,
+  limit = RECENT_RUN_COUNT,
+): RecentScheduleRun[] =>
+  (schedule?.info?.recentActions ?? [])
+    .filter(Boolean)
+    .sort(
+      (a, b) =>
+        getEpochMilliseconds(b.actualTime) - getEpochMilliseconds(a.actualTime),
+    )
+    .slice(0, limit)
+    .map((action) => ({
+      workflowId: action.startWorkflowResult?.workflowId ?? '',
+      runId: action.startWorkflowResult?.runId ?? '',
+      actualTime: action.actualTime,
+      status: toWorkflowStatusReadable(action.startWorkflowStatus ?? null),
+    }));
+
+export const withLatestWorkflowStatuses = (
+  runs: RecentScheduleRun[],
+  workflows: WorkflowExecution[],
+): RecentScheduleRun[] => {
+  const latest = new Map<string, WorkflowExecution>();
+  for (const workflow of workflows) {
+    const current = latest.get(workflow.id);
+    const isNewer =
+      !current ||
+      getEpochMilliseconds(workflow.startTime) >=
+        getEpochMilliseconds(current.startTime);
+    if (isNewer) {
+      latest.set(workflow.id, workflow);
+    }
+  }
+
+  return runs.map((run) => {
+    const workflow = latest.get(run.workflowId);
+    if (!workflow) {
+      return run;
+    }
+    return { ...run, status: workflow.status };
+  });
+};
+
+type RecentRunStatusParams = {
+  namespace: string;
+  scheduleId: string;
+  runs: RecentScheduleRun[];
+};
+
+/**
+ * `startWorkflowStatus` on a recent action is only refreshed while the
+ * scheduler is watching the run, so it goes stale for long stretches and never
+ * reports paused. Resolve the live status from visibility instead.
+ *
+ * Visibility cannot be sorted, so the query has to be narrow enough that a page
+ * can never truncate it: scoping to the runs on screen bounds it to those
+ * workflow ids, and excluding ContinuedAsNew discards every link of a
+ * continue-as-new chain but the last, leaving at most one execution per id.
+ */
+export const fetchRecentScheduleRunStatuses = async (
+  { namespace, scheduleId, runs }: RecentRunStatusParams,
+  request = fetch,
+): Promise<RecentScheduleRun[]> => {
+  const workflowIds = [
+    ...new Set(runs.map((run) => run.workflowId).filter(Boolean)),
+  ];
+  if (!workflowIds.length) {
+    return runs;
+  }
+
+  const ids = workflowIds
+    .map((workflowId) => `"${workflowId.replace(/"/g, '\\"')}"`)
+    .join(', ');
+  const query =
+    `TemporalScheduledById="${scheduleId}"` +
+    ` AND WorkflowId in (${ids})` +
+    ' AND ExecutionStatus != "ContinuedAsNew"';
+  const workflows = await fetchWorkflowsForQuery({ namespace, query }, request);
+
+  return withLatestWorkflowStatuses(runs, workflows);
+};
 
 export async function deleteSchedule(
   {

--- a/src/lib/services/schedule-service.ts
+++ b/src/lib/services/schedule-service.ts
@@ -172,8 +172,13 @@ export const fetchRecentScheduleRunStatuses = async (
     return runs;
   }
 
+  // Backslashes first: the query tokenizer treats them as escape characters, so
+  // an unescaped one swallows the character after it.
   const ids = workflowIds
-    .map((workflowId) => `"${workflowId.replace(/"/g, '\\"')}"`)
+    .map(
+      (workflowId) =>
+        `"${workflowId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
+    )
     .join(', ');
   const query =
     `TemporalScheduledById="${scheduleId}"` +

--- a/src/lib/services/workflow-service.ts
+++ b/src/lib/services/workflow-service.ts
@@ -208,6 +208,30 @@ export const fetchAllWorkflows = async (
   };
 };
 
+type WorkflowsForQueryParams = {
+  namespace: string;
+  query: string;
+  pageSize?: number;
+};
+
+export const fetchWorkflowsForQuery = async (
+  { namespace, query, pageSize = 100 }: WorkflowsForQueryParams,
+  request = fetch,
+): Promise<WorkflowExecution[]> => {
+  const route = routeForApi('workflows', { namespace });
+  const { executions } = (await requestFromAPI<ListWorkflowExecutionsResponse>(
+    route,
+    {
+      params: { query, pageSize: String(pageSize) },
+      request,
+      // Rejects rather than raising a toast, so callers decide how a failure surfaces.
+      notifyOnError: false,
+    },
+  )) ?? { executions: [] };
+
+  return toWorkflowExecutions({ executions });
+};
+
 type WorkflowForRunIdParams = {
   namespace: string;
   workflowId: string;

--- a/src/lib/types/schedule.ts
+++ b/src/lib/types/schedule.ts
@@ -42,9 +42,10 @@ export type DescribeFullSchedule = DescribeScheduleResponse & {
 };
 
 /**
- * A row in the schedule's recent runs list. `status` starts out as the status
- * recorded on the action and is replaced by the live one once visibility
- * answers.
+ * A row in the schedule's recent runs list. `status` and `runId` start out as
+ * the ones recorded on the action; once visibility answers they are replaced
+ * by the matching execution's, which for a continue-as-new chain is the latest
+ * run rather than the one the schedule started.
  */
 export type RecentScheduleRun = {
   workflowId: string;

--- a/src/lib/types/schedule.ts
+++ b/src/lib/types/schedule.ts
@@ -5,12 +5,14 @@ import type {
   Duration,
   IntervalSpec,
   Schedule,
+  ScheduleActionResult,
   SchedulePolicies,
   ScheduleSpec,
   ScheduleState,
   SearchAttribute,
   StructuredCalendarSpec,
 } from '$lib/types';
+import type { WorkflowStatus } from '$lib/types/workflows';
 
 type Override<T, U> = Omit<T, keyof U> & U;
 
@@ -37,6 +39,18 @@ export type ScheduleResponse = Override<
 export type DescribeFullSchedule = DescribeScheduleResponse & {
   schedule_id: string;
   schedule?: ScheduleResponse;
+};
+
+/**
+ * A row in the schedule's recent runs list. `status` starts out as the status
+ * recorded on the action and is replaced by the live one once visibility
+ * answers.
+ */
+export type RecentScheduleRun = {
+  workflowId: string;
+  runId: string;
+  actualTime: ScheduleActionResult['actualTime'];
+  status: WorkflowStatus;
 };
 
 /**


### PR DESCRIPTION
Recent run statuses on the schedule detail page can be wrong or significantly delayed -- paused statuses don't show as paused and status changes might not show up for minutes or more. While ultimately we are just rendering `info.recentActions.startWorkflowStatus` we can at least side-step the problem by relying on the visibility store for the specific workflows so our status reflects the actual status of the workflow. 

- Resolve the status from visibility instead, falling back to the recorded one whenever the query hasn't answered or a run isn't indexed yet
- Scope the query to the runs on screen and exclude `ContinuedAsNew`, bounding the result to one execution per row — visibility results can't be sorted, so a page must never be able to truncate them
- Add `fetchWorkflowsForQuery`, which rejects instead of raising a toast so a failed enrichment query degrades silently
- Unit tests for the run mapping, status merge, and query construction

https://github.com/user-attachments/assets/96ebea5f-2a36-4ef7-a1b9-ddf8da6b0805
