### PR TITLE
Raise version bump to minor when go.temporal.io/api is upgraded

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -65,6 +65,60 @@ jobs:
           echo "last-tag=$LAST_TAG" >> $GITHUB_OUTPUT
           echo "Last version tag: $LAST_TAG"
 
+      - name: Check for go.temporal.io/api upgrade
+        id: check-api-upgrade
+        if: inputs.mode == 'auto' || inputs.mode == 'dry-run'
+        env:
+          LAST_TAG: ${{ steps.last-tag.outputs.last-tag }}
+        run: |
+          api_version() {
+            awk '$1 == "go.temporal.io/api" { print $2; exit }'
+          }
+
+          # v1.63.5, v1.64.0-rc1 and v1.63.5-0.20240101-abc all reduce to "1 63 5"
+          version_core() {
+            printf '%s' "${1#v}" | sed -E 's/[-+].*$//' | tr '.' ' '
+          }
+
+          # Succeeds when $2 is a higher version than $1
+          is_upgrade() {
+            local -a previous current
+            read -r -a previous <<<"$(version_core "$1")"
+            read -r -a current <<<"$(version_core "$2")"
+            local i p c
+            for i in 0 1 2; do
+              p=${previous[$i]:-0}
+              c=${current[$i]:-0}
+              [[ "$p" =~ ^[0-9]+$ ]] || p=0
+              [[ "$c" =~ ^[0-9]+$ ]] || c=0
+              (( c > p )) && return 0
+              (( c < p )) && return 1
+            done
+            return 1
+          }
+
+          CURRENT=$(api_version < server/go.mod)
+          if [[ -z "$CURRENT" ]]; then
+            echo "⚠️ No go.temporal.io/api require found in server/go.mod, skipping check"
+          fi
+
+          if PREVIOUS_MOD=$(git show "$LAST_TAG:server/go.mod" 2>/dev/null); then
+            PREVIOUS=$(printf '%s\n' "$PREVIOUS_MOD" | api_version)
+            if [[ -z "$PREVIOUS" ]]; then
+              echo "⚠️ No go.temporal.io/api require found in server/go.mod at $LAST_TAG, skipping check"
+            fi
+          else
+            PREVIOUS=""
+            echo "⚠️ Could not read server/go.mod at $LAST_TAG"
+          fi
+
+          if [[ -n "$PREVIOUS" && -n "$CURRENT" ]] && is_upgrade "$PREVIOUS" "$CURRENT"; then
+            echo "✨ go.temporal.io/api upgraded from $PREVIOUS to $CURRENT since $LAST_TAG"
+            echo "upgraded=true" >> $GITHUB_OUTPUT
+          else
+            echo "upgraded=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Analyze merged PRs since last version
         id: analyze-prs
         if: inputs.mode == 'auto' || inputs.mode == 'dry-run'
@@ -72,6 +126,23 @@ jobs:
         with:
           from-ref: ${{ steps.last-tag.outputs.last-tag }}
           to-ref: HEAD
+
+      - name: Resolve bump type
+        id: resolve-bump
+        if: inputs.mode == 'auto' || inputs.mode == 'dry-run'
+        env:
+          ANALYZED_BUMP_TYPE: ${{ steps.analyze-prs.outputs.bump-type }}
+          API_UPGRADED: ${{ steps.check-api-upgrade.outputs.upgraded }}
+        run: |
+          BUMP_TYPE="$ANALYZED_BUMP_TYPE"
+
+          if [[ "$API_UPGRADED" == "true" && "$BUMP_TYPE" == "patch" ]]; then
+            echo "⬆️ go.temporal.io/api was upgraded, raising patch to minor"
+            BUMP_TYPE="minor"
+          fi
+
+          echo "Resolved bump type: $BUMP_TYPE (from commits: $ANALYZED_BUMP_TYPE)"
+          echo "bump-type=$BUMP_TYPE" >> $GITHUB_OUTPUT
 
       - name: Get HEAD SHA for changelog
         id: get-head-sha
@@ -93,7 +164,7 @@ jobs:
         uses: temporalio/pack-dependency-actions/calculate-semantic-version@bf23e855ebebec9a0be45eff67c88a4189210c55 # v1.5.0
         with:
           current-version: ${{ steps.validate-sync.outputs.current-version }}
-          bump-type: ${{ inputs.mode == 'manual' && inputs.version_type || steps.analyze-prs.outputs.bump-type }}
+          bump-type: ${{ inputs.mode == 'manual' && inputs.version_type || steps.resolve-bump.outputs.bump-type }}
           specific-version: ${{ inputs.specific_version }}
 
       - name: Dry run summary
