### PR TITLE
fix(modal): notify once on every dismissal via the dialog close event

### DIFF
--- a/src/lib/holocene/modal.svelte
+++ b/src/lib/holocene/modal.svelte
@@ -65,10 +65,13 @@
     toggleModal(open, modalElement);
   });
 
-  const handleCancel = () => {
-    onCancelModal?.();
-    open = false;
+  // Escape, backdrop, the close icon, the cancel button and the parent flipping
+  // `open` all end up here via the dialog's native close event.
+  const handleClose = () => {
     error = '';
+    if (!open) return; // the parent already closed us, the user did not cancel
+    open = false;
+    onCancelModal?.();
   };
 
   const confirmModal = () => {
@@ -76,7 +79,7 @@
   };
 
   const closeModal = () => {
-    open = false;
+    modalElement?.close();
   };
 
   const handleClick = (event: MouseEvent) => {
@@ -94,7 +97,7 @@
 
 <dialog
   {id}
-  onclose={handleCancel}
+  onclose={handleClose}
   bind:this={modalElement}
   class={merge(
     'body',

--- a/tests/integration/workflow-actions.spec.ts
+++ b/tests/integration/workflow-actions.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import { ResetReapplyExcludeType, ResetReapplyType } from '$src/lib/types';
 import {
@@ -329,6 +329,49 @@ test.describe('Workflow Actions for a Completed Workflow', () => {
       await page.getByRole('button', { name: 'More Actions' }).click();
 
       await expect(page.getByTestId('terminate-button')).toBeHidden();
+    });
+  });
+
+  test.describe('Modal dismissal', () => {
+    test.beforeEach(async ({ page }) => {
+      await mockWorkflowApis(page, mockCompletedWorkflow);
+      await mockClusterApi(page, { serverVersion: '1.24.0' });
+      await mockWorkflowResetApi(page);
+      await page.goto(workflowUrl);
+    });
+
+    const openResetModal = (page: Page) =>
+      page.getByRole('button', { name: 'Reset' }).click();
+
+    const visibleResetModal = (page: Page) =>
+      page.getByTestId('reset-confirmation-modal').locator('visible=true');
+
+    test('reopens after being dismissed with Escape', async ({ page }) => {
+      await expect(page.getByRole('button', { name: 'Reset' })).toBeEnabled();
+
+      await openResetModal(page);
+      await expect(visibleResetModal(page)).toHaveCount(1);
+
+      await page.keyboard.press('Escape');
+      await expect(visibleResetModal(page)).toHaveCount(0);
+
+      await openResetModal(page);
+      await expect(visibleResetModal(page)).toHaveCount(1);
+    });
+
+    test('reopens after being dismissed with the cancel button', async ({
+      page,
+    }) => {
+      await expect(page.getByRole('button', { name: 'Reset' })).toBeEnabled();
+
+      await openResetModal(page);
+      await expect(visibleResetModal(page)).toHaveCount(1);
+
+      await visibleResetModal(page).getByTestId('cancel-modal-button').click();
+      await expect(visibleResetModal(page)).toHaveCount(0);
+
+      await openResetModal(page);
+      await expect(visibleResetModal(page)).toHaveCount(1);
     });
   });
 });


### PR DESCRIPTION
## Description & motivation 💭

`Modal` had three ways to close itself and each one updated state differently, so `onCancelModal` was neither reliable nor exclusive:

- Escape fired the `cancel` listener **and** then the dialog's native `close` event, so `onCancelModal` ran twice.
- A parent-driven close — flipping `open` to `false` after a successful confirm — also reached `close`, so the consumer's cancel handler ran even though the user never cancelled. Cloud UI's failover modal hits this: on success it closes the modal, and the resulting "cancel" wiped the request handle it needed to render the outcome.
- The close icon and backdrop set `open = false` directly and skipped `error = ''`, leaving a stale error visible on the next open.

The dialog's `close` event already fires for every path, including after `cancel`, so it's the natural single funnel. `handleClose` is now the only place that mutates `open` or calls `onCancelModal`, and it returns early when `open` is already `false` — that's how a parent-initiated close is distinguished from a user dismissal. `closeModal` calls `modalElement.close()` instead of assigning to `open`, which is safe because a closed `<dialog>` is `display: none`, so the icon and cancel buttons aren't reachable when it isn't open.

Worth noting for consumers: writing to `open` only reaches the owner when it's bound. Components that pass a plain expression (`open={state === 'open'}`) depend entirely on the callback, which is why the callback contract had to be the thing that got fixed.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [x] E2E tests added

Full integration suite passes (152 tests) — it covers the terminate, cancel, signal, reset, schedule, bulk-action and saved-view modals, so no existing consumer regresses on the new funnel.

Two tests added to `tests/integration/workflow-actions.spec.ts`: dismiss the reset modal via Escape and via the cancel button, then reopen it. They guard the `modalElement.close()` funnel. They would also pass on `main` — the double-fire and the spurious cancel aren't observable in this repo, because every consumer here either binds `open` or writes an idempotent cancel handler.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Open any confirmation modal (Workflow → More Actions → Terminate is easiest):

1. Dismiss with Escape, with the X, with a backdrop click, and with Cancel — each should close and reopen cleanly.
2. Trigger an error in the modal, dismiss it, reopen — the error should be gone.
3. Confirm successfully — the cancel handler should not run.
