### PR TITLE
Get total slots based on available plus used

### DIFF
--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -309,8 +309,8 @@
               {:else}
                 {slots?.currentUsedSlots ?? 0}
               {/if}
-            </span>{#if slots?.currentAvailableSlots}
-              /{slots.currentAvailableSlots - (slots?.currentUsedSlots ?? 0)}
+            </span>{#if slots?.currentAvailableSlots && slots.currentAvailableSlots >= 0}
+              /{slots.currentAvailableSlots + (slots?.currentUsedSlots ?? 0)}
             {/if}
           </p>
           {#if slots?.slotSupplierKind}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

This PR adds `current_available_slots` + `current_used_slots` to get the true total number of slots available and adds a check for a value greater or equal to zero since
* [current_available_slots](https://github.com/temporalio/api/blob/78685101cb085ecb6588cbdfc8d0028b0ad0fb0a/temporal/api/worker/v1/message.proto#L30) are the number of slots **left** that are available (not the total number of slots available)
* [the value can be -1](https://github.com/temporalio/api/blob/78685101cb085ecb6588cbdfc8d0028b0ad0fb0a/temporal/api/worker/v1/message.proto#L29)

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
