### PR TITLE
Manual on-call dependency review with constrained Claude remediation

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -405,17 +405,16 @@ pnpm validate:versions
 ## Weekly Frontend On-Call Review
 
 `weekly-oncall-review.yml` creates one Slack thread in `#oncall-frontend` and
-fans out to small, independently callable review modules. It runs every Monday
-at 14:00 UTC and can also be started from **Actions → Weekly On-Call Review**.
-The scheduled run uses `apply` mode and notifications, so Claude can author a
-minimal dependency-security candidate and the workflow can update its draft PR.
-Manual runs default to `dry-run`; choose `apply` only when the
-generated dependency remediation draft PR may be updated. Manual notifications default to `C0BPXR260DA`
+fans out to small, independently callable review modules. Scheduling is
+intentionally disabled pending enablement; start it from **Actions → Weekly
+On-Call Review** when needed. Manual runs default to `dry-run`; choose `apply`
+only when the generated dependency remediation draft PR may be updated. Manual
+notifications default to `C0BPXR260DA`
 (`#other-ross-tests-stuff`) so test runs do not post to the on-call channel.
 The `slack_channel` input accepts another Slack channel ID when needed.
-Scheduled runs ignore that input and always use
-`ONCALL_FRONTEND_SLACK_CHANNEL`. `notify: false` runs the audits without
-posting to Slack.
+If scheduling is reintroduced, the dormant schedule fallback remains
+fail-safe: it uses `dry-run` mode and `ONCALL_FRONTEND_SLACK_CHANNEL`.
+`notify: false` runs the audits without posting to Slack.
 
 A separate `weekly-oncall-review-pr-test.yml` workflow validates internal pull
 requests that change the on-call workflows, their dependency-security scripts

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -407,9 +407,10 @@ pnpm validate:versions
 `weekly-oncall-review.yml` creates one Slack thread in `#oncall-frontend` and
 fans out to small, independently callable review modules. It runs every Monday
 at 14:00 UTC and can also be started from **Actions → Weekly On-Call Review**.
-The scheduled run uses `apply` mode and notifications. Manual runs default to
-`dry-run`; choose `apply` only when the generated dependency remediation draft
-PR may be updated. Manual notifications default to `C0BPXR260DA`
+The scheduled run uses `dry-run` mode and notifications. Until the Claude
+resolver is integrated, it does not update the generated dependency remediation
+draft PR. Manual runs also default to `dry-run`; choose `apply` only when the
+generated dependency remediation draft PR may be updated. Manual notifications default to `C0BPXR260DA`
 (`#other-ross-tests-stuff`) so test runs do not post to the on-call channel.
 The `slack_channel` input accepts another Slack channel ID when needed.
 Scheduled runs ignore that input and always use

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -402,6 +402,120 @@ pnpm validate:versions
 - [Peter Evans Actions](https://github.com/peter-evans)
 - [Release Drafter Configuration](https://github.com/release-drafter/release-drafter)
 
+## Weekly Frontend On-Call Review
+
+`weekly-oncall-review.yml` creates one Slack thread in `#oncall-frontend` and
+fans out to small, independently callable review modules. It runs every Monday
+at 14:00 UTC and can also be started from **Actions → Weekly On-Call Review**.
+The scheduled run uses `apply` mode and notifications. Manual runs default to
+`dry-run`; choose `apply` only when the generated dependency remediation draft
+PR may be updated. Manual notifications default to `C0BPXR260DA`
+(`#other-ross-tests-stuff`) so test runs do not post to the on-call channel.
+The `slack_channel` input accepts another Slack channel ID when needed.
+Scheduled runs ignore that input and always use
+`ONCALL_FRONTEND_SLACK_CHANNEL`. `notify: false` runs the audits without
+posting to Slack.
+
+A separate `weekly-oncall-review-pr-test.yml` workflow validates internal pull
+requests that change the on-call workflows, their dependency-security scripts
+or tests, `package.json`, or `pnpm-lock.yaml`. It checks out the PR head SHA and
+runs the dependency module in `dry-run` mode plus the VLN and external-review
+audits. Fork and Dependabot pull requests are skipped. The PR workflow passes
+no stored repository secrets and disables every notification path, so it
+validates the audit and remediation logic without posting to Slack or
+publishing changes.
+
+After merging, use a manual `dry-run` dispatch to the default test channel
+`C0BPXR260DA` when Slack delivery itself needs validation.
+
+The coordinator owns the root Slack post and a final status reply. Modules add
+their own replies in the same thread:
+
+- `weekly-dependency-security-review.yml` audits Dependabot alerts, produces a
+  minimal package remediation candidate, and reports its evidence.
+- `weekly-vln-review.yml` reports open VLN remediation PRs.
+- `weekly-external-contributor-review.yml` reports active, non-bot PRs from
+  external forks. It groups the top five review-ready, triage, and
+  author-follow-up candidates and includes a stale-count summary.
+
+The module boundary is intentional: a future on-call concern can be added as a
+new `workflow_call` workflow and one more coordinator job without modifying the
+existing reviewers.
+
+### Dependency-security safety model
+
+The dependency module is a two-stage workflow. Its audit/remediation job has a
+read-only `GITHUB_TOKEN`; it has no Slack token and no Temporal CI/CD App
+credential. That job is the only one that runs `pnpm` or project code. It:
+
+1. tests the automation scripts;
+2. reads Dependabot alerts using the narrow `vulnerability-alerts: read`
+   permission and writes JSON evidence;
+3. applies the manifest plan and resolves its lockfile before performing a
+   fresh frozen install, with lifecycle scripts and Husky disabled;
+4. permits only `package.json` and `pnpm-lock.yaml` changes;
+5. records the audited source revision SHA and SHA-256 hashes for both
+   candidate files in the remediation report and a separate attestation before
+   package executables run;
+6. runs `svelte-kit sync` explicitly to generate the ignored `.svelte-kit`
+   metadata normally produced by the disabled lifecycle hook, then runs Vitest
+   with one worker, `pnpm check`, and `pnpm build:server`;
+7. verifies that none of that package execution changed either candidate file,
+   and only then exports the trusted hashes as verified job outputs.
+
+The VLN and external-contributor modules pass narrower audit scopes. They do
+not request vulnerability-alert permissions and do not query Dependabot.
+
+Only a successful `apply` candidate is passed as an artifact to the publishing
+job. That job does **not** run a package manager or repository package code. It
+validates the candidate artifact and its hashes against the audit job's
+out-of-band verified outputs, and requires both its checkout and the current
+remote `main` to exactly match the audited base SHA. The artifact cannot vouch
+for its own integrity. A newer `main` aborts the publish step so the next run
+can regenerate and retest the candidate. The publisher then uses the existing
+`TEMPORAL_CICD_APP_ID` and
+`TEMPORAL_CICD_PRIVATE_KEY` GitHub App credentials with only contents and pull
+request write permissions, and creates or force-with-lease updates the single
+draft branch `automation/weekly-dependency-security`.
+
+Premerge PR runs cannot reach the publishing path: they call the dependency
+module with `mode: dry-run`, and its publishing job is additionally blocked
+for every `pull_request` event.
+
+The draft PR is therefore idempotent: one open PR accumulates the current
+week's minimal safe fixes. The workflow never dismisses Dependabot alerts;
+alerts resolve when a reviewed PR reaches `main`. If an alert needs a major
+upgrade, an unsupported manifest/ecosystem, or another manual decision, the
+Slack report calls it out instead of changing dependencies.
+
+Artifacts contain the audit, remediation plan, and any approved candidate for
+14 days. A Slack reply is still posted when the audit fails or no PR is needed,
+so on-call has a durable run link and failure signal. The dependency reply also
+receives the publish job's explicit `success`, `failure`, or `skipped` outcome;
+it only reports a published remediation when a successful job returned a PR
+URL.
+
+### Required configuration
+
+Repository secrets:
+
+- `SLACK_BOT_TOKEN` — used only by the root and module notification jobs.
+- `TEMPORAL_CICD_APP_ID` and `TEMPORAL_CICD_PRIVATE_KEY` — used only by the
+  dependency publishing job to update the draft PR.
+
+Repository variables:
+
+- `ONCALL_FRONTEND_SLACK_CHANNEL` — Slack channel ID for `#oncall-frontend`.
+
+The automation reports are covered by:
+
+```bash
+pnpm test:github-automation
+```
+
+This runs the shared audit, remediation planner, and digest tests without
+installing or executing the application dependency graph.
+
 ## 🔄 File Locations
 
 ### Workflows

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -407,9 +407,9 @@ pnpm validate:versions
 `weekly-oncall-review.yml` creates one Slack thread in `#oncall-frontend` and
 fans out to small, independently callable review modules. It runs every Monday
 at 14:00 UTC and can also be started from **Actions → Weekly On-Call Review**.
-The scheduled run uses `dry-run` mode and notifications. Until the Claude
-resolver is integrated, it does not update the generated dependency remediation
-draft PR. Manual runs also default to `dry-run`; choose `apply` only when the
+The scheduled run uses `apply` mode and notifications, so Claude can author a
+minimal dependency-security candidate and the workflow can update its draft PR.
+Manual runs default to `dry-run`; choose `apply` only when the
 generated dependency remediation draft PR may be updated. Manual notifications default to `C0BPXR260DA`
 (`#other-ross-tests-stuff`) so test runs do not post to the on-call channel.
 The `slack_channel` input accepts another Slack channel ID when needed.
@@ -432,8 +432,9 @@ After merging, use a manual `dry-run` dispatch to the default test channel
 The coordinator owns the root Slack post and a final status reply. Modules add
 their own replies in the same thread:
 
-- `weekly-dependency-security-review.yml` audits Dependabot alerts, produces a
-  minimal package remediation candidate, and reports its evidence.
+- `weekly-dependency-security-review.yml` audits Dependabot alerts, asks Claude
+  to produce a minimal package remediation candidate in `apply` mode, and
+  reports its evidence.
 - `weekly-vln-review.yml` reports open VLN remediation PRs.
 - `weekly-external-contributor-review.yml` reports active, non-bot PRs from
   external forks. It groups the top five review-ready, triage, and
@@ -452,17 +453,29 @@ credential. That job is the only one that runs `pnpm` or project code. It:
 1. tests the automation scripts;
 2. reads Dependabot alerts using the narrow `vulnerability-alerts: read`
    permission and writes JSON evidence;
-3. applies the manifest plan and resolves its lockfile before performing a
-   fresh frozen install, with lifecycle scripts and Husky disabled;
-4. permits only `package.json` and `pnpm-lock.yaml` changes;
-5. records the audited source revision SHA and SHA-256 hashes for both
+3. in `apply` mode, records the audited source SHA and snapshots hashes for the
+   audit and deterministic remediation plan before giving Claude only the
+   `Read` and `Edit` tools;
+4. immediately proves Claude did not move `HEAD`, stage or create files, tamper
+   with either evidence file, or change anything except the existing
+   `package.json`;
+5. reconstructs the immutable base manifest from that verified source SHA after
+   Claude runs, accepts Claude's manifest only when its bytes exactly match applying
+   the trusted deterministic plan's authorized actions to that base, and
+   records Claude as the resolver only for that exact non-empty result; manual
+   and ambiguous findings remain reported rather than changed;
+6. resolves `pnpm-lock.yaml` in the trusted workflow and performs a fresh frozen
+   install, with lifecycle scripts and Husky disabled;
+7. permits only `package.json` and `pnpm-lock.yaml` changes;
+8. records the audited source revision SHA and SHA-256 hashes for both
    candidate files in the remediation report and a separate attestation before
    package executables run;
-6. runs `svelte-kit sync` explicitly to generate the ignored `.svelte-kit`
+9. runs `svelte-kit sync` explicitly to generate the ignored `.svelte-kit`
    metadata normally produced by the disabled lifecycle hook, then runs Vitest
    with one worker, `pnpm check`, and `pnpm build:server`;
-7. verifies that none of that package execution changed either candidate file,
-   and only then exports the trusted hashes as verified job outputs.
+10. verifies that none of that package execution changed either candidate file
+    or the audit and final remediation evidence, and only then exports all four
+    trusted hashes as verified job outputs.
 
 The VLN and external-contributor modules pass narrower audit scopes. They do
 not request vulnerability-alert permissions and do not query Dependabot.
@@ -472,7 +485,10 @@ job. That job does **not** run a package manager or repository package code. It
 validates the candidate artifact and its hashes against the audit job's
 out-of-band verified outputs, and requires both its checkout and the current
 remote `main` to exactly match the audited base SHA. The artifact cannot vouch
-for its own integrity. A newer `main` aborts the publish step so the next run
+for its own integrity. The publisher verifies the audit and final remediation
+report hashes before trusting report fields, and the notifier likewise refuses
+to digest evidence that does not match those verified outputs. A newer `main`
+aborts the publish step so the next run
 can regenerate and retest the candidate. The publisher then uses the existing
 `TEMPORAL_CICD_APP_ID` and
 `TEMPORAL_CICD_PRIVATE_KEY` GitHub App credentials with only contents and pull
@@ -481,7 +497,8 @@ draft branch `automation/weekly-dependency-security`.
 
 Premerge PR runs cannot reach the publishing path: they call the dependency
 module with `mode: dry-run`, and its publishing job is additionally blocked
-for every `pull_request` event.
+for every `pull_request` event. Dry runs do not invoke Claude and require no
+Anthropic, Slack, or GitHub App secret.
 
 The draft PR is therefore idempotent: one open PR accumulates the current
 week's minimal safe fixes. The workflow never dismisses Dependabot alerts;
@@ -500,6 +517,8 @@ URL.
 
 Repository secrets:
 
+- `ANTHROPIC_API_KEY` — passed only to Claude in the read-only audit/remediation
+  job when `mode: apply`; Claude receives no GitHub App or Slack credential.
 - `SLACK_BOT_TOKEN` — used only by the root and module notification jobs.
 - `TEMPORAL_CICD_APP_ID` and `TEMPORAL_CICD_PRIVATE_KEY` — used only by the
   dependency publishing job to update the draft PR.

--- a/.github/scripts/apply-weekly-dependency-remediation.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.mjs
@@ -10,7 +10,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-const ROOT_MANIFEST = '/package.json';
+const REMEDIABLE_MANIFESTS = new Set(['package.json', 'pnpm-lock.yaml']);
 const DIRECT_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies'];
 const VERSION =
   /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -52,6 +52,37 @@ export function isVersionAtLeast(version, floor) {
   );
 }
 
+const RANGE_CONSTRAINT = /^(>=|<=|>|<|=)?\s*(.+)$/;
+
+function satisfiesConstraint(comparison, operator) {
+  if (operator === '<') return comparison < 0;
+  if (operator === '<=') return comparison <= 0;
+  if (operator === '>') return comparison > 0;
+  if (operator === '>=') return comparison >= 0;
+  return comparison === 0;
+}
+
+export function isVersionVulnerable(version, range) {
+  const target = parseSemver(version);
+  if (!target || typeof range !== 'string') return true;
+  const constraints = range
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (constraints.length === 0) return true;
+
+  for (const constraint of constraints) {
+    const match = RANGE_CONSTRAINT.exec(constraint);
+    if (!match) return true;
+    const bound = parseSemver(match[2]);
+    if (!bound) return true;
+    if (!satisfiesConstraint(compareSemver(target, bound), match[1] ?? '=')) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function rangeLowerBound(range) {
   if (typeof range !== 'string') return null;
   const match = VERSION_IN_RANGE.exec(range.trim());
@@ -67,6 +98,78 @@ function isSimpleRange(range) {
   return /^(?:\^|~|>=|>|=)?\s*\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
     range.trim(),
   );
+}
+
+const COMPOUND_RANGE =
+  /^(?<lowerOperator>>=|>)\s*(?<lower>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?)\s+(?<upperOperator><=|<)\s*(?<upper>(?:0|[1-9]\d*)(?:\.\d+){0,2})$/;
+
+function parseOverrideRange(range) {
+  if (typeof range !== 'string') return null;
+  if (isSimpleRange(range)) {
+    const bound = rangeLowerBound(range);
+    return bound ? { ...bound, upper: null } : null;
+  }
+  const match = COMPOUND_RANGE.exec(range.trim());
+  if (!match?.groups) return null;
+  return {
+    operator: match.groups.lowerOperator,
+    version: match.groups.lower,
+    upper: {
+      operator: match.groups.upperOperator,
+      version: match.groups.upper,
+    },
+  };
+}
+
+function satisfiesUpperBound(version, upper) {
+  const parts = upper.version.split('.');
+  while (parts.length < 3) parts.push('0');
+  const ceiling = parseSemver(parts.join('.'));
+  const target = parseSemver(version);
+  if (!ceiling || !target) return false;
+  const comparison = compareSemver(target, ceiling);
+  return upper.operator === '<=' ? comparison <= 0 : comparison < 0;
+}
+
+function raisedRange(bound, patched) {
+  if (!bound.upper) return `${bound.operator}${patched}`;
+  return `${bound.operator}${patched} ${bound.upper.operator}${bound.upper.version}`;
+}
+
+const LOCKFILE_PACKAGE_KEY = /^ {2}('?)(?<entry>[^'\s]+)\1:\s*$/;
+
+export function parseLockfileVersions(lockfileText) {
+  const versions = new Map();
+  if (typeof lockfileText !== 'string') return versions;
+
+  let insidePackages = false;
+  for (const line of lockfileText.split('\n')) {
+    if (/^\S/.test(line)) {
+      insidePackages = line.trimEnd() === 'packages:';
+      continue;
+    }
+    if (!insidePackages) continue;
+
+    const match = LOCKFILE_PACKAGE_KEY.exec(line);
+    if (!match?.groups) continue;
+
+    const entry = match.groups.entry.replace(/\(.*\)$/, '');
+    const separator = entry.lastIndexOf('@');
+    if (separator <= 0) continue;
+
+    const name = entry.slice(0, separator);
+    const version = entry.slice(separator + 1);
+    if (!parseSemver(version)) continue;
+
+    const found = versions.get(name) ?? [];
+    if (!found.includes(version)) found.push(version);
+    versions.set(name, found);
+  }
+
+  for (const found of versions.values()) {
+    found.sort((left, right) => compareSemver(left, right));
+  }
+  return versions;
 }
 
 function flattenAlerts(audit) {
@@ -124,16 +227,29 @@ export function normalizeAlerts(audit) {
         normalizedPackageName ??
         alert?.packageName,
       patchedVersion: firstPatched,
+      vulnerableRange:
+        vulnerability.vulnerable_version_range ??
+        vulnerability.vulnerableVersionRange ??
+        alert?.vulnerableRange ??
+        null,
     };
   });
 }
 
-function classification({ packageName, alertIds, status, reason, action }) {
+function classification({
+  packageName,
+  alertIds,
+  status,
+  reason,
+  action,
+  resolvedVersions,
+}) {
   return {
     packageName: packageName ?? null,
     alertIds,
     status,
     reason,
+    ...(resolvedVersions ? { resolvedVersions } : {}),
     ...(action ? { action } : {}),
   };
 }
@@ -146,9 +262,20 @@ function findDirectDependency(packageJson, packageName) {
   return null;
 }
 
+function overrideSelectorTarget(selector) {
+  let target = selector;
+  for (let index = 1; index < selector.length; index += 1) {
+    if (selector[index] !== '>') continue;
+    if (selector[index - 1] === '@') continue;
+    if (selector[index + 1] === '=') continue;
+    target = selector.slice(index + 1);
+  }
+  return target.trim();
+}
+
 function overrideTargetsPackage(selector, packageName) {
-  const target = selector.split('>').at(-1)?.trim();
-  return target === packageName || target?.startsWith(`${packageName}@`);
+  const target = overrideSelectorTarget(selector);
+  return target === packageName || target.startsWith(`${packageName}@`);
 }
 
 function findOverrides(packageJson, packageName) {
@@ -190,8 +317,8 @@ function incompatibleRangeReason({ kind, bound, patched }) {
 }
 
 function classifyOverride({ packageName, alertIds, patched, override }) {
-  const bound = rangeLowerBound(override.version);
-  if (!bound || !isSimpleRange(override.version)) {
+  const bound = parseOverrideRange(override.version);
+  if (!bound) {
     return classification({
       packageName,
       alertIds,
@@ -207,7 +334,15 @@ function classifyOverride({ packageName, alertIds, patched, override }) {
       reason: `Existing override lower bound ${bound.version} already meets ${patched}.`,
     });
   }
-  if (!isRangeCompatible(bound, patched)) {
+  if (bound.upper && !satisfiesUpperBound(patched, bound.upper)) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: `Override remediation to ${patched} exceeds the pinned upper bound ${bound.upper.operator}${bound.upper.version}.`,
+    });
+  }
+  if (!bound.upper && !isRangeCompatible(bound, patched)) {
     return classification({
       packageName,
       alertIds,
@@ -229,7 +364,7 @@ function classifyOverride({ packageName, alertIds, patched, override }) {
       type: 'pnpm-override',
       selector: override.selector,
       from: override.version,
-      to: `${bound.operator}${patched}`,
+      to: raisedRange(bound, patched),
     },
   });
 }
@@ -242,7 +377,13 @@ function highestPatchedVersion(alerts) {
   );
 }
 
-function classifyPackage(alerts, packageJson) {
+function classifyPackage(alerts, packageJson, resolvedVersions) {
+  const result = classifyPackageStatus(alerts, packageJson, resolvedVersions);
+  if (!resolvedVersions?.length || result.resolvedVersions) return result;
+  return { ...result, resolvedVersions };
+}
+
+function classifyPackageStatus(alerts, packageJson, resolvedVersions) {
   const packageName = alerts[0]?.packageName;
   const alertIds = alerts.map((alert) => alert.id);
   const patched = highestPatchedVersion(alerts);
@@ -275,6 +416,19 @@ function classifyPackage(alerts, packageJson) {
       status: 'manual',
       reason:
         'Alerts require patched versions across multiple major versions; dependency cascade is ambiguous.',
+    });
+  }
+
+  const vulnerableResolved = (resolvedVersions ?? []).filter((version) =>
+    alerts.some((item) => isVersionVulnerable(version, item.vulnerableRange)),
+  );
+  if (resolvedVersions?.length && vulnerableResolved.length === 0) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'alreadySafe',
+      reason: `The lockfile resolves ${packageName} to ${resolvedVersions.join(', ')}, which the advisory does not cover.`,
+      resolvedVersions,
     });
   }
 
