### PR TITLE
fix(timezone): use regular font weight for the timezone switcher

### DIFF
--- a/src/lib/components/timezone-select.svelte
+++ b/src/lib/components/timezone-select.svelte
@@ -129,7 +129,7 @@
 
 <MenuContainer
   {open}
-  class="text-sm font-medium text-primary max-md:w-full max-md:justify-items-end"
+  class="text-sm text-primary max-md:w-full max-md:justify-items-end"
 >
   <MenuButton
     label={translate('common.timezone', { timezone })}


### PR DESCRIPTION
## Description & motivation 💭

The timezone switcher in the top nav rendered its label at **medium** weight. This drops it to **regular**, matching the treatment [cloud-ui#3109](https://github.com/temporalio/cloud-ui/pull/3109) landed for the project and namespace switchers, and matching the Invite button in the cloud-ui top nav.

```diff
 <MenuContainer
   {open}
-  class="text-sm font-medium text-primary max-md:w-full max-md:justify-items-end"
+  class="text-sm text-primary max-md:w-full max-md:justify-items-end"
 >
```


Measured computed weights in the running app:

| Element | Before | After |
| --- | --- | --- |
| Trigger label (`local`) | 500 | **400** |
| Menu items (UTC / Local / timezone list) | 500 | **400** |
| `Timestamp Format` / `Hour Format` | 500 | 500 (unchanged) |

### Screenshots (if applicable) 📸

| Before | After |
| --- | --- | 
|  <img width="462" height="373" alt="Screenshot 2026-08-18 at 10 27 49 AM" src="https://github.com/user-attachments/assets/e1e64968-eb08-4431-bff1-df1344499776" /> | <img width="462" height="374" alt="Screenshot 2026-08-18 at 10 59 32 AM" src="https://github.com/user-attachments/assets/20186b73-0087-420c-89fa-5519aa79ffe7" />  |