### PR TITLE
Add back resetHeartbeat option to Standalone Activity reset

### DIFF
--- a/src/lib/components/activity/activity-reset-confirmation-modal.svelte
+++ b/src/lib/components/activity/activity-reset-confirmation-modal.svelte
@@ -7,16 +7,10 @@
   type Props = {
     open: boolean;
     activityId: string;
-    hideResetHeartbeatOption?: boolean;
     onConfirm: (resetHeartbeat: boolean) => Promise<void>;
   };
 
-  let {
-    hideResetHeartbeatOption = false,
-    open = $bindable(),
-    activityId,
-    onConfirm,
-  }: Props = $props();
+  let { open = $bindable(), activityId, onConfirm }: Props = $props();
 
   let error = $state('');
   let loading = $state(false);
@@ -65,13 +59,11 @@
   {#snippet content()}
     <div class="flex flex-col gap-4">
       <p>{translate('activities.reset-modal-description')}</p>
-      {#if !hideResetHeartbeatOption}
-        <Checkbox
-          bind:checked={resetHeartbeat}
-          label={translate('activities.reset-heartbeat-details')}
-          data-testid="reset-heartbeat-details"
-        />
-      {/if}
+      <Checkbox
+        bind:checked={resetHeartbeat}
+        label={translate('activities.reset-heartbeat-details')}
+        data-testid="reset-heartbeat-details"
+      />
     </div>
   {/snippet}
 </Modal>

--- a/src/lib/components/standalone-activities/activity-actions.svelte
+++ b/src/lib/components/standalone-activities/activity-actions.svelte
@@ -209,7 +209,6 @@
     bind:open={resetConfirmationModalOpen}
     {activityId}
     onConfirm={onConfirmReset}
-    hideResetHeartbeatOption // TODO: remove once API supports resetHeartbeat
   />
   {#key optionsUpdateDrawerOpen}
     <ActivityOptionsUpdateDrawer

--- a/src/lib/services/standalone-activities.ts
+++ b/src/lib/services/standalone-activities.ts
@@ -544,8 +544,7 @@ export const resetActivityExecution = async (
         namespace,
         activityId,
         runId,
-        // TODO: re-enable once API supports resetHeartbeat
-        // resetHeartbeat,
+        ...(resetHeartbeat && { resetHeartbeat }),
         ...(identity && { identity }),
       }),
     },


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Add back `resetHeartbeat` field to `ResetActivityExecutionRequest` for Standalone Activities. 


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