@@ -337,6 +491,15 @@ function classifyPackage(alerts, packageJson) {
           .join(', ')}; a direct-only bump could be superseded.`,
       });
     }
+    if (vulnerableResolved.length > 1) {
+      return classification({
+        packageName,
+        alertIds,
+        status: 'manual',
+        reason: `The lockfile resolves ${packageName} to ${vulnerableResolved.join(', ')}; a direct dependency bump cannot reach every vulnerable copy.`,
+        resolvedVersions,
+      });
+    }
 
     return classification({
       packageName,
@@ -383,8 +546,9 @@ function classifyPackage(alerts, packageJson) {
  * Return a deterministic, manifest-only remediation plan.
  * Unsupported alerts are intentionally not mixed with npm remediation groups.
  */
-export function planRemediation({ audit, packageJson }) {
+export function planRemediation({ audit, packageJson, lockfile }) {
   const normalized = normalizeAlerts(audit);
+  const resolved = parseLockfileVersions(lockfile);
   const unsupported = [];
   const npmByPackage = new Map();
 
@@ -400,7 +564,7 @@ export function planRemediation({ audit, packageJson }) {
       );
       continue;
     }
-    if (alert.manifestPath !== ROOT_MANIFEST) {
+    if (!REMEDIABLE_MANIFESTS.has(alert.manifestPath)) {
       unsupported.push(
         classification({
           packageName: alert.packageName,
@@ -420,7 +584,11 @@ export function planRemediation({ audit, packageJson }) {
     ...[...npmByPackage.keys()]
       .sort((a, b) => String(a).localeCompare(String(b)))
       .map((packageName) =>
-        classifyPackage(npmByPackage.get(packageName), packageJson),
+        classifyPackage(
+          npmByPackage.get(packageName),
+          packageJson,
+          resolved.get(packageName),
+        ),
       ),
     ...unsupported.sort((a, b) =>
       String(a.packageName).localeCompare(String(b.packageName)),
@@ -439,6 +607,9 @@ export function planRemediation({ audit, packageJson }) {
     sourceAlertCount: normalized.length,
     summary: {
       safe: classifications.filter((item) => item.status === 'safe').length,
+      alreadySafe: classifications.filter(
+        (item) => item.status === 'alreadySafe',
+      ).length,
       manual: classifications.filter((item) => item.status === 'manual').length,
       unsupported: classifications.filter(
         (item) => item.status === 'unsupported',
@@ -484,13 +655,20 @@ export function applyRemediation(packageJson, plan) {
 }
 
 function parseCliArguments(args) {
-  const options = { packageJson: 'package.json', apply: false };
+  const options = {
+    packageJson: 'package.json',
+    lockfile: 'pnpm-lock.yaml',
+    apply: false,
+  };
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === '--apply') options.apply = true;
     else if (arg === '--audit') options.audit = args[++index];
     else if (arg === '--package-json') options.packageJson = args[++index];
-    else if (arg === '--report') options.report = args[++index];
+    else if (arg === '--lockfile') {
+      options.lockfile = args[++index];
+      options.lockfileRequired = true;
+    } else if (arg === '--report') options.report = args[++index];
     else if (arg === '--help') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
   }
@@ -501,7 +679,7 @@ export async function runCli(args = process.argv.slice(2)) {
   const options = parseCliArguments(args);
   if (options.help) {
     console.log(
-      'Usage: node apply-weekly-dependency-remediation.mjs --audit audit.json [--package-json package.json] [--report remediation.json] [--apply]',
+      'Usage: node apply-weekly-dependency-remediation.mjs --audit audit.json [--package-json package.json] [--lockfile pnpm-lock.yaml] [--report remediation.json] [--apply]',
     );
     return { exitCode: 0 };
   }
@@ -511,9 +689,16 @@ export async function runCli(args = process.argv.slice(2)) {
     readFile(options.audit, 'utf8'),
     readFile(options.packageJson, 'utf8'),
   ]);
+  const lockfileText = await readFile(options.lockfile, 'utf8').catch(
+    (error) => {
+      if (options.lockfileRequired) throw error;
+      return undefined;
+    },
+  );
   const plan = planRemediation({
     audit: JSON.parse(auditText),
     packageJson: JSON.parse(packageJsonText),
+    lockfile: lockfileText,
   });
   const report = {
     ...plan,

--- a/.github/scripts/apply-weekly-dependency-remediation.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+
+/**
+ * Plans the smallest safe package.json change for Dependabot alerts.
+ *
+ * This script deliberately does not run a package manager or inspect/edit a
+ * lockfile. The workflow owns `pnpm install --lockfile-only` after a reviewed
+ * plan has changed the manifest.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ROOT_MANIFEST = '/package.json';
+const DIRECT_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies'];
+const VERSION =
+  /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const VERSION_IN_RANGE =
+  /(?<operator>\^|~|>=|>|=)?\s*(?<version>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/;
+
+export function parseSemver(version) {
+  if (typeof version !== 'string') return null;
+  const match = VERSION.exec(version.trim());
+  if (!match?.groups) return null;
+
+  return {
+    major: Number(match.groups.major),
+    minor: Number(match.groups.minor),
+    patch: Number(match.groups.patch),
+    version: version.trim(),
+  };
+}
+
+export function compareSemver(left, right) {
+  const a = typeof left === 'string' ? parseSemver(left) : left;
+  const b = typeof right === 'string' ? parseSemver(right) : right;
+  if (!a || !b)
+    throw new TypeError('compareSemver requires concrete semver versions');
+
+  for (const key of ['major', 'minor', 'patch']) {
+    if (a[key] !== b[key]) return a[key] < b[key] ? -1 : 1;
+  }
+  return 0;
+}
+
+export function isVersionAtLeast(version, floor) {
+  const parsedVersion = parseSemver(version);
+  const parsedFloor = parseSemver(floor);
+  return Boolean(
+    parsedVersion &&
+    parsedFloor &&
+    compareSemver(parsedVersion, parsedFloor) >= 0,
+  );
+}
+
+function rangeLowerBound(range) {
+  if (typeof range !== 'string') return null;
+  const match = VERSION_IN_RANGE.exec(range.trim());
+  if (!match?.groups) return null;
+  return {
+    operator: match.groups.operator ?? '',
+    version: `${match.groups.version}.${match.groups.minor}.${match.groups.patch}`,
+  };
+}
+
+function isSimpleRange(range) {
+  if (typeof range !== 'string') return false;
+  return /^(?:\^|~|>=|>|=)?\s*\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
+    range.trim(),
+  );
+}
+
+function flattenAlerts(audit) {
+  if (Array.isArray(audit)) return audit;
+  if (Array.isArray(audit?.dependabot?.alerts)) return audit.dependabot.alerts;
+  if (Array.isArray(audit?.alerts)) return audit.alerts;
+  if (Array.isArray(audit?.dependabotAlerts)) return audit.dependabotAlerts;
+  return [];
+}
+
+function vulnerabilityForAlert(alert) {
+  const direct = alert?.security_vulnerability ?? alert?.securityVulnerability;
+  if (direct) return direct;
+  return (
+    alert?.security_advisory?.vulnerabilities?.[0] ??
+    alert?.securityAdvisory?.vulnerabilities?.[0]
+  );
+}
+
+function versionIdentifier(value) {
+  if (typeof value === 'string') return value;
+  return value?.identifier ?? null;
+}
+
+/** Normalize either GitHub Dependabot REST responses or the weekly audit shape. */
+export function normalizeAlerts(audit) {
+  return flattenAlerts(audit).map((alert, index) => {
+    const vulnerability = vulnerabilityForAlert(alert) ?? {};
+    const dependency = alert?.dependency ?? {};
+    const dependencyPackage = dependency.package ?? {};
+    const vulnerabilityPackage = vulnerability.package ?? {};
+    const firstPatched =
+      versionIdentifier(vulnerability.first_patched_version) ??
+      versionIdentifier(vulnerability.firstPatchedVersion) ??
+      versionIdentifier(alert?.first_patched_version) ??
+      versionIdentifier(alert?.firstPatchedVersion) ??
+      null;
+    const normalizedPackageName =
+      typeof alert?.package === 'string' ? alert.package : alert?.package?.name;
+
+    return {
+      id: alert?.number ?? alert?.id ?? index + 1,
+      ecosystem:
+        dependencyPackage.ecosystem ??
+        vulnerabilityPackage.ecosystem ??
+        alert?.ecosystem,
+      manifestPath:
+        dependency.manifest_path ??
+        dependency.manifestPath ??
+        alert?.manifest_path ??
+        alert?.manifestPath,
+      packageName:
+        dependencyPackage.name ??
+        vulnerabilityPackage.name ??
+        normalizedPackageName ??
+        alert?.packageName,
+      patchedVersion: firstPatched,
+    };
+  });
+}
+
+function classification({ packageName, alertIds, status, reason, action }) {
+  return {
+    packageName: packageName ?? null,
+    alertIds,
+    status,
+    reason,
+    ...(action ? { action } : {}),
+  };
+}
+
+function findDirectDependency(packageJson, packageName) {
+  for (const section of DIRECT_DEPENDENCY_SECTIONS) {
+    const version = packageJson?.[section]?.[packageName];
+    if (typeof version === 'string') return { section, version };
+  }
+  return null;
+}
+
+function overrideTargetsPackage(selector, packageName) {
+  const target = selector.split('>').at(-1)?.trim();
+  return target === packageName || target?.startsWith(`${packageName}@`);
+}
+
+function findOverrides(packageJson, packageName) {
+  return Object.entries(packageJson?.pnpm?.overrides ?? {})
+    .filter(([selector]) => overrideTargetsPackage(selector, packageName))
+    .map(([selector, version]) => ({ selector, version }));
+}
+
+function isCaretCompatible(currentVersion, patchedVersion) {
+  const current = parseSemver(currentVersion);
+  const patched = parseSemver(patchedVersion);
+  if (!current || !patched || current.major !== patched.major) return false;
+  if (current.major > 0) return true;
+  if (current.minor !== patched.minor) return false;
+  if (current.minor > 0) return true;
+  return current.patch === patched.patch;
+}
+
+function isRangeCompatible(bound, patchedVersion) {
+  const current = parseSemver(bound.version);
+  const patched = parseSemver(patchedVersion);
+  if (!current || !patched) return false;
+  if (bound.operator === '~') {
+    return current.major === patched.major && current.minor === patched.minor;
+  }
+  return isCaretCompatible(bound.version, patchedVersion);
+}
+
+function incompatibleRangeReason({ kind, bound, patched }) {
+  const current = parseSemver(bound.version);
+  const target = parseSemver(patched);
+  if (current.major !== target.major) {
+    return `${kind} remediation requires a major upgrade from ${bound.version} to ${patched}.`;
+  }
+  if (bound.operator === '~') {
+    return `${kind} remediation from ${bound.version} to ${patched} is outside the tilde-compatible minor version.`;
+  }
+  return `${kind} remediation from ${bound.version} to ${patched} is outside caret-compatible pre-1.0 bounds.`;
+}
+
+function classifyOverride({ packageName, alertIds, patched, override }) {
+  const bound = rangeLowerBound(override.version);
+  if (!bound || !isSimpleRange(override.version)) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: `Existing pnpm override ${override.selector} uses an unsupported range: ${String(override.version)}.`,
+    });
+  }
+  if (isVersionAtLeast(bound.version, patched)) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'safe',
+      reason: `Existing override lower bound ${bound.version} already meets ${patched}.`,
+    });
+  }
+  if (!isRangeCompatible(bound, patched)) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: incompatibleRangeReason({
+        kind: 'Override',
+        bound,
+        patched,
+      }),
+    });
+  }
+
+  return classification({
+    packageName,
+    alertIds,
+    status: 'safe',
+    reason: `Update existing pnpm override ${override.selector} to the highest patched floor ${patched}.`,
+    action: {
+      type: 'pnpm-override',
+      selector: override.selector,
+      from: override.version,
+      to: `${bound.operator}${patched}`,
+    },
+  });
+}
+
+function highestPatchedVersion(alerts) {
+  const versions = alerts.map((alert) => alert.patchedVersion);
+  if (versions.some((version) => !parseSemver(version))) return null;
+  return versions.reduce((highest, version) =>
+    compareSemver(version, highest) > 0 ? version : highest,
+  );
+}
+
+function classifyPackage(alerts, packageJson) {
+  const packageName = alerts[0]?.packageName;
+  const alertIds = alerts.map((alert) => alert.id);
+  const patched = highestPatchedVersion(alerts);
+
+  if (!packageName) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: 'Alert did not identify an npm package.',
+    });
+  }
+
+  if (!patched) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: 'No concrete first patched version is available.',
+    });
+  }
+
+  const patchedMajors = new Set(
+    alerts.map((alert) => parseSemver(alert.patchedVersion)?.major),
+  );
+  if (patchedMajors.size !== 1) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason:
+        'Alerts require patched versions across multiple major versions; dependency cascade is ambiguous.',
+    });
+  }
+
+  const direct = findDirectDependency(packageJson, packageName);
+
+  if (direct) {
+    const bound = rangeLowerBound(direct.version);
+    if (!bound || !isSimpleRange(direct.version)) {
+      return classification({
+        packageName,
+        alertIds,
+        status: 'manual',
+        reason: `Direct dependency uses an unsupported range: ${direct.version}.`,
+      });
+    }
+    const interactingOverrides = findOverrides(packageJson, packageName);
+    if (isVersionAtLeast(bound.version, patched)) {
+      if (interactingOverrides.length > 1) {
+        return classification({
+          packageName,
+          alertIds,
+          status: 'manual',
+          reason: `Multiple pnpm override selectors target ${packageName}; selector choice is ambiguous.`,
+        });
+      }
+      if (interactingOverrides.length === 1) {
+        return classifyOverride({
+          packageName,
+          alertIds,
+          patched,
+          override: interactingOverrides[0],
+        });
+      }
+      return classification({
+        packageName,
+        alertIds,
+        status: 'safe',
+        reason: `Direct dependency lower bound ${bound.version} already meets ${patched}.`,
+      });
+    }
+    if (!isRangeCompatible(bound, patched)) {
+      return classification({
+        packageName,
+        alertIds,
+        status: 'manual',
+        reason: incompatibleRangeReason({
+          kind: 'Direct dependency',
+          bound,
+          patched,
+        }),
+      });
+    }
+    if (interactingOverrides.length > 0) {
+      return classification({
+        packageName,
+        alertIds,
+        status: 'manual',
+        reason: `Direct dependency also has pnpm override selector(s) ${interactingOverrides
+          .map(({ selector }) => selector)
+          .join(', ')}; a direct-only bump could be superseded.`,
+      });
+    }
+
+    return classification({
+      packageName,
+      alertIds,
+      status: 'safe',
+      reason: `Bump the direct dependency to the highest patched floor ${patched}.`,
+      action: {
+        type: 'direct-dependency',
+        section: direct.section,
+        from: direct.version,
+        to: `${bound.operator}${patched}`,
+      },
+    });
+  }
+
+  const overrides = findOverrides(packageJson, packageName);
+  if (overrides.length === 0) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason:
+        'Transitive package has no existing pnpm override; refusing to create an unqualified global override.',
+    });
+  }
+  if (overrides.length > 1) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: `Multiple pnpm override selectors target ${packageName}; selector choice is ambiguous.`,
+    });
+  }
+
+  return classifyOverride({
+    packageName,
+    alertIds,
+    patched,
+    override: overrides[0],
+  });
+}
+
+/**
+ * Return a deterministic, manifest-only remediation plan.
+ * Unsupported alerts are intentionally not mixed with npm remediation groups.
+ */
+export function planRemediation({ audit, packageJson }) {
+  const normalized = normalizeAlerts(audit);
+  const unsupported = [];
+  const npmByPackage = new Map();
+
+  for (const alert of normalized) {
+    if (alert.ecosystem !== 'npm') {
+      unsupported.push(
+        classification({
+          packageName: alert.packageName,
+          alertIds: [alert.id],
+          status: 'unsupported',
+          reason: `Unsupported ecosystem: ${alert.ecosystem ?? 'unknown'}.`,
+        }),
+      );
+      continue;
+    }
+    if (alert.manifestPath !== ROOT_MANIFEST) {
+      unsupported.push(
+        classification({
+          packageName: alert.packageName,
+          alertIds: [alert.id],
+          status: 'unsupported',
+          reason: `Unsupported manifest: ${alert.manifestPath ?? 'unknown'}.`,
+        }),
+      );
+      continue;
+    }
+    const group = npmByPackage.get(alert.packageName) ?? [];
+    group.push(alert);
+    npmByPackage.set(alert.packageName, group);
+  }
+
+  const classifications = [
+    ...[...npmByPackage.keys()]
+      .sort((a, b) => String(a).localeCompare(String(b)))
+      .map((packageName) =>
+        classifyPackage(npmByPackage.get(packageName), packageJson),
+      ),
+    ...unsupported.sort((a, b) =>
+      String(a.packageName).localeCompare(String(b.packageName)),
+    ),
+  ];
+  const actions = classifications
+    .filter((item) => item.action)
+    .map(({ packageName, alertIds, action }) => ({
+      packageName,
+      alertIds,
+      ...action,
+    }));
+
+  return {
+    schemaVersion: 1,
+    sourceAlertCount: normalized.length,
+    summary: {
+      safe: classifications.filter((item) => item.status === 'safe').length,
+      manual: classifications.filter((item) => item.status === 'manual').length,
+      unsupported: classifications.filter(
+        (item) => item.status === 'unsupported',
+      ).length,
+      actions: actions.length,
+    },
+    classifications,
+    actions,
+  };
+}
+
+/** Apply only the manifest paths explicitly permitted by a remediation plan. */
+export function applyRemediation(packageJson, plan) {
+  const next = structuredClone(packageJson);
+  for (const action of plan.actions) {
+    if (action.type === 'direct-dependency') {
+      if (!DIRECT_DEPENDENCY_SECTIONS.includes(action.section)) {
+        throw new Error(
+          `Refusing unsupported dependency section: ${action.section}`,
+        );
+      }
+      if (next[action.section]?.[action.packageName] !== action.from) {
+        throw new Error(
+          `Refusing to overwrite changed dependency: ${action.packageName}`,
+        );
+      }
+      next[action.section][action.packageName] = action.to;
+      continue;
+    }
+    if (action.type === 'pnpm-override') {
+      const current = next.pnpm?.overrides?.[action.selector];
+      if (current !== action.from) {
+        throw new Error(
+          `Refusing to overwrite changed override: ${action.selector}`,
+        );
+      }
+      next.pnpm.overrides[action.selector] = action.to;
+      continue;
+    }
+    throw new Error(`Refusing unsupported remediation action: ${action.type}`);
+  }
+  return next;
+}
+
+function parseCliArguments(args) {
+  const options = { packageJson: 'package.json', apply: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--apply') options.apply = true;
+    else if (arg === '--audit') options.audit = args[++index];
+    else if (arg === '--package-json') options.packageJson = args[++index];
+    else if (arg === '--report') options.report = args[++index];
+    else if (arg === '--help') options.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+export async function runCli(args = process.argv.slice(2)) {
+  const options = parseCliArguments(args);
+  if (options.help) {
+    console.log(
+      'Usage: node apply-weekly-dependency-remediation.mjs --audit audit.json [--package-json package.json] [--report remediation.json] [--apply]',
+    );
+    return { exitCode: 0 };
+  }
+  if (!options.audit) throw new Error('--audit is required');
+
+  const [auditText, packageJsonText] = await Promise.all([
+    readFile(options.audit, 'utf8'),
+    readFile(options.packageJson, 'utf8'),
+  ]);
+  const plan = planRemediation({
+    audit: JSON.parse(auditText),
+    packageJson: JSON.parse(packageJsonText),
+  });
+  const report = {
+    ...plan,
+    manifestPath: path.resolve(options.packageJson),
+    applied: options.apply && plan.actions.length > 0,
+  };
+
+  if (options.apply && plan.actions.length > 0) {
+    const next = applyRemediation(JSON.parse(packageJsonText), plan);
+    await writeFile(options.packageJson, `${JSON.stringify(next, null, 2)}\n`);
+  }
+  const serialized = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.report) await writeFile(options.report, serialized);
+  else process.stdout.write(serialized);
+  return { exitCode: 0, report };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/apply-weekly-dependency-remediation.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.mjs
@@ -11,6 +11,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const REMEDIABLE_MANIFESTS = new Set(['package.json', 'pnpm-lock.yaml']);
+const GO_MANIFESTS = new Set(['server/go.mod', 'server/go.sum']);
 const DIRECT_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies'];
 const VERSION =
   /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
@@ -170,6 +171,49 @@ export function parseLockfileVersions(lockfileText) {
     found.sort((left, right) => compareSemver(left, right));
   }
   return versions;
+}
+
+const GO_REQUIREMENT =
+  /^(?<module>[^\s()]+)\s+(?<version>v[^\s]+)(?<indirect>\s+\/\/\s*indirect)?$/;
+
+export function parseGoRequirements(goModText) {
+  const requirements = new Map();
+  if (typeof goModText !== 'string') return requirements;
+
+  let insideBlock = false;
+  for (const raw of goModText.split('\n')) {
+    const line = raw.trim();
+    if (line.startsWith('require (')) {
+      insideBlock = true;
+      continue;
+    }
+    if (insideBlock && line === ')') {
+      insideBlock = false;
+      continue;
+    }
+
+    const candidate = insideBlock
+      ? line
+      : line.startsWith('require ')
+        ? line.slice('require '.length).trim()
+        : null;
+    if (!candidate) continue;
+
+    const match = GO_REQUIREMENT.exec(candidate);
+    if (!match?.groups) continue;
+    requirements.set(match.groups.module, {
+      version: match.groups.version,
+      indirect: Boolean(match.groups.indirect),
+    });
+  }
+  return requirements;
+}
+
+function goSemver(version) {
+  if (typeof version !== 'string' || !version.startsWith('v')) return null;
+  const bare = version.slice(1);
+  if (bare.includes('-')) return null;
+  return parseSemver(bare);
 }
 
 function flattenAlerts(audit) {
@@ -542,18 +586,90 @@ function classifyPackageStatus(alerts, packageJson, resolvedVersions) {
   });
 }
 
+function classifyGoModule(alerts) {
+  const moduleName = alerts[0]?.moduleName;
+  const alertIds = alerts.map((alert) => alert.id);
+  const patched = highestPatchedVersion(alerts);
+  const requirement = alerts[0]?.requirement;
+
+  if (!patched) {
+    return classification({
+      packageName: moduleName,
+      alertIds,
+      status: 'manual',
+      reason: 'No concrete first patched version is available.',
+    });
+  }
+  if (!requirement) {
+    return classification({
+      packageName: moduleName,
+      alertIds,
+      status: 'manual',
+      reason: `server/go.mod does not require ${moduleName}.`,
+    });
+  }
+
+  const current = goSemver(requirement.version);
+  if (!current) {
+    return classification({
+      packageName: moduleName,
+      alertIds,
+      status: 'manual',
+      reason: `server/go.mod pins ${moduleName} to ${requirement.version}, which is not a comparable release.`,
+    });
+  }
+  if (isVersionAtLeast(current.version, patched)) {
+    return classification({
+      packageName: moduleName,
+      alertIds,
+      status: 'safe',
+      reason: `server/go.mod already requires ${moduleName} at ${requirement.version}.`,
+    });
+  }
+
+  const target = parseSemver(patched);
+  if (current.major !== target.major) {
+    return classification({
+      packageName: moduleName,
+      alertIds,
+      status: 'manual',
+      reason: `Remediation moves ${moduleName} from ${requirement.version} to v${patched}. A major upgrade changes the module path.`,
+    });
+  }
+
+  return classification({
+    packageName: moduleName,
+    alertIds,
+    status: 'safe',
+    reason: `Update ${moduleName} to the highest patched version v${patched}.`,
+    action: {
+      type: 'go-module',
+      from: requirement.version,
+      to: `v${patched}`,
+    },
+  });
+}
+
 /**
  * Return a deterministic, manifest-only remediation plan.
  * Unsupported alerts are intentionally not mixed with npm remediation groups.
  */
-export function planRemediation({ audit, packageJson, lockfile }) {
+export function planRemediation({ audit, packageJson, lockfile, goMod }) {
   const normalized = normalizeAlerts(audit);
   const resolved = parseLockfileVersions(lockfile);
+  const goRequirements = parseGoRequirements(goMod);
   const unsupported = [];
   const npmByPackage = new Map();
+  const goByModule = new Map();
 
   for (const alert of normalized) {
-    if (alert.ecosystem !== 'npm') {
+    const manifests =
+      alert.ecosystem === 'npm'
+        ? REMEDIABLE_MANIFESTS
+        : alert.ecosystem === 'go'
+          ? GO_MANIFESTS
+          : null;
+    if (!manifests) {
       unsupported.push(
         classification({
           packageName: alert.packageName,
@@ -564,7 +680,7 @@ export function planRemediation({ audit, packageJson, lockfile }) {
       );
       continue;
     }
-    if (!REMEDIABLE_MANIFESTS.has(alert.manifestPath)) {
+    if (!manifests.has(alert.manifestPath)) {
       unsupported.push(
         classification({
           packageName: alert.packageName,
@@ -575,9 +691,19 @@ export function planRemediation({ audit, packageJson, lockfile }) {
       );
       continue;
     }
-    const group = npmByPackage.get(alert.packageName) ?? [];
-    group.push(alert);
-    npmByPackage.set(alert.packageName, group);
+
+    const grouped = alert.ecosystem === 'go' ? goByModule : npmByPackage;
+    const group = grouped.get(alert.packageName) ?? [];
+    group.push(
+      alert.ecosystem === 'go'
+        ? {
+            ...alert,
+            moduleName: alert.packageName,
+            requirement: goRequirements.get(alert.packageName),
+          }
+        : alert,
+    );
+    grouped.set(alert.packageName, group);
   }
 
   const classifications = [
@@ -590,6 +716,9 @@ export function planRemediation({ audit, packageJson, lockfile }) {
           resolved.get(packageName),
         ),
       ),
+    ...[...goByModule.keys()]
+      .sort((a, b) => String(a).localeCompare(String(b)))
+      .map((moduleName) => classifyGoModule(goByModule.get(moduleName))),
     ...unsupported.sort((a, b) =>
       String(a.packageName).localeCompare(String(b.packageName)),
     ),
@@ -639,6 +768,7 @@ export function applyRemediation(packageJson, plan) {
       next[action.section][action.packageName] = action.to;
       continue;
     }
+    if (action.type === 'go-module') continue;
     if (action.type === 'pnpm-override') {
       const current = next.pnpm?.overrides?.[action.selector];
       if (current !== action.from) {
@@ -658,6 +788,7 @@ function parseCliArguments(args) {
   const options = {
     packageJson: 'package.json',
     lockfile: 'pnpm-lock.yaml',
+    goMod: 'server/go.mod',
     apply: false,
   };
   for (let index = 0; index < args.length; index += 1) {
@@ -668,6 +799,9 @@ function parseCliArguments(args) {
     else if (arg === '--lockfile') {
       options.lockfile = args[++index];
       options.lockfileRequired = true;
+    } else if (arg === '--go-mod') {
+      options.goMod = args[++index];
+      options.goModRequired = true;
     } else if (arg === '--report') options.report = args[++index];
     else if (arg === '--help') options.help = true;
     else throw new Error(`Unknown argument: ${arg}`);
@@ -679,7 +813,7 @@ export async function runCli(args = process.argv.slice(2)) {
   const options = parseCliArguments(args);
   if (options.help) {
     console.log(
-      'Usage: node apply-weekly-dependency-remediation.mjs --audit audit.json [--package-json package.json] [--lockfile pnpm-lock.yaml] [--report remediation.json] [--apply]',
+      'Usage: node apply-weekly-dependency-remediation.mjs --audit audit.json [--package-json package.json] [--lockfile pnpm-lock.yaml] [--go-mod server/go.mod] [--report remediation.json] [--apply]',
     );
     return { exitCode: 0 };
   }
@@ -695,10 +829,15 @@ export async function runCli(args = process.argv.slice(2)) {
       return undefined;
     },
   );
+  const goModText = await readFile(options.goMod, 'utf8').catch((error) => {
+    if (options.goModRequired) throw error;
+    return undefined;
+  });
   const plan = planRemediation({
     audit: JSON.parse(auditText),
     packageJson: JSON.parse(packageJsonText),
     lockfile: lockfileText,
+    goMod: goModText,
   });
   const report = {
     ...plan,

--- a/.github/scripts/apply-weekly-dependency-remediation.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.mjs
@@ -16,7 +16,7 @@ const DIRECT_DEPENDENCY_SECTIONS = ['dependencies', 'devDependencies'];
 const VERSION =
   /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const VERSION_IN_RANGE =
-  /(?<operator>\^|~|>=|>|=)?\s*(?<version>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/;
+  /(?<operator>\^|~|>=|>|=)?\s*(?<version>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?<prerelease>-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?/;
 
 export function parseSemver(version) {
   if (typeof version !== 'string') return null;
@@ -88,10 +88,16 @@ function rangeLowerBound(range) {
   if (typeof range !== 'string') return null;
   const match = VERSION_IN_RANGE.exec(range.trim());
   if (!match?.groups) return null;
+  const prerelease = match.groups.prerelease ?? '';
   return {
     operator: match.groups.operator ?? '',
-    version: `${match.groups.version}.${match.groups.minor}.${match.groups.patch}`,
+    version: `${match.groups.version}.${match.groups.minor}.${match.groups.patch}${prerelease}`,
+    prerelease: Boolean(prerelease),
   };
+}
+
+function prereleaseBoundReason(kind, bound) {
+  return `${kind} lower bound ${bound.version} carries a prerelease tag, which this planner does not order.`;
 }
 
 function isSimpleRange(range) {
@@ -370,6 +376,14 @@ function classifyOverride({ packageName, alertIds, patched, override }) {
       reason: `Existing pnpm override ${override.selector} uses an unsupported range: ${String(override.version)}.`,
     });
   }
+  if (bound.prerelease) {
+    return classification({
+      packageName,
+      alertIds,
+      status: 'manual',
+      reason: prereleaseBoundReason('Override', bound),
+    });
+  }
   if (isVersionAtLeast(bound.version, patched)) {
     return classification({
       packageName,
@@ -486,6 +500,14 @@ function classifyPackageStatus(alerts, packageJson, resolvedVersions) {
         alertIds,
         status: 'manual',
         reason: `Direct dependency uses an unsupported range: ${direct.version}.`,
+      });
+    }
+    if (bound.prerelease) {
+      return classification({
+        packageName,
+        alertIds,
+        status: 'manual',
+        reason: prereleaseBoundReason('Direct dependency', bound),
       });
     }
     const interactingOverrides = findOverrides(packageJson, packageName);

--- a/.github/scripts/apply-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.test.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
   applyRemediation,
+  isVersionVulnerable,
+  parseLockfileVersions,
   planRemediation,
+  runCli,
 } from './apply-weekly-dependency-remediation.mjs';
 
 function alert({
@@ -11,7 +17,8 @@ function alert({
   name = 'example',
   patched = '1.2.3',
   ecosystem = 'npm',
-  manifestPath = '/package.json',
+  manifestPath = 'package.json',
+  vulnerable = null,
 } = {}) {
   return {
     number,
@@ -22,6 +29,7 @@ function alert({
     security_vulnerability: {
       package: { ecosystem, name },
       first_patched_version: patched ? { identifier: patched } : null,
+      ...(vulnerable ? { vulnerable_version_range: vulnerable } : {}),
     },
   };
 }
@@ -73,7 +81,7 @@ test('plans and applies an audit-normalized direct dependency alert', () => {
             number: 42,
             package: 'lodash',
             ecosystem: 'npm',
-            manifestPath: '/package.json',
+            manifestPath: 'package.json',
             firstPatchedVersion: '4.17.21',
           },
         ],
@@ -279,14 +287,410 @@ test('marks missing patched versions and unsupported manifests as non-automatabl
       alert({
         number: 5,
         name: 'nested',
-        manifestPath: '/packages/nested/package.json',
+        manifestPath: 'packages/nested/package.json',
       }),
       alert({ number: 6, name: 'go-module', ecosystem: 'go' }),
+      alert({
+        number: 9,
+        name: 'npm-shrinkwrapped',
+        manifestPath: 'package-lock.json',
+      }),
     ],
     packageJson: manifest(),
   });
 
   assert.equal(plan.actions.length, 0);
   assert.equal(plan.summary.manual, 1);
-  assert.equal(plan.summary.unsupported, 2);
+  assert.equal(plan.summary.unsupported, 3);
+
+  const unsupported = plan.classifications.filter(
+    (item) => item.status === 'unsupported',
+  );
+  assert.deepEqual(unsupported.map((item) => item.reason).sort(), [
+    'Unsupported ecosystem: go.',
+    'Unsupported manifest: package-lock.json.',
+    'Unsupported manifest: packages/nested/package.json.',
+  ]);
+});
+
+test('plans a direct dependency bump for an alert reported against package.json', () => {
+  const packageJson = manifest({ dependencies: { lodash: '^4.17.20' } });
+  const plan = planRemediation({
+    audit: [
+      alert({
+        name: 'lodash',
+        patched: '4.17.21',
+        manifestPath: 'package.json',
+      }),
+    ],
+    packageJson,
+  });
+
+  assert.equal(plan.summary.unsupported, 0);
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'lodash',
+      alertIds: [1],
+      type: 'direct-dependency',
+      section: 'dependencies',
+      from: '^4.17.20',
+      to: '^4.17.21',
+    },
+  ]);
+});
+
+test('raises an existing override for a transitive alert reported against the lockfile', () => {
+  const packageJson = manifest({ overrides: { protobufjs: '^7.5.5' } });
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        patched: '7.6.5',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson,
+  });
+
+  assert.equal(plan.summary.unsupported, 0);
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'protobufjs',
+      alertIds: [338],
+      type: 'pnpm-override',
+      selector: 'protobufjs',
+      from: '^7.5.5',
+      to: '^7.6.5',
+    },
+  ]);
+});
+
+test('raises the floor of a versioned override selector', () => {
+  const packageJson = manifest({
+    overrides: { 'minimatch@>=5 <6': '^5.1.9' },
+  });
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 21,
+        name: 'minimatch',
+        patched: '5.1.10',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'minimatch',
+      alertIds: [21],
+      type: 'pnpm-override',
+      selector: 'minimatch@>=5 <6',
+      from: '^5.1.9',
+      to: '^5.1.10',
+    },
+  ]);
+  assert.equal(
+    applyRemediation(packageJson, plan).pnpm.overrides['minimatch@>=5 <6'],
+    '^5.1.10',
+  );
+});
+
+test('raises a nested override selector that also carries a version range', () => {
+  const packageJson = manifest({
+    overrides: { 'legacy-client>cookie@>=0 <1': '^0.6.0' },
+  });
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 22,
+        name: 'cookie',
+        patched: '0.6.1',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'cookie',
+      alertIds: [22],
+      type: 'pnpm-override',
+      selector: 'legacy-client>cookie@>=0 <1',
+      from: '^0.6.0',
+      to: '^0.6.1',
+    },
+  ]);
+});
+
+test('raises a compound override range and keeps its upper bound', () => {
+  const packageJson = manifest({
+    overrides: { undici: '>=6.27.0 <7' },
+  });
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 31,
+        name: 'undici',
+        patched: '6.28.0',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'undici',
+      alertIds: [31],
+      type: 'pnpm-override',
+      selector: 'undici',
+      from: '>=6.27.0 <7',
+      to: '>=6.28.0 <7',
+    },
+  ]);
+  assert.equal(
+    applyRemediation(packageJson, plan).pnpm.overrides.undici,
+    '>=6.28.0 <7',
+  );
+});
+
+test('refuses a compound override raise that crosses the upper bound', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 32,
+        name: 'undici',
+        patched: '7.1.0',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { undici: '>=6.27.0 <7' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /upper bound <7/);
+});
+
+test('reports a version below a one-sided vulnerable range as vulnerable', () => {
+  assert.equal(isVersionVulnerable('1.9.15', '< 1.9.16'), true);
+  assert.equal(isVersionVulnerable('1.9.16', '< 1.9.16'), false);
+});
+
+test('reports a version outside a two-sided vulnerable range as not vulnerable', () => {
+  assert.equal(isVersionVulnerable('1.14.3', '>= 1.14.0, < 1.14.4'), true);
+  assert.equal(isVersionVulnerable('1.14.4', '>= 1.14.0, < 1.14.4'), false);
+  assert.equal(isVersionVulnerable('1.13.9', '>= 1.14.0, < 1.14.4'), false);
+});
+
+test('reports the live advisory ranges for the open alerts', () => {
+  const protobufjs = ['>= 7.5.0, <= 7.6.4', '<= 7.6.0', '<= 7.6.2'];
+  for (const range of protobufjs) {
+    assert.equal(isVersionVulnerable('7.5.8', range), true);
+    assert.equal(isVersionVulnerable('7.6.5', range), false);
+  }
+
+  assert.equal(isVersionVulnerable('1.14.3', '>= 1.14.0, < 1.14.4'), true);
+  assert.equal(isVersionVulnerable('1.14.4', '>= 1.14.0, < 1.14.4'), false);
+});
+
+test('treats an unreadable vulnerable range as vulnerable', () => {
+  assert.equal(isVersionVulnerable('1.0.0', 'not a range'), true);
+  assert.equal(isVersionVulnerable('1.0.0', ''), true);
+  assert.equal(isVersionVulnerable('1.0.0', null), true);
+  assert.equal(isVersionVulnerable('not-a-version', '< 2.0.0'), true);
+});
+
+const LOCKFILE = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+overrides:
+  protobufjs: ^7.5.5
+
+importers:
+
+  .:
+    dependencies:
+      protobufjs:
+        specifier: ^7.5.5
+        version: 7.5.8
+
+packages:
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-aaa}
+    engines: {node: '>=12.10.0'}
+
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-bbb}
+
+  protobufjs@6.11.4:
+    resolution: {integrity: sha512-ccc}
+
+  'is-even@1.0.0(peer@2.0.0)':
+    resolution: {integrity: sha512-ddd}
+
+snapshots:
+
+  protobufjs@7.5.8:
+    dependencies: {}
+`;
+
+test('reports every version the lockfile resolves for a package', () => {
+  const versions = parseLockfileVersions(LOCKFILE);
+
+  assert.deepEqual(versions.get('protobufjs'), ['6.11.4', '7.5.8']);
+  assert.deepEqual(versions.get('@grpc/grpc-js'), ['1.14.3']);
+  assert.deepEqual(versions.get('is-even'), ['1.0.0']);
+  assert.equal(versions.get('absent'), undefined);
+});
+
+test('marks a package the lockfile already resolves above the advisory as already safe', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        patched: '7.6.5',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { protobufjs: '^7.5.5' } }),
+    lockfile: `lockfileVersion: '9.0'
+
+packages:
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-aaa}
+`,
+  });
+
+  assert.deepEqual(plan.actions, []);
+  assert.equal(plan.classifications[0].status, 'alreadySafe');
+  assert.deepEqual(plan.classifications[0].resolvedVersions, ['7.6.5']);
+  assert.equal(plan.summary.alreadySafe, 1);
+});
+
+test('refuses a direct dependency bump when the lockfile holds an unreachable copy', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 41,
+        name: 'foo',
+        patched: '1.0.5',
+        vulnerable: '< 1.0.5',
+        manifestPath: 'package.json',
+      }),
+    ],
+    packageJson: manifest({ dependencies: { foo: '^1.0.0' } }),
+    lockfile: `lockfileVersion: '9.0'
+
+packages:
+
+  foo@1.0.2:
+    resolution: {integrity: sha512-aaa}
+
+  foo@0.9.0:
+    resolution: {integrity: sha512-bbb}
+`,
+  });
+
+  assert.deepEqual(plan.actions, []);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /0\.9\.0, 1\.0\.2/);
+});
+
+test('reports the resolved versions on every npm classification', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        patched: '7.6.5',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+      alert({
+        number: 295,
+        name: 'grpc',
+        patched: '1.14.4',
+        vulnerable: '>= 1.14.0, < 1.14.4',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { protobufjs: '^7.5.5' } }),
+    lockfile: `lockfileVersion: '9.0'
+
+packages:
+
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-aaa}
+
+  grpc@1.14.3:
+    resolution: {integrity: sha512-bbb}
+`,
+  });
+
+  const byPackage = Object.fromEntries(
+    plan.classifications.map((item) => [item.packageName, item]),
+  );
+
+  assert.equal(byPackage.protobufjs.status, 'safe');
+  assert.deepEqual(byPackage.protobufjs.resolvedVersions, ['7.5.8']);
+  assert.equal(byPackage.grpc.status, 'manual');
+  assert.deepEqual(byPackage.grpc.resolvedVersions, ['1.14.3']);
+});
+
+test('reports lockfile evidence from the command line', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'weekly-remediation-'));
+  const auditPath = path.join(directory, 'audit.json');
+  const packageJsonPath = path.join(directory, 'package.json');
+  const lockfilePath = path.join(directory, 'pnpm-lock.yaml');
+
+  await writeFile(
+    auditPath,
+    JSON.stringify([
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        patched: '7.6.5',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ]),
+  );
+  await writeFile(
+    packageJsonPath,
+    JSON.stringify(manifest({ overrides: { protobufjs: '^7.5.5' } })),
+  );
+  await writeFile(
+    lockfilePath,
+    `lockfileVersion: '9.0'
+
+packages:
+
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-aaa}
+`,
+  );
+
+  const { report } = await runCli([
+    '--audit',
+    auditPath,
+    '--package-json',
+    packageJsonPath,
+    '--lockfile',
+    lockfilePath,
+    '--report',
+    path.join(directory, 'remediation.json'),
+  ]);
+
+  assert.deepEqual(report.classifications[0].resolvedVersions, ['7.5.8']);
 });

