### PR TITLE
fix(events): dedupe marker billable actions across both fetch cursors

### DIFF
--- a/src/lib/services/grouped-event-buffer.test.ts
+++ b/src/lib/services/grouped-event-buffer.test.ts
@@ -38,6 +38,7 @@ import {
   makeActivityTimedOut,
   makeActivityTimeoutGroup,
   makeChildWorkflowGroup,
+  makeLocalActivityMarker,
   makeNexusOperationGroup,
   makeSyntheticEvents,
   makeSyntheticEventsWithWorkflowTasks,
@@ -566,6 +567,52 @@ describe('setFailedEvent', () => {
     setFailedEvent(null);
     loadAll(events);
     expect(getGroupCount()).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10b. Marker billable-action dedup
+//
+// Several markers can share one workflow task, which bills once. The cursors
+// exist only to fetch in parallel, so which one delivered a marker must not
+// change the total.
+// ---------------------------------------------------------------------------
+
+describe('marker billable actions', () => {
+  const totalBillableActions = () =>
+    getEventArray().reduce(
+      (sum, event) => sum + (event.billableActions ?? 0),
+      0,
+    );
+
+  // IDs 11-13, all emitted by the workflow task completed at event 10.
+  const markers = [11, 12, 13].map((id) => makeLocalActivityMarker(id, 10));
+
+  it('bills one workflow task once on the ascending cursor', () => {
+    reset(20);
+    for (const marker of markers) processEvent(marker, true);
+    expect(totalBillableActions()).toBe(1);
+  });
+
+  it('bills one workflow task once on the descending cursor', () => {
+    reset(20);
+    for (const marker of markers.toReversed()) processEvent(marker, false);
+    expect(totalBillableActions()).toBe(1);
+  });
+
+  it('bills one workflow task once when the cursors split its markers', () => {
+    reset(20);
+    processEvent(markers[2], false);
+    processEvent(markers[0], true);
+    processEvent(markers[1], true);
+    expect(totalBillableActions()).toBe(1);
+  });
+
+  it('bills distinct workflow tasks separately', () => {
+    reset(20);
+    processEvent(makeLocalActivityMarker(11, 10), true);
+    processEvent(makeLocalActivityMarker(13, 12), false);
+    expect(totalBillableActions()).toBe(2);
   });
 });
 

--- a/src/lib/services/grouped-event-buffer.ts
+++ b/src/lib/services/grouped-event-buffer.ts
@@ -91,7 +91,9 @@ let _cachedLiveVersionNoWFT = -1;
 // Incremented each time liveGroups is modified so getGroupArray knows to bust.
 let _liveVersion = 0;
 
-// Accumulated WFT IDs for marker billable-action dedup (ascending cursor only)
+// Accumulated WFT IDs for marker billable-action dedup. Shared by both cursors
+// and the live poll — the direction an event arrives from is a fetch detail,
+// and one workflow task's markers bill once however they were loaded.
 const processedWorkflowTaskIds = new Set<string>();
 
 // Solo events that don't form groups (e.g. WorkflowExecutionStarted/Completed).
@@ -213,15 +215,10 @@ function shouldNotAddBillableAction(event: WorkflowEvent): boolean {
   return Number(event.id) < Number(failedEvent.eventId);
 }
 
-function toWorkflowEvent(
-  raw: HistoryEvent,
-  isAscending: boolean,
-): WorkflowEvent {
+function toWorkflowEvent(raw: HistoryEvent): WorkflowEvent {
   return toEvent(raw, {
     shouldNotAddBillableAction,
-    processedWorkflowTaskIds: isAscending
-      ? processedWorkflowTaskIds
-      : undefined,
+    processedWorkflowTaskIds,
   });
 }
 
@@ -312,7 +309,7 @@ function attachFollowerToPool(poolIdx: number, followerSlotIdx: number): void {
   const raw = eventSlots[followerSlotIdx];
   if (!raw || !meta.group) return;
 
-  const event = toWorkflowEvent(raw, false);
+  const event = toWorkflowEvent(raw);
   meta.group = withAddedEvent(meta.group, event);
 
   eventToGroup[followerSlotIdx] = poolIdx + 1;
@@ -486,7 +483,7 @@ export function processEvent(
     latestEventRef = raw;
   }
 
-  const event = toWorkflowEvent(raw, isAscending);
+  const event = toWorkflowEvent(raw);
   const gid = getGroupId(event as CommonHistoryEvent);
   const isHead = gid === event.id;
 
@@ -1014,7 +1011,7 @@ export function appendLiveEvent(raw: HistoryEvent): boolean {
   if (slotIdx < eventToGroup.length && eventToGroup[slotIdx] !== 0)
     return false;
 
-  const event = toWorkflowEvent(raw, true);
+  const event = toWorkflowEvent(raw);
   const gid = getGroupId(event as CommonHistoryEvent);
   const isHead = gid === event.id;
 

--- a/src/lib/services/test-helpers/synthetic-events.ts
+++ b/src/lib/services/test-helpers/synthetic-events.ts
@@ -289,6 +289,25 @@ export function makeNexusOperationCompleted(
   } as unknown as HistoryEvent;
 }
 
+/**
+ * A local-activity marker. Markers emitted by one workflow task bill once
+ * between them, so tests that care about that pass a shared
+ * workflowTaskCompletedEventId.
+ */
+export function makeLocalActivityMarker(
+  eventId: number,
+  workflowTaskCompletedEventId: number,
+): HistoryEvent {
+  return {
+    ...base(eventId, 'MarkerRecorded'),
+    markerRecordedEventAttributes: {
+      markerName: 'LocalActivity',
+      details: {},
+      workflowTaskCompletedEventId: String(workflowTaskCompletedEventId),
+    },
+  } as unknown as HistoryEvent;
+}
+
 // ---------------------------------------------------------------------------
 // Composite group builders (return events in ascending ID order)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description & motivation 💭

Marker billable actions were only deduped on the ascending cursor, so the same workflow could report a different billable-action total between page loads.

- Markers emitted by one workflow task bill once between them, deduped through a shared `processedWorkflowTaskIds` set. The buffer passed that set only when `isAscending`, so markers loaded by the descending cursor each charged 1 and never registered their task.
- The cursors exist only to fetch in parallel, and where they meet depends on network timing — both loops stop on `gap() <= 0` and abort the other — so which markers got deduped varied per load.
- `toWorkflowEvent` now passes the set unconditionally and no longer takes a direction. `processEvent` keeps `isAscending` for track assignment.
- `appendLiveEvent` (hardcoded `true`) and `attachFollowerToPool` (hardcoded `false`) now share the same set.

Regression from #3627, which introduced the bidirectional fetch. Before it, `toEventHistory` ran a single set over the whole history.

Known limitation: the total is now correct regardless of arrival order, but *which* marker row carries the charge follows whichever sibling was converted first, so the per-row Billable Actions column can move between the task's lowest and highest marker. Pinning it would mean re-attributing the charge to an already-ingested event and fixing up its group's eager sum; the clean fix is a server-side count on `WorkflowTaskCompleted`, since `MeteringMetadata` only reports non-first LA attempts.

## Testing 🧪

### How was this tested 👻

- [x] Unit tests added

Four cases in `marker billable actions`. Reverting only the source change fails the descending and split cases (3→1, 2→1) and leaves the two controls passing.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Open a workflow with several local activities in one workflow task and a history long enough for both cursors to page. The Billable Actions total should be identical across reloads.