### PR TITLE
Remove task queue types from compute configs

### DIFF
--- a/src/lib/services/deployments-service.test.ts
+++ b/src/lib/services/deployments-service.test.ts
@@ -284,7 +284,6 @@ describe('deployments service', () => {
       vi.mocked(requestFromAPI).mockResolvedValueOnce(undefined as never);
 
       const scalingGroup = {
-        taskQueueTypes: ['TASK_QUEUE_TYPE_WORKFLOW'],
         provider: {
           type: 'aws-lambda',
           details: { data: 'abc', metadata: { encoding: 'xyz' } },
@@ -324,7 +323,7 @@ describe('deployments service', () => {
       vi.mocked(requestFromAPI).mockResolvedValueOnce(undefined as never);
 
       const computeConfig = {
-        scalingGroups: { default: { taskQueueTypes: [] } },
+        scalingGroups: { default: {} },
       };
 
       await updateWorkerDeploymentVersionComputeConfig({
@@ -348,7 +347,6 @@ describe('deployments service', () => {
       vi.mocked(requestFromAPI).mockResolvedValueOnce({ valid: true } as never);
 
       const scalingGroup = {
-        taskQueueTypes: ['TASK_QUEUE_TYPE_ACTIVITY'],
         provider: {
           type: 'aws-lambda',
           details: { data: 'abc', metadata: { encoding: 'xyz' } },
@@ -438,10 +436,6 @@ describe('deployments service', () => {
 
       const scalingGroup = result.scalingGroups?.['default'];
       expect(scalingGroup).toBeDefined();
-      expect(scalingGroup?.taskQueueTypes).toEqual([
-        'TASK_QUEUE_TYPE_WORKFLOW',
-        'TASK_QUEUE_TYPE_ACTIVITY',
-      ]);
       expect(scalingGroup?.provider?.type).toBe('aws-lambda');
 
       const providerData = scalingGroup?.provider?.details?.data;
@@ -552,7 +546,7 @@ describe('deployments service', () => {
     });
 
     test('returns empty object when provider data is missing', () => {
-      const config = { scalingGroups: { default: { taskQueueTypes: [] } } };
+      const config = { scalingGroups: { default: {} } };
       expect(decodeLambdaProviderDetails(config)).toEqual({});
     });
   });
@@ -580,7 +574,7 @@ describe('deployments service', () => {
     });
 
     test('returns empty object when scaler data is missing', () => {
-      const config = { scalingGroups: { default: { taskQueueTypes: [] } } };
+      const config = { scalingGroups: { default: {} } };
       expect(decodeScalerDetails(config)).toEqual({});
     });
 

--- a/src/lib/services/deployments-service.ts
+++ b/src/lib/services/deployments-service.ts
@@ -439,10 +439,6 @@ export const buildLambdaComputeConfig = (
   return {
     scalingGroups: {
       default: {
-        taskQueueTypes: [
-          'TASK_QUEUE_TYPE_WORKFLOW',
-          'TASK_QUEUE_TYPE_ACTIVITY',
-        ],
         provider: {
           type: 'aws-lambda',
           details: { metadata: { encoding }, data: providerData },
@@ -489,10 +485,6 @@ export const buildGcpCloudRunComputeConfig = (
   return {
     scalingGroups: {
       default: {
-        taskQueueTypes: [
-          'TASK_QUEUE_TYPE_WORKFLOW',
-          'TASK_QUEUE_TYPE_ACTIVITY',
-        ],
         provider: {
           type: 'gcp-cloud-run',
           details: { metadata: { encoding }, data: providerData },

--- a/src/lib/utilities/deployment-has-compute-config.test.ts
+++ b/src/lib/utilities/deployment-has-compute-config.test.ts
@@ -11,7 +11,6 @@ import { deploymentHasComputeConfig } from './deployment-has-compute-config';
 const computeConfig: ComputeConfig = {
   scalingGroups: {
     default: {
-      taskQueueTypes: ['TASK_QUEUE_TYPE_WORKFLOW', 'TASK_QUEUE_TYPE_ACTIVITY'],
       provider: { type: 'aws-lambda' },
     },
   },
@@ -164,10 +163,6 @@ describe('deploymentHasComputeConfig', () => {
           computeConfig: {
             scalingGroups: {
               default: {
-                taskQueueTypes: [
-                  'TASK_QUEUE_TYPE_WORKFLOW',
-                  'TASK_QUEUE_TYPE_ACTIVITY',
-                ],
                 providerType: 'aws-lambda',
               },
             },


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
The UI set the task queue types to a subset of the needed values, which led to confusing errors so just removing it entirely to avoid confusion.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