--- a/.github/scripts/apply-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.test.mjs
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyRemediation,
+  planRemediation,
+} from './apply-weekly-dependency-remediation.mjs';
+
+function alert({
+  number = 1,
+  name = 'example',
+  patched = '1.2.3',
+  ecosystem = 'npm',
+  manifestPath = '/package.json',
+} = {}) {
+  return {
+    number,
+    dependency: {
+      manifest_path: manifestPath,
+      package: { ecosystem, name },
+    },
+    security_vulnerability: {
+      package: { ecosystem, name },
+      first_patched_version: patched ? { identifier: patched } : null,
+    },
+  };
+}
+
+function manifest({ dependencies, devDependencies, overrides } = {}) {
+  return {
+    name: 'fixture',
+    ...(dependencies ? { dependencies } : {}),
+    ...(devDependencies ? { devDependencies } : {}),
+    ...(overrides ? { pnpm: { overrides } } : {}),
+  };
+}
+
+test('plans and applies the smallest direct dependency bump', () => {
+  const packageJson = manifest({ dependencies: { lodash: '^4.17.20' } });
+  const plan = planRemediation({
+    audit: [alert({ name: 'lodash', patched: '4.17.21' })],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'lodash',
+      alertIds: [1],
+      type: 'direct-dependency',
+      section: 'dependencies',
+      from: '^4.17.20',
+      to: '^4.17.21',
+    },
+  ]);
+  assert.equal(
+    applyRemediation(packageJson, plan).dependencies.lodash,
+    '^4.17.21',
+  );
+});
+
+test('plans and applies an audit-normalized direct dependency alert', () => {
+  const packageJson = manifest({ dependencies: { lodash: '^4.17.20' } });
+  const plan = planRemediation({
+    audit: {
+      schemaVersion: 1,
+      generatedAt: '2026-08-12T12:00:00.000Z',
+      repository: 'temporalio/ui',
+      run: { url: 'https://github.com/temporalio/ui/actions/runs/1' },
+      dependabot: {
+        openAlertCount: 1,
+        alerts: [
+          {
+            number: 42,
+            package: 'lodash',
+            ecosystem: 'npm',
+            manifestPath: '/package.json',
+            firstPatchedVersion: '4.17.21',
+          },
+        ],
+      },
+      remediation: null,
+      vln: { pending: [], needsTriage: [] },
+      externalContributors: {
+        reviewReady: [],
+        triage: [],
+        authorFollowup: [],
+        staleCount: 0,
+      },
+    },
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'lodash',
+      alertIds: [42],
+      type: 'direct-dependency',
+      section: 'dependencies',
+      from: '^4.17.20',
+      to: '^4.17.21',
+    },
+  ]);
+  assert.equal(
+    applyRemediation(packageJson, plan).dependencies.lodash,
+    '^4.17.21',
+  );
+});
+
+test('requires manual remediation for a transitive alert without an existing override', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'cookie', patched: '0.7.0' })],
+    packageJson: manifest(),
+  });
+
+  assert.deepEqual(plan.actions, []);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /refusing to create/);
+});
+
+test('updates a compatible existing scoped override for a transitive alert', () => {
+  const packageJson = manifest({
+    overrides: { 'legacy-client>cookie': '^0.6.0' },
+  });
+  const plan = planRemediation({
+    audit: [alert({ name: 'cookie', patched: '0.6.1' })],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'cookie',
+      alertIds: [1],
+      type: 'pnpm-override',
+      selector: 'legacy-client>cookie',
+      from: '^0.6.0',
+      to: '^0.6.1',
+    },
+  ]);
+  assert.equal(
+    applyRemediation(packageJson, plan).pnpm.overrides['legacy-client>cookie'],
+    '^0.6.1',
+  );
+});
+
+test('rejects pre-1.0 remediation across minor versions', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'cookie', patched: '0.7.0' })],
+    packageJson: manifest({ dependencies: { cookie: '^0.6.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /caret-compatible pre-1\.0/);
+});
+
+test('rejects 0.0.x remediation across patch versions', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'tiny-package', patched: '0.0.4' })],
+    packageJson: manifest({ dependencies: { 'tiny-package': '^0.0.3' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /caret-compatible pre-1\.0/);
+});
+
+test('rejects a direct-only bump when an override could supersede it', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'lodash', patched: '4.17.21' })],
+    packageJson: manifest({
+      dependencies: { lodash: '^4.17.20' },
+      overrides: { lodash: '4.17.19' },
+    }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /could be superseded/);
+});
+
+test('updates a vulnerable override before calling a direct dependency safe', () => {
+  const packageJson = manifest({
+    dependencies: { foo: '^1.3.0' },
+    overrides: { foo: '1.2.0' },
+  });
+  const plan = planRemediation({
+    audit: [alert({ name: 'foo', patched: '1.3.0' })],
+    packageJson,
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'foo',
+      alertIds: [1],
+      type: 'pnpm-override',
+      selector: 'foo',
+      from: '1.2.0',
+      to: '1.3.0',
+    },
+  ]);
+  assert.equal(applyRemediation(packageJson, plan).pnpm.overrides.foo, '1.3.0');
+});
+
+test('allows a tilde dependency bump within the same minor version', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'example', patched: '1.2.3' })],
+    packageJson: manifest({ dependencies: { example: '~1.2.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 1);
+  assert.equal(plan.actions[0].to, '~1.2.3');
+});
+
+test('rejects a tilde dependency bump across minor versions', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'example', patched: '1.3.0' })],
+    packageJson: manifest({ dependencies: { example: '~1.2.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /tilde-compatible minor/);
+});
+
+test('uses the highest patched floor for multiple alerts affecting one package', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({ number: 2, name: 'ws', patched: '8.17.0' }),
+      alert({ number: 3, name: 'ws', patched: '8.18.0' }),
+    ],
+    packageJson: manifest({ dependencies: { ws: '^8.16.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 1);
+  assert.deepEqual(plan.actions[0].alertIds, [2, 3]);
+  assert.equal(plan.actions[0].to, '^8.18.0');
+});
+
+test('marks an already-safe direct dependency without editing it', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'axios', patched: '1.7.0' })],
+    packageJson: manifest({ dependencies: { axios: '^1.8.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'safe');
+  assert.match(plan.classifications[0].reason, /already meets/);
+});
+
+test('rejects a direct dependency remediation that needs a major upgrade', () => {
+  const plan = planRemediation({
+    audit: [alert({ name: 'vite', patched: '6.0.0' })],
+    packageJson: manifest({ devDependencies: { vite: '^5.4.0' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /major upgrade/);
+});
+
+test('rejects alert groups whose patched floors cross major versions', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({ number: 7, name: 'rollup', patched: '4.0.0' }),
+      alert({ number: 8, name: 'rollup', patched: '5.0.0' }),
+    ],
+    packageJson: manifest(),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /cascade is ambiguous/);
+});
+
+test('marks missing patched versions and unsupported manifests as non-automatable', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({ number: 4, name: 'no-patch', patched: null }),
+      alert({
+        number: 5,
+        name: 'nested',
+        manifestPath: '/packages/nested/package.json',
+      }),
+      alert({ number: 6, name: 'go-module', ecosystem: 'go' }),
+    ],
+    packageJson: manifest(),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.summary.manual, 1);
+  assert.equal(plan.summary.unsupported, 2);
+});

--- a/.github/scripts/apply-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.test.mjs
@@ -34,6 +34,21 @@ function alert({
   };
 }
 
