### PR TITLE
fix(a11y): give icon-only buttons an accessible name

### DIFF
--- a/src/lib/components/bottom-nav.svelte
+++ b/src/lib/components/bottom-nav.svelte
@@ -216,6 +216,7 @@
           size="xs"
           href={routeForNamespace({ namespace })}
           disabled={!namespaceExists}
+          aria-label={translate('namespaces.go-to-namespace')}
           ><Icon class="text-white" name="external-link" /></Button
         >
       </div>

--- a/src/lib/components/event/event-shortcut-keys.svelte
+++ b/src/lib/components/event/event-shortcut-keys.svelte
@@ -20,6 +20,7 @@
     variant="secondary"
     leadingIcon="keyboard"
     onclick={onOpen}
+    aria-label={translate('common.keyboard-shortcuts')}
   />
 </div>
 <Drawer

--- a/src/lib/components/search-attribute-filter/filter-bar.svelte
+++ b/src/lib/components/search-attribute-filter/filter-bar.svelte
@@ -73,6 +73,7 @@
           leadingIcon="json"
           active={viewManualQuery}
           data-testid="toggle-manual-query"
+          aria-label={viewManualQuery ? 'Hide raw query' : 'View raw query'}
           onclick={() => (viewManualQuery = !viewManualQuery)}
         />
       </Tooltip>

--- a/src/lib/components/search-attributes-form/search-attribute-row.svelte
+++ b/src/lib/components/search-attributes-form/search-attribute-row.svelte
@@ -93,6 +93,7 @@
       onclick={onRemove}
       disabled={submitting}
       leadingIcon="close"
+      aria-label={translate('search-attributes.remove-attribute-button')}
       class="rounded-full"
     />
   {:else if isDeletable}
@@ -107,6 +108,7 @@
         onclick={onRemove}
         disabled={submitting || isCloud}
         leadingIcon="trash"
+        aria-label={translate('search-attributes.delete-attribute-button')}
       />
     </Tooltip>
   {/if}

--- a/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
+++ b/src/lib/components/standalone-nexus-operations/nexus-operations-summary-configurable-table.svelte
@@ -86,6 +86,7 @@
           data-testid="nexus-operations-summary-table-configuration-button"
           size="xs"
           variant="ghost"
+          aria-label={translate('common.configure-columns')}
         >
           <Icon name="settings" />
         </Button>

--- a/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
+++ b/src/lib/components/standalone-nexus-operations/start-standalone-nexus-operation-form/form.svelte
@@ -589,6 +589,9 @@
               type="button"
               variant="ghost"
               leadingIcon="close"
+              aria-label={translate(
+                'standalone-nexus-operations.form-remove-nexus-header',
+              )}
               onclick={() => removeNexusHeader(index)}
             />
           </div>

--- a/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
+++ b/src/lib/components/workflow/client-actions/update-confirmation-modal.svelte
@@ -158,6 +158,7 @@
               }}
               variant="secondary"
               leadingIcon="close"
+              aria-label={translate('workflows.clear-custom-update-name')}
               disabled={loading}
             />
           {/if}

--- a/src/lib/components/workflow/search-attribute-input/index.svelte
+++ b/src/lib/components/workflow/search-attribute-input/index.svelte
@@ -88,6 +88,9 @@
       leadingIcon="close"
       data-testid="search-attribute-close-button"
       class="mt-6 w-10 rounded-full sm:hidden"
+      aria-label={translate('workflows.remove-filter-label', {
+        attribute: label,
+      })}
       onclick={() => onRemove(label)}
     />
   </div>
@@ -145,6 +148,9 @@
     leadingIcon="close"
     data-testid="search-attribute-close-button"
     class="mt-6 w-10 rounded-full max-sm:hidden"
+    aria-label={translate('workflows.remove-filter-label', {
+      attribute: label,
+    })}
     onclick={() => onRemove(label)}
   />
 </div>

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -604,6 +604,7 @@
                 {href}
                 disabled={hrefDisabled}
                 leadingIcon="external-link"
+                aria-label={actionTooltip}
               />
             </Tooltip>
           {:else}
@@ -613,6 +614,7 @@
               {href}
               disabled={hrefDisabled}
               leadingIcon="external-link"
