### PR TITLE
fix(auth): derive auth cookie Secure attribute from the OIDC callback URL

### DIFF
--- a/server/server/auth/auth.go
+++ b/server/server/auth/auth.go
@@ -58,7 +58,7 @@ func stripBearerPrefix(token string) string {
 	return strings.TrimPrefix(token, "Bearer ")
 }
 
-func SetUser(c echo.Context, user *User) error {
+func SetUser(c echo.Context, user *User, secure bool) error {
 	if user.OAuth2Token == nil {
 		return errors.New("no OAuth2Token")
 	}
@@ -89,7 +89,7 @@ func SetUser(c echo.Context, user *User) error {
 			Name:     "user" + strconv.Itoa(i),
 			Value:    p,
 			MaxAge:   int(time.Minute.Seconds()),
-			Secure:   c.Request().TLS != nil,
+			Secure:   secure,
 			HttpOnly: false,
 			Path:     "/",
 			SameSite: http.SameSiteStrictMode,
@@ -126,7 +126,7 @@ func SetUser(c echo.Context, user *User) error {
 			Name:     "refresh",
 			Value:    rt,
 			MaxAge:   refreshMaxAge,
-			Secure:   c.Request().TLS != nil,
+			Secure:   secure,
 			HttpOnly: true,
 			Path:     "/",
 			SameSite: http.SameSiteStrictMode,
@@ -141,7 +141,7 @@ func SetUser(c echo.Context, user *User) error {
 
 // SetSessionStart sets a cookie with the current timestamp to track when the session began.
 // This should only be called on initial login, NOT on token refresh.
-func SetSessionStart(c echo.Context, maxSessionDuration time.Duration) {
+func SetSessionStart(c echo.Context, maxSessionDuration time.Duration, secure bool) {
 	if maxSessionDuration <= 0 {
 		return
 	}
@@ -150,7 +150,7 @@ func SetSessionStart(c echo.Context, maxSessionDuration time.Duration) {
 		Name:     sessionStartCookie,
 		Value:    strconv.FormatInt(time.Now().Unix(), 10),
 		MaxAge:   int(maxSessionDuration.Seconds()),
-		Secure:   c.Request().TLS != nil,
+		Secure:   secure,
 		HttpOnly: true,
 		Path:     "/",
 		SameSite: http.SameSiteStrictMode,

--- a/server/server/auth/auth_test.go
+++ b/server/server/auth/auth_test.go
@@ -25,6 +25,7 @@ package auth_test
 import (
 	_ "embed"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v4"
@@ -95,7 +96,7 @@ func TestSetUser(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := auth.SetUser(tt.ctx, &tt.user)
+			err := auth.SetUser(tt.ctx, &tt.user, true)
 			cookies := tt.ctx.Cookies()
 
 			if tt.wantErr {
@@ -106,6 +107,34 @@ func TestSetUser(t *testing.T) {
 				assert.NoError(t, err)
 				setCookie := tt.ctx.Response().Header().Get(echo.HeaderSetCookie)
 				assert.Contains(t, setCookie, "user0")
+			}
+		})
+	}
+}
+
+// TestSetUserSecureFlag asserts that the auth cookies carry Secure according to the
+// `secure` argument passed to SetUser.
+func TestSetUserSecureFlag(t *testing.T) {
+	for name, secure := range map[string]bool{"secure=true": true, "secure=false": false} {
+		t.Run(name, func(t *testing.T) {
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/auth/sso/callback", nil)
+			c := e.NewContext(req, httptest.NewRecorder())
+			user := auth.User{OAuth2Token: &oauth2.Token{AccessToken: "AAA", RefreshToken: "RRR"}}
+
+			a := assert.New(t)
+			a.NoError(auth.SetUser(c, &user, secure))
+
+			for _, sc := range c.Response().Header()[echo.HeaderSetCookie] {
+				cookieName := strings.SplitN(sc, "=", 2)[0]
+				if !strings.HasPrefix(cookieName, "user") && cookieName != "refresh" {
+					continue
+				}
+				if secure {
+					a.Contains(sc, "Secure", "%s must be Secure", cookieName)
+				} else {
+					a.NotContains(sc, "Secure", "%s must not be Secure", cookieName)
+				}
 			}
 		})
 	}

--- a/server/server/route/auth.go
+++ b/server/server/route/auth.go
@@ -108,15 +108,43 @@ func SetAuthRoutes(e *echo.Echo, cfgProvider *config.ConfigProviderWithRefresh) 
 		Scopes:       providerCfg.Scopes,
 	}
 
+	secure, err := cookieSecureForCallbackURL(providerCfg.CallbackURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	api := e.Group("/auth")
-	api.GET("/sso", authenticate(&oauthCfg, providerCfg.Options, serverCfg.CORS.AllowOrigins))
-	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
-	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration)) // compatibility with UI v1
-	api.GET("/refresh", refreshTokens(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration))
-	api.GET("/logout", logout())
+	api.GET("/sso", authenticate(&oauthCfg, providerCfg.Options, serverCfg.CORS.AllowOrigins, secure))
+	api.GET("/sso/callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration, secure))
+	api.GET("/sso_callback", authenticateCb(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration, secure)) // compatibility with UI v1
+	api.GET("/refresh", refreshTokens(ctx, &oauthCfg, provider, serverCfg.Auth.MaxSessionDuration, secure))
+	api.GET("/logout", logout(secure))
 }
 
-func authenticate(config *oauth2.Config, options map[string]interface{}, allowedOrigins []string) func(echo.Context) error {
+// cookieSecureForCallbackURL reports whether the auth cookies may carry the Secure
+// attribute, based on the scheme of the OIDC callback URL. That URL is the
+// browser-facing address the identity provider redirects back to, so it is the
+// authoritative record of how a browser reaches this deployment.
+//
+// An unrecognized scheme is an error rather than a false return, so that a malformed
+// callback URL fails loudly at startup.
+func cookieSecureForCallbackURL(callbackURL string) (bool, error) {
+	u, err := url.Parse(callbackURL)
+	if err != nil {
+		return false, fmt.Errorf("unable to parse auth callback url: %w", err)
+	}
+
+	switch u.Scheme {
+	case "https":
+		return true, nil
+	case "http":
+		return false, nil
+	default:
+		return false, fmt.Errorf("auth callback url must use http or https, got %q", callbackURL)
+	}
+}
+
+func authenticate(config *oauth2.Config, options map[string]interface{}, allowedOrigins []string, secure bool) func(echo.Context) error {
 	return func(c echo.Context) error {
 		state, err := randString()
 		if err != nil {
@@ -126,8 +154,8 @@ func authenticate(config *oauth2.Config, options map[string]interface{}, allowed
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		setCallbackCookie(c, "state", state)
-		setCallbackCookie(c, "nonce", nonce)
+		setCallbackCookie(c, "state", state, secure)
+		setCallbackCookie(c, "nonce", nonce, secure)
 
 		opts := []oauth2.AuthCodeOption{
 			oidc.Nonce(nonce),
@@ -154,20 +182,20 @@ func authenticate(config *oauth2.Config, options map[string]interface{}, allowed
 	}
 }
 
-func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration) func(echo.Context) error {
+func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration, secure bool) func(echo.Context) error {
 	return func(c echo.Context) error {
 		user, err := auth.ExchangeCode(ctx, c.Request(), oauthCfg, provider)
 		if err != nil {
 			return err
 		}
 
-		err = auth.SetUser(c, user)
+		err = auth.SetUser(c, user, secure)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set user: "+err.Error())
 		}
 
 		// Set session start time for max session duration enforcement
-		auth.SetSessionStart(c, maxSessionDuration)
+		auth.SetSessionStart(c, maxSessionDuration, secure)
 
 		nonceS, err := c.Request().Cookie("nonce")
 		if err != nil {
@@ -189,7 +217,7 @@ func authenticateCb(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc
 
 // refreshTokens exchanges a refresh token (stored in an HttpOnly cookie) for a new access token
 // and optionally a new ID token. It resets the cookies using auth.SetUser and returns 200.
-func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration) func(echo.Context) error {
+func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.Provider, maxSessionDuration time.Duration, secure bool) func(echo.Context) error {
 	return func(c echo.Context) error {
 		startTime := time.Now()
 		clientIP := c.RealIP()
@@ -239,7 +267,7 @@ func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.
 			}
 		}
 
-		if err := auth.SetUser(c, &user); err != nil {
+		if err := auth.SetUser(c, &user, secure); err != nil {
 			duration := time.Since(startTime).Milliseconds()
 			log.Printf("token_refresh_failed reason=set_user_failed ip=%s error=%q duration_ms=%d", clientIP, err.Error(), duration)
 			return echo.NewHTTPError(http.StatusInternalServerError, "unable to set refreshed user: "+err.Error())
@@ -254,22 +282,22 @@ func refreshTokens(ctx context.Context, oauthCfg *oauth2.Config, provider *oidc.
 }
 
 // logout clears authentication cookies and redirects to root
-func logout() func(echo.Context) error {
+func logout(secure bool) func(echo.Context) error {
 	return func(c echo.Context) error {
 		log.Printf("[Auth] User logout initiated from %s", c.RealIP())
 
 		// Clear refresh token cookie
-		clearCookie(c, "refresh")
+		clearCookie(c, "refresh", secure)
 		log.Printf("[Auth] Cleared refresh token cookie")
 
 		// Clear session start cookie
-		clearCookie(c, "session_start")
+		clearCookie(c, "session_start", secure)
 
 		// Clear user data cookies (user0, user1, etc.)
 		// We don't know how many chunks exist, so clear up to 10
 		for i := 0; i < 10; i++ {
 			cookieName := "user" + strconv.Itoa(i)
-			clearCookie(c, cookieName)
+			clearCookie(c, cookieName, secure)
 		}
 		log.Printf("[Auth] Cleared user data cookies")
 
@@ -279,27 +307,27 @@ func logout() func(echo.Context) error {
 }
 
 // clearCookie sets a cookie with MaxAge=-1 to delete it
-func clearCookie(c echo.Context, name string) {
+func clearCookie(c echo.Context, name string, secure bool) {
 	cookie := &http.Cookie{
 		Name:     name,
 		Value:    "",
 		MaxAge:   -1, // Instructs browser to delete cookie
 		Path:     "/",
-		Secure:   c.Request().TLS != nil,
+		Secure:   secure,
 		HttpOnly: true,
 		SameSite: http.SameSiteStrictMode,
 	}
 	c.SetCookie(cookie)
 }
 
-func setCallbackCookie(c echo.Context, name, value string) {
+func setCallbackCookie(c echo.Context, name, value string, secure bool) {
 	// Explicitly expire pre v2.8.0 state and nonce cookies.
 	// As they had different path, they were not being cleared and in some cases result in "state did not match" error.
 	cookiePreV280 := &http.Cookie{
 		Name:     name,
 		Value:    "",
 		MaxAge:   -1,
-		Secure:   c.Request().TLS != nil,
+		Secure:   secure,
 		Path:     "",
 		HttpOnly: true,
 	}
@@ -309,7 +337,7 @@ func setCallbackCookie(c echo.Context, name, value string) {
 		Name:     name,
 		Value:    value,
 		MaxAge:   int(time.Hour.Seconds()),
-		Secure:   c.Request().TLS != nil,
+		Secure:   secure,
 		Path:     "/",
 		HttpOnly: true,
 	}

--- a/server/server/route/auth_test.go
+++ b/server/server/route/auth_test.go
@@ -1,0 +1,65 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCookieSecureForCallbackURL(t *testing.T) {
+	tests := map[string]struct {
+		callbackURL string
+		want        bool
+		wantErr     bool
+	}{
+		"https": {
+			callbackURL: "https://temporal.example.com/auth/sso/callback",
+			want:        true,
+		},
+		"https with port": {
+			callbackURL: "https://temporal.example.com:8080/auth/sso/callback",
+			want:        true,
+		},
+		"http": {
+			callbackURL: "http://localhost:8080/auth/sso/callback",
+			want:        false,
+		},
+		"uppercase scheme is normalized": {
+			callbackURL: "HTTPS://temporal.example.com/auth/sso/callback",
+			want:        true,
+		},
+		"missing scheme": {
+			callbackURL: "temporal.example.com/auth/sso/callback",
+			wantErr:     true,
+		},
+		"empty": {
+			callbackURL: "",
+			wantErr:     true,
+		},
+		"unsupported scheme": {
+			callbackURL: "ftp://temporal.example.com/auth/sso/callback",
+			wantErr:     true,
+		},
+		"unparseable": {
+			callbackURL: "https://temporal.example.com/auth/sso/callback\x7f",
+			wantErr:     true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			a := assert.New(t)
+
+			got, err := cookieSecureForCallbackURL(tt.callbackURL)
+
+			if tt.wantErr {
+				a.Error(err)
+				a.False(got, "must not report Secure when the callback URL is rejected")
+				return
+			}
+
+			a.NoError(err)
+			a.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Description & motivation 💭

The auth cookies (`user*`, `refresh`, `session_start`, OAuth `state`/`nonce`, and the
logout clears) took their `Secure` attribute from `c.Request().TLS` — ui-server's own
inbound connection, which isn't necessarily how the browser reaches the deployment.

Derive it from the scheme of the configured OIDC callback URL instead: that URL is the
browser-facing address the identity provider redirects back to, so it's the
authoritative record. `https` callback ⇒ cookies are `Secure`; `http` ⇒ they aren't.
No new configuration, and this brings the auth cookies in line with `_csrf`.

An unrecognized callback-URL scheme is now a startup error rather than a silent
`false`, so a malformed `callbackUrl` fails loudly.

### Alternatives considered

**Reusing `CORS.CookieInsecure`** (i.e. `secure := !serverCfg.CORS.CookieInsecure`) was
the first approach, and mirrors what the CSRF cookie already does in `server.go`. We
rejected it on three counts:

- **It overloads a knob that is documented and surfaced as CSRF-specific.** The field
  comment says "allows CSRF cookie to be sent…", and `config/docker.yaml` exposes it as
  `TEMPORAL_CSRF_COOKIE_INSECURE`. Operators who set that for CSRF reasons would have
  been changing auth cookie behavior without knowing it.
- **It regresses a configuration that is correct today.** A deployment terminating TLS
  directly *and* setting `cookieInsecure: true` currently gets `Secure` auth cookies
  from `Request().TLS`; keying off the flag alone would take it away.
- **It breaks plaintext deployments on upgrade.** The shipped default is
  `cookieInsecure: false` (`development.yaml`, `e2e.yaml`, `with-auth.yaml`, and the
  docker template), so any HTTP deployment that never touched the knob would start
  emitting `Secure` cookies and fail to log in.

**A dedicated `auth.cookieInsecure` option** was also considered. It has the cleanest
semantics but adds a config key, an env var, and helm/docker template surface — and it
doesn't avoid the upgrade break, since plaintext deployments would still have to opt
out. The callback URL already states the deployment's topology; asking operators to
restate it is redundant.

**`X-Forwarded-Proto`** is client-supplied and would need trusted-proxy configuration
to rely on.

## Testing 🧪

- [x] Unit tests added

`TestCookieSecureForCallbackURL` covers scheme handling (https/http/uppercase/missing/
unsupported/unparseable); `TestSetUserSecureFlag` asserts the cookies honor the flag.
Full `server` suite passes.