+function goMod({ direct = [], indirect = [] } = {}) {
+  return `module github.com/temporalio/ui-server/v2
+
+go 1.26.5
+
+require (
+${direct.map((line) => `\t${line}`).join('\n')}
+)
+
+require (
+${indirect.map((line) => `\t${line} // indirect`).join('\n')}
+)
+`;
+}
+
 function manifest({ dependencies, devDependencies, overrides } = {}) {
   return {
     name: 'fixture',
@@ -289,11 +304,17 @@ test('marks missing patched versions and unsupported manifests as non-automatabl
         name: 'nested',
         manifestPath: 'packages/nested/package.json',
       }),
-      alert({ number: 6, name: 'go-module', ecosystem: 'go' }),
+      alert({ number: 6, name: 'rubygem', ecosystem: 'rubygems' }),
       alert({
         number: 9,
         name: 'npm-shrinkwrapped',
         manifestPath: 'package-lock.json',
+      }),
+      alert({
+        number: 10,
+        name: 'golang.org/x/net',
+        ecosystem: 'go',
+        manifestPath: 'package.json',
       }),
     ],
     packageJson: manifest(),
@@ -301,14 +322,15 @@ test('marks missing patched versions and unsupported manifests as non-automatabl
 
   assert.equal(plan.actions.length, 0);
   assert.equal(plan.summary.manual, 1);
-  assert.equal(plan.summary.unsupported, 3);
+  assert.equal(plan.summary.unsupported, 4);
 
   const unsupported = plan.classifications.filter(
     (item) => item.status === 'unsupported',
   );
   assert.deepEqual(unsupported.map((item) => item.reason).sort(), [
-    'Unsupported ecosystem: go.',
+    'Unsupported ecosystem: rubygems.',
     'Unsupported manifest: package-lock.json.',
+    'Unsupported manifest: package.json.',
     'Unsupported manifest: packages/nested/package.json.',
   ]);
 });
@@ -693,4 +715,207 @@ packages:
   ]);
 
   assert.deepEqual(report.classifications[0].resolvedVersions, ['7.5.8']);
+});
+
+test('plans a version bump for a direct Go requirement', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 354,
+        name: 'google.golang.org/grpc',
+        ecosystem: 'go',
+        patched: '1.82.1',
+        vulnerable: '< 1.82.1',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({ direct: ['google.golang.org/grpc v1.79.3'] }),
+  });
+
+  assert.equal(plan.summary.unsupported, 0);
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'google.golang.org/grpc',
+      alertIds: [354],
+      type: 'go-module',
+      from: 'v1.79.3',
+      to: 'v1.82.1',
+    },
+  ]);
+});
+
+test('plans a version bump for an indirect Go requirement', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        ecosystem: 'go',
+        patched: '0.52.0',
+        vulnerable: '< 0.52.0',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({ indirect: ['golang.org/x/crypto v0.51.0'] }),
+  });
+
+  assert.deepEqual(plan.actions, [
+    {
+      packageName: 'golang.org/x/crypto',
+      alertIds: [335],
+      type: 'go-module',
+      from: 'v0.51.0',
+      to: 'v0.52.0',
+    },
+  ]);
+});
+
+test('refuses a Go bump that changes the major version', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 400,
+        name: 'example.com/lib',
+        ecosystem: 'go',
+        patched: '2.0.0',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({ direct: ['example.com/lib v1.4.0'] }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /changes the module path/);
+});
+
+test('refuses a Go module pinned to a pseudo-version', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 401,
+        name: 'github.com/gomarkdown/markdown',
+        ecosystem: 'go',
+        patched: '0.1.0',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({
+      direct: [
+        'github.com/gomarkdown/markdown v0.0.0-20260411013819-759bbc3e3207',
+      ],
+    }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /not a comparable release/);
+});
+
+test('reports a Go module that go.mod does not require as manual', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 402,
+        name: 'example.com/absent',
+        ecosystem: 'go',
+        patched: '1.1.0',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({ direct: ['example.com/other v1.0.0'] }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /does not require/);
+});
+
+test('reports a Go requirement that already meets the patched version as safe', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 403,
+        name: 'golang.org/x/net',
+        ecosystem: 'go',
+        patched: '0.55.0',
+        manifestPath: 'server/go.mod',
+      }),
+    ],
+    packageJson: manifest(),
+    goMod: goMod({ direct: ['golang.org/x/net v0.55.0'] }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'safe');
+  assert.match(plan.classifications[0].reason, /already requires/);
+});
+
+test('leaves package.json unchanged for a plan that holds only Go actions', () => {
+  const packageJson = manifest({ dependencies: { lodash: '^4.17.20' } });
+  const plan = {
+    actions: [
+      {
+        packageName: 'golang.org/x/crypto',
+        alertIds: [335],
+        type: 'go-module',
+        from: 'v0.51.0',
+        to: 'v0.52.0',
+      },
+    ],
+  };
+
+  assert.deepEqual(applyRemediation(packageJson, plan), packageJson);
+});
+
+test('plans a Go remediation from the command line', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'weekly-go-plan-'));
+  const auditPath = path.join(directory, 'audit.json');
+  const packageJsonPath = path.join(directory, 'package.json');
+  const goModPath = path.join(directory, 'go.mod');
+
+  await writeFile(
+    auditPath,
+    JSON.stringify([
+      alert({
+        number: 354,
+        name: 'google.golang.org/grpc',
+        ecosystem: 'go',
+        patched: '1.82.1',
+        vulnerable: '< 1.82.1',
+        manifestPath: 'server/go.mod',
+      }),
+    ]),
+  );
+  await writeFile(packageJsonPath, JSON.stringify(manifest()));
+  await writeFile(
+    goModPath,
+    goMod({ direct: ['google.golang.org/grpc v1.79.3'] }),
+  );
+
+  const { report } = await runCli([
+    '--audit',
+    auditPath,
+    '--package-json',
+    packageJsonPath,
+    '--go-mod',
+    goModPath,
+    '--report',
+    path.join(directory, 'remediation.json'),
+  ]);
+
+  assert.deepEqual(report.actions, [
+    {
+      packageName: 'google.golang.org/grpc',
+      alertIds: [354],
+      type: 'go-module',
+      from: 'v1.79.3',
+      to: 'v1.82.1',
+    },
+  ]);
 });

--- a/.github/scripts/apply-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.test.mjs
@@ -919,3 +919,41 @@ test('plans a Go remediation from the command line', async () => {
     },
   ]);
 });
+
+test('refuses a direct dependency whose lower bound carries a prerelease', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 51,
+        name: 'thing',
+        patched: '1.2.3',
+        vulnerable: '< 1.2.3',
+      }),
+    ],
+    packageJson: manifest({ dependencies: { thing: '^1.2.3-beta.1' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /1\.2\.3-beta\.1/);
+  assert.match(plan.classifications[0].reason, /prerelease/);
+});
+
+test('refuses an override whose lower bound carries a prerelease', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 52,
+        name: 'thing',
+        patched: '1.2.3',
+        vulnerable: '< 1.2.3',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { thing: '>=1.2.3-rc.1' } }),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /prerelease/);
+});

--- a/.github/scripts/validate-claude-dependency-remediation.mjs
+++ b/.github/scripts/validate-claude-dependency-remediation.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { appendFile, readFile, writeFile } from 'node:fs/promises';
+
+import { applyRemediation } from './apply-weekly-dependency-remediation.mjs';
+
+export function validateClaudeRemediation({ baseText, candidateText, report }) {
+  const base = JSON.parse(baseText);
+  JSON.parse(candidateText);
+
+  if (!Array.isArray(report?.actions)) {
+    throw new Error('Remediation report must contain an actions array.');
+  }
+
+  const hasAuthorizedActions = report.actions.length > 0;
+  const expectedText = hasAuthorizedActions
+    ? `${JSON.stringify(applyRemediation(base, report), null, 2)}\n`
+    : baseText;
+  const changed = hasAuthorizedActions && expectedText !== baseText;
+
+  if (candidateText !== expectedText) {
+    throw new Error(
+      'Claude candidate does not exactly match the authorized remediation actions.',
+    );
+  }
+
+  const validatedReport = structuredClone(report);
+  if (changed) {
+    validatedReport.applied = true;
+    validatedReport.resolver = 'claude-code';
+  } else {
+    validatedReport.applied = false;
+    delete validatedReport.resolver;
+  }
+
+  return { changed, report: validatedReport };
+}
+
+function parseArguments(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--base') options.base = args[++index];
+    else if (argument === '--candidate') options.candidate = args[++index];
+    else if (argument === '--report') options.report = args[++index];
+    else if (argument === '--github-output')
+      options.githubOutput = args[++index];
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  for (const required of ['base', 'candidate', 'report']) {
+    if (!options[required]) throw new Error(`--${required} is required`);
+  }
+  return options;
+}
+
+export async function runCli(args = process.argv.slice(2)) {
+  const options = parseArguments(args);
+  const [baseText, candidateText, reportText] = await Promise.all([
+    readFile(options.base, 'utf8'),
+    readFile(options.candidate, 'utf8'),
+    readFile(options.report, 'utf8'),
+  ]);
+  const validated = validateClaudeRemediation({
+    baseText,
+    candidateText,
+    report: JSON.parse(reportText),
+  });
+  await writeFile(
+    options.report,
+    `${JSON.stringify(validated.report, null, 2)}\n`,
+  );
+  if (options.githubOutput) {
+    await appendFile(options.githubOutput, `changed=${validated.changed}\n`);
+  }
+  return validated;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/validate-claude-dependency-remediation.test.mjs
+++ b/.github/scripts/validate-claude-dependency-remediation.test.mjs
@@ -101,3 +101,23 @@ test('rejects a candidate change when no action is authorized', () => {
     /does not exactly match/,
   );
 });
+
+test('accepts an unchanged package.json for a Go-only remediation', () => {
+  const result = validateClaudeRemediation({
+    baseText: text(base),
+    candidateText: text(base),
+    report: report([
+      {
+        packageName: 'golang.org/x/crypto',
+        alertIds: [335],
+        type: 'go-module',
+        from: 'v0.51.0',
+        to: 'v0.52.0',
+      },
+    ]),
+  });
+
+  assert.equal(result.changed, false);
+  assert.equal(result.report.applied, false);
+  assert.equal(result.report.resolver, undefined);
+});

--- a/.github/scripts/validate-claude-dependency-remediation.test.mjs
+++ b/.github/scripts/validate-claude-dependency-remediation.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateClaudeRemediation } from './validate-claude-dependency-remediation.mjs';
+
+const base = {
+  name: 'fixture',
+  scripts: { test: 'vitest' },
+  dependencies: { lodash: '^4.17.20', zod: '^3.23.0' },
+};
+const text = (value) => `${JSON.stringify(value, null, 2)}\n`;
+const action = {
+  packageName: 'lodash',
+  alertIds: [1],
+  type: 'direct-dependency',
+  section: 'dependencies',
+  from: '^4.17.20',
+  to: '^4.17.21',
+};
+const report = (actions = [action]) => ({
+  schemaVersion: 1,
+  actions,
+  applied: false,
+});
+
+test('accepts the exact authorized dependency bump', () => {
+  const candidate = structuredClone(base);
+  candidate.dependencies.lodash = '^4.17.21';
+  const result = validateClaudeRemediation({
+    baseText: text(base),
+    candidateText: text(candidate),
+    report: report(),
+  });
+  assert.equal(result.changed, true);
+  assert.equal(result.report.applied, true);
+  assert.equal(result.report.resolver, 'claude-code');
+});
+
+test('rejects a script or unrelated field modification', () => {
+  const candidate = structuredClone(base);
+  candidate.dependencies.lodash = '^4.17.21';
+  candidate.scripts.test = 'echo compromised';
+  assert.throws(
+    () =>
+      validateClaudeRemediation({
+        baseText: text(base),
+        candidateText: text(candidate),
+        report: report(),
+      }),
+    /does not exactly match/,
+  );
+});
+
+test('rejects a wrong or downgraded dependency version', () => {
+  const candidate = structuredClone(base);
+  candidate.dependencies.lodash = '^4.17.19';
+  assert.throws(
+    () =>
+      validateClaudeRemediation({
+        baseText: text(base),
+        candidateText: text(candidate),
+        report: report(),
+      }),
+    /does not exactly match/,
+  );
+});
+
+test('rejects a whitespace-only candidate diff', () => {
+  assert.throws(
+    () =>
+      validateClaudeRemediation({
+        baseText: text(base),
+        candidateText: JSON.stringify(base),
+        report: report([]),
+      }),
+    /does not exactly match/,
+  );
+});
+
+test('accepts no action with an unchanged candidate', () => {
+  const result = validateClaudeRemediation({
+    baseText: text(base),
+    candidateText: text(base),
+    report: report([]),
+  });
+  assert.equal(result.changed, false);
+  assert.equal(result.report.applied, false);
+  assert.equal('resolver' in result.report, false);
+});
+
+test('rejects a candidate change when no action is authorized', () => {
+  const candidate = structuredClone(base);
+  candidate.dependencies.zod = '^3.24.0';
+  assert.throws(
+    () =>
+      validateClaudeRemediation({
+        baseText: text(base),
+        candidateText: text(candidate),
+        report: report([]),
+      }),
+    /does not exactly match/,
+  );
+});

--- a/.github/scripts/verify-weekly-dependency-remediation.mjs
+++ b/.github/scripts/verify-weekly-dependency-remediation.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * Confirms that a remediated alert no longer matches its advisory.
+ *
+ * The workflow runs this after it installs the candidate dependency graph, so
+ * the lockfile holds the versions the change actually resolves.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+
+import {
+  isVersionVulnerable,
+  normalizeAlerts,
+  parseLockfileVersions,
+} from './apply-weekly-dependency-remediation.mjs';
+
+export function verifyRemediation({ audit, report, lockfileText }) {
+  const resolved = parseLockfileVersions(lockfileText);
+  const remediatedIds = new Set(
+    (report?.actions ?? []).flatMap((action) => action.alertIds ?? []),
+  );
+  const failures = [];
+  const evidence = [];
+
+  for (const item of normalizeAlerts(audit)) {
+    if (!remediatedIds.has(item.id)) continue;
+
+    const resolvedVersions = resolved.get(item.packageName) ?? [];
+    evidence.push({
+      alertId: item.id,
+      packageName: item.packageName,
+      resolvedVersions,
+    });
+
+    if (resolvedVersions.length === 0) {
+      failures.push({
+        alertId: item.id,
+        packageName: item.packageName,
+        resolvedVersions,
+        reason: `The lockfile does not contain ${item.packageName}, so the remediation cannot be confirmed.`,
+      });
+      continue;
+    }
+
+    const stillVulnerable = resolvedVersions.filter((version) =>
+      isVersionVulnerable(version, item.vulnerableRange),
+    );
+    if (stillVulnerable.length > 0) {
+      failures.push({
+        alertId: item.id,
+        packageName: item.packageName,
+        resolvedVersions: stillVulnerable,
+        reason: `The lockfile resolves ${item.packageName} to ${stillVulnerable.join(', ')}, which the advisory range ${item.vulnerableRange} still covers.`,
+      });
+    }
+  }
+
+  const verified = failures.length === 0;
+  return {
+    verified,
+    failures,
+    evidence,
+    report: {
+      ...report,
+      verification: { verified, alerts: evidence, failures },
+    },
+  };
+}
+
+function parseArguments(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === '--audit') options.audit = args[++index];
+    else if (argument === '--report') options.report = args[++index];
+    else if (argument === '--lockfile') options.lockfile = args[++index];
+    else throw new Error(`Unknown argument: ${argument}`);
+  }
+  for (const required of ['audit', 'report', 'lockfile']) {
+    if (!options[required]) throw new Error(`--${required} is required`);
+  }
+  return options;
+}
+
+export async function runCli(args = process.argv.slice(2)) {
+  const options = parseArguments(args);
+  const [auditText, reportText, lockfileText] = await Promise.all([
+    readFile(options.audit, 'utf8'),
+    readFile(options.report, 'utf8'),
+    readFile(options.lockfile, 'utf8'),
+  ]);
+
+  const result = verifyRemediation({
+    audit: JSON.parse(auditText),
+    report: JSON.parse(reportText),
+    lockfileText,
+  });
+
+  await writeFile(
+    options.report,
+    `${JSON.stringify(result.report, null, 2)}\n`,
+  );
+
+  for (const failure of result.failures) {
+    console.error(failure.reason);
+  }
+  return { exitCode: result.verified ? 0 : 1, report: result.report };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runCli()
+    .then(({ exitCode }) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}

--- a/.github/scripts/verify-weekly-dependency-remediation.mjs
+++ b/.github/scripts/verify-weekly-dependency-remediation.mjs
@@ -11,11 +11,21 @@ import { readFile, writeFile } from 'node:fs/promises';
 import {
   isVersionVulnerable,
   normalizeAlerts,
+  parseGoRequirements,
   parseLockfileVersions,
 } from './apply-weekly-dependency-remediation.mjs';
 
-export function verifyRemediation({ audit, report, lockfileText }) {
+function goResolvedVersions(requirements, moduleName) {
+  const requirement = requirements.get(moduleName);
+  if (!requirement?.version?.startsWith('v')) return [];
+  const bare = requirement.version.slice(1);
+  if (bare.includes('-')) return [];
+  return [bare];
+}
+
+export function verifyRemediation({ audit, report, lockfileText, goModText }) {
   const resolved = parseLockfileVersions(lockfileText);
+  const goRequirements = parseGoRequirements(goModText);
   const remediatedIds = new Set(
     (report?.actions ?? []).flatMap((action) => action.alertIds ?? []),
   );
@@ -25,7 +35,10 @@ export function verifyRemediation({ audit, report, lockfileText }) {
   for (const item of normalizeAlerts(audit)) {
     if (!remediatedIds.has(item.id)) continue;
 
-    const resolvedVersions = resolved.get(item.packageName) ?? [];
+    const resolvedVersions =
+      item.ecosystem === 'go'
+        ? goResolvedVersions(goRequirements, item.packageName)
+        : (resolved.get(item.packageName) ?? []);
     evidence.push({
       alertId: item.id,
       packageName: item.packageName,
@@ -37,7 +50,10 @@ export function verifyRemediation({ audit, report, lockfileText }) {
         alertId: item.id,
         packageName: item.packageName,
         resolvedVersions,
-        reason: `The lockfile does not contain ${item.packageName}, so the remediation cannot be confirmed.`,
+        reason:
+          item.ecosystem === 'go'
+            ? `server/go.mod does not require ${item.packageName} at a comparable version, so the remediation cannot be confirmed.`
+            : `The lockfile does not contain ${item.packageName}, so the remediation cannot be confirmed.`,
       });
       continue;
     }
@@ -50,7 +66,7 @@ export function verifyRemediation({ audit, report, lockfileText }) {
         alertId: item.id,
         packageName: item.packageName,
         resolvedVersions: stillVulnerable,
-        reason: `The lockfile resolves ${item.packageName} to ${stillVulnerable.join(', ')}, which the advisory range ${item.vulnerableRange} still covers.`,
+        reason: `${item.ecosystem === 'go' ? 'server/go.mod requires' : 'The lockfile resolves'} ${item.packageName} at ${stillVulnerable.join(', ')}, which the advisory range ${item.vulnerableRange} still covers.`,
       });
     }
   }
@@ -74,6 +90,7 @@ function parseArguments(args) {
     if (argument === '--audit') options.audit = args[++index];
     else if (argument === '--report') options.report = args[++index];
     else if (argument === '--lockfile') options.lockfile = args[++index];
+    else if (argument === '--go-mod') options.goMod = args[++index];
     else throw new Error(`Unknown argument: ${argument}`);
   }
   for (const required of ['audit', 'report', 'lockfile']) {
@@ -89,11 +106,15 @@ export async function runCli(args = process.argv.slice(2)) {
     readFile(options.report, 'utf8'),
     readFile(options.lockfile, 'utf8'),
   ]);
+  const goModText = options.goMod
+    ? await readFile(options.goMod, 'utf8')
+    : undefined;
 
   const result = verifyRemediation({
     audit: JSON.parse(auditText),
     report: JSON.parse(reportText),
     lockfileText,
+    goModText,
   });
 
   await writeFile(

--- a/.github/scripts/verify-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/verify-weekly-dependency-remediation.test.mjs
@@ -295,3 +295,160 @@ test('requires the lockfile', async () => {
     /ENOENT/,
   );
 });
+
+const goAlert = ({ number, name, vulnerable, patched }) => ({
+  number,
+  dependency: {
+    manifest_path: 'server/go.mod',
+    package: { ecosystem: 'go', name },
+  },
+  security_vulnerability: {
+    package: { ecosystem: 'go', name },
+    first_patched_version: { identifier: patched },
+    vulnerable_version_range: vulnerable,
+  },
+});
+
+const goModText = (requirements) =>
+  `module github.com/temporalio/ui-server/v2
+
+go 1.26.5
+
+require (
+${requirements.map((line) => `\t${line}`).join('\n')}
+)
+`;
+
+const goReport = () =>
+  report({
+    actions: [
+      {
+        packageName: 'golang.org/x/crypto',
+        alertIds: [335],
+        type: 'go-module',
+        from: 'v0.51.0',
+        to: 'v0.52.0',
+      },
+    ],
+  });
+
+test('confirms a remediated Go alert when go.mod escapes its range', () => {
+  const result = verifyRemediation({
+    audit: [
+      goAlert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        vulnerable: '< 0.52.0',
+        patched: '0.52.0',
+      }),
+    ],
+    report: goReport(),
+    lockfileText: lockfile(['unrelated@1.0.0']),
+    goModText: goModText(['golang.org/x/crypto v0.52.0']),
+  });
+
+  assert.equal(result.verified, true);
+  assert.deepEqual(result.report.verification.alerts, [
+    {
+      alertId: 335,
+      packageName: 'golang.org/x/crypto',
+      resolvedVersions: ['0.52.0'],
+    },
+  ]);
+});
+
+test('rejects a remediated Go alert when go.mod stays vulnerable', () => {
+  const result = verifyRemediation({
+    audit: [
+      goAlert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        vulnerable: '< 0.52.0',
+        patched: '0.52.0',
+      }),
+    ],
+    report: goReport(),
+    lockfileText: lockfile(['unrelated@1.0.0']),
+    goModText: goModText(['golang.org/x/crypto v0.51.0']),
+  });
+
+  assert.equal(result.verified, false);
+  assert.match(result.failures[0].reason, /server\/go\.mod requires/);
+});
+
+test('accepts a Go version above the authorized one', () => {
+  const result = verifyRemediation({
+    audit: [
+      goAlert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        vulnerable: '< 0.52.0',
+        patched: '0.52.0',
+      }),
+    ],
+    report: goReport(),
+    lockfileText: lockfile(['unrelated@1.0.0']),
+    goModText: goModText(['golang.org/x/crypto v0.53.0']),
+  });
+
+  assert.equal(result.verified, true);
+});
+
+test('rejects a remediated Go module that go.mod pins to a pseudo-version', () => {
+  const result = verifyRemediation({
+    audit: [
+      goAlert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        vulnerable: '< 0.52.0',
+        patched: '0.52.0',
+      }),
+    ],
+    report: goReport(),
+    lockfileText: lockfile(['unrelated@1.0.0']),
+    goModText: goModText([
+      'golang.org/x/crypto v0.0.0-20260411013819-759bbc3e3207',
+    ]),
+  });
+
+  assert.equal(result.verified, false);
+  assert.match(result.failures[0].reason, /comparable version/);
+});
+
+test('reads go.mod from the command line', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'weekly-verify-go-'));
+  const auditPath = path.join(directory, 'audit.json');
+  const reportPath = path.join(directory, 'remediation.json');
+  const lockfilePath = path.join(directory, 'pnpm-lock.yaml');
+  const goModPath = path.join(directory, 'go.mod');
+
+  await writeFile(
+    auditPath,
+    JSON.stringify([
+      goAlert({
+        number: 335,
+        name: 'golang.org/x/crypto',
+        vulnerable: '< 0.52.0',
+        patched: '0.52.0',
+      }),
+    ]),
+  );
+  await writeFile(reportPath, JSON.stringify(goReport()));
+  await writeFile(lockfilePath, lockfile(['unrelated@1.0.0']));
+  await writeFile(goModPath, goModText(['golang.org/x/crypto v0.52.0']));
+
+  const result = await runCli([
+    '--audit',
+    auditPath,
+    '--report',
+    reportPath,
+    '--lockfile',
+    lockfilePath,
+    '--go-mod',
+    goModPath,
+  ]);
+
+  assert.equal(result.exitCode, 0);
+  const written = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.deepEqual(written.verification.alerts[0].resolvedVersions, ['0.52.0']);
+});

--- a/.github/scripts/verify-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/verify-weekly-dependency-remediation.test.mjs
@@ -1,0 +1,297 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  runCli,
+  verifyRemediation,
+} from './verify-weekly-dependency-remediation.mjs';
+
+const alert = ({ number, name, vulnerable, patched }) => ({
+  number,
+  dependency: {
+    manifest_path: 'pnpm-lock.yaml',
+    package: { ecosystem: 'npm', name },
+  },
+  security_vulnerability: {
+    package: { ecosystem: 'npm', name },
+    first_patched_version: { identifier: patched },
+    vulnerable_version_range: vulnerable,
+  },
+});
+
+const lockfile = (entries) =>
+  `lockfileVersion: '9.0'
+
+packages:
+
+${entries
+  .map(
+    (entry) => `  ${entry}:
+    resolution: {integrity: sha512-aaa}
+`,
+  )
+  .join('\n')}`;
+
+const report = ({ actions, classifications = [] }) => ({
+  schemaVersion: 1,
+  actions,
+  classifications,
+  applied: true,
+  resolver: 'claude-code',
+});
+
+test('confirms a remediated alert when every resolved copy escapes its range', () => {
+  const result = verifyRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        patched: '7.6.5',
+      }),
+    ],
+    report: report({
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338],
+          type: 'pnpm-override',
+          selector: 'protobufjs',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+    }),
+    lockfileText: lockfile(['protobufjs@7.6.5']),
+  });
+
+  assert.equal(result.verified, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test('records the resolved version after the install in the report', () => {
+  const result = verifyRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        patched: '7.6.5',
+      }),
+    ],
+    report: report({
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338],
+          type: 'pnpm-override',
+          selector: 'protobufjs',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+    }),
+    lockfileText: lockfile(['protobufjs@7.6.5']),
+  });
+
+  assert.equal(result.report.verification.verified, true);
+  assert.deepEqual(result.report.verification.alerts, [
+    { alertId: 338, packageName: 'protobufjs', resolvedVersions: ['7.6.5'] },
+  ]);
+  assert.deepEqual(result.report.verification.failures, []);
+  assert.equal(result.report.applied, true);
+});
+
+test('rejects a remediated alert when a resolved copy stays inside its range', () => {
+  const result = verifyRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        patched: '7.6.5',
+      }),
+    ],
+    report: report({
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338],
+          type: 'pnpm-override',
+          selector: 'protobufjs',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+    }),
+    lockfileText: lockfile(['protobufjs@7.6.5', 'protobufjs@7.5.8']),
+  });
+
+  assert.equal(result.verified, false);
+  assert.equal(result.failures.length, 1);
+  assert.deepEqual(result.failures[0].resolvedVersions, ['7.5.8']);
+  assert.match(result.failures[0].reason, /still covers/);
+});
+
+test('rejects a remediated package the lockfile no longer contains', () => {
+  const result = verifyRemediation({
+    audit: [
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        patched: '7.6.5',
+      }),
+    ],
+    report: report({
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338],
+          type: 'pnpm-override',
+          selector: 'protobufjs',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+    }),
+    lockfileText: lockfile(['unrelated@1.0.0']),
+  });
+
+  assert.equal(result.verified, false);
+  assert.equal(result.failures.length, 1);
+  assert.match(result.failures[0].reason, /does not contain/);
+});
+
+test('ignores an alert the plan did not remediate', () => {
+  const result = verifyRemediation({
+    audit: [
+      alert({
+        number: 295,
+        name: '@grpc/grpc-js',
+        vulnerable: '>= 1.14.0, < 1.14.4',
+        patched: '1.14.4',
+      }),
+    ],
+    report: report({
+      actions: [],
+      classifications: [
+        {
+          packageName: '@grpc/grpc-js',
+          alertIds: [295],
+          status: 'manual',
+          reason: 'Transitive package has no existing pnpm override.',
+        },
+      ],
+    }),
+    lockfileText: lockfile(['@grpc/grpc-js@1.14.3']),
+  });
+
+  assert.equal(result.verified, true);
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.report.verification.alerts, []);
+});
+
+async function fixtureFiles({ resolvedVersion }) {
+  const directory = await mkdtemp(path.join(tmpdir(), 'weekly-verify-'));
+  const auditPath = path.join(directory, 'audit.json');
+  const reportPath = path.join(directory, 'remediation.json');
+  const lockfilePath = path.join(directory, 'pnpm-lock.yaml');
+
+  await writeFile(
+    auditPath,
+    JSON.stringify([
+      alert({
+        number: 338,
+        name: 'protobufjs',
+        vulnerable: '>= 7.5.0, <= 7.6.4',
+        patched: '7.6.5',
+      }),
+    ]),
+  );
+  await writeFile(
+    reportPath,
+    JSON.stringify(
+      report({
+        actions: [
+          {
+            packageName: 'protobufjs',
+            alertIds: [338],
+            type: 'pnpm-override',
+            selector: 'protobufjs',
+            from: '^7.5.5',
+            to: '^7.6.5',
+          },
+        ],
+      }),
+    ),
+  );
+  await writeFile(lockfilePath, lockfile([`protobufjs@${resolvedVersion}`]));
+  return { auditPath, reportPath, lockfilePath };
+}
+
+test('writes the verified report and succeeds from the command line', async () => {
+  const { auditPath, reportPath, lockfilePath } = await fixtureFiles({
+    resolvedVersion: '7.6.5',
+  });
+
+  const result = await runCli([
+    '--audit',
+    auditPath,
+    '--report',
+    reportPath,
+    '--lockfile',
+    lockfilePath,
+  ]);
+
+  assert.equal(result.exitCode, 0);
+  const written = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(written.verification.verified, true);
+  assert.deepEqual(written.verification.alerts[0].resolvedVersions, ['7.6.5']);
+});
+
+test('fails the run from the command line when a copy stays vulnerable', async () => {
+  const { auditPath, reportPath, lockfilePath } = await fixtureFiles({
+    resolvedVersion: '7.5.8',
+  });
+
+  const result = await runCli([
+    '--audit',
+    auditPath,
+    '--report',
+    reportPath,
+    '--lockfile',
+    lockfilePath,
+  ]);
+
+  assert.equal(result.exitCode, 1);
+  const written = JSON.parse(await readFile(reportPath, 'utf8'));
+  assert.equal(written.verification.verified, false);
+  assert.equal(written.verification.failures.length, 1);
+});
+
+test('requires the lockfile', async () => {
+  const { auditPath, reportPath } = await fixtureFiles({
+    resolvedVersion: '7.6.5',
+  });
+
+  await assert.rejects(
+    () => runCli(['--audit', auditPath, '--report', reportPath]),
+    /--lockfile is required/,
+  );
+  await assert.rejects(
+    () =>
+      runCli([
+        '--audit',
+        auditPath,
+        '--report',
+        reportPath,
+        '--lockfile',
+        path.join(path.dirname(auditPath), 'absent-lock.yaml'),
+      ]),
+    /ENOENT/,
+  );
+});

--- a/.github/scripts/weekly-dependency-security-audit.mjs
+++ b/.github/scripts/weekly-dependency-security-audit.mjs
@@ -261,9 +261,15 @@ export const classifyVln = (pullRequest) => {
 export const isRemediationPullRequest = (
   pullRequest,
   remediationBranch = DEFAULT_REMEDIATION_BRANCH,
-) =>
-  pullRequest.head?.ref === remediationBranch ||
-  /weekly dependency[- ]security/i.test(pullRequest.title ?? '');
+) => {
+  const headRef = pullRequest.headRef ?? pullRequest.head?.ref ?? null;
+  return (
+    headRef === remediationBranch ||
+    /weekly (?:dependabot|dependency)[- ]security/i.test(
+      pullRequest.title ?? '',
+    )
+  );
+};
 
 export const isExternalContributorPullRequest = (pullRequest) => {
   const author = pullRequest.user ?? {};

--- a/.github/scripts/weekly-dependency-security-audit.mjs
+++ b/.github/scripts/weekly-dependency-security-audit.mjs
@@ -1,0 +1,627 @@
+import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const DEFAULT_REMEDIATION_BRANCH = 'automation/weekly-dependency-security';
+const EXTERNAL_CONTRIBUTOR_LIMIT = 5;
+const STALE_EXTERNAL_PR_DAYS = 14;
+const PR_ENRICHMENT_CONCURRENCY = 4;
+const GITHUB_MAX_ATTEMPTS = 4;
+const GITHUB_MAX_EXPONENTIAL_DELAY_MS = 5_000;
+const AUDIT_SCOPES = new Set([
+  'all',
+  'dependency-security',
+  'vln-review',
+  'external-contributors',
+]);
+const VLN_TITLE = /^\s*(VLN-\d+)\b/i;
+const VLN_JIRA_LINK = /https?:\/\/[^\s)]*\/browse\/(VLN-\d+)\b/gi;
+const CAMPAIGN_MARKER = /\b(?:camper|automated(?:\s+security)?\s+campaign)\b/i;
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const toIso = (value) => (value ? new Date(value).toISOString() : null);
+
+const unique = (items) => [...new Set(items.filter(Boolean))];
+
+export const mapWithConcurrency = async (items, limit, mapper) => {
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new TypeError('Concurrency limit must be a positive integer');
+  }
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker()),
+  );
+  return results;
+};
+
+export const retryGithubRequest = async (
+  operation,
+  {
+    maxAttempts = GITHUB_MAX_ATTEMPTS,
+    baseDelayMs = 250,
+    maxDelayMs = GITHUB_MAX_EXPONENTIAL_DELAY_MS,
+    sleep = (delayMs) =>
+      new Promise((resolveSleep) => setTimeout(resolveSleep, delayMs)),
+  } = {},
+) => {
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new TypeError('maxAttempts must be a positive integer');
+  }
+  let attempt = 0;
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      if (!error?.retryable || attempt >= maxAttempts) throw error;
+      const exponentialDelay = baseDelayMs * 2 ** (attempt - 1);
+      const delay = Number.isFinite(error.retryAfterMs)
+        ? Math.max(
+            error.retryAfterMs *
+              (error.exponentialRetryAfter ? 2 ** (attempt - 1) : 1),
+            0,
+          )
+        : Math.min(exponentialDelay, maxDelayMs);
+      await sleep(delay);
+    }
+  }
+  throw new Error('GitHub request retry loop exhausted unexpectedly');
+};
+
+export const githubRetryMetadata = ({
+  status,
+  responseBody = '',
+  retryAfterHeader = null,
+  rateLimitResetHeader = null,
+  nowMs = Date.now(),
+}) => {
+  const retryAfterValue = retryAfterHeader?.trim() ?? '';
+  const retryAfterSeconds = /^\d+(?:\.\d+)?$/.test(retryAfterValue)
+    ? Number(retryAfterValue)
+    : null;
+  const retryAfterDateMs = retryAfterValue ? Date.parse(retryAfterValue) : NaN;
+  const rateLimitResetSeconds =
+    rateLimitResetHeader === null ? NaN : Number(rateLimitResetHeader);
+  const isRateLimitResponse =
+    status === 429 ||
+    (status === 403 && /secondary rate limit|rate limit/i.test(responseBody));
+  const isSecondaryRateLimit =
+    status === 403 && /secondary rate limit/i.test(responseBody);
+  const hasRetryAfter =
+    Number.isFinite(retryAfterSeconds) || Number.isFinite(retryAfterDateMs);
+  const hasRateLimitReset =
+    isRateLimitResponse && Number.isFinite(rateLimitResetSeconds);
+  const retryAfterMs = Number.isFinite(retryAfterSeconds)
+    ? retryAfterSeconds * 1_000
+    : Number.isFinite(retryAfterDateMs)
+      ? Math.max(retryAfterDateMs - nowMs, 0)
+      : hasRateLimitReset
+        ? Math.max(rateLimitResetSeconds * 1_000 - nowMs, 0)
+        : isSecondaryRateLimit
+          ? 60_000
+          : undefined;
+  return {
+    retryable: status === 429 || status >= 500 || isRateLimitResponse,
+    retryAfterMs,
+    ...(isSecondaryRateLimit && !hasRetryAfter && !hasRateLimitReset
+      ? { exponentialRetryAfter: true }
+      : {}),
+  };
+};
+
+export const normalizeDependabotAlert = (alert) => {
+  const vulnerability = alert.security_vulnerability ?? {};
+  const advisory = alert.security_advisory ?? {};
+
+  return {
+    number: alert.number,
+    url: alert.html_url,
+    severity: advisory.severity ?? 'unknown',
+    summary: advisory.summary ?? 'No advisory summary',
+    package: vulnerability.package?.name ?? 'unknown',
+    ecosystem: vulnerability.package?.ecosystem ?? 'unknown',
+    vulnerableRange: vulnerability.vulnerable_version_range ?? null,
+    firstPatchedVersion:
+      vulnerability.first_patched_version?.identifier ?? null,
+    manifestPath: alert.dependency?.manifest_path ?? null,
+    createdAt: toIso(alert.created_at),
+  };
+};
+
+export const summarizeReviews = (reviews, requestedReviewers = []) => {
+  const latestReviews = new Map();
+  for (const review of asArray(reviews)) {
+    const login = review.user?.login;
+    if (!login || review.state === 'PENDING') continue;
+    const previous = latestReviews.get(login);
+    if (
+      !previous ||
+      new Date(review.submitted_at) >= new Date(previous.submitted_at)
+    ) {
+      latestReviews.set(login, review);
+    }
+  }
+
+  const states = [...latestReviews.values()].map((review) => review.state);
+  const approvals = states.filter((state) => state === 'APPROVED').length;
+  const changesRequested = states.filter(
+    (state) => state === 'CHANGES_REQUESTED',
+  ).length;
+  const requested = asArray(requestedReviewers)
+    .map((reviewer) => reviewer.login)
+    .filter(Boolean);
+
+  return {
+    status:
+      changesRequested > 0
+        ? 'changes_requested'
+        : approvals > 0
+          ? 'approved'
+          : requested.length > 0
+            ? 'review_requested'
+            : 'pending',
+    approvals,
+    changesRequested,
+    requested,
+  };
+};
+
+export const summarizeChecks = (checkRuns) => {
+  const checks = asArray(checkRuns);
+  const pending = checks.filter((check) => check.status !== 'completed');
+  const failed = checks.filter(
+    (check) =>
+      check.status === 'completed' &&
+      [
+        'action_required',
+        'cancelled',
+        'failure',
+        'startup_failure',
+        'timed_out',
+      ].includes(check.conclusion),
+  );
+
+  return {
+    status:
+      failed.length > 0
+        ? 'failing'
+        : pending.length > 0
+          ? 'pending'
+          : checks.length > 0
+            ? 'passing'
+            : 'none',
+    total: checks.length,
+    failing: failed.map((check) => check.name),
+    pending: pending.map((check) => check.name),
+  };
+};
+
+export const summarizeMergeability = (pullRequest) => {
+  const mergeableState = pullRequest.mergeable_state;
+  if (pullRequest.mergeable === null || !mergeableState) return 'unknown';
+  if (pullRequest.mergeable === false || mergeableState === 'dirty') {
+    return 'conflicting';
+  }
+  if (['blocked', 'behind', 'unstable'].includes(mergeableState)) {
+    return mergeableState;
+  }
+  return 'mergeable';
+};
+
+export const classifyVln = (pullRequest) => {
+  const title = pullRequest.title ?? '';
+  const body = pullRequest.body ?? '';
+  const titleMatch = title.match(VLN_TITLE);
+  const jiraTickets = unique(
+    [...body.matchAll(VLN_JIRA_LINK)].map((match) => match[1].toUpperCase()),
+  );
+  const hasCampaignMarker = CAMPAIGN_MARKER.test(body);
+  const inlineTicket = /\bVLN-\d+\b/i.test(body);
+  const titleHasTicket = /\bVLN-\d+\b/i.test(title);
+
+  if (titleMatch) {
+    return {
+      kind: 'vln',
+      ticket: titleMatch[1].toUpperCase(),
+      reason: 'title',
+    };
+  }
+
+  if (jiraTickets.length > 0 && hasCampaignMarker) {
+    return { kind: 'vln', ticket: jiraTickets[0], reason: 'campaign_body' };
+  }
+
+  if (
+    jiraTickets.length > 0 ||
+    hasCampaignMarker ||
+    inlineTicket ||
+    titleHasTicket
+  ) {
+    return {
+      kind: 'needs_triage',
+      ticket: jiraTickets[0] ?? null,
+      reason:
+        jiraTickets.length > 0
+          ? 'jira_link_without_campaign_marker'
+          : 'vln_like_metadata',
+    };
+  }
+
+  return { kind: 'other', ticket: null, reason: null };
+};
+
+export const isRemediationPullRequest = (
+  pullRequest,
+  remediationBranch = DEFAULT_REMEDIATION_BRANCH,
+) =>
+  pullRequest.head?.ref === remediationBranch ||
+  /weekly dependency[- ]security/i.test(pullRequest.title ?? '');
+
+export const isExternalContributorPullRequest = (pullRequest) => {
+  const author = pullRequest.user ?? {};
+  const login = author.login ?? '';
+  const memberAssociation = ['MEMBER', 'COLLABORATOR', 'OWNER'];
+  const headRepository = pullRequest.head?.repo?.full_name;
+  const baseRepository = pullRequest.base?.repo?.full_name;
+  const isCrossRepository = Boolean(
+    headRepository && baseRepository && headRepository !== baseRepository,
+  );
+  const isBot = author.type === 'Bot' || /\[bot\]$/i.test(login);
+
+  return (
+    isCrossRepository &&
+    !isBot &&
+    !memberAssociation.includes(pullRequest.author_association)
+  );
+};
+
+export const prioritizeExternalContributorPullRequest = (pullRequest) => {
+  if (
+    pullRequest.review.status === 'changes_requested' ||
+    pullRequest.checks.status === 'failing' ||
+    pullRequest.merge === 'conflicting'
+  ) {
+    return 'author_followup';
+  }
+  if (
+    !pullRequest.draft &&
+    ['passing', 'none'].includes(pullRequest.checks.status) &&
+    pullRequest.merge === 'mergeable' &&
+    pullRequest.review.status !== 'approved'
+  ) {
+    return 'review_ready';
+  }
+  return 'triage';
+};
+
+export const normalizePullRequest = (
+  pullRequest,
+  { reviews = [], checks = [] } = {},
+) => {
+  const classification = classifyVln(pullRequest);
+
+  return {
+    number: pullRequest.number,
+    url: pullRequest.html_url,
+    title: pullRequest.title ?? '',
+    body: pullRequest.body ?? '',
+    draft: Boolean(pullRequest.draft),
+    author: pullRequest.user?.login ?? null,
+    authorAssociation: pullRequest.author_association ?? 'UNKNOWN',
+    headRef: pullRequest.head?.ref ?? null,
+    isCrossRepository:
+      Boolean(pullRequest.head?.repo?.full_name) &&
+      pullRequest.head.repo.full_name !== pullRequest.base?.repo?.full_name,
+    createdAt: toIso(pullRequest.created_at),
+    updatedAt: toIso(pullRequest.updated_at),
+    review: summarizeReviews(reviews, pullRequest.requested_reviewers),
+    merge: summarizeMergeability(pullRequest),
+    checks: summarizeChecks(checks),
+    vln: classification,
+  };
+};
+
+const isVlnCandidate = (pullRequest) =>
+  classifyVln(pullRequest).kind !== 'other';
+
+export const pullRequestMatchesAuditScope = (
+  pullRequest,
+  scope,
+  remediationBranch = DEFAULT_REMEDIATION_BRANCH,
+) => {
+  if (scope === 'all') return true;
+  if (scope === 'dependency-security') {
+    return isRemediationPullRequest(pullRequest, remediationBranch);
+  }
+  if (scope === 'vln-review') return isVlnCandidate(pullRequest);
+  if (scope === 'external-contributors') {
+    return isExternalContributorPullRequest(pullRequest);
+  }
+  throw new Error(`Unsupported audit scope: ${scope}`);
+};
+
+/**
+ * Produces a serializable read-only audit.  The client is deliberately small so
+ * Actions and tests can supply the same data shape without GitHub SDK coupling.
+ */
+export const collectWeeklySecurityAudit = async ({
+  repository,
+  scope = 'all',
+  runUrl = null,
+  now = new Date(),
+  remediationBranch = DEFAULT_REMEDIATION_BRANCH,
+  listDependabotAlerts,
+  listPullRequests,
+  getPullRequest,
+  listReviews,
+  listCheckRuns,
+}) => {
+  if (!AUDIT_SCOPES.has(scope)) {
+    throw new Error(`Unsupported audit scope: ${scope}`);
+  }
+  const [rawAlerts, listedPullRequests] = await Promise.all([
+    scope === 'all' || scope === 'dependency-security'
+      ? listDependabotAlerts()
+      : [],
+    listPullRequests(),
+  ]);
+  const relevantPullRequests = asArray(listedPullRequests).filter(
+    (pullRequest) =>
+      pullRequestMatchesAuditScope(pullRequest, scope, remediationBranch),
+  );
+  const enrichReviewState = scope !== 'dependency-security';
+  const enrichedPullRequests = await mapWithConcurrency(
+    relevantPullRequests,
+    PR_ENRICHMENT_CONCURRENCY,
+    async (listedPullRequest) => {
+      const pullRequest = getPullRequest
+        ? await getPullRequest(listedPullRequest.number)
+        : listedPullRequest;
+      const [reviews, checks] = await Promise.all([
+        enrichReviewState && listReviews ? listReviews(pullRequest.number) : [],
+        enrichReviewState && listCheckRuns && pullRequest.head?.sha
+          ? listCheckRuns(pullRequest.head.sha)
+          : [],
+      ]);
+      return {
+        raw: pullRequest,
+        normalized: normalizePullRequest(pullRequest, { reviews, checks }),
+      };
+    },
+  );
+  const decoratedPullRequests = enrichedPullRequests.map(
+    ({ normalized }) => normalized,
+  );
+
+  const vlnPullRequests = decoratedPullRequests.filter(
+    (pullRequest) => pullRequest.vln.kind === 'vln',
+  );
+  const needsTriage = decoratedPullRequests.filter(
+    (pullRequest) => pullRequest.vln.kind === 'needs_triage',
+  );
+  const remediation = decoratedPullRequests.find((pullRequest) =>
+    isRemediationPullRequest(pullRequest, remediationBranch),
+  );
+  const externalContributorPullRequests = enrichedPullRequests
+    .filter(({ raw }) => isExternalContributorPullRequest(raw))
+    .map(({ normalized }) => ({
+      ...normalized,
+      externalPriority: prioritizeExternalContributorPullRequest(normalized),
+    }));
+  const staleExternalPullRequestCount = externalContributorPullRequests.filter(
+    (pullRequest) =>
+      pullRequest.updatedAt &&
+      now.getTime() - new Date(pullRequest.updatedAt).getTime() >=
+        STALE_EXTERNAL_PR_DAYS * 24 * 60 * 60 * 1000,
+  ).length;
+  const externalByPriority = (priority) =>
+    externalContributorPullRequests
+      .filter((pullRequest) => pullRequest.externalPriority === priority)
+      .sort(
+        (left, right) => new Date(left.createdAt) - new Date(right.createdAt),
+      );
+  const reviewReady = externalByPriority('review_ready');
+  const triage = externalByPriority('triage');
+  const authorFollowup = externalByPriority('author_followup');
+
+  return {
+    schemaVersion: 1,
+    scope,
+    generatedAt: now.toISOString(),
+    repository,
+    run: { url: runUrl },
+    dependabot: {
+      openAlertCount: asArray(rawAlerts).length,
+      alerts: asArray(rawAlerts).map(normalizeDependabotAlert),
+    },
+    remediation: remediation ?? null,
+    vln: {
+      pending: vlnPullRequests,
+      needsTriage,
+    },
+    externalContributors: {
+      totalCount: externalContributorPullRequests.length,
+      reviewReadyCount: reviewReady.length,
+      triageCount: triage.length,
+      authorFollowupCount: authorFollowup.length,
+      reviewReady: reviewReady.slice(0, EXTERNAL_CONTRIBUTOR_LIMIT),
+      triage: triage.slice(0, EXTERNAL_CONTRIBUTOR_LIMIT),
+      authorFollowup: authorFollowup.slice(0, EXTERNAL_CONTRIBUTOR_LIMIT),
+      staleCount: staleExternalPullRequestCount,
+    },
+  };
+};
+
+const parseLinkHeader = (header) => {
+  if (!header) return null;
+  const next = header
+    .split(',')
+    .map((part) => part.trim())
+    .find((part) => /rel="next"/.test(part));
+  return next?.match(/<([^>]+)>/)?.[1] ?? null;
+};
+
+const githubClient = ({ token, apiUrl, fetchImplementation = fetch }) => {
+  const request = (pathOrUrl) =>
+    retryGithubRequest(async () => {
+      const url = pathOrUrl.startsWith('http')
+        ? pathOrUrl
+        : new URL(pathOrUrl, apiUrl).toString();
+      let response;
+      try {
+        response = await fetchImplementation(url, {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        });
+      } catch (error) {
+        throw Object.assign(error, { retryable: true });
+      }
+      if (!response.ok) {
+        const responseBody = await response.text();
+        const retry = githubRetryMetadata({
+          status: response.status,
+          responseBody,
+          retryAfterHeader: response.headers.get('retry-after'),
+          rateLimitResetHeader: response.headers.get('x-ratelimit-reset'),
+        });
+        throw Object.assign(
+          new Error(
+            `GitHub API ${response.status} for ${url}: ${responseBody.slice(0, 300)}`,
+          ),
+          retry,
+        );
+      }
+      return {
+        data: await response.json(),
+        next: parseLinkHeader(response.headers.get('link')),
+      };
+    });
+
+  const listAll = async (path) => {
+    const results = [];
+    let next = path;
+    while (next) {
+      const page = await request(next);
+      results.push(...asArray(page.data));
+      next = page.next;
+    }
+    return results;
+  };
+
+  return { request, listAll };
+};
+
+const writeGithubOutput = async (name, value) => {
+  if (!process.env.GITHUB_OUTPUT) return;
+  await appendFile(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`);
+};
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf8'));
+
+const parseArgs = (argv) => {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    if (argv[index]?.startsWith('--'))
+      args.set(argv[index].slice(2), argv[index + 1]);
+  }
+  return args;
+};
+
+export const runAuditCli = async ({
+  argv = process.argv.slice(2),
+  env = process.env,
+} = {}) => {
+  const args = parseArgs(argv);
+  const scope = args.get('scope') ?? env.AUDIT_SCOPE ?? 'all';
+  const outputPath = resolve(
+    args.get('output') ?? 'weekly-dependency-security-audit.json',
+  );
+  const [owner, repo] = (env.GITHUB_REPOSITORY ?? '').split('/');
+  const fixturePath = args.get('fixture') ?? env.AUDIT_FIXTURE_JSON;
+  let audit;
+
+  if (fixturePath) {
+    const fixture = await readJson(resolve(fixturePath));
+    audit = await collectWeeklySecurityAudit({
+      repository: fixture.repository ?? env.GITHUB_REPOSITORY ?? 'owner/repo',
+      scope,
+      runUrl: fixture.runUrl ?? null,
+      listDependabotAlerts: async () => fixture.alerts ?? [],
+      listPullRequests: async () => fixture.pullRequests ?? [],
+      getPullRequest: async (number) =>
+        fixture.pullRequestDetails?.[number] ??
+        fixture.pullRequests?.find(
+          (pullRequest) => pullRequest.number === number,
+        ),
+      listReviews: async (number) => fixture.reviews?.[number] ?? [],
+      listCheckRuns: async (sha) => fixture.checkRuns?.[sha] ?? [],
+    });
+  } else {
+    if (!owner || !repo || !env.GITHUB_TOKEN) {
+      throw new Error(
+        'GITHUB_REPOSITORY and GITHUB_TOKEN are required without --fixture',
+      );
+    }
+    const apiUrl = env.GITHUB_API_URL ?? 'https://api.github.com';
+    const client = githubClient({ token: env.GITHUB_TOKEN, apiUrl });
+    const basePath = `/repos/${owner}/${repo}`;
+    const runUrl =
+      env.GITHUB_RUN_ID && env.GITHUB_SERVER_URL
+        ? `${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}/actions/runs/${env.GITHUB_RUN_ID}`
+        : null;
+    audit = await collectWeeklySecurityAudit({
+      repository: env.GITHUB_REPOSITORY,
+      scope,
+      runUrl,
+      listDependabotAlerts: () =>
+        client.listAll(`${basePath}/dependabot/alerts?state=open&per_page=100`),
+      listPullRequests: () =>
+        client.listAll(`${basePath}/pulls?state=open&per_page=100`),
+      getPullRequest: async (number) =>
+        (await client.request(`${basePath}/pulls/${number}`)).data,
+      listReviews: async (number) =>
+        client.listAll(`${basePath}/pulls/${number}/reviews?per_page=100`),
+      listCheckRuns: async (sha) => {
+        const checks = [];
+        let next = `${basePath}/commits/${sha}/check-runs?per_page=100`;
+        while (next) {
+          const page = await client.request(next);
+          checks.push(...asArray(page.data.check_runs));
+          next = page.next;
+        }
+        return checks;
+      },
+    });
+  }
+
+  await writeFile(outputPath, `${JSON.stringify(audit, null, 2)}\n`);
+  await writeGithubOutput('audit-file', outputPath);
+  await writeGithubOutput('open-alert-count', audit.dependabot.openAlertCount);
+  await writeGithubOutput('vln-count', audit.vln.pending.length);
+  await writeGithubOutput('needs-triage-count', audit.vln.needsTriage.length);
+  await writeGithubOutput(
+    'external-contributor-pr-count',
+    audit.externalContributors.totalCount,
+  );
+  await writeGithubOutput('remediation-pr-url', audit.remediation?.url ?? '');
+  console.log(JSON.stringify(audit));
+  return audit;
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runAuditCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/weekly-dependency-security-audit.test.mjs
+++ b/.github/scripts/weekly-dependency-security-audit.test.mjs
@@ -1,0 +1,511 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  classifyVln,
+  collectWeeklySecurityAudit,
+  githubRetryMetadata,
+  isExternalContributorPullRequest,
+  mapWithConcurrency,
+  normalizeDependabotAlert,
+  normalizePullRequest,
+  prioritizeExternalContributorPullRequest,
+  retryGithubRequest,
+  summarizeChecks,
+  summarizeReviews,
+} from './weekly-dependency-security-audit.mjs';
+
+const pullRequest = (overrides = {}) => ({
+  number: 42,
+  html_url: 'https://github.com/temporalio/ui/pull/42',
+  title: 'VLN-1585: update checkout',
+  body: '',
+  draft: false,
+  user: { login: 'camper' },
+  head: {
+    ref: 'camper/vln-1585',
+    sha: 'abc123',
+    repo: { full_name: 'temporalio/ui' },
+  },
+  base: { repo: { full_name: 'temporalio/ui' } },
+  author_association: 'MEMBER',
+  requested_reviewers: [],
+  mergeable: true,
+  mergeable_state: 'clean',
+  created_at: '2026-08-10T12:00:00Z',
+  updated_at: '2026-08-12T12:00:00Z',
+  ...overrides,
+});
+
+test('normalizes Dependabot alerts to the remediation-relevant fields', () => {
+  assert.deepEqual(
+    normalizeDependabotAlert({
+      number: 5,
+      html_url: 'https://github.com/temporalio/ui/security/dependabot/5',
+      security_advisory: { severity: 'high', summary: 'bad package' },
+      security_vulnerability: {
+        package: { name: 'lodash', ecosystem: 'npm' },
+        vulnerable_version_range: '< 4.17.22',
+        first_patched_version: { identifier: '4.17.22' },
+      },
+      dependency: { manifest_path: '/package.json' },
+      created_at: '2026-08-12T12:00:00Z',
+    }),
+    {
+      number: 5,
+      url: 'https://github.com/temporalio/ui/security/dependabot/5',
+      severity: 'high',
+      summary: 'bad package',
+      package: 'lodash',
+      ecosystem: 'npm',
+      vulnerableRange: '< 4.17.22',
+      firstPatchedVersion: '4.17.22',
+      manifestPath: '/package.json',
+      createdAt: '2026-08-12T12:00:00.000Z',
+    },
+  );
+});
+
+test('recognizes title VLNs and only recognizes body VLNs with both required signals', () => {
+  assert.deepEqual(classifyVln(pullRequest()), {
+    kind: 'vln',
+    ticket: 'VLN-1585',
+    reason: 'title',
+  });
+  assert.deepEqual(
+    classifyVln(
+      pullRequest({
+        title: 'Update an action pin',
+        body: 'Camper campaign: https://temporalio.atlassian.net/browse/VLN-1601',
+      }),
+    ),
+    { kind: 'vln', ticket: 'VLN-1601', reason: 'campaign_body' },
+  );
+  assert.deepEqual(
+    classifyVln(
+      pullRequest({
+        title: 'Update an action pin',
+        body: 'https://temporalio.atlassian.net/browse/VLN-1601',
+      }),
+    ),
+    {
+      kind: 'needs_triage',
+      ticket: 'VLN-1601',
+      reason: 'jira_link_without_campaign_marker',
+    },
+  );
+  assert.equal(
+    classifyVln(pullRequest({ title: 'Fix VLN-1601 eventually' })).kind,
+    'needs_triage',
+  );
+});
+
+test('summarizes the latest reviewer decision and check status', () => {
+  assert.deepEqual(
+    summarizeReviews(
+      [
+        {
+          user: { login: 'ross' },
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-08-10T00:00:00Z',
+        },
+        {
+          user: { login: 'ross' },
+          state: 'APPROVED',
+          submitted_at: '2026-08-11T00:00:00Z',
+        },
+        {
+          user: { login: 'tegan' },
+          state: 'CHANGES_REQUESTED',
+          submitted_at: '2026-08-11T00:00:00Z',
+        },
+      ],
+      [{ login: 'bilal' }],
+    ),
+    {
+      status: 'changes_requested',
+      approvals: 1,
+      changesRequested: 1,
+      requested: ['bilal'],
+    },
+  );
+  assert.deepEqual(
+    summarizeChecks([
+      { name: 'lint', status: 'completed', conclusion: 'success' },
+      { name: 'test', status: 'in_progress', conclusion: null },
+    ]),
+    { status: 'pending', total: 2, failing: [], pending: ['test'] },
+  );
+});
+
+test('collects normalized read-only alert, remediation, VLN and triage data', async () => {
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    now: new Date('2026-08-12T12:00:00Z'),
+    runUrl: 'https://github.com/temporalio/ui/actions/runs/1',
+    listDependabotAlerts: async () => [
+      {
+        number: 7,
+        security_advisory: { severity: 'critical', summary: 'alert' },
+        security_vulnerability: { package: { name: 'foo', ecosystem: 'npm' } },
+      },
+    ],
+    listPullRequests: async () => [
+      pullRequest({ number: 1, title: 'VLN-1585: action pin' }),
+      pullRequest({
+        number: 2,
+        title: 'Weekly dependency-security review',
+        head: { ref: 'automation/weekly-dependency-security', sha: 'def456' },
+      }),
+      pullRequest({ number: 3, title: 'Maybe VLN-1999 someday' }),
+    ],
+    getPullRequest: async (number) =>
+      ({
+        1: pullRequest({ number: 1, title: 'VLN-1585: action pin' }),
+        2: pullRequest({
+          number: 2,
+          title: 'Weekly dependency-security review',
+          head: { ref: 'automation/weekly-dependency-security', sha: 'def456' },
+        }),
+        3: pullRequest({ number: 3, title: 'Maybe VLN-1999 someday' }),
+      })[number],
+    listReviews: async () => [],
+    listCheckRuns: async () => [],
+  });
+
+  assert.equal(audit.dependabot.openAlertCount, 1);
+  assert.equal(audit.remediation.number, 2);
+  assert.deepEqual(
+    audit.vln.pending.map((pr) => pr.number),
+    [1],
+  );
+  assert.deepEqual(
+    audit.vln.needsTriage.map((pr) => pr.number),
+    [3],
+  );
+  assert.equal(normalizePullRequest(pullRequest()).merge, 'mergeable');
+});
+
+test('includes only eligible external contributors in review priority buckets', async () => {
+  const externalReady = pullRequest({
+    number: 20,
+    title: 'Improve docs',
+    user: { login: 'community-user', type: 'User' },
+    author_association: 'CONTRIBUTOR',
+    head: {
+      ref: 'docs',
+      sha: 'external1',
+      repo: { full_name: 'community/ui' },
+    },
+    created_at: '2026-07-01T12:00:00Z',
+    updated_at: '2026-07-01T12:00:00Z',
+  });
+  const internal = pullRequest({ number: 21 });
+  const bot = pullRequest({
+    number: 22,
+    user: { login: 'dependabot[bot]', type: 'Bot' },
+    author_association: 'CONTRIBUTOR',
+    head: { ref: 'bot', sha: 'botsha', repo: { full_name: 'dependabot/ui' } },
+  });
+  assert.equal(isExternalContributorPullRequest(externalReady), true);
+  assert.equal(isExternalContributorPullRequest(internal), false);
+  assert.equal(isExternalContributorPullRequest(bot), false);
+  assert.equal(
+    prioritizeExternalContributorPullRequest(
+      normalizePullRequest(externalReady, {
+        checks: [{ name: 'test', status: 'completed', conclusion: 'success' }],
+      }),
+    ),
+    'review_ready',
+  );
+
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    now: new Date('2026-08-12T12:00:00Z'),
+    listDependabotAlerts: async () => [],
+    listPullRequests: async () => [externalReady, internal, bot],
+    getPullRequest: async (number) =>
+      ({ 20: externalReady, 21: internal, 22: bot })[number],
+    listReviews: async () => [],
+    listCheckRuns: async () => [
+      { name: 'test', status: 'completed', conclusion: 'success' },
+    ],
+  });
+  assert.deepEqual(
+    audit.externalContributors.reviewReady.map((pr) => pr.number),
+    [20],
+  );
+  assert.equal(audit.externalContributors.staleCount, 1);
+});
+
+test('scopes API work to relevant module data and PR details', async () => {
+  const listed = [
+    pullRequest({ number: 1, title: 'Ordinary change' }),
+    pullRequest({ number: 2, title: 'VLN-2001: action update' }),
+    pullRequest({
+      number: 3,
+      title: 'Weekly dependency-security review',
+      head: {
+        ref: 'automation/weekly-dependency-security',
+        sha: 'security',
+        repo: { full_name: 'temporalio/ui' },
+      },
+    }),
+  ];
+  const detailsRequested = [];
+  const reviewsRequested = [];
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    scope: 'vln-review',
+    now: new Date('2026-08-12T12:00:00Z'),
+    listDependabotAlerts: async () => {
+      throw new Error('VLN scope must not query Dependabot');
+    },
+    listPullRequests: async () => listed,
+    getPullRequest: async (number) => {
+      detailsRequested.push(number);
+      return listed.find((item) => item.number === number);
+    },
+    listReviews: async (number) => {
+      reviewsRequested.push(number);
+      return [];
+    },
+    listCheckRuns: async () => [],
+  });
+  assert.deepEqual(detailsRequested, [2]);
+  assert.deepEqual(reviewsRequested, [2]);
+  assert.equal(audit.dependabot.openAlertCount, 0);
+  assert.deepEqual(
+    audit.vln.pending.map((item) => item.number),
+    [2],
+  );
+});
+
+test('dependency scope fetches only the remediation PR without review enrichment', async () => {
+  const listed = [
+    pullRequest({ number: 1, title: 'Ordinary change' }),
+    pullRequest({
+      number: 2,
+      title: 'Weekly dependency-security review',
+      head: {
+        ref: 'automation/weekly-dependency-security',
+        sha: 'security',
+        repo: { full_name: 'temporalio/ui' },
+      },
+    }),
+  ];
+  const detailsRequested = [];
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    scope: 'dependency-security',
+    listDependabotAlerts: async () => [],
+    listPullRequests: async () => listed,
+    getPullRequest: async (number) => {
+      detailsRequested.push(number);
+      return listed.find((item) => item.number === number);
+    },
+    listReviews: async () => {
+      throw new Error('Dependency scope must not fetch reviews');
+    },
+    listCheckRuns: async () => {
+      throw new Error('Dependency scope must not fetch checks');
+    },
+  });
+  assert.deepEqual(detailsRequested, [2]);
+  assert.equal(audit.remediation.number, 2);
+});
+
+test('external scope enriches only eligible non-bot fork PRs', async () => {
+  const external = pullRequest({
+    number: 3,
+    title: 'Community fix',
+    user: { login: 'community-user', type: 'User' },
+    author_association: 'CONTRIBUTOR',
+    head: {
+      ref: 'community-fix',
+      sha: 'community-sha',
+      repo: { full_name: 'community/ui' },
+    },
+  });
+  const listed = [pullRequest({ number: 1 }), external];
+  const detailsRequested = [];
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    scope: 'external-contributors',
+    listDependabotAlerts: async () => {
+      throw new Error('External scope must not query Dependabot');
+    },
+    listPullRequests: async () => listed,
+    getPullRequest: async (number) => {
+      detailsRequested.push(number);
+      return listed.find((item) => item.number === number);
+    },
+    listReviews: async () => [],
+    listCheckRuns: async () => [],
+  });
+  assert.deepEqual(detailsRequested, [3]);
+  assert.equal(audit.externalContributors.totalCount, 1);
+});
+
+test('bounds enrichment concurrency while preserving result order', async () => {
+  let active = 0;
+  let maximumActive = 0;
+  const results = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (item) => {
+    active += 1;
+    maximumActive = Math.max(maximumActive, active);
+    await new Promise((resolveTask) => setImmediate(resolveTask));
+    active -= 1;
+    return item * 2;
+  });
+  assert.deepEqual(results, [2, 4, 6, 8, 10]);
+  assert.equal(maximumActive, 2);
+});
+
+test('retries a bounded number of times while honoring server-directed delays', async () => {
+  const delays = [];
+  let attempts = 0;
+  const result = await retryGithubRequest(
+    async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error('secondary limit'), {
+          retryable: true,
+          retryAfterMs: 60_000,
+        });
+      }
+      if (attempts === 2) {
+        throw Object.assign(new Error('server error'), { retryable: true });
+      }
+      return 'ok';
+    },
+    {
+      baseDelayMs: 10,
+      maxDelayMs: 5_000,
+      sleep: async (delayMs) => delays.push(delayMs),
+    },
+  );
+  assert.equal(result, 'ok');
+  assert.equal(attempts, 3);
+  assert.deepEqual(delays, [60_000, 20]);
+  const nowMs = Date.parse('2026-08-12T12:00:00Z');
+  assert.deepEqual(
+    githubRetryMetadata({
+      status: 403,
+      responseBody: 'You have exceeded a secondary rate limit.',
+      retryAfterHeader: '2',
+      rateLimitResetHeader: String((nowMs + 60_000) / 1_000),
+      nowMs,
+    }),
+    { retryable: true, retryAfterMs: 2_000 },
+  );
+  assert.deepEqual(
+    githubRetryMetadata({
+      status: 429,
+      retryAfterHeader: 'Wed, 12 Aug 2026 12:00:05 GMT',
+      rateLimitResetHeader: String((nowMs + 60_000) / 1_000),
+      nowMs,
+    }),
+    { retryable: true, retryAfterMs: 5_000 },
+  );
+  assert.deepEqual(
+    githubRetryMetadata({
+      status: 403,
+      responseBody: 'API rate limit exceeded',
+      retryAfterHeader: 'not-a-date',
+      rateLimitResetHeader: String((nowMs + 7_000) / 1_000),
+      nowMs,
+    }),
+    { retryable: true, retryAfterMs: 7_000 },
+  );
+  const ordinaryServerError = githubRetryMetadata({
+    status: 500,
+    responseBody: 'internal server error',
+    rateLimitResetHeader: String((nowMs + 60_000) / 1_000),
+    nowMs,
+  });
+  assert.deepEqual(ordinaryServerError, {
+    retryable: true,
+    retryAfterMs: undefined,
+  });
+  const serverErrorDelays = [];
+  let serverErrorAttempts = 0;
+  await retryGithubRequest(
+    async () => {
+      serverErrorAttempts += 1;
+      if (serverErrorAttempts === 1) {
+        throw Object.assign(new Error('server error'), ordinaryServerError);
+      }
+      return 'recovered';
+    },
+    {
+      baseDelayMs: 25,
+      sleep: async (delayMs) => serverErrorDelays.push(delayMs),
+    },
+  );
+  assert.deepEqual(serverErrorDelays, [25]);
+
+  const headerlessSecondary = githubRetryMetadata({
+    status: 403,
+    responseBody: 'You have exceeded a secondary rate limit.',
+    nowMs,
+  });
+  assert.deepEqual(headerlessSecondary, {
+    retryable: true,
+    retryAfterMs: 60_000,
+    exponentialRetryAfter: true,
+  });
+  const secondaryDelays = [];
+  let secondaryAttempts = 0;
+  await assert.rejects(
+    retryGithubRequest(
+      async () => {
+        secondaryAttempts += 1;
+        throw Object.assign(new Error('secondary limit'), headerlessSecondary);
+      },
+      {
+        maxAttempts: 4,
+        baseDelayMs: 10,
+        sleep: async (delayMs) => secondaryDelays.push(delayMs),
+      },
+    ),
+    /secondary limit/,
+  );
+  assert.equal(secondaryAttempts, 4);
+  assert.deepEqual(secondaryDelays, [60_000, 120_000, 240_000]);
+
+  const tooManyRequests = githubRetryMetadata({
+    status: 429,
+    responseBody: 'too many requests',
+    rateLimitResetHeader: String((nowMs + 11_000) / 1_000),
+    nowMs,
+  });
+  assert.deepEqual(tooManyRequests, {
+    retryable: true,
+    retryAfterMs: 11_000,
+  });
+  assert.equal(
+    githubRetryMetadata({ status: 404, responseBody: 'not found' }).retryable,
+    false,
+  );
+
+  let boundedAttempts = 0;
+  const boundedDelays = [];
+  await assert.rejects(
+    retryGithubRequest(
+      async () => {
+        boundedAttempts += 1;
+        throw Object.assign(new Error('still limited'), {
+          retryable: true,
+          retryAfterMs: 9_000,
+        });
+      },
+      {
+        maxAttempts: 2,
+        sleep: async (delayMs) => boundedDelays.push(delayMs),
+      },
+    ),
+    /still limited/,
+  );
+  assert.equal(boundedAttempts, 2);
+  assert.deepEqual(boundedDelays, [9_000]);
+});