+              aria-label={translate('common.view-label', { label })}
             />
           {/if}
         </div>

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -91,6 +91,7 @@ export const Strings = {
   delete: 'Delete',
   discard: 'Discard',
   view: 'View',
+  'view-label': 'View {{label}}',
   memo: 'Memo',
   notes: 'Notes',
   news: 'Temporal News',

--- a/src/lib/i18n/locales/en/search-attributes.ts
+++ b/src/lib/i18n/locales/en/search-attributes.ts
@@ -17,6 +17,8 @@ export const Strings = {
 
   // Buttons
   'add-attribute-button': 'Add New Custom Search Attribute',
+  'remove-attribute-button': 'Remove Custom Search Attribute',
+  'delete-attribute-button': 'Delete Custom Search Attribute',
   'save-button': 'Save',
   'saving-button': 'Saving...',
   'cancel-button': 'Cancel',

--- a/src/lib/i18n/locales/en/standalone-nexus-operations.ts
+++ b/src/lib/i18n/locales/en/standalone-nexus-operations.ts
@@ -135,6 +135,7 @@ export const Strings = {
   'form-nexus-header-key-placeholder': 'Key',
   'form-nexus-header-value-placeholder': 'Value',
   'form-add-nexus-header': 'Add Header',
+  'form-remove-nexus-header': 'Remove Header',
   'form-search-attributes-heading': 'Search Attributes',
   'form-search-attributes-description':
     'Custom fields used to filter Nexus Operations in tables and lists.',

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -120,6 +120,7 @@ export const Strings = {
   'signal-payload-input-label': 'Data',
   'signal-payload-input-label-hint': 'Single JSON payload supported.',
   'update-modal-title': 'Send an Update',
+  'clear-custom-update-name': 'Clear custom Update name',
   'cancel-request-sent': 'Cancel Request Sent',
   'cancel-request-sent-description':
     "The request to cancel this Workflow Execution has been sent. If the Workflow uses the cancellation API, it'll cancel at the next available opportunity.",

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -130,6 +130,7 @@
             data-testid="deployments-table-configuration-button"
             size="xs"
             variant="ghost"
+            aria-label={translate('common.configure-columns')}
           >
             <Icon name="settings" />
           </Button>


### PR DESCRIPTION
## Description & motivation 💭

Thirteen icon-only buttons had no accessible name, so screen readers announced them as an unnamed "button" with no indication of what they do. Each now carries an `aria-label`.

- Reuses existing keys where one already matched the visible text: `common.keyboard-shortcuts`, `common.configure-columns` (both configure buttons already sat inside a "Configure Columns" tooltip), `namespaces.go-to-namespace`, and `workflows.remove-filter-label` parameterized with the attribute name
- Adds five keys for labels with no existing equivalent: `search-attributes.remove-attribute-button`, `search-attributes.delete-attribute-button`, `standalone-nexus-operations.form-remove-nexus-header`, `workflows.clear-custom-update-name`, `common.view-label`
- `combobox` reuses the caller's `actionTooltip` for its link button when one is supplied, falling back to `common.view-label` when it isn't
- `filter-bar` mirrors its own conditional tooltip text as a plain string; that file has no i18n import and its tooltip is already untranslated

No behaviour or layout changes — additive attributes and i18n keys only.

### Screenshots (if applicable) 📸

n/a, nothing visual changes.

### Design Considerations 🎨

The five new strings could use a copy review.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

A script that parses every `<Button>` in `src/`, identifies the icon-only ones and checks for an accessible name reports zero remaining. `pnpm lint` passes and the unit suite is unchanged at 2614 passing. Not yet checked with a real screen reader.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Focus each button and confirm it announces a name rather than just "button":

- event history keyboard-shortcuts toggle
- Workflows filter bar raw-query toggle
- Deployments and Nexus Operations "Configure Columns"
- custom search attributes rows (remove and delete)
- search attribute filter remove, mobile and desktop
- Send an Update modal, custom-name clear
- Start Nexus Operation form, remove header row
- bottom nav namespace external link
- combobox link button

## Checklists

### Draft Checklist

- [ ] Copy review on the five new strings
- [ ] Verify with a screen reader
- [ ] Confirm whether this closes `4.1.2-button-anchor-empty` and add the `A11y-Audit-Ref:` trailer if it does

### Merge Checklist

### Issue(s) closed

## Docs

### Any docs updates needed?

No.
