### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine3.23 AS server-builder
+FROM golang:1.26.5-alpine3.23 AS server-builder
 
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
@@ -15,7 +15,7 @@ COPY . ./
 
 RUN make build-server
 
-FROM golang:1.26.3-alpine3.23 AS dockerize-builder
+FROM golang:1.26.5-alpine3.23 AS dockerize-builder
 
 ARG DOCKERIZE_VERSION=v0.10.1
 RUN go install github.com/jwilder/dockerize@${DOCKERIZE_VERSION} && \

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/temporalio/ui-server/v2
 
-go 1.26.3
+go 1.26.5
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
## Description & motivation 💭

Bumps the Go toolchain used by UI Server from 1.26.3 to 1.26.5 in `server/go.mod` and both Docker build stages.

Go 1.26.5 includes the security fixes from 1.26.4 plus the subsequent `crypto/tls` and `os` fixes released in July.

Supersedes #3608, which targets the now-outdated Go 1.26.4 release.

## Testing 🧪

### How was this tested 👻

- [x] `go mod verify`
- [x] `go test ./...`
- [x] `git diff --check`

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Build the generated UI assets.
2. Run `go test ./...` from `server/`.

## Checklists

### Draft Checklist

- [x] Go version pins are synchronized across `go.mod` and both Docker build stages.

### Merge Checklist

- [ ] CI passes.

### Issue(s) closed

Supersedes #3608.

## Docs

### Any docs updates needed?

No documentation changes are required.