--- a/.github/scripts/weekly-dependency-security-audit.test.mjs
+++ b/.github/scripts/weekly-dependency-security-audit.test.mjs
@@ -6,6 +6,7 @@ import {
   collectWeeklySecurityAudit,
   githubRetryMetadata,
   isExternalContributorPullRequest,
+  isRemediationPullRequest,
   mapWithConcurrency,
   normalizeDependabotAlert,
   normalizePullRequest,
@@ -508,4 +509,44 @@ test('retries a bounded number of times while honoring server-directed delays', 
   );
   assert.equal(boundedAttempts, 2);
   assert.deepEqual(boundedDelays, [9_000]);
+});
+
+test('recognizes the remediation pull request from a normalized object', () => {
+  const raw = pullRequest({
+    title: 'fix: weekly Dependabot security remediation',
+    head: {
+      ref: 'automation/weekly-dependency-security',
+      sha: 'abc',
+      repo: { full_name: 'temporalio/ui' },
+    },
+  });
+
+  assert.equal(isRemediationPullRequest(raw), true);
+  assert.equal(isRemediationPullRequest(normalizePullRequest(raw)), true);
+});
+
+test('reports the remediation pull request in a dependency-scope audit', async () => {
+  const raw = pullRequest({
+    number: 3815,
+    title: 'fix: weekly Dependabot security remediation',
+    draft: true,
+    head: {
+      ref: 'automation/weekly-dependency-security',
+      sha: 'abc',
+      repo: { full_name: 'temporalio/ui' },
+    },
+    base: { repo: { full_name: 'temporalio/ui' } },
+  });
+
+  const audit = await collectWeeklySecurityAudit({
+    repository: 'temporalio/ui',
+    scope: 'dependency-security',
+    listDependabotAlerts: async () => [],
+    listPullRequests: async () => [raw],
+    getPullRequest: async () => raw,
+    listReviews: async () => [],
+    listCheckRuns: async () => [],
+  });
+
+  assert.equal(audit.remediation?.number, 3815);
 });

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -161,9 +161,15 @@ const unresolvedItems = ({ audit, remediation }) => {
   if (unresolved.length > 0) {
     return {
       lines: unresolved.slice(0, DEFAULT_UNRESOLVED_LIMIT).map((item) => {
+        const name = item.package ?? item.packageName ?? item.title ?? null;
+        const alertReference = item.number
+          ? `#${item.number}`
+          : Array.isArray(item.alertIds) && item.alertIds.length > 0
+            ? item.alertIds.map((id) => `#${id}`).join(', ')
+            : null;
         const label = item.number
-          ? `#${item.number} ${item.package ?? item.packageName ?? item.title ?? 'alert'}`
-          : (item.package ?? item.packageName ?? item.title ?? String(item));
+          ? `${alertReference} ${name ?? 'alert'}`
+          : (name ?? alertReference ?? 'unidentified alert');
         const reason = item.reason ? ` — ${item.reason}` : '';
         return `• ${escapeSlackMrkdwn(truncateText(label))}${escapeSlackMrkdwn(truncateText(reason))}`;
       }),

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -1,0 +1,410 @@
+import { appendFile, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { escapeSlackMrkdwn } from './slack-utils.mjs';
+
+const DEFAULT_VLN_LIMIT = 10;
+const DEFAULT_UNRESOLVED_LIMIT = 10;
+const SLACK_SECTION_TEXT_LIMIT = 3_000;
+const SLACK_DYNAMIC_TEXT_LIMIT = 800;
+const PUBLISH_STATUSES = new Set(['success', 'failure', 'skipped']);
+
+const truncateText = (text, limit = SLACK_DYNAMIC_TEXT_LIMIT) => {
+  const value = String(text ?? '');
+  return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`;
+};
+
+const slackLink = (url, label) =>
+  `<${url}|${escapeSlackMrkdwn(truncateText(label))}>`;
+
+const omittedLine = (count, runUrl) => {
+  const suffix = runUrl ? `; ${slackLink(runUrl, 'see workflow run')}` : '';
+  return `• …and ${count} more${suffix}`;
+};
+
+export const splitSlackSectionText = (
+  text,
+  maxLength = SLACK_SECTION_TEXT_LIMIT,
+) => {
+  if (!Number.isInteger(maxLength) || maxLength < 1) {
+    throw new TypeError('Slack section limit must be a positive integer');
+  }
+  const chunks = [];
+  let current = '';
+  const append = (line) => {
+    const candidate = current ? `${current}\n${line}` : line;
+    if (candidate.length <= maxLength) {
+      current = candidate;
+      return;
+    }
+    if (current) chunks.push(current);
+    current = line;
+  };
+  for (const line of String(text).split('\n')) {
+    if (line.length <= maxLength) {
+      append(line);
+      continue;
+    }
+    let remaining = line;
+    while (remaining.length > maxLength) {
+      let boundary = remaining.lastIndexOf(' ', maxLength);
+      if (boundary < Math.floor(maxLength / 2)) boundary = maxLength;
+      append(remaining.slice(0, boundary));
+      remaining = remaining.slice(boundary).trimStart();
+    }
+    append(remaining);
+  }
+  if (current || chunks.length === 0) chunks.push(current);
+  return chunks;
+};
+
+const statusText = (pullRequest) => {
+  const parts = [];
+  if (pullRequest.draft) parts.push('draft');
+  if (pullRequest.review?.status && pullRequest.review.status !== 'pending') {
+    parts.push(pullRequest.review.status.replaceAll('_', ' '));
+  }
+  if (pullRequest.merge && pullRequest.merge !== 'mergeable') {
+    parts.push(pullRequest.merge);
+  }
+  if (pullRequest.checks?.status && pullRequest.checks.status !== 'passing') {
+    parts.push(`checks ${pullRequest.checks.status}`);
+  }
+  return parts.length > 0 ? ` — ${parts.join(', ')}` : '';
+};
+
+const renderPullRequest = (pullRequest) =>
+  `• ${slackLink(pullRequest.url, `#${pullRequest.number}: ${pullRequest.title}`)}${statusText(pullRequest)}`;
+
+const remediationActionCount = (result) =>
+  result?.summary?.actions ?? result?.actions?.length ?? null;
+
+const remediationActionText = (result, published = false) => {
+  const actions = remediationActionCount(result);
+  if (!Number.isInteger(actions)) return '';
+  if (actions === 0) return ' — no safe changes were needed';
+  return ` — ${actions} safe change${actions === 1 ? '' : 's'} ${published ? 'applied' : 'planned'}`;
+};
+
+export const validatePublishStatus = (publishStatus) => {
+  if (!PUBLISH_STATUSES.has(publishStatus)) {
+    throw new Error(`Unsupported publish status: ${publishStatus}`);
+  }
+  return publishStatus;
+};
+
+const remediationLine = ({ audit, remediation, publishStatus }) => {
+  const result = remediation ?? audit.remediationResult;
+  const resultPullRequest = result?.pullRequest;
+  const publishedPullRequest =
+    publishStatus === 'success' && result?.pullRequestUrl
+      ? {
+          url: result.pullRequestUrl,
+          number: resultPullRequest?.number,
+          title: resultPullRequest?.title,
+        }
+      : publishStatus === 'success' && resultPullRequest?.url
+        ? resultPullRequest
+        : null;
+
+  if (result?.applied && publishedPullRequest) {
+    const label = publishedPullRequest.number
+      ? `#${publishedPullRequest.number}: ${publishedPullRequest.title}`
+      : 'view draft remediation PR';
+    return `Draft remediation PR: ${slackLink(publishedPullRequest.url, label)}${remediationActionText(result, true)}`;
+  }
+
+  if (result?.applied) {
+    const actionCount = remediationActionCount(result);
+    const candidate = Number.isInteger(actionCount)
+      ? `${actionCount} safe change${actionCount === 1 ? '' : 's'} prepared`
+      : 'Safe changes prepared';
+    if (publishStatus === 'failure') {
+      return `Remediation candidate: ${candidate}, but publication failed. Manual review required.`;
+    }
+    if (publishStatus === 'success') {
+      return `Remediation candidate: ${candidate}, but publication reported success without a PR link. Manual review required.`;
+    }
+    return `Remediation candidate: ${candidate}, but publication was skipped. Manual review required.`;
+  }
+
+  const pullRequest = resultPullRequest ?? audit.remediation;
+
+  if (pullRequest) {
+    const addressed = result?.addressedAlertCount;
+    const suffix = Number.isInteger(addressed)
+      ? ` — ${addressed} alert${addressed === 1 ? '' : 's'} addressed`
+      : '';
+    return `Draft remediation PR: ${slackLink(pullRequest.url, `#${pullRequest.number}: ${pullRequest.title}`)}${suffix}${remediationActionText(result)}`;
+  }
+  if (Number.isInteger(remediationActionCount(result))) {
+    return `Remediation: ${remediationActionText(result).replace(/^ — /, '')}.`;
+  }
+  if (result?.status === 'no_changes') {
+    return 'Remediation: no safe dependency changes were needed.';
+  }
+  if (audit.dependabot.openAlertCount === 0) {
+    return 'Remediation: no open Dependabot alerts.';
+  }
+  return 'Remediation: no draft PR was created; see unresolved items.';
+};
+
+const unresolvedItems = ({ audit, remediation }) => {
+  const result = remediation ?? audit.remediationResult;
+  const unresolved =
+    result?.unresolved ??
+    result?.classifications?.filter(
+      (item) => item.status === 'manual' || item.status === 'unsupported',
+    ) ??
+    audit.unresolved ??
+    [];
+  if (unresolved.length > 0) {
+    return {
+      lines: unresolved.slice(0, DEFAULT_UNRESOLVED_LIMIT).map((item) => {
+        const label = item.number
+          ? `#${item.number} ${item.package ?? item.packageName ?? item.title ?? 'alert'}`
+          : (item.package ?? item.packageName ?? item.title ?? String(item));
+        const reason = item.reason ? ` — ${item.reason}` : '';
+        return `• ${escapeSlackMrkdwn(truncateText(label))}${escapeSlackMrkdwn(truncateText(reason))}`;
+      }),
+      omittedCount: Math.max(unresolved.length - DEFAULT_UNRESOLVED_LIMIT, 0),
+    };
+  }
+  return { lines: [], omittedCount: 0 };
+};
+
+const dependencySecurityText = ({
+  audit,
+  remediation,
+  publishStatus,
+  runUrl,
+}) => {
+  const lines = [
+    '*Dependency security*',
+    remediationLine({ audit, remediation, publishStatus }),
+  ];
+  const unresolved = unresolvedItems({ audit, remediation });
+  if (unresolved.lines.length > 0) {
+    lines.push('', '*Needs human handling*', ...unresolved.lines);
+    if (unresolved.omittedCount > 0) {
+      lines.push(omittedLine(unresolved.omittedCount, runUrl));
+    }
+  }
+  if (runUrl) lines.push('', `Run: ${slackLink(runUrl, 'view workflow run')}`);
+  return lines.join('\n');
+};
+
+const vlnReviewText = ({ audit, vlnLimit, runUrl }) => {
+  const vlns = audit.vln?.pending ?? [];
+  const needsTriage = audit.vln?.needsTriage ?? [];
+  const visibleVlns = vlns.slice(0, vlnLimit);
+  const lines = ['*VLN review*'];
+
+  if (visibleVlns.length > 0) {
+    lines.push('', '*Pending VLN PRs*', ...visibleVlns.map(renderPullRequest));
+    if (vlns.length > visibleVlns.length) {
+      lines.push(omittedLine(vlns.length - visibleVlns.length, runUrl));
+    }
+  } else {
+    lines.push('', 'Pending VLN PRs: none');
+  }
+  if (needsTriage.length > 0) {
+    lines.push(
+      '',
+      '*VLN matches needing triage*',
+      ...needsTriage.slice(0, vlnLimit).map(renderPullRequest),
+    );
+    if (needsTriage.length > vlnLimit) {
+      lines.push(omittedLine(needsTriage.length - vlnLimit, runUrl));
+    }
+  }
+  if (runUrl) lines.push('', `Run: ${slackLink(runUrl, 'view workflow run')}`);
+  return lines.join('\n');
+};
+
+const asThreadReply = ({ channel = null, threadTs = null, text }) => ({
+  channel,
+  thread_ts: threadTs,
+  text,
+  blocks: splitSlackSectionText(text).map((sectionText) => ({
+    type: 'section',
+    text: { type: 'mrkdwn', text: sectionText },
+  })),
+});
+
+/**
+ * Returns the dependency-security reply for a Slack root thread. Posting stays
+ * in the workflow so this module has no Slack token or network side effects.
+ */
+export const buildDependencySecurityReply = ({
+  audit,
+  remediation = null,
+  publishStatus = 'skipped',
+  runUrl = audit.run?.url ?? null,
+  channel = null,
+  threadTs = null,
+}) => {
+  validatePublishStatus(publishStatus);
+  return asThreadReply({
+    channel,
+    threadTs,
+    text: dependencySecurityText({
+      audit,
+      remediation,
+      publishStatus,
+      runUrl,
+    }),
+  });
+};
+
+/** Returns the VLN-review reply for the same Slack root thread. */
+export const buildVlnReviewReply = ({
+  audit,
+  runUrl = audit.run?.url ?? null,
+  vlnLimit = DEFAULT_VLN_LIMIT,
+  channel = null,
+  threadTs = null,
+}) =>
+  asThreadReply({
+    channel,
+    threadTs,
+    text: vlnReviewText({ audit, vlnLimit, runUrl }),
+  });
+
+/** Returns the external-contributor review reply for the Slack root thread. */
+export const buildExternalContributorReply = ({
+  audit,
+  runUrl = audit.run?.url ?? null,
+  channel = null,
+  threadTs = null,
+}) => {
+  const external = audit.externalContributors ?? {};
+  const sections = [
+    [
+      '*Ready for review*',
+      external.reviewReady ?? [],
+      external.reviewReadyCount,
+    ],
+    ['*Needs triage*', external.triage ?? [], external.triageCount],
+    [
+      '*Waiting on author*',
+      external.authorFollowup ?? [],
+      external.authorFollowupCount,
+    ],
+  ];
+  const lines = ['*External contributor PRs*'];
+  for (const [heading, pullRequests, totalCount] of sections) {
+    if (pullRequests.length > 0) {
+      lines.push('', heading, ...pullRequests.map(renderPullRequest));
+      const omittedCount = Math.max(
+        (totalCount ?? pullRequests.length) - pullRequests.length,
+        0,
+      );
+      if (omittedCount > 0) lines.push(omittedLine(omittedCount, runUrl));
+    }
+  }
+  if (sections.every(([, pullRequests]) => pullRequests.length === 0)) {
+    lines.push('', 'No eligible external contributor PRs.');
+  }
+  if (external.staleCount > 0) {
+    lines.push(
+      `\n${external.staleCount} external PR${external.staleCount === 1 ? ' has' : 's have'} not been updated in 14+ days.`,
+    );
+  }
+  if (runUrl) lines.push('', `Run: ${slackLink(runUrl, 'view workflow run')}`);
+  return asThreadReply({ channel, threadTs, text: lines.join('\n') });
+};
+
+// Kept as a small compatibility wrapper for callers that only need a single
+// textual summary. New workflows should post the two module replies instead.
+export const buildWeeklySecurityDigest = (options) => {
+  const dependency = buildDependencySecurityReply(options);
+  const vln = buildVlnReviewReply(options);
+  const external = buildExternalContributorReply(options);
+  return {
+    text: `${dependency.text}\n\n${vln.text}\n\n${external.text}`,
+    blocks: [...dependency.blocks, ...vln.blocks, ...external.blocks],
+  };
+};
+
+const parseArgs = (argv) => {
+  const args = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    if (argv[index]?.startsWith('--'))
+      args.set(argv[index].slice(2), argv[index + 1]);
+  }
+  return args;
+};
+
+const readJson = async (path) => JSON.parse(await readFile(path, 'utf8'));
+
+const writeGithubOutput = async (name, value) => {
+  if (!process.env.GITHUB_OUTPUT) return;
+  await appendFile(
+    process.env.GITHUB_OUTPUT,
+    `${name}<<__WEEKLY_SECURITY_DIGEST__\n${value}\n__WEEKLY_SECURITY_DIGEST__\n`,
+  );
+};
+
+export const runDigestCli = async ({
+  argv = process.argv.slice(2),
+  env = process.env,
+} = {}) => {
+  const args = parseArgs(argv);
+  const input = resolve(
+    args.get('input') ??
+      env.AUDIT_REPORT_FILE ??
+      'weekly-dependency-security-audit.json',
+  );
+  const output = resolve(
+    args.get('output') ?? 'weekly-dependency-security-digest.json',
+  );
+  const remediationPath =
+    args.get('remediation') ?? env.REMEDIATION_REPORT_FILE;
+  const remediationPrUrl =
+    args.get('remediation-pr-url') ?? env.REMEDIATION_PR_URL ?? null;
+  const publishStatus =
+    args.get('publish-status') ?? env.PUBLISH_STATUS ?? 'skipped';
+  const module =
+    args.get('module') ?? env.WEEKLY_SECURITY_MODULE ?? 'dependency-security';
+  const threadTs = args.get('thread-ts') ?? env.SLACK_THREAD_TS ?? null;
+  const channel = args.get('channel') ?? env.SLACK_CHANNEL ?? null;
+  const audit = await readJson(input);
+  const remediationReport = remediationPath
+    ? await readJson(resolve(remediationPath))
+    : null;
+  const remediation = remediationPrUrl
+    ? { ...remediationReport, pullRequestUrl: remediationPrUrl }
+    : remediationReport;
+  const options = {
+    audit,
+    remediation,
+    publishStatus,
+    runUrl: args.get('run-url') ?? env.GITHUB_RUN_URL ?? audit.run?.url,
+    vlnLimit: Number(args.get('vln-limit') ?? DEFAULT_VLN_LIMIT),
+    threadTs,
+    channel,
+  };
+  const payload =
+    module === 'dependency-security'
+      ? buildDependencySecurityReply(options)
+      : module === 'vln-review'
+        ? buildVlnReviewReply(options)
+        : module === 'external-contributors'
+          ? buildExternalContributorReply(options)
+          : (() => {
+              throw new Error(`Unsupported --module value: ${module}`);
+            })();
+  await writeFile(output, `${JSON.stringify(payload, null, 2)}\n`);
+  await writeGithubOutput('digest-file', output);
+  await writeGithubOutput('slack-text', payload.text);
+  console.log(JSON.stringify(payload));
+  return payload;
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runDigestCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -234,3 +234,24 @@ test('bounds every VLN and external Slack section and reports omitted PRs', () =
     assert.ok(reply.blocks.every((block) => block.text.text.length <= 3_000));
   }
 });
+
+test('labels an unresolved classification that names no package', () => {
+  const reply = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    remediation: {
+      summary: { actions: 0, manual: 1, unsupported: 0 },
+      applied: false,
+      classifications: [
+        {
+          status: 'manual',
+          packageName: null,
+          alertIds: [77],
+          reason: 'Alert did not identify an npm package.',
+        },
+      ],
+    },
+  });
+
+  assert.doesNotMatch(reply.text, /\[object Object\]/);
+  assert.match(reply.text, /#77/);
+});

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -1,0 +1,236 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildDependencySecurityReply,
+  buildExternalContributorReply,
+  buildVlnReviewReply,
+  buildWeeklySecurityDigest,
+  splitSlackSectionText,
+  validatePublishStatus,
+} from './weekly-dependency-security-digest.mjs';
+
+const pullRequest = (number, title, overrides = {}) => ({
+  number,
+  url: `https://github.com/temporalio/ui/pull/${number}`,
+  title,
+  draft: false,
+  review: { status: 'pending' },
+  merge: 'mergeable',
+  checks: { status: 'passing' },
+  ...overrides,
+});
+
+const audit = {
+  run: { url: 'https://github.com/temporalio/ui/actions/runs/99' },
+  dependabot: { openAlertCount: 2 },
+  remediation: pullRequest(10, 'Weekly dependency-security review'),
+  vln: {
+    pending: [
+      pullRequest(11, 'VLN-1601: *unsafe*', { checks: { status: 'pending' } }),
+      pullRequest(12, 'VLN-1602: dependency bump', { draft: true }),
+    ],
+    needsTriage: [pullRequest(13, 'Possible VLN-1603')],
+  },
+  externalContributors: {
+    reviewReady: [pullRequest(14, 'Community fix')],
+    triage: [
+      pullRequest(15, 'Needs maintainer context', {
+        checks: { status: 'pending' },
+      }),
+    ],
+    authorFollowup: [
+      pullRequest(16, 'Fix CI', { review: { status: 'changes_requested' } }),
+    ],
+    staleCount: 2,
+  },
+};
+
+test('builds a dependency-security thread reply with escaped PR text and unresolved items', () => {
+  const reply = buildDependencySecurityReply({
+    audit,
+    channel: 'C123',
+    threadTs: '172345.000001',
+    remediation: {
+      pullRequest: audit.remediation,
+      addressedAlertCount: 2,
+      unresolved: [
+        { number: 9, package: 'go/pkg', reason: 'manual remediation required' },
+      ],
+    },
+  });
+
+  assert.equal(reply.channel, 'C123');
+  assert.equal(reply.thread_ts, '172345.000001');
+  assert.match(reply.text, /2 alerts addressed/);
+  assert.match(reply.text, /Needs human handling/);
+  assert.match(reply.text, /view workflow run/);
+  assert.equal(reply.blocks[0].type, 'section');
+});
+
+test('renders the remediation planner report without requiring a published PR', () => {
+  const reply = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    publishStatus: 'success',
+    remediation: {
+      summary: { actions: 2, manual: 1, unsupported: 1 },
+      applied: true,
+      pullRequestUrl: 'https://github.com/temporalio/ui/pull/20',
+      classifications: [
+        {
+          status: 'manual',
+          packageName: 'go/pkg',
+          reason: 'requires a major upgrade',
+        },
+        {
+          status: 'unsupported',
+          packageName: 'ruby/pkg',
+          reason: 'unsupported ecosystem',
+        },
+      ],
+    },
+  });
+  assert.match(reply.text, /2 safe changes applied/);
+  assert.match(reply.text, /view draft remediation PR/);
+  assert.match(reply.text, /go\/pkg/);
+  assert.match(reply.text, /unsupported ecosystem/);
+});
+
+test('never reports an applied remediation without successful publication and a PR URL', () => {
+  const remediation = {
+    summary: { actions: 2 },
+    applied: true,
+    classifications: [],
+  };
+  const failed = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    remediation,
+    publishStatus: 'failure',
+  });
+  assert.doesNotMatch(failed.text, /changes applied/);
+  assert.match(failed.text, /publication failed/);
+  assert.match(failed.text, /Manual review required/);
+
+  const skipped = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    remediation,
+    publishStatus: 'skipped',
+  });
+  assert.doesNotMatch(skipped.text, /changes applied/);
+  assert.match(skipped.text, /publication was skipped/);
+
+  const missingLink = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    remediation,
+    publishStatus: 'success',
+  });
+  assert.doesNotMatch(missingLink.text, /changes applied/);
+  assert.match(missingLink.text, /success without a PR link/);
+
+  assert.throws(
+    () => validatePublishStatus('unknown'),
+    /Unsupported publish status/,
+  );
+});
+
+test('builds capped VLN replies and separately surfaces odd matches', () => {
+  const reply = buildVlnReviewReply({
+    audit,
+    vlnLimit: 1,
+    channel: 'C123',
+    threadTs: '172345.000001',
+  });
+
+  assert.match(reply.text, /VLN review/);
+  assert.ok(reply.text.includes('#11: VLN-1601: \u200B*unsafe\u200B*'));
+  assert.match(reply.text, /…and 1 more/);
+  assert.match(reply.text, /VLN matches needing triage/);
+  assert.match(reply.text, /#13: Possible VLN-1603/);
+  assert.doesNotMatch(reply.text, /#12:/);
+});
+
+test('compatibility summary combines the two independent replies', () => {
+  const digest = buildWeeklySecurityDigest({ audit });
+  assert.match(digest.text, /Dependency security/);
+  assert.match(digest.text, /VLN review/);
+  assert.match(digest.text, /External contributor PRs/);
+  assert.equal(digest.blocks.length, 3);
+});
+
+test('builds external contributor replies by action bucket with stale count', () => {
+  const reply = buildExternalContributorReply({
+    audit,
+    channel: 'C123',
+    threadTs: '172345.000001',
+  });
+  assert.equal(reply.channel, 'C123');
+  assert.match(reply.text, /Ready for review/);
+  assert.match(reply.text, /#14: Community fix/);
+  assert.match(reply.text, /Waiting on author/);
+  assert.match(reply.text, /2 external PRs have not been updated in 14\+ days/);
+});
+
+test('splits Slack sections at the 3000-character boundary', () => {
+  assert.deepEqual(splitSlackSectionText('x'.repeat(3_000)), [
+    'x'.repeat(3_000),
+  ]);
+  const chunks = splitSlackSectionText('x'.repeat(3_001));
+  assert.equal(chunks.length, 2);
+  assert.ok(chunks.every((chunk) => chunk.length <= 3_000));
+  assert.equal(chunks.join(''), 'x'.repeat(3_001));
+});
+
+test('caps long dependency findings with an omitted count and workflow link', () => {
+  const classifications = Array.from({ length: 13 }, (_, index) => ({
+    status: 'manual',
+    packageName: `package-${index}`,
+    reason: `manual ${'detail '.repeat(200)}`,
+  }));
+  const reply = buildDependencySecurityReply({
+    audit: { ...audit, remediation: null },
+    remediation: {
+      summary: { actions: 0 },
+      applied: false,
+      classifications,
+    },
+  });
+  assert.match(reply.text, /…and 3 more/);
+  assert.match(reply.text, /see workflow run/);
+  assert.ok(
+    reply.blocks.every(
+      (block) =>
+        block.text.type === 'mrkdwn' && block.text.text.length <= 3_000,
+    ),
+  );
+  assert.ok(reply.blocks.length > 1);
+});
+
+test('bounds every VLN and external Slack section and reports omitted PRs', () => {
+  const manyPullRequests = Array.from({ length: 12 }, (_, index) =>
+    pullRequest(
+      100 + index,
+      `VLN-${2000 + index}: ${'long title '.repeat(200)}`,
+    ),
+  );
+  const largeAudit = {
+    ...audit,
+    vln: { pending: manyPullRequests, needsTriage: manyPullRequests },
+    externalContributors: {
+      reviewReady: manyPullRequests.slice(0, 5),
+      reviewReadyCount: 12,
+      triage: manyPullRequests.slice(0, 5),
+      triageCount: 12,
+      authorFollowup: manyPullRequests.slice(0, 5),
+      authorFollowupCount: 12,
+      staleCount: 0,
+    },
+  };
+  for (const reply of [
+    buildVlnReviewReply({ audit: largeAudit }),
+    buildExternalContributorReply({ audit: largeAudit }),
+  ]) {
+    assert.match(reply.text, /…and [27] more/);
+    assert.match(reply.text, /see workflow run/);
+    assert.ok(reply.blocks.every((block) => block.text.text.length <= 3_000));
+  }
+});

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -22,6 +22,8 @@ on:
         default: main
         type: string
     secrets:
+      ANTHROPIC_API_KEY:
+        required: false
       SLACK_BOT_TOKEN:
         required: false
       TEMPORAL_CICD_APP_ID:
@@ -48,8 +50,10 @@ jobs:
       artifact_name: ${{ steps.artifact.outputs.name }}
       base_sha: ${{ steps.verified.outputs.base_sha }}
       changed: ${{ steps.changes.outputs.changed }}
+      audit_sha256: ${{ steps.verified.outputs.audit_sha256 }}
       package_json_sha256: ${{ steps.verified.outputs.package_json_sha256 }}
       pnpm_lock_sha256: ${{ steps.verified.outputs.pnpm_lock_sha256 }}
+      remediation_report_sha256: ${{ steps.verified.outputs.remediation_report_sha256 }}
     # This is the only job that installs or executes package code. It has a
     # read-only GITHUB_TOKEN and receives neither App nor Slack credentials.
     permissions:
@@ -98,25 +102,93 @@ jobs:
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_RUN_ID: ${{ github.run_id }}
 
-      - name: Plan manifest-only remediation
-        if: inputs.mode == 'dry-run'
+      - name: Plan manifest-only remediation evidence
         run: >-
           node .github/scripts/apply-weekly-dependency-remediation.mjs
           --audit weekly-dependency-security-audit.json
           --package-json package.json
           --report weekly-dependency-remediation.json
 
-      - name: Apply manifest-only remediation
+      - id: audited-base
+        name: Record the audited source revision
         if: inputs.mode == 'apply'
-        run: >-
-          node .github/scripts/apply-weekly-dependency-remediation.mjs
-          --audit weekly-dependency-security-audit.json
-          --package-json package.json
-          --report weekly-dependency-remediation.json
-          --apply
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo 'ANTHROPIC_API_KEY is required in apply mode.' >&2
+            exit 1
+          fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "audit_sha256=$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+          echo "remediation_sha256=$(sha256sum weekly-dependency-remediation.json | cut -d ' ' -f 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Ask Claude to author the manifest remediation
+        if: inputs.mode == 'apply'
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
+          show_full_output: false
+          display_report: false
+          prompt: |
+            You are preparing the smallest safe dependency-security remediation for this repository.
+
+            Read `weekly-dependency-security-audit.json`,
+            `weekly-dependency-remediation.json`, and the existing `package.json`.
+            Apply exactly the actions already authorized in
+            `weekly-dependency-remediation.json`. Do not address alerts classified as
+            manual or unsupported, and do not perform unrelated upgrades, configuration,
+            script, or formatting changes. If the plan has no actions, leave package.json
+            byte-for-byte unchanged.
+
+            You may edit only the existing `package.json`. Do not create files, edit the
+            lockfile, run commands, use the network, commit, push, comment, or open a pull
+            request. The trusted workflow will regenerate the lockfile, test the candidate,
+            attest it, and publish it through a separate credentialed job.
+          claude_args: |
+            --allowedTools "Read,Edit"
+            --disallowedTools "Bash,Write,WebFetch,WebSearch"
+            --max-turns 10
+
+      - id: claude-candidate
+        name: Reject out-of-scope Claude changes and record resolver evidence
+        if: inputs.mode == 'apply'
+        env:
+          AUDITED_BASE_SHA: ${{ steps.audited-base.outputs.sha }}
+          AUDIT_SHA256: ${{ steps.audited-base.outputs.audit_sha256 }}
+          REMEDIATION_SHA256: ${{ steps.audited-base.outputs.remediation_sha256 }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$AUDITED_BASE_SHA"
+          git diff --cached --quiet
+
+          test -f weekly-dependency-security-audit.json
+          test -f weekly-dependency-remediation.json
+          test "$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)" = "$AUDIT_SHA256"
+          test "$(sha256sum weekly-dependency-remediation.json | cut -d ' ' -f 1)" = "$REMEDIATION_SHA256"
+
+          unexpected_untracked="$(git ls-files --others --exclude-standard | grep -vE '^weekly-dependency-(security-audit|remediation)\.json$' || true)"
+          if [ -n "$unexpected_untracked" ]; then
+            echo "Claude created unexpected files:" >&2
+            echo "$unexpected_untracked" >&2
+            exit 1
+          fi
+
+          unexpected="$(git diff --name-only | grep -vE '^package\.json$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Claude changed files outside package.json:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+          git show "${AUDITED_BASE_SHA}:package.json" > "$RUNNER_TEMP/weekly-dependency-base-package.json"
+          node .github/scripts/validate-claude-dependency-remediation.mjs \
+            --base "$RUNNER_TEMP/weekly-dependency-base-package.json" \
+            --candidate package.json \
+            --report weekly-dependency-remediation.json \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Resolve the lockfile without lifecycle scripts
-        if: inputs.mode == 'apply'
+        if: inputs.mode == 'apply' && steps.claude-candidate.outputs.changed == 'true'
         run: pnpm install --lockfile-only --ignore-scripts
         env:
           HUSKY: '0'
@@ -130,18 +202,21 @@ jobs:
         name: Attest the audited base and candidate dependency files
         run: |
           base_sha="$(git rev-parse HEAD)"
+          audit_hash="$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
           lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
 
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "audit_sha256=$audit_hash" >> "$GITHUB_OUTPUT"
           echo "package_json_sha256=$package_hash" >> "$GITHUB_OUTPUT"
           echo "pnpm_lock_sha256=$lockfile_hash" >> "$GITHUB_OUTPUT"
 
           jq -n \
             --arg baseSha "$base_sha" \
+            --arg auditSha256 "$audit_hash" \
             --arg packageJsonSha256 "$package_hash" \
             --arg pnpmLockSha256 "$lockfile_hash" \
-            '{schemaVersion: 1, baseSha: $baseSha, packageJsonSha256: $packageJsonSha256, pnpmLockSha256: $pnpmLockSha256}' \
+            '{schemaVersion: 1, baseSha: $baseSha, auditSha256: $auditSha256, packageJsonSha256: $packageJsonSha256, pnpmLockSha256: $pnpmLockSha256}' \
             > weekly-dependency-candidate-attestation.json
 
           jq \
@@ -150,6 +225,8 @@ jobs:
             weekly-dependency-remediation.json \
             > weekly-dependency-remediation.with-candidate.json
           mv weekly-dependency-remediation.with-candidate.json weekly-dependency-remediation.json
+          report_hash="$(sha256sum weekly-dependency-remediation.json | cut -d ' ' -f 1)"
+          echo "remediation_report_sha256=$report_hash" >> "$GITHUB_OUTPUT"
 
       - name: Generate SvelteKit build metadata
         run: pnpm exec svelte-kit sync
@@ -162,7 +239,7 @@ jobs:
       - name: Reject changes outside the approved dependency files
         if: inputs.mode == 'apply'
         run: |
-          unexpected="$(git diff --name-only --diff-filter=ACMRTUXB | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
           if [ -n "$unexpected" ]; then
             echo "Unexpected file changes:" >&2
             echo "$unexpected" >&2
@@ -191,19 +268,26 @@ jobs:
         name: Verify package execution did not change the candidate
         env:
           EXPECTED_BASE_SHA: ${{ steps.attest.outputs.base_sha }}
+          EXPECTED_AUDIT_HASH: ${{ steps.attest.outputs.audit_sha256 }}
           EXPECTED_PACKAGE_HASH: ${{ steps.attest.outputs.package_json_sha256 }}
           EXPECTED_LOCKFILE_HASH: ${{ steps.attest.outputs.pnpm_lock_sha256 }}
+          EXPECTED_REPORT_HASH: ${{ steps.attest.outputs.remediation_report_sha256 }}
         run: |
+          actual_audit_hash="$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           actual_package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
           actual_lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
+          actual_report_hash="$(sha256sum weekly-dependency-remediation.json | cut -d ' ' -f 1)"
 
+          test "$actual_audit_hash" = "$EXPECTED_AUDIT_HASH"
           test "$actual_package_hash" = "$EXPECTED_PACKAGE_HASH"
           test "$actual_lockfile_hash" = "$EXPECTED_LOCKFILE_HASH"
+          test "$actual_report_hash" = "$EXPECTED_REPORT_HASH"
           jq --exit-status \
             --arg baseSha "$EXPECTED_BASE_SHA" \
+            --arg auditSha256 "$EXPECTED_AUDIT_HASH" \
             --arg packageJsonSha256 "$EXPECTED_PACKAGE_HASH" \
             --arg pnpmLockSha256 "$EXPECTED_LOCKFILE_HASH" \
-            '.baseSha == $baseSha and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
             weekly-dependency-candidate-attestation.json \
             > /dev/null
           jq --exit-status \
@@ -213,8 +297,10 @@ jobs:
             > /dev/null
 
           echo "base_sha=$EXPECTED_BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "audit_sha256=$EXPECTED_AUDIT_HASH" >> "$GITHUB_OUTPUT"
           echo "package_json_sha256=$EXPECTED_PACKAGE_HASH" >> "$GITHUB_OUTPUT"
           echo "pnpm_lock_sha256=$EXPECTED_LOCKFILE_HASH" >> "$GITHUB_OUTPUT"
+          echo "remediation_report_sha256=$EXPECTED_REPORT_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Upload reports and approved candidate
         if: always()
@@ -262,26 +348,36 @@ jobs:
       - name: Verify and stage only the approved candidate files
         env:
           TRUSTED_BASE_SHA: ${{ needs.audit-and-remediate.outputs.base_sha }}
+          TRUSTED_AUDIT_HASH: ${{ needs.audit-and-remediate.outputs.audit_sha256 }}
           TRUSTED_PACKAGE_HASH: ${{ needs.audit-and-remediate.outputs.package_json_sha256 }}
           TRUSTED_LOCKFILE_HASH: ${{ needs.audit-and-remediate.outputs.pnpm_lock_sha256 }}
+          TRUSTED_REPORT_HASH: ${{ needs.audit-and-remediate.outputs.remediation_report_sha256 }}
         run: |
+          test -f candidate/weekly-dependency-security-audit.json
           test -f candidate/package.json
           test -f candidate/pnpm-lock.yaml
           test -f candidate/weekly-dependency-remediation.json
           test -f candidate/weekly-dependency-candidate-attestation.json
-          jq --exit-status '.applied == true' candidate/weekly-dependency-remediation.json > /dev/null
-          jq empty candidate/package.json
-
+          actual_audit_hash="$(sha256sum candidate/weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           actual_package_hash="$(sha256sum candidate/package.json | cut -d ' ' -f 1)"
           actual_lockfile_hash="$(sha256sum candidate/pnpm-lock.yaml | cut -d ' ' -f 1)"
+          actual_report_hash="$(sha256sum candidate/weekly-dependency-remediation.json | cut -d ' ' -f 1)"
 
+          test "$actual_audit_hash" = "$TRUSTED_AUDIT_HASH"
           test "$actual_package_hash" = "$TRUSTED_PACKAGE_HASH"
           test "$actual_lockfile_hash" = "$TRUSTED_LOCKFILE_HASH"
+          test "$actual_report_hash" = "$TRUSTED_REPORT_HASH"
+          jq --exit-status \
+            '.applied == true and .resolver == "claude-code" and (.actions | type == "array" and length > 0)' \
+            candidate/weekly-dependency-remediation.json \
+            > /dev/null
+          jq empty candidate/package.json
           jq --exit-status \
             --arg baseSha "$TRUSTED_BASE_SHA" \
+            --arg auditSha256 "$TRUSTED_AUDIT_HASH" \
             --arg packageJsonSha256 "$TRUSTED_PACKAGE_HASH" \
             --arg pnpmLockSha256 "$TRUSTED_LOCKFILE_HASH" \
-            '.baseSha == $baseSha and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
             candidate/weekly-dependency-candidate-attestation.json \
             > /dev/null
           jq --exit-status \
@@ -299,7 +395,7 @@ jobs:
           cp candidate/package.json package.json
           cp candidate/pnpm-lock.yaml pnpm-lock.yaml
 
-          unexpected="$(git diff --name-only --diff-filter=ACMRTUXB | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
           if [ -n "$unexpected" ]; then
             echo "Refusing to publish unexpected changes:" >&2
             echo "$unexpected" >&2
@@ -350,7 +446,7 @@ jobs:
             git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
           fi
 
-          body="This draft is maintained by the weekly dependency-security review.\n\nIt contains only package.json and pnpm-lock.yaml changes produced by the minimal remediation planner. The workflow does not dismiss Dependabot alerts; merging this PR is the resolution path.\n\nWorkflow evidence: ${RUN_URL}"
+          body="This draft is maintained by the weekly dependency-security review.\n\nClaude authored the package.json remediation from read-only Dependabot evidence. The trusted workflow regenerated pnpm-lock.yaml, rejected changes outside those two files, and passed the candidate through the full validation and hash-attestation boundary before this separate publishing job received write credentials. The workflow does not dismiss Dependabot alerts; merging this PR is the resolution path.\n\nWorkflow evidence: ${RUN_URL}"
           pr_url="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --base main --state open --json url --jq '.[0].url')"
           if [ -n "$pr_url" ]; then
             gh pr edit "$pr_url" --repo "$REPOSITORY" --title 'fix: weekly Dependabot security remediation' --body "$body"
@@ -392,10 +488,22 @@ jobs:
           PUBLISH_RESULT: ${{ needs.publish.result }}
           CHANNEL: ${{ inputs.slack_channel }}
           REMEDIATION_PR_URL: ${{ needs.publish.outputs.pr_url }}
+          TRUSTED_AUDIT_HASH: ${{ needs.audit-and-remediate.outputs.audit_sha256 }}
+          TRUSTED_REPORT_HASH: ${{ needs.audit-and-remediate.outputs.remediation_report_sha256 }}
           THREAD_TS: ${{ inputs.thread_ts }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -f evidence/weekly-dependency-security-audit.json ]; then
+          evidence_valid=false
+          if [ -n "$TRUSTED_AUDIT_HASH" ] && \
+             [ -n "$TRUSTED_REPORT_HASH" ] && \
+             [ -f evidence/weekly-dependency-security-audit.json ] && \
+             [ -f evidence/weekly-dependency-remediation.json ] && \
+             [ "$(sha256sum evidence/weekly-dependency-security-audit.json | cut -d ' ' -f 1)" = "$TRUSTED_AUDIT_HASH" ] && \
+             [ "$(sha256sum evidence/weekly-dependency-remediation.json | cut -d ' ' -f 1)" = "$TRUSTED_REPORT_HASH" ]; then
+            evidence_valid=true
+          fi
+
+          if [ "$evidence_valid" = true ]; then
             case "$PUBLISH_RESULT" in
               success)
                 if [ -n "$REMEDIATION_PR_URL" ]; then
@@ -417,9 +525,7 @@ jobs:
               --publish-status "$publish_status"
               --run-url "$RUN_URL"
             )
-            if [ -f evidence/weekly-dependency-remediation.json ]; then
-              args+=(--remediation evidence/weekly-dependency-remediation.json)
-            fi
+            args+=(--remediation evidence/weekly-dependency-remediation.json)
             if [ -n "$REMEDIATION_PR_URL" ]; then
               args+=(--remediation-pr-url "$REMEDIATION_PR_URL")
             fi

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -1,0 +1,452 @@
+name: Weekly Dependency Security Review Module
+
+on:
+  workflow_call:
+    inputs:
+      mode:
+        description: 'dry-run reports findings; apply may update the draft remediation PR'
+        required: true
+        type: string
+      notify:
+        required: true
+        type: boolean
+      slack_channel:
+        required: false
+        type: string
+      thread_ts:
+        required: false
+        type: string
+      source_ref:
+        description: 'Revision that contains the audited automation source'
+        required: false
+        default: main
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
+      TEMPORAL_CICD_APP_ID:
+        required: false
+      TEMPORAL_CICD_PRIVATE_KEY:
+        required: false
+
+# This module is deliberately callable only. The coordinator owns scheduling,
+# the root Slack message, and later additive on-call modules.
+permissions:
+  contents: read
+  pull-requests: read
+  vulnerability-alerts: read
+
+concurrency:
+  group: weekly-dependency-security-review-${{ inputs.source_ref }}
+  cancel-in-progress: false
+
+jobs:
+  audit-and-remediate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    outputs:
+      artifact_name: ${{ steps.artifact.outputs.name }}
+      base_sha: ${{ steps.verified.outputs.base_sha }}
+      changed: ${{ steps.changes.outputs.changed }}
+      package_json_sha256: ${{ steps.verified.outputs.package_json_sha256 }}
+      pnpm_lock_sha256: ${{ steps.verified.outputs.pnpm_lock_sha256 }}
+    # This is the only job that installs or executes package code. It has a
+    # read-only GITHUB_TOKEN and receives neither App nor Slack credentials.
+    permissions:
+      contents: read
+      pull-requests: read
+      vulnerability-alerts: read
+    steps:
+      - name: Checkout trusted workflow source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - name: Validate remediation mode
+        env:
+          MODE: ${{ inputs.mode }}
+        run: |
+          case "$MODE" in
+            dry-run|apply) ;;
+            *) echo "Invalid remediation mode: $MODE" >&2; exit 1 ;;
+          esac
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '^22.23.1'
+          cache: pnpm
+
+      - id: artifact
+        name: Name the candidate artifact
+        run: echo "name=weekly-dependency-security-candidate-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Audit open Dependabot alerts and VLN pull requests
+        run: >-
+          node .github/scripts/weekly-dependency-security-audit.mjs
+          --scope dependency-security
+          --output weekly-dependency-security-audit.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      - name: Plan manifest-only remediation
+        if: inputs.mode == 'dry-run'
+        run: >-
+          node .github/scripts/apply-weekly-dependency-remediation.mjs
+          --audit weekly-dependency-security-audit.json
+          --package-json package.json
+          --report weekly-dependency-remediation.json
+
+      - name: Apply manifest-only remediation
+        if: inputs.mode == 'apply'
+        run: >-
+          node .github/scripts/apply-weekly-dependency-remediation.mjs
+          --audit weekly-dependency-security-audit.json
+          --package-json package.json
+          --report weekly-dependency-remediation.json
+          --apply
+
+      - name: Resolve the lockfile without lifecycle scripts
+        if: inputs.mode == 'apply'
+        run: pnpm install --lockfile-only --ignore-scripts
+        env:
+          HUSKY: '0'
+
+      - name: Install the candidate dependency graph from its lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          HUSKY: '0'
+
+      - id: attest
+        name: Attest the audited base and candidate dependency files
+        run: |
+          base_sha="$(git rev-parse HEAD)"
+          package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
+          lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
+
+          echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+          echo "package_json_sha256=$package_hash" >> "$GITHUB_OUTPUT"
+          echo "pnpm_lock_sha256=$lockfile_hash" >> "$GITHUB_OUTPUT"
+
+          jq -n \
+            --arg baseSha "$base_sha" \
+            --arg packageJsonSha256 "$package_hash" \
+            --arg pnpmLockSha256 "$lockfile_hash" \
+            '{schemaVersion: 1, baseSha: $baseSha, packageJsonSha256: $packageJsonSha256, pnpmLockSha256: $pnpmLockSha256}' \
+            > weekly-dependency-candidate-attestation.json
+
+          jq \
+            --slurpfile candidate weekly-dependency-candidate-attestation.json \
+            '. + {candidate: $candidate[0]}' \
+            weekly-dependency-remediation.json \
+            > weekly-dependency-remediation.with-candidate.json
+          mv weekly-dependency-remediation.with-candidate.json weekly-dependency-remediation.json
+
+      - name: Generate SvelteKit build metadata
+        run: pnpm exec svelte-kit sync
+        env:
+          HUSKY: '0'
+
+      - name: Test GitHub automation scripts
+        run: pnpm test:github-automation
+
+      - name: Reject changes outside the approved dependency files
+        if: inputs.mode == 'apply'
+        run: |
+          unexpected="$(git diff --name-only --diff-filter=ACMRTUXB | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected file changes:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+
+      - id: changes
+        name: Record whether an approved candidate exists
+        run: |
+          if git diff --quiet -- package.json pnpm-lock.yaml; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Vitest with one worker
+        run: pnpm test -- --run --minWorkers=1 --maxWorkers=1
+
+      - name: Run type checks
+        run: pnpm check
+
+      - name: Build the server bundle
+        run: pnpm build:server
+
+      - id: verified
+        name: Verify package execution did not change the candidate
+        env:
+          EXPECTED_BASE_SHA: ${{ steps.attest.outputs.base_sha }}
+          EXPECTED_PACKAGE_HASH: ${{ steps.attest.outputs.package_json_sha256 }}
+          EXPECTED_LOCKFILE_HASH: ${{ steps.attest.outputs.pnpm_lock_sha256 }}
+        run: |
+          actual_package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
+          actual_lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
+
+          test "$actual_package_hash" = "$EXPECTED_PACKAGE_HASH"
+          test "$actual_lockfile_hash" = "$EXPECTED_LOCKFILE_HASH"
+          jq --exit-status \
+            --arg baseSha "$EXPECTED_BASE_SHA" \
+            --arg packageJsonSha256 "$EXPECTED_PACKAGE_HASH" \
+            --arg pnpmLockSha256 "$EXPECTED_LOCKFILE_HASH" \
+            '.baseSha == $baseSha and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            weekly-dependency-candidate-attestation.json \
+            > /dev/null
+          jq --exit-status \
+            --slurpfile candidateAttestation weekly-dependency-candidate-attestation.json \
+            '.candidate == $candidateAttestation[0]' \
+            weekly-dependency-remediation.json \
+            > /dev/null
+
+          echo "base_sha=$EXPECTED_BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "package_json_sha256=$EXPECTED_PACKAGE_HASH" >> "$GITHUB_OUTPUT"
+          echo "pnpm_lock_sha256=$EXPECTED_LOCKFILE_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Upload reports and approved candidate
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            weekly-dependency-security-audit.json
+            weekly-dependency-remediation.json
+            weekly-dependency-candidate-attestation.json
+            package.json
+            pnpm-lock.yaml
+
+  publish:
+    needs: audit-and-remediate
+    if: >-
+      github.event_name != 'pull_request' &&
+      inputs.mode == 'apply' &&
+      needs.audit-and-remediate.outputs.changed == 'true' &&
+      needs.audit-and-remediate.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pr_url: ${{ steps.pull-request.outputs.pr_url }}
+    # No package manager or repository package code runs in this job.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout source revision without persisted credentials
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download the approved candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.audit-and-remediate.outputs.artifact_name }}
+          path: candidate
+
+      - name: Verify and stage only the approved candidate files
+        env:
+          TRUSTED_BASE_SHA: ${{ needs.audit-and-remediate.outputs.base_sha }}
+          TRUSTED_PACKAGE_HASH: ${{ needs.audit-and-remediate.outputs.package_json_sha256 }}
+          TRUSTED_LOCKFILE_HASH: ${{ needs.audit-and-remediate.outputs.pnpm_lock_sha256 }}
+        run: |
+          test -f candidate/package.json
+          test -f candidate/pnpm-lock.yaml
+          test -f candidate/weekly-dependency-remediation.json
+          test -f candidate/weekly-dependency-candidate-attestation.json
+          jq --exit-status '.applied == true' candidate/weekly-dependency-remediation.json > /dev/null
+          jq empty candidate/package.json
+
+          actual_package_hash="$(sha256sum candidate/package.json | cut -d ' ' -f 1)"
+          actual_lockfile_hash="$(sha256sum candidate/pnpm-lock.yaml | cut -d ' ' -f 1)"
+
+          test "$actual_package_hash" = "$TRUSTED_PACKAGE_HASH"
+          test "$actual_lockfile_hash" = "$TRUSTED_LOCKFILE_HASH"
+          jq --exit-status \
+            --arg baseSha "$TRUSTED_BASE_SHA" \
+            --arg packageJsonSha256 "$TRUSTED_PACKAGE_HASH" \
+            --arg pnpmLockSha256 "$TRUSTED_LOCKFILE_HASH" \
+            '.baseSha == $baseSha and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            candidate/weekly-dependency-candidate-attestation.json \
+            > /dev/null
+          jq --exit-status \
+            --slurpfile candidateAttestation candidate/weekly-dependency-candidate-attestation.json \
+            '.candidate == $candidateAttestation[0]' \
+            candidate/weekly-dependency-remediation.json \
+            > /dev/null
+
+          git fetch origin '+refs/heads/main:refs/remotes/origin/main'
+          current_main="$(git rev-parse origin/main)"
+          checked_out_base="$(git rev-parse HEAD)"
+          test "$checked_out_base" = "$TRUSTED_BASE_SHA"
+          test "$current_main" = "$TRUSTED_BASE_SHA"
+
+          cp candidate/package.json package.json
+          cp candidate/pnpm-lock.yaml pnpm-lock.yaml
+
+          unexpected="$(git diff --name-only --diff-filter=ACMRTUXB | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Refusing to publish unexpected changes:" >&2
+            echo "$unexpected" >&2
+            exit 1
+          fi
+
+          git add -- package.json pnpm-lock.yaml
+          if git diff --cached --quiet; then
+            echo 'Candidate artifact did not contain a dependency change.' >&2
+            exit 1
+          fi
+
+      - name: Create a short-lived Temporal CI/CD App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          owner: temporalio
+          repositories: ui
+          permission-contents: write
+          permission-pull-requests: write
+
+      - id: pull-request
+        name: Update the single draft remediation pull request
+        env:
+          BRANCH: automation/weekly-dependency-security
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          HUSKY: '0'
+          REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TRUSTED_BASE_SHA: ${{ needs.audit-and-remediate.outputs.base_sha }}
+        run: |
+          git config user.name 'temporal-cicd[bot]'
+          git config user.email 'temporal-cicd[bot]@users.noreply.github.com'
+          git remote set-url origin "https://x-access-token:${GITHUB_APP_TOKEN}@github.com/${REPOSITORY}.git"
+          git fetch origin '+refs/heads/main:refs/remotes/origin/main'
+          test "$(git rev-parse HEAD)" = "$TRUSTED_BASE_SHA"
+          test "$(git rev-parse origin/main)" = "$TRUSTED_BASE_SHA"
+
+          git commit -m 'fix: weekly Dependabot security remediation'
+          git fetch origin "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" || true
+          if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
+            expected="$(git rev-parse "refs/remotes/origin/${BRANCH}")"
+            git push "--force-with-lease=refs/heads/${BRANCH}:${expected}" origin "HEAD:refs/heads/${BRANCH}"
+          else
+            git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
+          fi
+
+          body="This draft is maintained by the weekly dependency-security review.\n\nIt contains only package.json and pnpm-lock.yaml changes produced by the minimal remediation planner. The workflow does not dismiss Dependabot alerts; merging this PR is the resolution path.\n\nWorkflow evidence: ${RUN_URL}"
+          pr_url="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --base main --state open --json url --jq '.[0].url')"
+          if [ -n "$pr_url" ]; then
+            gh pr edit "$pr_url" --repo "$REPOSITORY" --title 'fix: weekly Dependabot security remediation' --body "$body"
+          else
+            pr_url="$(gh pr create --repo "$REPOSITORY" --base main --head "$BRANCH" --draft --title 'fix: weekly Dependabot security remediation' --body "$body")"
+          fi
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+  notify:
+    needs: [audit-and-remediate, publish]
+    if: always() && inputs.notify && inputs.thread_ts != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      status: ${{ steps.status.outputs.status }}
+    # This job gets the Slack token only. It does not install dependencies or
+    # receive the GitHub App token.
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted digest source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - name: Download audit evidence when available
+        id: evidence
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.audit-and-remediate.outputs.artifact_name }}
+          path: evidence
+
+      - id: payload
+        name: Build the threaded Slack reply
+        env:
+          AUDIT_RESULT: ${{ needs.audit-and-remediate.result }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+          CHANNEL: ${{ inputs.slack_channel }}
+          REMEDIATION_PR_URL: ${{ needs.publish.outputs.pr_url }}
+          THREAD_TS: ${{ inputs.thread_ts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -f evidence/weekly-dependency-security-audit.json ]; then
+            case "$PUBLISH_RESULT" in
+              success)
+                if [ -n "$REMEDIATION_PR_URL" ]; then
+                  publish_status='success'
+                else
+                  publish_status='failure'
+                fi
+                ;;
+              failure|cancelled) publish_status='failure' ;;
+              *) publish_status='skipped' ;;
+            esac
+
+            args=(
+              --module dependency-security
+              --channel "$CHANNEL"
+              --thread-ts "$THREAD_TS"
+              --input evidence/weekly-dependency-security-audit.json
+              --output weekly-dependency-security-reply.json
+              --publish-status "$publish_status"
+              --run-url "$RUN_URL"
+            )
+            if [ -f evidence/weekly-dependency-remediation.json ]; then
+              args+=(--remediation evidence/weekly-dependency-remediation.json)
+            fi
+            if [ -n "$REMEDIATION_PR_URL" ]; then
+              args+=(--remediation-pr-url "$REMEDIATION_PR_URL")
+            fi
+            node .github/scripts/weekly-dependency-security-digest.mjs "${args[@]}"
+          else
+            jq -n \
+              --arg channel "$CHANNEL" \
+              --arg thread_ts "$THREAD_TS" \
+              --arg audit_result "$AUDIT_RESULT" \
+              --arg publish_result "$PUBLISH_RESULT" \
+              --arg run_url "$RUN_URL" \
+              '{channel: $channel, thread_ts: $thread_ts, text: ("Dependency security review did not produce evidence. Audit: " + $audit_result + "; publish: " + $publish_result + ". " + $run_url)}' \
+              > weekly-dependency-security-reply.json
+          fi
+          {
+            echo 'payload<<EOF'
+            cat weekly-dependency-security-reply.json
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post dependency-security digest
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          errors: true
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: ${{ steps.payload.outputs.payload }}
+
+      - id: status
+        run: echo 'status=success' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -102,7 +102,7 @@ jobs:
 
       - id: artifact
         name: Name the candidate artifact
-        run: echo "name=weekly-dependency-security-candidate-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+        run: echo "name=weekly-dependency-security-candidate-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
       - name: Audit open Dependabot alerts and VLN pull requests
         run: >-

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -198,6 +198,14 @@ jobs:
         env:
           HUSKY: '0'
 
+      - name: Verify that the candidate resolves every remediated alert
+        if: inputs.mode == 'apply'
+        run: >-
+          node .github/scripts/verify-weekly-dependency-remediation.mjs
+          --audit weekly-dependency-security-audit.json
+          --report weekly-dependency-remediation.json
+          --lockfile pnpm-lock.yaml
+
       - id: attest
         name: Attest the audited base and candidate dependency files
         run: |
@@ -368,7 +376,7 @@ jobs:
           test "$actual_lockfile_hash" = "$TRUSTED_LOCKFILE_HASH"
           test "$actual_report_hash" = "$TRUSTED_REPORT_HASH"
           jq --exit-status \
-            '.applied == true and .resolver == "claude-code" and (.actions | type == "array" and length > 0)' \
+            '.applied == true and .resolver == "claude-code" and .verification.verified == true and (.actions | type == "array" and length > 0)' \
             candidate/weekly-dependency-remediation.json \
             > /dev/null
           jq empty candidate/package.json

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -10,6 +10,11 @@ on:
       notify:
         required: true
         type: boolean
+      publish:
+        description: 'Allow the credentialed job to update the draft PR. Set false to rehearse.'
+        required: false
+        default: true
+        type: boolean
       slack_channel:
         required: false
         type: string
@@ -201,8 +206,8 @@ jobs:
         name: Apply the authorized Go module remediation
         if: inputs.mode == 'apply'
         run: |
-          modules="$(jq -r '[.actions[] | select(.type == "go-module")][] | "\(.packageName)@\(.to)"' weekly-dependency-remediation.json)"
-          if [ -z "$modules" ]; then
+          go_modules="$(jq -r '[.actions[] | select(.type == "go-module")][] | "\(.packageName)@\(.to)"' weekly-dependency-remediation.json)"
+          if [ -z "$go_modules" ]; then
             echo 'changed=false' >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -211,7 +216,7 @@ jobs:
             [ -n "$module" ] || continue
             echo "Updating $module"
             go get "$module"
-          done <<< "$modules"
+          done <<< "$go_modules"
           go mod tidy
           echo 'changed=true' >> "$GITHUB_OUTPUT"
 
@@ -375,6 +380,7 @@ jobs:
     needs: audit-and-remediate
     if: >-
       github.event_name != 'pull_request' &&
+      inputs.publish &&
       inputs.mode == 'apply' &&
       needs.audit-and-remediate.outputs.changed == 'true' &&
       needs.audit-and-remediate.result == 'success'

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -53,6 +53,8 @@ jobs:
       audit_sha256: ${{ steps.verified.outputs.audit_sha256 }}
       package_json_sha256: ${{ steps.verified.outputs.package_json_sha256 }}
       pnpm_lock_sha256: ${{ steps.verified.outputs.pnpm_lock_sha256 }}
+      go_mod_sha256: ${{ steps.verified.outputs.go_mod_sha256 }}
+      go_sum_sha256: ${{ steps.verified.outputs.go_sum_sha256 }}
       remediation_report_sha256: ${{ steps.verified.outputs.remediation_report_sha256 }}
     # This is the only job that installs or executes package code. It has a
     # read-only GITHUB_TOKEN and receives neither App nor Slack credentials.
@@ -87,6 +89,12 @@ jobs:
           node-version: '^22.23.1'
           cache: pnpm
 
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
       - id: artifact
         name: Name the candidate artifact
         run: echo "name=weekly-dependency-security-candidate-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
@@ -107,6 +115,8 @@ jobs:
           node .github/scripts/apply-weekly-dependency-remediation.mjs
           --audit weekly-dependency-security-audit.json
           --package-json package.json
+          --lockfile pnpm-lock.yaml
+          --go-mod server/go.mod
           --report weekly-dependency-remediation.json
 
       - id: audited-base
@@ -187,6 +197,24 @@ jobs:
             --report weekly-dependency-remediation.json \
             --github-output "$GITHUB_OUTPUT"
 
+      - id: go-candidate
+        name: Apply the authorized Go module remediation
+        if: inputs.mode == 'apply'
+        run: |
+          modules="$(jq -r '[.actions[] | select(.type == "go-module")][] | "\(.packageName)@\(.to)"' weekly-dependency-remediation.json)"
+          if [ -z "$modules" ]; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cd server
+          while IFS= read -r module; do
+            [ -n "$module" ] || continue
+            echo "Updating $module"
+            go get "$module"
+          done <<< "$modules"
+          go mod tidy
+          echo 'changed=true' >> "$GITHUB_OUTPUT"
+
       - name: Resolve the lockfile without lifecycle scripts
         if: inputs.mode == 'apply' && steps.claude-candidate.outputs.changed == 'true'
         run: pnpm install --lockfile-only --ignore-scripts
@@ -205,6 +233,7 @@ jobs:
           --audit weekly-dependency-security-audit.json
           --report weekly-dependency-remediation.json
           --lockfile pnpm-lock.yaml
+          --go-mod server/go.mod
 
       - id: attest
         name: Attest the audited base and candidate dependency files
@@ -213,18 +242,24 @@ jobs:
           audit_hash="$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
           lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
+          go_mod_hash="$(sha256sum server/go.mod | cut -d ' ' -f 1)"
+          go_sum_hash="$(sha256sum server/go.sum | cut -d ' ' -f 1)"
 
           echo "base_sha=$base_sha" >> "$GITHUB_OUTPUT"
           echo "audit_sha256=$audit_hash" >> "$GITHUB_OUTPUT"
           echo "package_json_sha256=$package_hash" >> "$GITHUB_OUTPUT"
           echo "pnpm_lock_sha256=$lockfile_hash" >> "$GITHUB_OUTPUT"
+          echo "go_mod_sha256=$go_mod_hash" >> "$GITHUB_OUTPUT"
+          echo "go_sum_sha256=$go_sum_hash" >> "$GITHUB_OUTPUT"
 
           jq -n \
             --arg baseSha "$base_sha" \
             --arg auditSha256 "$audit_hash" \
             --arg packageJsonSha256 "$package_hash" \
             --arg pnpmLockSha256 "$lockfile_hash" \
-            '{schemaVersion: 1, baseSha: $baseSha, auditSha256: $auditSha256, packageJsonSha256: $packageJsonSha256, pnpmLockSha256: $pnpmLockSha256}' \
+            --arg goModSha256 "$go_mod_hash" \
+            --arg goSumSha256 "$go_sum_hash" \
+            '{schemaVersion: 1, baseSha: $baseSha, auditSha256: $auditSha256, packageJsonSha256: $packageJsonSha256, pnpmLockSha256: $pnpmLockSha256, goModSha256: $goModSha256, goSumSha256: $goSumSha256}' \
             > weekly-dependency-candidate-attestation.json
 
           jq \
@@ -247,7 +282,7 @@ jobs:
       - name: Reject changes outside the approved dependency files
         if: inputs.mode == 'apply'
         run: |
-          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml|server/go\.mod|server/go\.sum)$' || true)"
           if [ -n "$unexpected" ]; then
             echo "Unexpected file changes:" >&2
             echo "$unexpected" >&2