@@ -103,7 +174,8 @@ jobs:
           NEW_VERSION: ${{ steps.calculate-version.outputs.new-version }}
           SPECIFIC_VERSION: ${{ inputs.specific_version }}
           INPUT_MODE: ${{ inputs.mode }}
-          BUMP_TYPE: ${{ steps.analyze-prs.outputs.bump-type }}
+          BUMP_TYPE: ${{ steps.resolve-bump.outputs.bump-type }}
+          API_UPGRADED: ${{ steps.check-api-upgrade.outputs.upgraded }}
           VERSION_CHANGED: ${{ steps.calculate-version.outputs.version-changed }}
           CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
         run: |
@@ -121,6 +193,9 @@ jobs:
             fi
             echo "**Version Source:** $VERSION_SOURCE"
             echo "**Bump Type:** $BUMP_TYPE"
+            if [[ "$API_UPGRADED" == "true" ]]; then
+              echo "**go.temporal.io/api:** upgraded since last version (minimum minor)"
+            fi
           fi
           echo "**Version Changed:** $VERSION_CHANGED"
           echo ""
@@ -164,7 +239,8 @@ jobs:
 
             Auto-generated version bump from ${{ steps.validate-sync.outputs.current-version }} to ${{ steps.calculate-version.outputs.new-version }}
 
-            ${{ inputs.specific_version && format('Specific version: {0}', inputs.specific_version) || format('Bump type: {0}', inputs.mode == 'manual' && inputs.version_type || steps.analyze-prs.outputs.bump-type) }}
+            ${{ inputs.specific_version && format('Specific version: {0}', inputs.specific_version) || format('Bump type: {0}', inputs.mode == 'manual' && inputs.version_type || steps.resolve-bump.outputs.bump-type) }}
+            ${{ steps.check-api-upgrade.outputs.upgraded == 'true' && 'go.temporal.io/api: upgraded since last version (minimum minor)' || '' }}
 
             Changes included:
             ${{ steps.generate-changelog.outputs.changelog || 'No commits since last version' }}
@@ -179,7 +255,8 @@ jobs:
             - `server/server/version/version.go`
 
             ### 📝 Bump Details
-            ${{ inputs.specific_version && format('- **Version Source:** Specific version override\n- **Specified Version:** {0}', inputs.specific_version) || format('- **Bump Type:** {0}', inputs.mode == 'manual' && inputs.version_type || steps.analyze-prs.outputs.bump-type) }}
+            ${{ inputs.specific_version && format('- **Version Source:** Specific version override\n- **Specified Version:** {0}', inputs.specific_version) || format('- **Bump Type:** {0}', inputs.mode == 'manual' && inputs.version_type || steps.resolve-bump.outputs.bump-type) }}
+            ${{ steps.check-api-upgrade.outputs.upgraded == 'true' && '- **go.temporal.io/api:** upgraded since last version (minimum minor)' || '' }}
             - **Mode:** ${{ inputs.mode }}
 
             ### 📖 Changes Since Last Version


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

The Version Bump workflow decides `major`/`minor`/`patch` by grepping commit subjects since the last tag (via `analyze-commits-for-bump`). A release that picks up a new `go.temporal.io/api` typically lands as `fix:`/`chore:`/`deps:` commits, so it was shipping as a **patch** even though the server's API surface changed.

This adds a rule: if `go.temporal.io/api` in `server/go.mod` has been **upgraded** since the last version tag, the bump is at minimum `minor`.

- **`check-api-bump`** — reads the `go.temporal.io/api` version out of `server/go.mod` at `HEAD` and at the last tag, and outputs `bumped=true` only when the version went **up**. It compares `major.minor.patch` numerically rather than diffing lines, so reformatting the require block or reordering deps can't trigger a false positive, and `1.63.10 > 1.63.5` compares correctly.
- **`resolve-bump`** — raises the floor rather than overriding: `patch` → `minor` when the api was upgraded; `minor` and `major` pass through untouched.

`calculate-version` now consumes `resolve-bump`'s output, and the dry-run summary, commit message, and PR body all report the resolved type plus a `go.temporal.io/api: upgraded since last version (minimum minor)` note, so a reviewer can tell a `minor` came from the dependency rather than a misclassifiedcommit.

- **`manual` mode is untouched** — an explicit `version_type` choice always wins.
- **Downgrades don't count.** A patch-level bump or higher does.
- **Only `server/go.mod`** is inspected (the other `go.mod` files under `server/proto/dependencies/api/` aren't part of a tagged release).
- Every path that disables the check logs a warning, so a silent no-op (e.g. if the module path ever becomes `go.temporal.io/api/v2`) is visible in the run log.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
