### PR TITLE
fix: align heading/timestamp spacing across primitive list headers

### DIFF
--- a/src/lib/layouts/workers-layout.svelte
+++ b/src/lib/layouts/workers-layout.svelte
@@ -51,7 +51,7 @@
 <header class="flex flex-col gap-2">
   <div class="flex min-h-10 flex-wrap items-center justify-between gap-2">
     <div>
-      <div class="flex items-center gap-2">
+      <div class="flex items-start gap-2">
         <h1 class="leading-7" data-cy="workers-title">
           {translate('workers.workers')}
         </h1>

--- a/src/lib/pages/standalone-activities.svelte
+++ b/src/lib/pages/standalone-activities.svelte
@@ -198,7 +198,7 @@
             <Translate key="standalone-activities.recent-activities" />
           {/if}
         </h1>
-        <p class="mt-2 text-xs text-secondary">
+        <p class="mt-3 text-xs text-secondary">
           {refreshTimeFormatted}
         </p>
       </div>

--- a/src/lib/pages/standalone-nexus-operations.svelte
+++ b/src/lib/pages/standalone-nexus-operations.svelte
@@ -96,7 +96,7 @@
             />
           {/if}
         </h1>
-        <p class="mt-2 text-xs text-secondary">
+        <p class="mt-3 text-xs text-secondary">
           {refreshTimeFormatted}
         </p>
       </div>


### PR DESCRIPTION
## Problem

The gap between the heading and the timestamp underneath it is different on every primitive list page. The timestamp's offset was picking up whatever leftover height the neighboring **Refresh** button contributed to the heading's flex row, and that leftover differs depending on how each page nests the button, so the declared `mt-2` never actually described what shipped.

The heading is `leading-7` (28px); the `xs` Refresh button is `h-8` (32px). Where the two share a flex row, the row is 4px taller than the heading and that slack lands on the timestamp.

## Before / after

| Page | Before | After | Cause of the difference |
| --- | --- | --- | --- |
| Workflows | 12px | 12px | unchanged — heading row is 4px taller than the heading |
| Schedules | 12px | 12px | unchanged — same as Workflows |
| Workers | **10px** | **12px** | row uses `items-center`, so the heading shifts down 2px and only half the slack reaches the timestamp |
| Standalone Activities | **8px** | **12px** | Refresh button sits outside the title block, so the timestamp only got the declared `mt-2` |
| Standalone Nexus Operations | **8px** | **12px** | same as Standalone Activities |

All five now render **12px**, matching what Workflows and Schedules already looked like, the two highest-traffic pages are visually untouched.