@@ -257,7 +292,7 @@ jobs:
       - id: changes
         name: Record whether an approved candidate exists
         run: |
-          if git diff --quiet -- package.json pnpm-lock.yaml; then
+          if git diff --quiet -- package.json pnpm-lock.yaml server/go.mod server/go.sum; then
             echo 'changed=false' >> "$GITHUB_OUTPUT"
           else
             echo 'changed=true' >> "$GITHUB_OUTPUT"
@@ -279,23 +314,31 @@ jobs:
           EXPECTED_AUDIT_HASH: ${{ steps.attest.outputs.audit_sha256 }}
           EXPECTED_PACKAGE_HASH: ${{ steps.attest.outputs.package_json_sha256 }}
           EXPECTED_LOCKFILE_HASH: ${{ steps.attest.outputs.pnpm_lock_sha256 }}
+          EXPECTED_GO_MOD_HASH: ${{ steps.attest.outputs.go_mod_sha256 }}
+          EXPECTED_GO_SUM_HASH: ${{ steps.attest.outputs.go_sum_sha256 }}
           EXPECTED_REPORT_HASH: ${{ steps.attest.outputs.remediation_report_sha256 }}
         run: |
           actual_audit_hash="$(sha256sum weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           actual_package_hash="$(sha256sum package.json | cut -d ' ' -f 1)"
           actual_lockfile_hash="$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)"
+          actual_go_mod_hash="$(sha256sum server/go.mod | cut -d ' ' -f 1)"
+          actual_go_sum_hash="$(sha256sum server/go.sum | cut -d ' ' -f 1)"
           actual_report_hash="$(sha256sum weekly-dependency-remediation.json | cut -d ' ' -f 1)"
 
           test "$actual_audit_hash" = "$EXPECTED_AUDIT_HASH"
           test "$actual_package_hash" = "$EXPECTED_PACKAGE_HASH"
           test "$actual_lockfile_hash" = "$EXPECTED_LOCKFILE_HASH"
+          test "$actual_go_mod_hash" = "$EXPECTED_GO_MOD_HASH"
+          test "$actual_go_sum_hash" = "$EXPECTED_GO_SUM_HASH"
           test "$actual_report_hash" = "$EXPECTED_REPORT_HASH"
           jq --exit-status \
             --arg baseSha "$EXPECTED_BASE_SHA" \
             --arg auditSha256 "$EXPECTED_AUDIT_HASH" \
             --arg packageJsonSha256 "$EXPECTED_PACKAGE_HASH" \
             --arg pnpmLockSha256 "$EXPECTED_LOCKFILE_HASH" \
-            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            --arg goModSha256 "$EXPECTED_GO_MOD_HASH" \
+            --arg goSumSha256 "$EXPECTED_GO_SUM_HASH" \
+            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256 and .goModSha256 == $goModSha256 and .goSumSha256 == $goSumSha256' \
             weekly-dependency-candidate-attestation.json \
             > /dev/null
           jq --exit-status \
@@ -308,6 +351,8 @@ jobs:
           echo "audit_sha256=$EXPECTED_AUDIT_HASH" >> "$GITHUB_OUTPUT"
           echo "package_json_sha256=$EXPECTED_PACKAGE_HASH" >> "$GITHUB_OUTPUT"
           echo "pnpm_lock_sha256=$EXPECTED_LOCKFILE_HASH" >> "$GITHUB_OUTPUT"
+          echo "go_mod_sha256=$EXPECTED_GO_MOD_HASH" >> "$GITHUB_OUTPUT"
+          echo "go_sum_sha256=$EXPECTED_GO_SUM_HASH" >> "$GITHUB_OUTPUT"
           echo "remediation_report_sha256=$EXPECTED_REPORT_HASH" >> "$GITHUB_OUTPUT"
 
       - name: Upload reports and approved candidate
@@ -323,6 +368,8 @@ jobs:
             weekly-dependency-candidate-attestation.json
             package.json
             pnpm-lock.yaml
+            server/go.mod
+            server/go.sum
 
   publish:
     needs: audit-and-remediate
@@ -359,24 +406,35 @@ jobs:
           TRUSTED_AUDIT_HASH: ${{ needs.audit-and-remediate.outputs.audit_sha256 }}
           TRUSTED_PACKAGE_HASH: ${{ needs.audit-and-remediate.outputs.package_json_sha256 }}
           TRUSTED_LOCKFILE_HASH: ${{ needs.audit-and-remediate.outputs.pnpm_lock_sha256 }}
+          TRUSTED_GO_MOD_HASH: ${{ needs.audit-and-remediate.outputs.go_mod_sha256 }}
+          TRUSTED_GO_SUM_HASH: ${{ needs.audit-and-remediate.outputs.go_sum_sha256 }}
           TRUSTED_REPORT_HASH: ${{ needs.audit-and-remediate.outputs.remediation_report_sha256 }}
         run: |
           test -f candidate/weekly-dependency-security-audit.json
           test -f candidate/package.json
           test -f candidate/pnpm-lock.yaml
+          test -f candidate/server/go.mod
+          test -f candidate/server/go.sum
           test -f candidate/weekly-dependency-remediation.json
           test -f candidate/weekly-dependency-candidate-attestation.json
           actual_audit_hash="$(sha256sum candidate/weekly-dependency-security-audit.json | cut -d ' ' -f 1)"
           actual_package_hash="$(sha256sum candidate/package.json | cut -d ' ' -f 1)"
           actual_lockfile_hash="$(sha256sum candidate/pnpm-lock.yaml | cut -d ' ' -f 1)"
+          actual_go_mod_hash="$(sha256sum candidate/server/go.mod | cut -d ' ' -f 1)"
+          actual_go_sum_hash="$(sha256sum candidate/server/go.sum | cut -d ' ' -f 1)"
           actual_report_hash="$(sha256sum candidate/weekly-dependency-remediation.json | cut -d ' ' -f 1)"
 
           test "$actual_audit_hash" = "$TRUSTED_AUDIT_HASH"
           test "$actual_package_hash" = "$TRUSTED_PACKAGE_HASH"
           test "$actual_lockfile_hash" = "$TRUSTED_LOCKFILE_HASH"
+          test "$actual_go_mod_hash" = "$TRUSTED_GO_MOD_HASH"
+          test "$actual_go_sum_hash" = "$TRUSTED_GO_SUM_HASH"
           test "$actual_report_hash" = "$TRUSTED_REPORT_HASH"
           jq --exit-status \
-            '.applied == true and .resolver == "claude-code" and .verification.verified == true and (.actions | type == "array" and length > 0)' \
+            '.verification.verified == true
+             and (.actions | type == "array" and length > 0)
+             and ((.actions | map(select(.type != "go-module")) | length) == 0
+                  or (.applied == true and .resolver == "claude-code"))' \
             candidate/weekly-dependency-remediation.json \
             > /dev/null
           jq empty candidate/package.json
@@ -385,7 +443,9 @@ jobs:
             --arg auditSha256 "$TRUSTED_AUDIT_HASH" \
             --arg packageJsonSha256 "$TRUSTED_PACKAGE_HASH" \
             --arg pnpmLockSha256 "$TRUSTED_LOCKFILE_HASH" \
-            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256' \
+            --arg goModSha256 "$TRUSTED_GO_MOD_HASH" \
+            --arg goSumSha256 "$TRUSTED_GO_SUM_HASH" \
+            '.baseSha == $baseSha and .auditSha256 == $auditSha256 and .packageJsonSha256 == $packageJsonSha256 and .pnpmLockSha256 == $pnpmLockSha256 and .goModSha256 == $goModSha256 and .goSumSha256 == $goSumSha256' \
             candidate/weekly-dependency-candidate-attestation.json \
             > /dev/null
           jq --exit-status \
@@ -402,15 +462,17 @@ jobs:
 
           cp candidate/package.json package.json
           cp candidate/pnpm-lock.yaml pnpm-lock.yaml
+          cp candidate/server/go.mod server/go.mod
+          cp candidate/server/go.sum server/go.sum
 
-          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml)$' || true)"
+          unexpected="$(git diff --name-only | grep -vE '^(package\.json|pnpm-lock\.yaml|server/go\.mod|server/go\.sum)$' || true)"
           if [ -n "$unexpected" ]; then
             echo "Refusing to publish unexpected changes:" >&2
             echo "$unexpected" >&2
             exit 1
           fi
 
-          git add -- package.json pnpm-lock.yaml
+          git add -- package.json pnpm-lock.yaml server/go.mod server/go.sum
           if git diff --cached --quiet; then
             echo 'Candidate artifact did not contain a dependency change.' >&2
             exit 1

--- a/.github/workflows/weekly-external-contributor-review.yml
+++ b/.github/workflows/weekly-external-contributor-review.yml
@@ -1,0 +1,128 @@
+name: Weekly External Contributor Review Module
+
+on:
+  workflow_call:
+    inputs:
+      notify:
+        required: true
+        type: boolean
+      slack_channel:
+        required: false
+        type: string
+      thread_ts:
+        required: false
+        type: string
+      source_ref:
+        description: 'Revision that contains the audit and digest source'
+        required: false
+        default: main
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      artifact_name: ${{ steps.artifact.outputs.name }}
+    # This is metadata-only. Checking out main makes the shared audit and
+    # digest scripts available; it does not install or execute package code.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout trusted audit source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - id: artifact
+        name: Name the contributor audit artifact
+        run: echo "name=weekly-external-contributor-audit-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Identify active external-contributor pull requests
+        run: >-
+          node .github/scripts/weekly-dependency-security-audit.mjs
+          --scope external-contributors
+          --output weekly-external-contributor-audit.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      - name: Upload external-contributor audit evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: weekly-external-contributor-audit.json
+
+  notify:
+    needs: audit
+    if: always() && inputs.notify && inputs.thread_ts != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted digest source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - name: Download contributor audit evidence when available
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.audit.outputs.artifact_name }}
+          path: evidence
+
+      - id: payload
+        name: Build the threaded contributor reply
+        env:
+          AUDIT_RESULT: ${{ needs.audit.result }}
+          CHANNEL: ${{ inputs.slack_channel }}
+          THREAD_TS: ${{ inputs.thread_ts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -f evidence/weekly-external-contributor-audit.json ]; then
+            node .github/scripts/weekly-dependency-security-digest.mjs \
+              --module external-contributors \
+              --channel "$CHANNEL" \
+              --thread-ts "$THREAD_TS" \
+              --input evidence/weekly-external-contributor-audit.json \
+              --output weekly-external-contributor-reply.json \
+              --run-url "$RUN_URL"
+          else
+            jq -n \
+              --arg channel "$CHANNEL" \
+              --arg thread_ts "$THREAD_TS" \
+              --arg audit_result "$AUDIT_RESULT" \
+              --arg run_url "$RUN_URL" \
+              '{channel: $channel, thread_ts: $thread_ts, text: ("External contributor review did not produce evidence. Audit: " + $audit_result + ". " + $run_url)}' \
+              > weekly-external-contributor-reply.json
+          fi
+          {
+            echo 'payload<<EOF'
+            cat weekly-external-contributor-reply.json
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post external-contributor digest
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          errors: true
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: ${{ steps.payload.outputs.payload }}

--- a/.github/workflows/weekly-external-contributor-review.yml
+++ b/.github/workflows/weekly-external-contributor-review.yml
@@ -45,7 +45,7 @@ jobs:
 
       - id: artifact
         name: Name the contributor audit artifact
-        run: echo "name=weekly-external-contributor-audit-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+        run: echo "name=weekly-external-contributor-audit-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
       - name: Identify active external-contributor pull requests
         run: >-

--- a/.github/workflows/weekly-oncall-review-pr-test.yml
+++ b/.github/workflows/weekly-oncall-review-pr-test.yml
@@ -13,6 +13,8 @@ on:
       - .github/scripts/weekly-dependency-security-audit.test.mjs
       - .github/scripts/apply-weekly-dependency-remediation.mjs
       - .github/scripts/apply-weekly-dependency-remediation.test.mjs
+      - .github/scripts/validate-claude-dependency-remediation.mjs
+      - .github/scripts/validate-claude-dependency-remediation.test.mjs
       - .github/scripts/weekly-dependency-security-digest.mjs
       - .github/scripts/weekly-dependency-security-digest.test.mjs
       - package.json

--- a/.github/workflows/weekly-oncall-review-pr-test.yml
+++ b/.github/workflows/weekly-oncall-review-pr-test.yml
@@ -1,6 +1,16 @@
 name: Weekly On-Call Review PR Test
 
 on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Rehearse the dependency-security module. apply exercises the full remediation path without publishing.'
+        required: true
+        default: apply
+        type: choice
+        options:
+          - dry-run
+          - apply
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -15,6 +25,8 @@ on:
       - .github/scripts/apply-weekly-dependency-remediation.test.mjs
       - .github/scripts/validate-claude-dependency-remediation.mjs
       - .github/scripts/validate-claude-dependency-remediation.test.mjs
+      - .github/scripts/verify-weekly-dependency-remediation.mjs
+      - .github/scripts/verify-weekly-dependency-remediation.test.mjs
       - .github/scripts/weekly-dependency-security-digest.mjs
       - .github/scripts/weekly-dependency-security-digest.test.mjs
       - package.json
@@ -26,12 +38,26 @@ permissions:
   vulnerability-alerts: read
 
 concurrency:
-  group: weekly-oncall-review-pr-test-${{ github.event.pull_request.number }}
+  group: weekly-oncall-review-pr-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # Rehearses the full remediation path on any ref. publish is false, so the
+  # credentialed job never runs and no pull request is touched.
+  dependency-security-rehearsal:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/weekly-dependency-security-review.yml
+    with:
+      mode: ${{ inputs.mode }}
+      notify: false
+      publish: false
+      source_ref: ${{ github.sha }}
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
   dependency-security:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/weekly-dependency-security-review.yml
@@ -42,6 +68,7 @@ jobs:
 
   vln-review:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/weekly-vln-review.yml
@@ -51,6 +78,7 @@ jobs:
 
   external-contributor-review:
     if: >-
+      github.event_name == 'pull_request' &&
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/weekly-external-contributor-review.yml

--- a/.github/workflows/weekly-oncall-review-pr-test.yml
+++ b/.github/workflows/weekly-oncall-review-pr-test.yml
@@ -1,0 +1,57 @@
+name: Weekly On-Call Review PR Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - .github/workflows/weekly-oncall-review.yml
+      - .github/workflows/weekly-oncall-review-pr-test.yml
+      - .github/workflows/weekly-dependency-security-review.yml
+      - .github/workflows/weekly-vln-review.yml
+      - .github/workflows/weekly-external-contributor-review.yml
+      - .github/scripts/weekly-dependency-security-audit.mjs
+      - .github/scripts/weekly-dependency-security-audit.test.mjs
+      - .github/scripts/apply-weekly-dependency-remediation.mjs
+      - .github/scripts/apply-weekly-dependency-remediation.test.mjs
+      - .github/scripts/weekly-dependency-security-digest.mjs
+      - .github/scripts/weekly-dependency-security-digest.test.mjs
+      - package.json
+      - pnpm-lock.yaml
+
+permissions:
+  contents: read
+  pull-requests: read
+  vulnerability-alerts: read
+
+concurrency:
+  group: weekly-oncall-review-pr-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-security:
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/weekly-dependency-security-review.yml
+    with:
+      mode: dry-run
+      notify: false
+      source_ref: ${{ github.event.pull_request.head.sha }}
+
+  vln-review:
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/weekly-vln-review.yml
+    with:
+      notify: false
+      source_ref: ${{ github.event.pull_request.head.sha }}
+
+  external-contributor-review:
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/weekly-external-contributor-review.yml
+    with:
+      notify: false
+      source_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -57,7 +57,7 @@ jobs:
           slack_channel="$REQUESTED_SLACK_CHANNEL"
 
           if [ "$EVENT_NAME" = 'schedule' ]; then
-            mode='apply'
+            mode='dry-run'
             notify='true'
             slack_channel="$SCHEDULED_SLACK_CHANNEL"
           fi
@@ -117,7 +117,7 @@ jobs:
     with:
       mode: ${{ needs.resolve-inputs.outputs.mode }}
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
-      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/weekly-vln-review.yml
     with:
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
-      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
     uses: ./.github/workflows/weekly-external-contributor-review.yml
     with:
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
-      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -57,7 +57,7 @@ jobs:
           slack_channel="$REQUESTED_SLACK_CHANNEL"
 
           if [ "$EVENT_NAME" = 'schedule' ]; then
-            mode='dry-run'
+            mode='apply'
             notify='true'
             slack_channel="$SCHEDULED_SLACK_CHANNEL"
           fi
@@ -120,6 +120,7 @@ jobs:
       slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
     secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       TEMPORAL_CICD_APP_ID: ${{ secrets.TEMPORAL_CICD_APP_ID }}
       TEMPORAL_CICD_PRIVATE_KEY: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -1,0 +1,173 @@
+name: Weekly On-Call Review
+
+on:
+  schedule:
+    # 10:00 Eastern during daylight saving time; runs in the morning on Mondays year-round.
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Whether dependency remediations may update the draft PR'
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - apply
+      notify:
+        description: 'Post the weekly review thread to Slack'
+        required: true
+        default: true
+        type: boolean
+      slack_channel:
+        description: 'Slack channel ID for this manual run'
+        required: true
+        default: C0BPXR260DA
+        type: string
+
+# The GitHub App token is scoped to the publishing job in the called workflow.
+# The workflow GITHUB_TOKEN never needs write access.
+permissions:
+  contents: read
+  pull-requests: read
+  vulnerability-alerts: read
+
+concurrency:
+  group: weekly-oncall-review
+  cancel-in-progress: false
+
+jobs:
+  resolve-inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.inputs.outputs.mode }}
+      notify: ${{ steps.inputs.outputs.notify }}
+      slack_channel: ${{ steps.inputs.outputs.slack_channel }}
+    steps:
+      - id: inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_MODE: ${{ inputs.mode }}
+          REQUESTED_NOTIFY: ${{ inputs.notify }}
+          REQUESTED_SLACK_CHANNEL: ${{ inputs.slack_channel }}
+          SCHEDULED_SLACK_CHANNEL: ${{ vars.ONCALL_FRONTEND_SLACK_CHANNEL }}
+        run: |
+          mode="$REQUESTED_MODE"
+          notify="$REQUESTED_NOTIFY"
+          slack_channel="$REQUESTED_SLACK_CHANNEL"
+
+          if [ "$EVENT_NAME" = 'schedule' ]; then
+            mode='apply'
+            notify='true'
+            slack_channel="$SCHEDULED_SLACK_CHANNEL"
+          fi
+
+          case "$mode" in
+            dry-run|apply) ;;
+            *) echo "Invalid mode: $mode" >&2; exit 1 ;;
+          esac
+          case "$notify" in
+            true|false) ;;
+            *) echo "Invalid notify value: $notify" >&2; exit 1 ;;
+          esac
+          if [ "$notify" = 'true' ] && ! [[ "$slack_channel" =~ ^[CGD][A-Z0-9]{8,}$ ]]; then
+            echo 'Slack channel must be a channel ID, not a channel name.' >&2
+            exit 1
+          fi
+          echo "mode=$mode" >> "$GITHUB_OUTPUT"
+          echo "notify=$notify" >> "$GITHUB_OUTPUT"
+          echo "slack_channel=$slack_channel" >> "$GITHUB_OUTPUT"
+
+  start-thread:
+    needs: resolve-inputs
+    if: needs.resolve-inputs.outputs.notify == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      slack_channel: ${{ fromJSON(steps.post.outputs.response).channel }}
+      thread_ts: ${{ fromJSON(steps.post.outputs.response).ts }}
+    steps:
+      - id: post
+        name: Start the weekly on-call review thread
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          errors: true
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.resolve-inputs.outputs.slack_channel }}"
+            text: "Weekly frontend on-call review has started."
+            blocks:
+              - type: header
+                text:
+                  type: plain_text
+                  text: "Weekly frontend on-call review"
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "Dependency security and pending VLN PRs are being reviewed in this thread."
+              - type: context
+                elements:
+                  - type: mrkdwn
+                    text: "Mode: `${{ needs.resolve-inputs.outputs.mode }}` • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow run>"
+
+  dependency-security:
+    needs: [resolve-inputs, start-thread]
+    if: always() && needs.resolve-inputs.result == 'success'
+    uses: ./.github/workflows/weekly-dependency-security-review.yml
+    with:
+      mode: ${{ needs.resolve-inputs.outputs.mode }}
+      notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
+      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      TEMPORAL_CICD_APP_ID: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+      TEMPORAL_CICD_PRIVATE_KEY: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
+  vln-review:
+    needs: [resolve-inputs, start-thread]
+    if: always() && needs.resolve-inputs.result == 'success'
+    uses: ./.github/workflows/weekly-vln-review.yml
+    with:
+      notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
+      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  external-contributor-review:
+    needs: [resolve-inputs, start-thread]
+    if: always() && needs.resolve-inputs.result == 'success'
+    uses: ./.github/workflows/weekly-external-contributor-review.yml
+    with:
+      notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
+      slack_channel: ${{ needs.resolve-inputs.outputs.slack_channel }}
+      thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  finish-thread:
+    needs:
+      [
+        resolve-inputs,
+        start-thread,
+        dependency-security,
+        vln-review,
+        external-contributor-review,
+      ]
+    if: >-
+      always() &&
+      needs.resolve-inputs.outputs.notify == 'true' &&
+      needs.start-thread.outputs.thread_ts != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post module status
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          errors: true
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "${{ needs.start-thread.outputs.slack_channel }}"
+            thread_ts: "${{ needs.start-thread.outputs.thread_ts }}"
+            text: "Weekly review finished. Dependency security: ${{ needs.dependency-security.result }}. VLN review: ${{ needs.vln-review.result }}. External contributors: ${{ needs.external-contributor-review.result }}."

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -1,9 +1,6 @@
 name: Weekly On-Call Review
 
 on:
-  schedule:
-    # 10:00 Eastern during daylight saving time; runs in the morning on Mondays year-round.
-    - cron: '0 14 * * 1'
   workflow_dispatch:
     inputs:
       mode:
@@ -57,7 +54,7 @@ jobs:
           slack_channel="$REQUESTED_SLACK_CHANNEL"
 
           if [ "$EVENT_NAME" = 'schedule' ]; then
-            mode='apply'
+            mode='dry-run'
             notify='true'
             slack_channel="$SCHEDULED_SLACK_CHANNEL"
           fi

--- a/.github/workflows/weekly-vln-review.yml
+++ b/.github/workflows/weekly-vln-review.yml
@@ -45,7 +45,7 @@ jobs:
 
       - id: artifact
         name: Name the audit artifact
-        run: echo "name=weekly-vln-audit-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+        run: echo "name=weekly-vln-audit-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
 
       - name: Audit open VLN pull requests
         run: >-

--- a/.github/workflows/weekly-vln-review.yml
+++ b/.github/workflows/weekly-vln-review.yml
@@ -1,0 +1,128 @@
+name: Weekly VLN Review Module
+
+on:
+  workflow_call:
+    inputs:
+      notify:
+        required: true
+        type: boolean
+      slack_channel:
+        required: false
+        type: string
+      thread_ts:
+        required: false
+        type: string
+      source_ref:
+        description: 'Revision that contains the audit and digest source'
+        required: false
+        default: main
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        required: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      artifact_name: ${{ steps.artifact.outputs.name }}
+    # This job reads GitHub metadata only: no package installation, Slack, or
+    # GitHub App credential is available here.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout trusted audit source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - id: artifact
+        name: Name the audit artifact
+        run: echo "name=weekly-vln-audit-${{ github.run_id }}" >> "$GITHUB_OUTPUT"
+
+      - name: Audit open VLN pull requests
+        run: >-
+          node .github/scripts/weekly-dependency-security-audit.mjs
+          --scope vln-review
+          --output weekly-vln-audit.json
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      - name: Upload VLN audit evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.artifact.outputs.name }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: weekly-vln-audit.json
+
+  notify:
+    needs: audit
+    if: always() && inputs.notify && inputs.thread_ts != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted digest source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.source_ref }}
+          persist-credentials: false
+
+      - name: Download VLN audit evidence when available
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.audit.outputs.artifact_name }}
+          path: evidence
+
+      - id: payload
+        name: Build the threaded VLN reply
+        env:
+          AUDIT_RESULT: ${{ needs.audit.result }}
+          CHANNEL: ${{ inputs.slack_channel }}
+          THREAD_TS: ${{ inputs.thread_ts }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -f evidence/weekly-vln-audit.json ]; then
+            node .github/scripts/weekly-dependency-security-digest.mjs \
+              --module vln-review \
+              --channel "$CHANNEL" \
+              --thread-ts "$THREAD_TS" \
+              --input evidence/weekly-vln-audit.json \
+              --output weekly-vln-review-reply.json \
+              --run-url "$RUN_URL"
+          else
+            jq -n \
+              --arg channel "$CHANNEL" \
+              --arg thread_ts "$THREAD_TS" \
+              --arg audit_result "$AUDIT_RESULT" \
+              --arg run_url "$RUN_URL" \
+              '{channel: $channel, thread_ts: $thread_ts, text: ("VLN review did not produce evidence. Audit: " + $audit_result + ". " + $run_url)}' \
+              > weekly-vln-review-reply.json
+          fi
+          {
+            echo 'payload<<EOF'
+            cat weekly-vln-review-reply.json
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post VLN digest
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          errors: true
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: ${{ steps.payload.outputs.payload }}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "audit:tailwind": "esno scripts/audit-tailwind-colors",
     "validate:versions": "./scripts/validate-versions.sh",
     "knip": "knip",
-    "a11y:manifest:test": "node scripts/a11y/manifest.test.mjs"
+    "a11y:manifest:test": "node scripts/a11y/manifest.test.mjs",
+    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "validate:versions": "./scripts/validate-versions.sh",
     "knip": "knip",
     "a11y:manifest:test": "node scripts/a11y/manifest.test.mjs",
-    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/validate-claude-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
+    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/validate-claude-dependency-remediation.test.mjs .github/scripts/verify-weekly-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "validate:versions": "./scripts/validate-versions.sh",
     "knip": "knip",
     "a11y:manifest:test": "node scripts/a11y/manifest.test.mjs",
-    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
+    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/validate-claude-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",


### PR DESCRIPTION
## Description & motivation 💭

This branch makes the weekly dependency-security review a manual, dry-run-first on-call workflow. The later commits correct the planner, which did not act on any Dependabot alert before them.

Two credential boundaries hold the design together. Claude holds no credential and can edit one file. Only the second job holds a write token, and that job runs no package code.

```mermaid
flowchart TD
  subgraph J1["Job 1. Read-only token."]
    A["Audit the open Dependabot alerts"] --> B["Plan the remediation"]
    B --> C{"Action type"}
    C -->|npm| D["Claude edits package.json.<br/>Read and Edit only.<br/>No shell, no network."]
    D --> E["Byte-match gate.<br/>Reject anything the plan<br/>did not authorize."]
    E --> F["pnpm install --lockfile-only"]
    C -->|go| G["go get, then go mod tidy.<br/>The toolchain applies the change.<br/>No model reads a Go file."]
    F --> H{"Does every remediated<br/>alert close?"}
    G --> H
    H -->|no| X["Fail the run"]
    H -->|yes| I["Attest the file hashes"]
  end

  I --> J

  subgraph J2["Job 2. GitHub App token."]
    J{"Publish gate"}
    J -->|pass| K["Update one draft pull request"]
    J -->|fail| Y["Publish nothing"]
  end
```

Job 1 is the only job that installs or runs package code, and its token cannot write. Job 2 holds the write token and runs no package code. It receives the candidate files with their hashes, checks each hash again, and stages only the four approved files.

## The defect

`ROOT_MANIFEST` held the value `/package.json`. GitHub never sends that path. Every alert therefore classified as unsupported.

The path values across all 321 alerts in this repository:

| value | count |
| -- | -- |
| `pnpm-lock.yaml` | 254 |
| `server/go.mod` | 33 |
| `package.json` | 26 |
| `package-lock.json` | 3 |
| `e2e/go.mod`, `e2e/go.sum` | 4 |
| `server/go.sum` | 1 |
| `/package.json` | 0 |

The test suite passed because its fixture held the same wrong value. The tests checked the code against itself.

## What the planner now does

- It accepts the manifest paths GitHub sends, for npm and for Go.
- It matches an override selector that carries a version range. The earlier code split the selector on `>`, which also occurs in `>=`. 12 of the 36 selectors in this repository did not match. That fault also disabled the guard that refuses a direct bump which an override would supersede.
- It raises a compound override range and keeps the upper bound. The earlier code refused these ranges. A raise without this care produced `>=7.1.0 <7`, which no version satisfies.
- It reads `pnpm-lock.yaml` and reports the resolved version of each package. A new `alreadySafe` status covers a package that the advisory no longer reaches. The planner refuses a direct bump when the lockfile holds a copy that the bump cannot reach.
- It remediates Go modules in `server/go.mod`. A Go major version belongs to the module path, so the planner refuses a change of major version. It also refuses a pseudo-version, because two pseudo-versions do not compare as releases.

## Proof that a remediation closes its alert

A new script reads `pnpm-lock.yaml` and `server/go.mod` after the install. It compares each resolved version against the advisory range of every alert the plan remediated. The run fails when a copy stays inside the range, and it fails when the file no longer holds the package. The script writes the resolved version into the report.

The publish gate then requires that proof. It requires Claude authorship only for the npm actions, so the Go path does not need a claim that no model made:

```text
publish when
  the report says verification passed
  and the plan holds at least one action
  and if the plan holds an npm action
        Claude authored it and the byte-match gate accepted it
```

## Live result

The five open alerts produce one authorized action:

```
safe    protobufjs      alerts [338,300,299]  resolved 7.5.8   raise override to ^7.6.5
manual  @grpc/grpc-js   alerts [295,294]      resolved 1.14.3  no override exists
```

The two `@grpc/grpc-js` alerts need a new override. That work is out of scope here. See UI-139.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

77 tests pass through `pnpm test:github-automation`. Prettier and ESLint report no problem. Both workflow files parse.

A local rehearsal covers the full path for both ecosystems against the live alert data.

npm:

1. The plan authorized one action.
2. The byte-match gate accepted the manifest and set `changed=true`, `applied=true`, and `resolver=claude-code`.
3. `pnpm install --lockfile-only --ignore-scripts` resolved protobufjs to 7.6.5.
4. Verification passed and recorded the resolved version for each of the three alerts.
5. The publish gate returned true.

Go:

1. A stale `server/go.mod` held `v0.51.0` and `v1.79.3`.
2. `go get` and `go mod tidy` moved both modules to `v0.52.0` and `v1.82.1`. Those versions match the versions the team chose by hand in 506d4f72c. The net difference is zero.
3. Verification passed for all five alerts.

The publish gate was checked directly with jq across nine cases:

| case | result |
| -- | -- |
| npm only, Claude authored, verified | publish |
| npm only, not Claude authored | block |
| npm only, wrong resolver | block |
| go only, verified | publish |
| go only, not verified | block |
| mixed, Claude authored, verified | publish |
| mixed, not Claude authored | block |
| no action | block |
| no verification block | block |

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Run the rehearsal. Open Actions, select **Weekly On-Call Review PR Test**, select **Run workflow** on this branch, and set the mode to `apply`.

The rehearsal sets the new `publish` input to false, so the job that holds the GitHub App token does not run and no pull request is touched. The publish job also refuses a pull request event, so the rehearsal has two independent guards.

## Checklists

### Merge Checklist

- [ ] Run the apply-mode rehearsal on this branch. Three items need a real run: the Claude action itself, `pnpm install --frozen-lockfile --ignore-scripts` followed by the tests and the build, and the artifact transfer of `server/go.mod` to the publish job.
- [ ] Confirm that the install without lifecycle scripts still builds. `onlyBuiltDependencies` names `esbuild`, `@swc/core`, and `@temporalio/core-bridge`, and the install skips all three.

### Issue(s) closed

UI-132, UI-133, UI-134, UI-136. UI-135 stays open for the digest work.

## Docs

### Any docs updates needed?

`.github/WORKFLOWS.md` describes the release workflows only. It does not describe the weekly review. A separate change should add that section.
