### PR TITLE
[UI-104] Build a revision-bound Promote contract

### DIFF
--- a/scripts/catalog/ui-authoring.test.ts
+++ b/scripts/catalog/ui-authoring.test.ts
@@ -69,6 +69,84 @@ afterEach(async () => {
 });
 
 describe('UI catalog authoring adapter', () => {
+  it('previews the exact repository effects without mutating or reserving the example', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    await authoring.scaffold('preview-effects');
+
+    const preview = await authoring.previewPromote({
+      exampleId: 'preview-effects',
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+
+    expect(preview).toEqual({
+      authoredSource: 'catalog.local/examples/preview-effects',
+      destination: {
+        id: 'oss',
+        path: 'src/lib/catalog/worker/examples/preview-effects',
+      },
+      exampleId: 'preview-effects',
+      generatedOutputs: [
+        { gitEffect: 'ignored-update', path: 'catalog.local/registration.ts' },
+        { gitEffect: 'ignored-update', path: 'catalog.local/workflows.ts' },
+        {
+          gitEffect: 'ignored-update',
+          path: 'catalog.local/catalog.generated.json',
+        },
+        {
+          gitEffect: 'tracked-update',
+          path: 'src/lib/catalog/worker/examples/index.ts',
+        },
+        {
+          gitEffect: 'tracked-update',
+          path: 'src/lib/catalog/worker/workflows.ts',
+        },
+        {
+          gitEffect: 'tracked-update',
+          path: 'src/lib/catalog/browser/catalog.generated.json',
+        },
+        {
+          gitEffect: 'tracked-update',
+          path: 'src/lib/catalog/browser/catalog.generated.ts',
+        },
+      ],
+      gitEffects: {
+        destination: 'tracked-addition',
+        source: 'ignored-removal',
+      },
+      revision: expect.any(String),
+      source: {
+        id: 'local',
+        path: 'catalog.local/examples/preview-effects',
+      },
+      status: 'available',
+    });
+    expect(preview.status === 'available' && preview.revision).not.toContain(
+      rootDirectory,
+    );
+    await expect(
+      readFile(
+        join(
+          rootDirectory,
+          'catalog.local/examples/preview-effects/example.ts',
+        ),
+        'utf8',
+      ),
+    ).resolves.toContain("id: 'preview-effects'");
+    await expect(
+      readFile(join(rootDirectory, '.catalog.lock'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readFile(
+        join(
+          rootDirectory,
+          'src/lib/catalog/worker/examples/preview-effects/example.ts',
+        ),
+        'utf8',
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('regenerates and verifies the canonical UI catalog', async () => {
     const rootDirectory = await createIsolatedCatalogRoot();
     const authoring = createUiCatalogAuthoring(rootDirectory);

--- a/scripts/catalog/ui-authoring.ts
+++ b/scripts/catalog/ui-authoring.ts
@@ -124,6 +124,21 @@ export const createUiCatalogAuthoring = (rootDirectory = getProjectRoot()) => {
       ],
     },
     rootDirectory,
+    describePromotion: ({ from, to }) => ({
+      authoredSource: from,
+      destination: { id: 'oss', path: to },
+      generatedOutputs: uiCatalogGeneratedPaths.map((path) => ({
+        gitEffect: path.startsWith('catalog.local/')
+          ? ('ignored-update' as const)
+          : ('tracked-update' as const),
+        path,
+      })),
+      gitEffects: {
+        destination: 'tracked-addition',
+        source: 'ignored-removal',
+      },
+      source: { id: 'local', path: from },
+    }),
     parseModuleSpecifiers: parseCatalogTypeScriptModuleSpecifiers,
     localExamplesPath: 'catalog.local/examples',
     trackedExamplesPath: 'src/lib/catalog/worker/examples',

--- a/src/lib/catalog/authoring.test.ts
+++ b/src/lib/catalog/authoring.test.ts
@@ -6,8 +6,10 @@ import {
   readdir,
   readFile,
   realpath,
+  rename,
   rm,
   symlink,
+  unlink,
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -22,6 +24,7 @@ import {
   composeCatalogArtifacts,
   createCatalogAuthoring as createCatalogAuthoringSdk,
   createCatalogLocalArtifactVitePlugin,
+  createCatalogMutationRevision,
   defineCatalogArtifact,
   renderCatalogSourceAssembly,
   runCatalogCli,
@@ -36,12 +39,12 @@ const temporaryDirectories: string[] = [];
 const createCatalogAuthoring = (
   adapter: Omit<
     CatalogAuthoringAdapter,
-    'graph' | 'loadExamples' | 'parseModuleSpecifiers'
+    'describePromotion' | 'graph' | 'loadExamples' | 'parseModuleSpecifiers'
   > &
     Partial<
       Pick<
         CatalogAuthoringAdapter,
-        'graph' | 'loadExamples' | 'parseModuleSpecifiers'
+        'describePromotion' | 'graph' | 'loadExamples' | 'parseModuleSpecifiers'
       >
     >,
 ) => {
@@ -52,6 +55,19 @@ const createCatalogAuthoring = (
     '.catalog-test/tracked-workflows.ts',
   ];
   return createCatalogAuthoringSdk({
+    describePromotion: ({ from, to }) => ({
+      authoredSource: from,
+      destination: { id: 'tracked', path: to },
+      generatedOutputs: adapter.generatedPaths.map((path) => ({
+        gitEffect: 'tracked-update' as const,
+        path,
+      })),
+      gitEffects: {
+        destination: 'tracked-addition' as const,
+        source: 'ignored-removal' as const,
+      },
+      source: { id: 'local', path: from },
+    }),
     graph: {
       boundaries: {
         browserPaths: [],
@@ -115,6 +131,1262 @@ afterEach(async () => {
 });
 
 describe('catalog authoring', () => {
+  it('confirms a saved Local promotion with the same result as Promote', async () => {
+    const createPromotionFixture = async () => {
+      const rootDirectory = await createTemporaryDirectory();
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths: ['generated/catalog.json'],
+        scaffold: ({ exampleId }) => [
+          {
+            path: `local/examples/${exampleId}/example.ts`,
+            content: 'export const example = true;\n',
+          },
+        ],
+        generate: async () => {
+          const tracked = await readdir(
+            join(rootDirectory, 'tracked/examples'),
+          ).catch(() => []);
+          return [
+            {
+              path: 'generated/catalog.json',
+              content: `${JSON.stringify(tracked.sort())}\n`,
+            },
+          ];
+        },
+      });
+      await authoring.scaffold('saved-example');
+      return { authoring, rootDirectory };
+    };
+    const confirmedFixture = await createPromotionFixture();
+    const directFixture = await createPromotionFixture();
+
+    const preview = await confirmedFixture.authoring.previewPromote({
+      exampleId: 'saved-example',
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    expect(preview.status).toBe('available');
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+    const confirmed = await confirmedFixture.authoring.confirmPromote({
+      exampleId: 'saved-example',
+      revision: preview.revision,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    const direct = await directFixture.authoring.promote('saved-example');
+
+    expect(confirmed).toEqual({
+      commit: 'durable',
+      direction: 'promote',
+      result: direct,
+      status: 'succeeded',
+    });
+    await expect(
+      readFile(
+        join(confirmedFixture.rootDirectory, 'generated/catalog.json'),
+        'utf8',
+      ),
+    ).resolves.toBe(
+      await readFile(
+        join(directFixture.rootDirectory, 'generated/catalog.json'),
+        'utf8',
+      ),
+    );
+  });
+
+  it('makes Promote available only for a durable Save and explains each unavailable state', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const localExample = join(rootDirectory, 'local/examples/save-state');
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    await expect(
+      authoring.previewPromote({
+        exampleId: 'save-state',
+        saveState: { status: 'dirty' },
+      }),
+    ).resolves.toEqual({ reason: 'unsaved-changes', status: 'unavailable' });
+    await expect(
+      authoring.previewPromote({
+        exampleId: 'save-state',
+        saveState: { status: 'stale' },
+      }),
+    ).resolves.toEqual({
+      reason: 'saved-revision-stale',
+      status: 'unavailable',
+    });
+    await expect(
+      authoring.previewPromote({
+        exampleId: 'save-state',
+        saveState: { status: 'failed' },
+      }),
+    ).resolves.toEqual({ reason: 'save-failed', status: 'unavailable' });
+    await expect(
+      authoring.previewPromote({
+        exampleId: 'save-state',
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({ status: 'available' });
+  });
+
+  it('keeps legacy adapters usable when promotion preview effects are not configured', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const legacyAdapter = {
+      generatedPaths: [],
+      generate: () => [],
+      graph: {
+        boundaries: {
+          browserPaths: [],
+          packageJsonPath: 'package.json',
+          workerPaths: [],
+        },
+        outputs: [],
+        sources: [],
+        targets: [],
+      },
+      loadExamples: () => [],
+      localExamplesPath: 'local/examples',
+      parseModuleSpecifiers: () => [],
+      rootDirectory,
+      scaffold: () => [],
+      trackedExamplesPath: 'tracked/examples',
+    } satisfies CatalogAuthoringAdapter;
+    const authoring = createCatalogAuthoringSdk(legacyAdapter);
+
+    await expect(
+      authoring.previewPromote({
+        exampleId: 'legacy-adapter',
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      reason: 'preview-not-supported',
+      status: 'unavailable',
+    });
+    await expect(authoring.verify()).resolves.toBeUndefined();
+  });
+
+  it('changes its deterministic opaque revision for every source and destination change', async () => {
+    const revision = (
+      overrides: {
+        destination?: {
+          contentHash?: string;
+          entries?: {
+            contentHash: string;
+            mode: number;
+            path: string;
+            type: 'directory' | 'file';
+          }[];
+          mode?: number;
+          path?: string;
+          state: 'absent' | 'directory' | 'file';
+        };
+        source?: {
+          contentHash: string;
+          mode: number;
+          path: string;
+          type: 'directory' | 'file';
+        }[];
+        sourceRoot?: { identity: string; mode: number; path: string };
+      } = {},
+    ) =>
+      createCatalogMutationRevision({
+        destination: overrides.destination
+          ? { path: '/repo/tracked/example', ...overrides.destination }
+          : { path: '/repo/tracked/example', state: 'absent' },
+        source: overrides.source ?? [
+          {
+            contentHash: 'first',
+            mode: 0o644,
+            path: 'example.ts',
+            type: 'file',
+          },
+        ],
+        sourceRoot: overrides.sourceRoot ?? {
+          identity: 'source-root-1',
+          mode: 0o755,
+          path: '/repo/local/example',
+        },
+      });
+    const original = revision();
+    const variants = [
+      revision({
+        source: [
+          {
+            contentHash: 'first',
+            mode: 0o644,
+            path: 'example.ts',
+            type: 'file',
+          },
+          {
+            contentHash: 'added',
+            mode: 0o644,
+            path: 'workflow.ts',
+            type: 'file',
+          },
+        ],
+      }),
+      revision({ source: [] }),
+      revision({
+        source: [
+          {
+            contentHash: 'changed',
+            mode: 0o644,
+            path: 'example.ts',
+            type: 'file',
+          },
+        ],
+      }),
+      revision({
+        source: [
+          {
+            contentHash: 'first',
+            mode: 0o755,
+            path: 'example.ts',
+            type: 'file',
+          },
+        ],
+      }),
+      revision({
+        source: [
+          {
+            contentHash: 'first',
+            mode: 0o644,
+            path: 'example.ts',
+            type: 'directory',
+          },
+        ],
+      }),
+      revision({
+        sourceRoot: {
+          identity: 'source-root-1',
+          mode: 0o700,
+          path: '/repo/local/example',
+        },
+      }),
+      revision({
+        destination: {
+          contentHash: 'destination-one',
+          mode: 0o644,
+          path: '/repo/tracked/example',
+          state: 'file',
+        },
+      }),
+      revision({
+        destination: {
+          contentHash: 'destination-two',
+          mode: 0o644,
+          path: '/repo/tracked/example',
+          state: 'file',
+        },
+      }),
+      revision({
+        destination: {
+          contentHash: 'destination-one',
+          mode: 0o600,
+          path: '/repo/tracked/example',
+          state: 'file',
+        },
+      }),
+      revision({
+        destination: {
+          entries: [],
+          mode: 0o755,
+          path: '/repo/tracked/example',
+          state: 'directory',
+        },
+      }),
+      revision({
+        destination: {
+          path: '/repo/tracked/renamed-example',
+          state: 'absent',
+        },
+      }),
+    ];
+
+    expect(original).toMatch(/^[a-f0-9]{64}$/);
+    expect(new Set(variants).size).toBe(variants.length);
+    expect(variants).not.toContain(original);
+    expect(
+      revision({
+        source: [
+          {
+            contentHash: 'added',
+            mode: 0o644,
+            path: 'workflow.ts',
+            type: 'file',
+          },
+          {
+            contentHash: 'first',
+            mode: 0o644,
+            path: 'example.ts',
+            type: 'file',
+          },
+        ],
+      }),
+    ).toBe(variants[0]);
+    expect(original).not.toContain('example.ts');
+    expect(original).not.toContain('first');
+  });
+
+  it('refuses a stale confirmation before moving a changed source', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const localExample = join(rootDirectory, 'local/examples/stale-preview');
+    await mkdir(localExample, { recursive: true });
+    await writeFile(
+      join(localExample, 'example.ts'),
+      'export const value = 1;\n',
+    );
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+    const preview = await authoring.previewPromote({
+      exampleId: 'stale-preview',
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+    await writeFile(
+      join(localExample, 'example.ts'),
+      'export const value = 2;\n',
+    );
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId: 'stale-preview',
+        revision: preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      reason: 'stale-preview',
+      status: 'refused',
+    });
+    await expect(
+      readFile(join(localExample, 'example.ts'), 'utf8'),
+    ).resolves.toContain('value = 2');
+    await expect(
+      access(join(rootDirectory, 'tracked/examples/stale-preview')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('returns a named refusal with a repository-relative detail for invalid source', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const exampleId = 'invalid-source';
+    const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+    const preview = await authoring.previewPromote({
+      exampleId,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+    await writeFile(
+      join(localExample, 'example.ts'),
+      "import '../../outside';\n",
+    );
+
+    const result = await authoring.confirmPromote({
+      exampleId,
+      revision: preview.revision,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    expect(result).toEqual({
+      detail:
+        'local/examples/invalid-source/example.ts relative imports must stay within its example directory',
+      direction: 'promote',
+      reason: 'source-invalid',
+      status: 'refused',
+    });
+    expect(JSON.stringify(result)).not.toContain(rootDirectory);
+  });
+
+  it('returns a named refusal when the previewed source disappears', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const exampleId = 'missing-source';
+    const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+    const preview = await authoring.previewPromote({
+      exampleId,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+    await rm(localExample, { recursive: true });
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId,
+        revision: preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      detail:
+        'Local catalog example does not exist: local/examples/missing-source',
+      direction: 'promote',
+      reason: 'source-invalid',
+      status: 'refused',
+    });
+  });
+
+  it('returns typed destination and lock refusals before moving the source', async () => {
+    const createFixture = async (exampleId: string) => {
+      const rootDirectory = await createTemporaryDirectory();
+      const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+      await mkdir(localExample, { recursive: true });
+      await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths: [],
+        scaffold: () => [],
+        generate: () => [],
+      });
+      const preview = await authoring.previewPromote({
+        exampleId,
+        saveState: { durability: 'durable', status: 'saved' },
+      });
+      if (preview.status !== 'available')
+        throw new Error('preview unavailable');
+      return { authoring, localExample, preview, rootDirectory };
+    };
+    const conflict = await createFixture('destination-conflict');
+    await mkdir(
+      join(conflict.rootDirectory, 'tracked/examples/destination-conflict'),
+      { recursive: true },
+    );
+    await expect(
+      conflict.authoring.confirmPromote({
+        exampleId: 'destination-conflict',
+        revision: conflict.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      reason: 'destination-conflict',
+      status: 'refused',
+    });
+    await expect(access(conflict.localExample)).resolves.toBeUndefined();
+
+    const busy = await createFixture('busy-catalog');
+    await writeFile(
+      join(busy.rootDirectory, '.catalog.lock'),
+      `${JSON.stringify({ createdAt: Date.now(), pid: process.pid })}\n`,
+    );
+    await expect(
+      busy.authoring.confirmPromote({
+        exampleId: 'busy-catalog',
+        revision: busy.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      reason: 'catalog-busy',
+      status: 'refused',
+    });
+    await expect(access(busy.localExample)).resolves.toBeUndefined();
+
+    const recovery = await createFixture('recovery-refusal');
+    await writeFile(
+      join(recovery.rootDirectory, '.catalog.lock'),
+      `${JSON.stringify({ createdAt: 0, pid: 999_999_999 })}\n`,
+    );
+    await writeFile(
+      join(recovery.rootDirectory, '.catalog.lock.recovery'),
+      'not a directory\n',
+    );
+    await expect(
+      recovery.authoring.confirmPromote({
+        exampleId: 'recovery-refusal',
+        revision: recovery.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      reason: 'recovery-refused',
+      status: 'refused',
+    });
+    await expect(access(recovery.localExample)).resolves.toBeUndefined();
+  });
+
+  it('replans and completes all validation under the mutation lock before durable success', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const localExample = join(rootDirectory, 'local/examples/checked-confirm');
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+    const calls: string[] = [];
+    let expectLock = false;
+    const record = async (name: string) => {
+      if (expectLock) {
+        await expect(
+          access(join(rootDirectory, '.catalog.lock')),
+        ).resolves.toBeUndefined();
+      }
+      calls.push(name);
+    };
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: async () => {
+        await record('generate');
+        return [];
+      },
+      parseModuleSpecifiers: async () => {
+        await record('self-containment');
+        return [];
+      },
+      validatePromotion: async () => record('promotion-policy'),
+      verifyGenerated: async () => record('verify-generated'),
+      verify: async () => record('verify-all'),
+    });
+    const preview = await authoring.previewPromote({
+      exampleId: 'checked-confirm',
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+    calls.length = 0;
+    expectLock = true;
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId: 'checked-confirm',
+        revision: preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({ status: 'succeeded' });
+    expect(calls).toEqual([
+      'self-containment',
+      'promotion-policy',
+      'generate',
+      'self-containment',
+      'promotion-policy',
+      'generate',
+      'verify-generated',
+      'verify-all',
+    ]);
+  });
+
+  it('runs server-owned peer checks in order, stops on blocking failure, and continues after advisory failure', async () => {
+    const createFixture = async (
+      exampleId: string,
+      checks: CatalogAuthoringAdapter['promotionChecks'],
+    ) => {
+      const rootDirectory = await createTemporaryDirectory();
+      const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+      await mkdir(localExample, { recursive: true });
+      await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths: [],
+        scaffold: () => [],
+        generate: () => [],
+        promotionChecks: checks,
+      });
+      const preview = await authoring.previewPromote({
+        exampleId,
+        saveState: { durability: 'durable', status: 'saved' },
+      });
+      if (preview.status !== 'available')
+        throw new Error('preview unavailable');
+      return { authoring, localExample, preview };
+    };
+    const blockingCalls: string[] = [];
+    const blocking = await createFixture('blocking-check', [
+      {
+        id: 'first',
+        label: 'First check',
+        run: async () => {
+          blockingCalls.push('first');
+          return { status: 'passed' as const };
+        },
+        severity: 'blocking',
+      },
+      {
+        id: 'blocked',
+        label: 'Blocking check',
+        run: async () => {
+          blockingCalls.push('blocked');
+          return { detail: 'fix the peer', status: 'failed' as const };
+        },
+        severity: 'blocking',
+      },
+      {
+        id: 'later',
+        label: 'Later check',
+        run: async () => {
+          blockingCalls.push('later');
+          return { status: 'passed' as const };
+        },
+        severity: 'advisory',
+      },
+    ]);
+    expect(blocking.preview).not.toHaveProperty('replayPolicy');
+    await expect(
+      blocking.authoring.confirmPromote({
+        exampleId: 'blocking-check',
+        revision: blocking.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      checks: [
+        {
+          id: 'first',
+          label: 'First check',
+          severity: 'blocking',
+          status: 'passed',
+        },
+        {
+          detail: 'fix the peer',
+          id: 'blocked',
+          label: 'Blocking check',
+          severity: 'blocking',
+          status: 'failed',
+        },
+        {
+          id: 'later',
+          label: 'Later check',
+          severity: 'advisory',
+          status: 'not-reached',
+        },
+      ],
+      direction: 'promote',
+      reason: 'check-blocked',
+      status: 'refused',
+    });
+    expect(blockingCalls).toEqual(['first', 'blocked']);
+    await expect(access(blocking.localExample)).resolves.toBeUndefined();
+
+    const advisoryCalls: string[] = [];
+    const advisory = await createFixture('advisory-check', [
+      {
+        id: 'advisory',
+        label: 'Advisory check',
+        run: async () => {
+          advisoryCalls.push('advisory');
+          return { detail: 'informational', status: 'failed' as const };
+        },
+        severity: 'advisory',
+      },
+      {
+        id: 'after-advisory',
+        label: 'After advisory',
+        run: async () => {
+          advisoryCalls.push('after-advisory');
+          return { status: 'passed' as const };
+        },
+        severity: 'blocking',
+      },
+    ]);
+    await expect(
+      advisory.authoring.confirmPromote({
+        exampleId: 'advisory-check',
+        revision: advisory.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({
+      checks: [
+        {
+          detail: 'informational',
+          id: 'advisory',
+          label: 'Advisory check',
+          severity: 'advisory',
+          status: 'failed',
+        },
+        {
+          id: 'after-advisory',
+          label: 'After advisory',
+          severity: 'blocking',
+          status: 'passed',
+        },
+      ],
+      status: 'succeeded',
+    });
+    expect(advisoryCalls).toEqual(['advisory', 'after-advisory']);
+  });
+
+  it('revalidates source and destination after slow peer checks before moving', async () => {
+    const createFixture = async (
+      exampleId: string,
+      duringCheck: (context: {
+        localExample: string;
+        rootDirectory: string;
+      }) => Promise<void>,
+    ) => {
+      const rootDirectory = await createTemporaryDirectory();
+      const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+      await mkdir(localExample, { recursive: true });
+      await writeFile(
+        join(localExample, 'example.ts'),
+        'export const value = 1;\n',
+      );
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths: [],
+        scaffold: () => [],
+        generate: () => [],
+        promotionChecks: [
+          {
+            id: 'slow-peer',
+            label: 'Slow peer',
+            run: async () => {
+              await duringCheck({ localExample, rootDirectory });
+              return { status: 'passed' as const };
+            },
+            severity: 'blocking',
+          },
+        ],
+      });
+      const preview = await authoring.previewPromote({
+        exampleId,
+        saveState: { durability: 'durable', status: 'saved' },
+      });
+      if (preview.status !== 'available')
+        throw new Error('preview unavailable');
+      return { authoring, localExample, preview, rootDirectory };
+    };
+
+    const edited = await createFixture(
+      'edited-during-check',
+      async ({ localExample }) => {
+        await writeFile(
+          join(localExample, 'example.ts'),
+          'export const value = 2;\n',
+        );
+      },
+    );
+    await expect(
+      edited.authoring.confirmPromote({
+        exampleId: 'edited-during-check',
+        revision: edited.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({
+      direction: 'promote',
+      reason: 'stale-preview',
+      status: 'refused',
+    });
+    await expect(
+      readFile(join(edited.localExample, 'example.ts'), 'utf8'),
+    ).resolves.toContain('value = 2');
+
+    const conflicted = await createFixture(
+      'created-during-check',
+      async ({ rootDirectory }) => {
+        await mkdir(
+          join(rootDirectory, 'tracked/examples/created-during-check'),
+          { recursive: true },
+        );
+      },
+    );
+    await expect(
+      conflicted.authoring.confirmPromote({
+        exampleId: 'created-during-check',
+        revision: conflicted.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({
+      direction: 'promote',
+      reason: 'destination-conflict',
+      status: 'refused',
+    });
+    await expect(access(conflicted.localExample)).resolves.toBeUndefined();
+  });
+
+  it('does not replace a destination created after the final promotion plan', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const exampleId = 'late-destination';
+    const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+    const destination = join(rootDirectory, `tracked/examples/${exampleId}`);
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {}\n');
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: async () => {
+        await mkdir(destination, { recursive: true });
+        return [];
+      },
+    });
+    const preview = await authoring.previewPromote({
+      exampleId,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId,
+        revision: preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({
+      direction: 'promote',
+      reason: 'destination-conflict',
+      status: 'refused',
+    });
+    await expect(access(localExample)).resolves.toBeUndefined();
+    await expect(readdir(destination)).resolves.toEqual([]);
+  });
+
+  it('reports truthful direction-neutral mutation lifecycle outcomes', async () => {
+    const createFixture = async ({
+      exampleId,
+      finalizePromotion,
+      generate,
+      generatedPaths = [],
+      promotionChecks,
+    }: {
+      exampleId: string;
+      finalizePromotion?: CatalogAuthoringAdapter['finalizePromotion'];
+      generate: CatalogAuthoringAdapter['generate'];
+      generatedPaths?: string[];
+      promotionChecks?: CatalogAuthoringAdapter['promotionChecks'];
+    }) => {
+      const rootDirectory = await createTemporaryDirectory();
+      const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+      await mkdir(localExample, { recursive: true });
+      await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths,
+        scaffold: () => [],
+        generate,
+        finalizePromotion,
+        promotionChecks,
+      });
+      const preview = await authoring.previewPromote({
+        exampleId,
+        saveState: { durability: 'durable', status: 'saved' },
+      });
+      if (preview.status !== 'available')
+        throw new Error('preview unavailable');
+      return { authoring, localExample, preview, rootDirectory };
+    };
+    let cleanGenerationCalls = 0;
+    const cleanRollback = await createFixture({
+      exampleId: 'clean-rollback',
+      generatedPaths: ['generated/catalog.json'],
+      generate: () => {
+        cleanGenerationCalls += 1;
+        if (cleanGenerationCalls === 1) {
+          return [{ content: 'after\n', path: 'generated/catalog.json' }];
+        }
+        throw new Error('generation failed after move');
+      },
+    });
+    await mkdir(join(cleanRollback.rootDirectory, 'generated'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(cleanRollback.rootDirectory, 'generated/catalog.json'),
+      'before\n',
+    );
+    const refused = await createFixture({
+      exampleId: 'save-state-refusal',
+      generate: () => [],
+    });
+    await expect(
+      refused.authoring.confirmPromote({
+        exampleId: 'save-state-refusal',
+        revision: refused.preview.revision,
+        saveState: { status: 'dirty' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      reason: 'save-state-changed',
+      status: 'refused',
+    });
+    await expect(access(refused.localExample)).resolves.toBeUndefined();
+
+    await expect(
+      cleanRollback.authoring.confirmPromote({
+        exampleId: 'clean-rollback',
+        revision: cleanRollback.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      filesystem: 'restored',
+      reason: 'execution-failed',
+      recovery: 'rolled-back',
+      status: 'failed',
+    });
+    await expect(access(cleanRollback.localExample)).resolves.toBeUndefined();
+    await expect(
+      access(
+        join(cleanRollback.rootDirectory, 'tracked/examples/clean-rollback'),
+      ),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(
+      readFile(
+        join(cleanRollback.rootDirectory, 'generated/catalog.json'),
+        'utf8',
+      ),
+    ).resolves.toBe('before\n');
+
+    let incompleteRoot = '';
+    let incompleteGenerationCalls = 0;
+    const incomplete = await createFixture({
+      exampleId: 'incomplete-rollback',
+      generatedPaths: ['generated/catalog.json'],
+      generate: async () => {
+        incompleteGenerationCalls += 1;
+        if (incompleteGenerationCalls === 1) {
+          return [{ content: 'after\n', path: 'generated/catalog.json' }];
+        }
+        await rm(join(incompleteRoot, 'generated'), {
+          force: true,
+          recursive: true,
+        });
+        await symlink(
+          await createTemporaryDirectory(),
+          join(incompleteRoot, 'generated'),
+          'dir',
+        );
+        throw new Error('generation and rollback fail');
+      },
+    });
+    incompleteRoot = incomplete.rootDirectory;
+    await mkdir(join(incompleteRoot, 'generated'), { recursive: true });
+    await writeFile(join(incompleteRoot, 'generated/catalog.json'), 'before\n');
+    await expect(
+      incomplete.authoring.confirmPromote({
+        exampleId: 'incomplete-rollback',
+        revision: incomplete.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      filesystem: 'may-have-changed',
+      reason: 'recovery-incomplete',
+      recovery: 'incomplete',
+      status: 'failed',
+    });
+
+    let finalizedUnderLock = false;
+    const finalization = await createFixture({
+      exampleId: 'finalization-failure',
+      finalizePromotion: async () => {
+        finalizedUnderLock = await access(
+          join(finalization.rootDirectory, '.catalog.lock'),
+        )
+          .then(() => true)
+          .catch(() => false);
+        throw new Error('finalization failed');
+      },
+      generate: () => [],
+    });
+    await expect(
+      finalization.authoring.confirmPromote({
+        exampleId: 'finalization-failure',
+        revision: finalization.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      filesystem: 'changed',
+      reason: 'finalization-failed',
+      recovery: 'committed',
+      status: 'failed',
+    });
+    expect(finalizedUnderLock).toBe(true);
+    await expect(access(finalization.localExample)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+
+    const unknown = await createFixture({
+      exampleId: 'unknown-outcome',
+      generate: () => [],
+      promotionChecks: [
+        {
+          id: 'unknown',
+          label: 'Unknown outcome',
+          run: () => {
+            throw new Error('peer disappeared');
+          },
+          severity: 'blocking',
+        },
+      ],
+    });
+    await expect(
+      unknown.authoring.confirmPromote({
+        exampleId: 'unknown-outcome',
+        revision: unknown.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      detail: 'unknown: peer disappeared',
+      direction: 'promote',
+      reason: 'check-failed',
+      status: 'refused',
+    });
+
+    const policyRoot = await createTemporaryDirectory();
+    const policyExample = join(policyRoot, 'local/examples/policy-refusal');
+    await mkdir(policyExample, { recursive: true });
+    await writeFile(join(policyExample, 'example.ts'), 'export {};\n');
+    let policyCalls = 0;
+    const policy = createCatalogAuthoring({
+      rootDirectory: policyRoot,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+      validatePromotion: () => {
+        policyCalls += 1;
+        if (policyCalls > 1) throw new Error('repository policy rejected it');
+      },
+    });
+    const policyPreview = await policy.previewPromote({
+      exampleId: 'policy-refusal',
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (policyPreview.status !== 'available')
+      throw new Error('preview unavailable');
+    await expect(
+      policy.confirmPromote({
+        exampleId: 'policy-refusal',
+        revision: policyPreview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      detail: 'repository policy rejected it',
+      direction: 'promote',
+      reason: 'policy-rejected',
+      status: 'refused',
+    });
+
+    const durable = await createFixture({
+      exampleId: 'durable-success',
+      generate: () => [],
+    });
+    await expect(
+      durable.authoring.confirmPromote({
+        exampleId: 'durable-success',
+        revision: durable.preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({ commit: 'durable', status: 'succeeded' });
+    await mkdir(join(durable.rootDirectory, '.catalog.transaction-committed'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(durable.rootDirectory, '.catalog.journal.json'),
+      `${JSON.stringify({
+        id: 'committed',
+        move: {
+          from: 'local/examples/durable-success',
+          marker: '.catalog-move-owner-committed',
+          to: 'tracked/examples/durable-success',
+        },
+        snapshots: [],
+        state: 'committed',
+        transactionPath: '.catalog.transaction-committed',
+      })}\n`,
+    );
+    await durable.authoring.verify();
+    await expect(access(durable.localExample)).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    await expect(
+      access(
+        join(
+          durable.rootDirectory,
+          'tracked/examples/durable-success/example.ts',
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it.each(['unlink', 'rm'] as const)(
+    'retains committed recovery evidence when transaction %s cleanup fails',
+    async (failedOperation) => {
+      const rootDirectory = await createTemporaryDirectory();
+      const exampleId = `cleanup-${failedOperation}`;
+      const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+      await mkdir(localExample, { recursive: true });
+      await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+      let failOnce = true;
+      const authoring = createCatalogAuthoring({
+        rootDirectory,
+        localExamplesPath: 'local/examples',
+        trackedExamplesPath: 'tracked/examples',
+        generatedPaths: [],
+        scaffold: () => [],
+        generate: () => [],
+        transactionFilesystem: {
+          rm: async (path, options) => {
+            if (
+              failedOperation === 'rm' &&
+              failOnce &&
+              path.includes('.catalog.transaction-')
+            ) {
+              failOnce = false;
+              throw new Error('transaction rm failed');
+            }
+            await rm(path, options);
+          },
+          unlink: async (path) => {
+            if (
+              failedOperation === 'unlink' &&
+              failOnce &&
+              path.endsWith('.catalog.journal.json')
+            ) {
+              failOnce = false;
+              throw new Error('journal unlink failed');
+            }
+            await unlink(path);
+          },
+        },
+      });
+      const preview = await authoring.previewPromote({
+        exampleId,
+        saveState: { durability: 'durable', status: 'saved' },
+      });
+      if (preview.status !== 'available')
+        throw new Error('preview unavailable');
+
+      await expect(
+        authoring.confirmPromote({
+          exampleId,
+          revision: preview.revision,
+          saveState: { durability: 'durable', status: 'saved' },
+        }),
+      ).resolves.toMatchObject({
+        direction: 'promote',
+        filesystem: 'changed',
+        reason: 'committed-finalization-failed',
+        recovery: 'committed',
+        recoveryEvidence: {
+          journal: '.catalog.journal.json',
+          transaction: expect.stringMatching(/^\.catalog\.transaction-/),
+        },
+        status: 'failed',
+      });
+      await expect(access(localExample)).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+      await expect(
+        access(join(rootDirectory, '.catalog.journal.json')),
+      ).resolves.toBeUndefined();
+
+      await authoring.verify();
+      await expect(
+        access(join(rootDirectory, '.catalog.journal.json')),
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+      await expect(
+        access(join(rootDirectory, `tracked/examples/${exampleId}/example.ts`)),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it('reports outcome unknown when rollback loses the result of its move', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const exampleId = 'unknown-rollback';
+    const localExample = join(rootDirectory, `local/examples/${exampleId}`);
+    await mkdir(localExample, { recursive: true });
+    await writeFile(join(localExample, 'example.ts'), 'export {};\n');
+    let generationCalls = 0;
+    let loseRollbackResponse = true;
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => {
+        generationCalls += 1;
+        if (generationCalls === 2) throw new Error('fail after move');
+        return [];
+      },
+      transactionFilesystem: {
+        rename: async (from, to) => {
+          await rename(from, to);
+          if (
+            loseRollbackResponse &&
+            to.endsWith(`/local/examples/${exampleId}`)
+          ) {
+            loseRollbackResponse = false;
+            throw Object.assign(new Error('rollback response lost'), {
+              code: 'EIO',
+            });
+          }
+        },
+        rm,
+        unlink,
+      },
+    });
+    const preview = await authoring.previewPromote({
+      exampleId,
+      saveState: { durability: 'durable', status: 'saved' },
+    });
+    if (preview.status !== 'available') throw new Error('preview unavailable');
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId,
+        revision: preview.revision,
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toEqual({
+      direction: 'promote',
+      filesystem: 'unknown',
+      reason: 'outcome-unknown',
+      recovery: 'unknown',
+      status: 'failed',
+    });
+    await expect(
+      access(join(rootDirectory, '.catalog.journal.json')),
+    ).resolves.toBeUndefined();
+    await authoring.verify();
+    await expect(readdir(localExample)).resolves.toEqual(['example.ts']);
+    await expect(
+      access(join(rootDirectory, '.catalog.journal.json')),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('runs one configured example through scaffold, generation, dry-run promotion, and verification', async () => {
     const rootDirectory = await createTemporaryDirectory();
     const listExampleIds = async (path: string) =>
@@ -1055,6 +2327,139 @@ try {
     ).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
+  it('refuses a journal move marker that can escape its destination', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const victim = join(rootDirectory, 'victim');
+    await writeFile(victim, 'keep me\n');
+    await mkdir(join(rootDirectory, 'tracked/examples/hostile-marker'), {
+      recursive: true,
+    });
+    await mkdir(join(rootDirectory, '.catalog.transaction-hostile'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(rootDirectory, '.catalog.journal.json'),
+      `${JSON.stringify({
+        id: 'hostile',
+        move: {
+          from: 'local/examples/hostile-marker',
+          marker: '../../../victim',
+          to: 'tracked/examples/hostile-marker',
+        },
+        snapshots: [],
+        state: 'pending',
+        transactionPath: '.catalog.transaction-hostile',
+      })}\n`,
+    );
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    await expect(authoring.verify()).rejects.toThrow(
+      'Catalog transaction journal is invalid',
+    );
+    await expect(readFile(victim, 'utf8')).resolves.toBe('keep me\n');
+    await expect(
+      access(join(rootDirectory, '.catalog.journal.json')),
+    ).resolves.toBeUndefined();
+  });
+
+  it('refuses a move journal without its exact owner marker', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    await mkdir(join(rootDirectory, '.catalog.transaction-markerless'), {
+      recursive: true,
+    });
+    await writeFile(
+      join(rootDirectory, '.catalog.journal.json'),
+      `${JSON.stringify({
+        id: 'markerless',
+        move: {
+          from: 'local/examples/markerless',
+          to: 'tracked/examples/markerless',
+        },
+        snapshots: [],
+        state: 'pending',
+        transactionPath: '.catalog.transaction-markerless',
+      })}\n`,
+    );
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    await expect(authoring.verify()).rejects.toThrow(
+      'Catalog transaction journal is invalid',
+    );
+    await expect(
+      access(join(rootDirectory, '.catalog.journal.json')),
+    ).resolves.toBeUndefined();
+  });
+
+  it('preserves ambiguous recovery evidence when a crash precedes the owner marker', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const source = join(rootDirectory, 'local/examples/unowned-destination');
+    const destination = join(
+      rootDirectory,
+      'tracked/examples/unowned-destination',
+    );
+    const transaction = join(rootDirectory, '.catalog.transaction-unowned');
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, 'example.ts'), 'export {};\n');
+    await mkdir(destination, { recursive: true });
+    await mkdir(transaction, { recursive: true });
+    await writeFile(
+      join(rootDirectory, '.catalog.journal.json'),
+      `${JSON.stringify({
+        id: 'unowned',
+        move: {
+          from: 'local/examples/unowned-destination',
+          marker: '.catalog-move-owner-unowned',
+          to: 'tracked/examples/unowned-destination',
+        },
+        snapshots: [],
+        state: 'pending',
+        transactionPath: '.catalog.transaction-unowned',
+      })}\n`,
+    );
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    await expect(
+      authoring.confirmPromote({
+        exampleId: 'unowned-destination',
+        revision: 'preview-revision',
+        saveState: { durability: 'durable', status: 'saved' },
+      }),
+    ).resolves.toMatchObject({
+      direction: 'promote',
+      filesystem: 'may-have-changed',
+      reason: 'recovery-incomplete',
+      recovery: 'incomplete',
+      status: 'failed',
+    });
+    await expect(access(source)).resolves.toBeUndefined();
+    await expect(access(destination)).resolves.toBeUndefined();
+    await expect(access(transaction)).resolves.toBeUndefined();
+    await expect(
+      access(join(rootDirectory, '.catalog.journal.json')),
+    ).resolves.toBeUndefined();
+  });
+
   it('rejects a symlink or special file inside an authored example', async () => {
     const rootDirectory = await createTemporaryDirectory();
     const externalDirectory = await createTemporaryDirectory();
@@ -1191,7 +2596,7 @@ try {
   });
 
   it('rejects removed CLI aliases', async () => {
-    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+    const authoring: Parameters<typeof runCatalogCli>[0]['authoring'] = {
       demote: async () => ({
         changedPaths: [],
         moved: { from: '', to: '' },
@@ -1233,7 +2638,7 @@ try {
         { kind: 'verify' as const },
       ],
     };
-    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+    const authoring: Parameters<typeof runCatalogCli>[0]['authoring'] = {
       demote: async () => {
         calls.push('demote');
         return { changedPaths: [], moved: { from: '', to: '' } };
@@ -1265,9 +2670,55 @@ try {
     expect(output).toEqual([JSON.stringify(expectedPlan, null, 2)]);
   });
 
+  it('dispatches promotion dry-run to planPromote without mutating or changing its JSON', async () => {
+    const calls: string[] = [];
+    const output: string[] = [];
+    const expectedPlan = {
+      operations: [
+        {
+          from: 'local/examples/cli-example',
+          kind: 'move-directory' as const,
+          to: 'tracked/examples/cli-example',
+        },
+        { kind: 'generate' as const },
+        { kind: 'verify' as const },
+      ],
+    };
+    const authoring: Parameters<typeof runCatalogCli>[0]['authoring'] = {
+      demote: async () => ({
+        changedPaths: [],
+        moved: { from: '', to: '' },
+      }),
+      scaffold: async () => undefined,
+      generate: async () => [],
+      verify: async () => undefined,
+      planDemote: async () => ({ operations: [] }),
+      planPromote: async (exampleId) => {
+        calls.push(`plan:${exampleId}`);
+        return expectedPlan;
+      },
+      promote: async () => {
+        calls.push('promote');
+        return { changedPaths: [], moved: { from: '', to: '' } };
+      },
+    };
+
+    await runCatalogCli({
+      authoring,
+      argv: ['promote', 'cli-example', '--dry-run'],
+      io: {
+        writeError: () => undefined,
+        writeOutput: (message) => output.push(message),
+      },
+    });
+
+    expect(calls).toEqual(['plan:cli-example']);
+    expect(output).toEqual([JSON.stringify(expectedPlan, null, 2)]);
+  });
+
   it('reports promotion as a concise shared-catalog handoff', async () => {
     const output: string[] = [];
-    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+    const authoring: Parameters<typeof runCatalogCli>[0]['authoring'] = {
       demote: async () => ({
         changedPaths: [],
         moved: { from: '', to: '' },
@@ -1312,7 +2763,7 @@ try {
   it('reports a demoted example as local and ignored by Git without calling it deleted', async () => {
     const calls: string[] = [];
     const output: string[] = [];
-    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+    const authoring: Parameters<typeof runCatalogCli>[0]['authoring'] = {
       demote: async (exampleId) => {
         calls.push(`demote:${exampleId}`);
         return {

--- a/src/lib/catalog/authoring.ts
+++ b/src/lib/catalog/authoring.ts
@@ -1,8 +1,9 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   access,
   chmod,
   copyFile,
+  cp,
   lstat,
   mkdir,
   open,
@@ -69,6 +70,149 @@ export type CatalogComposedExample = {
   workflowType?: string;
 };
 
+export type CatalogSavedState =
+  | { durability: 'durable'; status: 'saved' }
+  | { status: 'dirty' | 'failed' | 'stale' };
+
+export type CatalogMutationDirection = 'demote' | 'promote';
+
+export type CatalogMutationCheckResult = {
+  detail?: string;
+  id: string;
+  label: string;
+  severity: 'advisory' | 'blocking';
+  status: 'failed' | 'not-reached' | 'passed';
+};
+
+export type CatalogMutationMoveResult = {
+  changedPaths: string[];
+  moved: { from: string; to: string };
+};
+
+export type CatalogMutationOutcome<Result = CatalogMutationMoveResult> =
+  | {
+      checks?: CatalogMutationCheckResult[];
+      commit: 'durable';
+      direction: CatalogMutationDirection;
+      result: Result;
+      status: 'succeeded';
+    }
+  | {
+      checks?: CatalogMutationCheckResult[];
+      detail?: string;
+      direction: CatalogMutationDirection;
+      reason:
+        | 'catalog-busy'
+        | 'check-blocked'
+        | 'destination-conflict'
+        | 'check-failed'
+        | 'generation-failed'
+        | 'policy-rejected'
+        | 'recovery-refused'
+        | 'save-state-changed'
+        | 'source-invalid'
+        | 'stale-preview';
+      status: 'refused';
+    }
+  | {
+      direction: CatalogMutationDirection;
+      filesystem: 'changed' | 'may-have-changed' | 'restored' | 'unknown';
+      reason:
+        | 'committed-finalization-failed'
+        | 'execution-failed'
+        | 'finalization-failed'
+        | 'outcome-unknown'
+        | 'recovery-incomplete';
+      recovery: 'committed' | 'incomplete' | 'rolled-back' | 'unknown';
+      recoveryEvidence?: { journal: string; transaction: string };
+      status: 'failed';
+    };
+
+class CatalogMutationRefusalError extends Error {
+  constructor(
+    readonly reason: Extract<
+      CatalogMutationOutcome,
+      { status: 'refused' }
+    >['reason'],
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+class CatalogCommittedFinalizationError extends Error {
+  constructor(
+    readonly recoveryEvidence: { journal: string; transaction: string },
+    cause: unknown,
+  ) {
+    super('Committed catalog mutation cleanup failed', { cause });
+  }
+}
+
+const isIndeterminateFilesystemError = (error: unknown): boolean => {
+  if ((error as NodeJS.ErrnoException | undefined)?.code === 'EIO') return true;
+  return (
+    error instanceof AggregateError &&
+    error.errors.some(isIndeterminateFilesystemError)
+  );
+};
+
+export type CatalogMutationRevisionInput = {
+  destination: {
+    contentHash?: string;
+    entries?: readonly {
+      contentHash: string;
+      mode: number;
+      path: string;
+      type: 'directory' | 'file';
+    }[];
+    mode?: number;
+    path: string;
+    state: 'absent' | 'directory' | 'file';
+  };
+  source: readonly {
+    contentHash: string;
+    mode: number;
+    path: string;
+    type: 'directory' | 'file';
+  }[];
+  sourceRoot: { identity: string; mode: number; path: string };
+};
+
+export const createCatalogMutationRevision = ({
+  destination,
+  source,
+  sourceRoot,
+}: CatalogMutationRevisionInput) => {
+  const hash = createHash('sha256');
+  const append = (value: string) => {
+    hash.update(String(Buffer.byteLength(value)));
+    hash.update(':');
+    hash.update(value);
+  };
+  const appendEntries = (entries: CatalogMutationRevisionInput['source']) => {
+    for (const entry of [...entries].sort((left, right) =>
+      left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
+    )) {
+      append(entry.path);
+      append(entry.type);
+      append(entry.mode.toString(8));
+      append(entry.contentHash);
+    }
+  };
+  append('catalog-mutation-revision-v2');
+  append(sourceRoot.path);
+  append(sourceRoot.identity);
+  append(sourceRoot.mode.toString(8));
+  append(destination.path);
+  append(destination.state);
+  append(destination.mode?.toString(8) ?? '');
+  append(destination.contentHash ?? '');
+  appendEntries(destination.entries ?? []);
+  appendEntries(source);
+  return hash.digest('hex');
+};
+
 export type CatalogAssemblyExample = CatalogComposedExample & {
   definitionImportPath: string;
   workflowExport?: string;
@@ -76,6 +220,38 @@ export type CatalogAssemblyExample = CatalogComposedExample & {
 };
 
 export type CatalogAuthoringAdapter = {
+  finalizePromotion?: (context: {
+    direction: 'promote';
+    exampleId: string;
+  }) => void | Promise<void>;
+  promotionChecks?: readonly {
+    id: string;
+    label: string;
+    run: (context: {
+      direction: 'promote';
+      exampleId: string;
+    }) =>
+      | { detail?: string; status: 'failed' | 'passed' }
+      | Promise<{ detail?: string; status: 'failed' | 'passed' }>;
+    severity: 'advisory' | 'blocking';
+  }[];
+  describePromotion?: (context: {
+    exampleId: string;
+    from: string;
+    to: string;
+  }) => {
+    authoredSource: string;
+    destination: { id: string; path: string };
+    generatedOutputs: readonly {
+      gitEffect: 'ignored-update' | 'tracked-update';
+      path: string;
+    }[];
+    gitEffects: {
+      destination: 'tracked-addition';
+      source: 'ignored-removal';
+    };
+    source: { id: string; path: string };
+  };
   generatedPaths: readonly string[];
   graph: CatalogAuthoringGraph;
   generate: () =>
@@ -97,6 +273,14 @@ export type CatalogAuthoringAdapter = {
     | readonly CatalogAuthoringArtifact[]
     | Promise<readonly CatalogAuthoringArtifact[]>;
   trackedExamplesPath: string;
+  transactionFilesystem?: {
+    rename?: (from: string, to: string) => Promise<void>;
+    rm: (
+      path: string,
+      options: { force: boolean; recursive: boolean },
+    ) => Promise<void>;
+    unlink: (path: string) => Promise<void>;
+  };
   validatePromotion?: (context: { exampleId: string }) => void | Promise<void>;
   verify?: (context: {
     exampleIds: { local: string[]; tracked: string[] };
@@ -135,8 +319,9 @@ type FileSnapshot = {
 
 type TransactionJournal = {
   id: string;
-  move?: { from: string; to: string };
+  move?: { from: string; marker?: string; to: string };
   snapshots: FileSnapshot[];
+  state: 'committed' | 'pending';
   transactionPath: string;
 };
 
@@ -572,11 +757,38 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     }
   };
   const journalRelativePath = '.catalog.journal.json';
+  const transactionFilesystem = adapter.transactionFilesystem ?? {
+    rename,
+    rm,
+    unlink,
+  };
+  const recoveryRename = transactionFilesystem.rename ?? rename;
+  const cleanupRecoveryEvidence = async (transactionPath: string) => {
+    await transactionFilesystem.rm(await safeAbsolutePath(transactionPath), {
+      force: true,
+      recursive: true,
+    });
+    await transactionFilesystem.unlink(
+      await safeAbsolutePath(journalRelativePath),
+    );
+  };
   const writeJournal = async (journal: TransactionJournal) => {
     const temporaryPath = `.catalog.journal.${journal.id}.tmp`;
     await writeFile(
       await safeAbsolutePath(temporaryPath),
       `${JSON.stringify(journal, null, 2)}\n`,
+      { flag: 'wx' },
+    );
+    await rename(
+      await safeAbsolutePath(temporaryPath),
+      await safeAbsolutePath(journalRelativePath),
+    );
+  };
+  const markJournalCommitted = async (journal: TransactionJournal) => {
+    const temporaryPath = `.catalog.journal.${journal.id}.committed.tmp`;
+    await writeFile(
+      await safeAbsolutePath(temporaryPath),
+      `${JSON.stringify({ ...journal, state: 'committed' }, null, 2)}\n`,
       { flag: 'wx' },
     );
     await rename(
@@ -594,36 +806,68 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     if (!metadata.isFile() || metadata.isSymbolicLink()) {
       throw new Error('Catalog transaction journal must be a regular file');
     }
-    const journal = JSON.parse(
-      await readFile(path, 'utf8'),
-    ) as TransactionJournal;
+    const journal = JSON.parse(await readFile(path, 'utf8')) as Omit<
+      TransactionJournal,
+      'state'
+    > & {
+      state?: TransactionJournal['state'];
+    };
     if (
       !journal ||
       typeof journal.id !== 'string' ||
       journal.transactionPath !== `.catalog.transaction-${journal.id}` ||
-      !Array.isArray(journal.snapshots)
+      !Array.isArray(journal.snapshots) ||
+      (journal.state !== undefined &&
+        !['committed', 'pending'].includes(journal.state))
     ) {
       throw new Error('Catalog transaction journal is invalid');
     }
-    assertExplicitRelativePath(journal.transactionPath);
-    for (const snapshot of journal.snapshots) {
-      assertExplicitRelativePath(snapshot.path);
-      if (
-        snapshot.backupPath &&
-        !snapshot.backupPath.startsWith(`${journal.transactionPath}/backups/`)
-      ) {
-        throw new Error('Catalog transaction journal is invalid');
+    try {
+      assertExplicitRelativePath(journal.transactionPath);
+      for (const snapshot of journal.snapshots) {
+        if (
+          !snapshot ||
+          typeof snapshot !== 'object' ||
+          typeof snapshot.existed !== 'boolean' ||
+          typeof snapshot.path !== 'string' ||
+          (snapshot.mode !== undefined && typeof snapshot.mode !== 'number') ||
+          (snapshot.backupPath !== undefined &&
+            typeof snapshot.backupPath !== 'string')
+        ) {
+          throw new Error('invalid snapshot');
+        }
+        assertExplicitRelativePath(snapshot.path);
+        if (
+          snapshot.backupPath &&
+          !snapshot.backupPath.startsWith(`${journal.transactionPath}/backups/`)
+        ) {
+          throw new Error('invalid backup');
+        }
       }
+      if (journal.move) {
+        if (
+          typeof journal.move !== 'object' ||
+          typeof journal.move.from !== 'string' ||
+          typeof journal.move.to !== 'string' ||
+          journal.move.marker !== `.catalog-move-owner-${journal.id}`
+        ) {
+          throw new Error('invalid move');
+        }
+        assertExplicitRelativePath(journal.move.from);
+        assertExplicitRelativePath(journal.move.to);
+      }
+    } catch {
+      throw new Error('Catalog transaction journal is invalid');
     }
-    if (journal.move) {
-      assertExplicitRelativePath(journal.move.from);
-      assertExplicitRelativePath(journal.move.to);
-    }
-    return journal;
+    return { ...journal, state: journal.state ?? 'pending' };
   };
   const recoverJournal = async () => {
     const journal = await readJournal();
     if (!journal) return;
+    if (journal.state === 'committed') {
+      await cleanupRecoveryEvidence(journal.transactionPath);
+      return;
+    }
     const rollbackErrors: unknown[] = [];
     try {
       await restoreFiles(journal.snapshots);
@@ -637,10 +881,35 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
         pathExists(sourcePath),
         pathExists(destinationPath),
       ]);
-      if (!sourceExists && destinationExists) {
+      const markerPath = journal.move.marker
+        ? join(destinationPath, journal.move.marker)
+        : undefined;
+      const ownsDestination = markerPath
+        ? await readFile(markerPath, 'utf8')
+            .then((owner) => owner.trim() === journal.id)
+            .catch(() => false)
+        : false;
+      if (sourceExists && destinationExists && ownsDestination) {
+        try {
+          await rm(destinationPath, { force: true, recursive: true });
+        } catch (error) {
+          rollbackErrors.push(error);
+        }
+      } else if (sourceExists && destinationExists) {
+        rollbackErrors.push(
+          new Error(
+            'Catalog move recovery cannot establish destination ownership',
+          ),
+        );
+      } else if (!sourceExists && destinationExists) {
         try {
           await ensureSafeParent(journal.move.from);
-          await rename(destinationPath, sourcePath);
+          await recoveryRename(destinationPath, sourcePath);
+          if (journal.move.marker) {
+            await unlink(join(sourcePath, journal.move.marker)).catch(
+              () => undefined,
+            );
+          }
         } catch (error) {
           rollbackErrors.push(error);
         }
@@ -652,28 +921,29 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
         'Catalog crash recovery was incomplete',
       );
     }
-    await unlink(await safeAbsolutePath(journalRelativePath));
-    await rm(await safeAbsolutePath(journal.transactionPath), {
-      force: true,
-      recursive: true,
-    });
+    await cleanupRecoveryEvidence(journal.transactionPath);
   };
   const withJournaledFiles = async <Result>(
     paths: readonly string[],
-    action: (transactionPath: string) => Promise<Result>,
+    action: (transactionPath: string, transactionId: string) => Promise<Result>,
     move?: { from: string; to: string },
   ) => {
     const id = randomUUID();
     const transactionPath = `.catalog.transaction-${id}`;
     await ensureSafeDirectory(transactionPath);
     const snapshots = await snapshotFiles(paths, transactionPath);
-    const journal = { id, move, snapshots, transactionPath };
+    const journal: TransactionJournal = {
+      id,
+      move: move ? { ...move, marker: `.catalog-move-owner-${id}` } : undefined,
+      snapshots,
+      state: 'pending',
+      transactionPath,
+    };
     await writeJournal(journal);
-    let cleanupRecoveryData = false;
+    let result: Result;
     try {
-      const result = await action(transactionPath);
-      cleanupRecoveryData = true;
-      return result;
+      result = await action(transactionPath, id);
+      await markJournalCommitted(journal);
     } catch (error) {
       try {
         await restoreFiles(snapshots);
@@ -685,10 +955,15 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
             (await pathExists(destinationPath))
           ) {
             await ensureSafeParent(move.from);
-            await rename(destinationPath, sourcePath);
+            await recoveryRename(destinationPath, sourcePath);
+            if (journal.move?.marker) {
+              await unlink(join(sourcePath, journal.move.marker)).catch(
+                () => undefined,
+              );
+            }
           }
         }
-        cleanupRecoveryData = true;
+        await cleanupRecoveryEvidence(transactionPath);
       } catch (rollbackError) {
         throw new AggregateError(
           [error, rollbackError],
@@ -696,17 +971,16 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
         );
       }
       throw error;
-    } finally {
-      if (cleanupRecoveryData) {
-        await unlink(await safeAbsolutePath(journalRelativePath)).catch(
-          () => undefined,
-        );
-        await rm(await safeAbsolutePath(transactionPath), {
-          force: true,
-          recursive: true,
-        }).catch(() => undefined);
-      }
     }
+    try {
+      await cleanupRecoveryEvidence(transactionPath);
+    } catch (error) {
+      throw new CatalogCommittedFinalizationError(
+        { journal: journalRelativePath, transaction: transactionPath },
+        error,
+      );
+    }
+    return result;
   };
   const generateUnlocked = async (transactionPath: string) => {
     const artifacts = await renderGeneratedArtifacts();
@@ -1062,21 +1336,50 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     }
   };
   const planPromote = async (exampleId: string) => {
-    const { from, sourcePath, to } = await planDirectoryMove({
-      destinationKind: 'Promotion',
-      exampleId,
-      fromRoot: adapter.localExamplesPath,
-      sourceKind: 'Local',
-      toRoot: adapter.trackedExamplesPath,
-    });
-    await validateSelfContainedExample({
-      absoluteImportError: (filePath) =>
-        `${filePath} imports cannot use absolute paths or file URLs`,
-      relativeImportError: (filePath) =>
-        `${filePath} relative imports must stay within its example directory`,
-      sourcePath,
-    });
-    await adapter.validatePromotion?.({ exampleId });
+    let move: Awaited<ReturnType<typeof planDirectoryMove>>;
+    try {
+      move = await planDirectoryMove({
+        destinationKind: 'Promotion',
+        exampleId,
+        fromRoot: adapter.localExamplesPath,
+        sourceKind: 'Local',
+        toRoot: adapter.trackedExamplesPath,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      if (message.startsWith('Promotion destination already exists:')) {
+        throw error;
+      }
+      throw new CatalogMutationRefusalError(
+        'source-invalid',
+        message || 'Source validation failed',
+      );
+    }
+    const { from, sourcePath, to } = move;
+    try {
+      await validateSelfContainedExample({
+        absoluteImportError: (filePath) =>
+          `${filePath} imports cannot use absolute paths or file URLs`,
+        relativeImportError: (filePath) =>
+          `${filePath} relative imports must stay within its example directory`,
+        sourcePath,
+      });
+    } catch (error) {
+      throw new CatalogMutationRefusalError(
+        'source-invalid',
+        error instanceof Error ? error.message : 'Source validation failed',
+      );
+    }
+    try {
+      await adapter.validatePromotion?.({ exampleId });
+    } catch (error) {
+      throw new CatalogMutationRefusalError(
+        'policy-rejected',
+        error instanceof Error
+          ? error.message
+          : 'Repository policy rejected it',
+      );
+    }
     return {
       operations: [
         { from, kind: 'move-directory' as const, to },
@@ -1108,6 +1411,90 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
       ],
     };
   };
+  const promotionRevision = async (move: { from: string; to: string }) => {
+    const sourceRoot = await safeAbsolutePath(move.from);
+    const collectTree = async (
+      directory: string,
+      relativeDirectory = '',
+    ): Promise<CatalogMutationRevisionInput['source'][number][]> => {
+      const entries = await readdir(directory, { withFileTypes: true });
+      const records: CatalogMutationRevisionInput['source'][number][] = [];
+      for (const entry of entries.sort((left, right) =>
+        left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+      )) {
+        const path = join(directory, entry.name);
+        const relativePath = relativeDirectory
+          ? `${relativeDirectory}/${entry.name}`
+          : entry.name;
+        const metadata = await lstat(path);
+        if (metadata.isSymbolicLink()) {
+          throw new Error(
+            `Catalog example sources must be regular files: ${relativePath}`,
+          );
+        }
+        if (metadata.isDirectory()) {
+          records.push({
+            contentHash: '',
+            mode: metadata.mode & 0o7777,
+            path: relativePath,
+            type: 'directory',
+          });
+          records.push(...(await collectTree(path, relativePath)));
+          continue;
+        }
+        if (!metadata.isFile()) {
+          throw new Error(
+            `Catalog example sources must be regular files: ${relativePath}`,
+          );
+        }
+        records.push({
+          contentHash: createHash('sha256')
+            .update(await readFile(path))
+            .digest('hex'),
+          mode: metadata.mode & 0o7777,
+          path: relativePath,
+          type: 'file',
+        });
+      }
+      return records;
+    };
+    const sourceRootMetadata = await lstat(sourceRoot);
+    const destinationPath = await safeAbsolutePath(move.to);
+    const destinationMetadata = await lstat(destinationPath).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    });
+    return createCatalogMutationRevision({
+      destination: {
+        ...(destinationMetadata
+          ? {
+              mode: destinationMetadata.mode & 0o7777,
+              ...(destinationMetadata.isDirectory()
+                ? { entries: await collectTree(destinationPath) }
+                : destinationMetadata.isFile()
+                  ? {
+                      contentHash: createHash('sha256')
+                        .update(await readFile(destinationPath))
+                        .digest('hex'),
+                    }
+                  : {}),
+            }
+          : {}),
+        path: destinationPath,
+        state: destinationMetadata
+          ? destinationMetadata.isDirectory()
+            ? 'directory'
+            : 'file'
+          : 'absent',
+      },
+      source: await collectTree(sourceRoot),
+      sourceRoot: {
+        identity: `${sourceRootMetadata.dev}:${sourceRootMetadata.ino}`,
+        mode: sourceRootMetadata.mode & 0o7777,
+        path: sourceRoot,
+      },
+    });
+  };
   const executePlannedMove = async (
     plan: Awaited<ReturnType<typeof planDemote>>,
     operation: string,
@@ -1118,11 +1505,53 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     }
     return withJournaledFiles(
       adapter.generatedPaths,
-      async (transactionPath) => {
+      async (transactionPath, transactionId) => {
         const sourcePath = await safeAbsolutePath(move.from);
         const destinationPath = await safeAbsolutePath(move.to);
         await ensureSafeParent(move.to);
-        await rename(sourcePath, destinationPath);
+        if (operation === 'Promotion') {
+          const marker = `.catalog-move-owner-${transactionId}`;
+          try {
+            await mkdir(destinationPath);
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+              throw new Error(
+                `Promotion destination already exists: ${move.to}`,
+              );
+            }
+            throw error;
+          }
+          let sourceMoved = false;
+          try {
+            await writeFile(join(destinationPath, marker), transactionId, {
+              flag: 'wx',
+            });
+            const sourceMetadata = await lstat(sourcePath);
+            for (const entry of await readdir(sourcePath)) {
+              await cp(join(sourcePath, entry), join(destinationPath, entry), {
+                errorOnExist: true,
+                force: false,
+                preserveTimestamps: true,
+                recursive: true,
+              });
+            }
+            await chmod(destinationPath, sourceMetadata.mode & 0o7777);
+            const stagedSource = await safeAbsolutePath(
+              `${transactionPath}/promoted-source`,
+            );
+            await rename(sourcePath, stagedSource);
+            sourceMoved = true;
+            await rm(stagedSource, { force: true, recursive: true });
+            await unlink(join(destinationPath, marker));
+          } catch (error) {
+            if (!sourceMoved) {
+              await rm(destinationPath, { force: true, recursive: true });
+            }
+            throw error;
+          }
+        } else {
+          await rename(sourcePath, destinationPath);
+        }
         await generateUnlocked(transactionPath);
         await verifyUnlocked();
         return {
@@ -1132,6 +1561,58 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
       },
       move,
     );
+  };
+
+  const previewPromote = async ({
+    exampleId,
+    saveState,
+  }: {
+    exampleId: string;
+    saveState: CatalogSavedState;
+  }) => {
+    assertExampleId(exampleId);
+    if (saveState.status !== 'saved') {
+      const reasons = {
+        dirty: 'unsaved-changes',
+        failed: 'save-failed',
+        stale: 'saved-revision-stale',
+      } as const;
+      return {
+        reason: reasons[saveState.status],
+        status: 'unavailable' as const,
+      };
+    }
+    if (!adapter.describePromotion) {
+      return {
+        reason: 'preview-not-supported' as const,
+        status: 'unavailable' as const,
+      };
+    }
+    const plan = await planPromote(exampleId);
+    const move = plan.operations[0];
+    if (!move || move.kind !== 'move-directory') {
+      throw new Error('Promotion plan has no directory move');
+    }
+    return {
+      ...adapter.describePromotion({
+        exampleId,
+        from: move.from,
+        to: move.to,
+      }),
+      exampleId,
+      ...(adapter.promotionChecks?.length
+        ? {
+            checks: adapter.promotionChecks.map(({ id, label, severity }) => ({
+              id,
+              label,
+              severity,
+              status: 'pending' as const,
+            })),
+          }
+        : {}),
+      revision: await promotionRevision(move),
+      status: 'available' as const,
+    };
   };
 
   return {
@@ -1180,6 +1661,7 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     verify: () => withLock(verifyUnlocked),
     planDemote,
     planPromote,
+    previewPromote,
     promote: async (exampleId: string) => {
       assertExampleId(exampleId);
       return withLock(() =>
@@ -1187,6 +1669,232 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
           executePlannedMove(plan, 'Promotion'),
         ),
       );
+    },
+    confirmPromote: async ({
+      exampleId,
+      revision,
+      saveState,
+    }: {
+      exampleId: string;
+      revision: string;
+      saveState: CatalogSavedState;
+    }): Promise<CatalogMutationOutcome> => {
+      assertExampleId(exampleId);
+      if (saveState.status !== 'saved' || saveState.durability !== 'durable') {
+        return {
+          direction: 'promote' as const,
+          reason: 'save-state-changed' as const,
+          status: 'refused' as const,
+        };
+      }
+      let confirmation:
+        | {
+            checks: CatalogMutationCheckResult[];
+            kind: 'blocked';
+          }
+        | {
+            checks: CatalogMutationCheckResult[];
+            kind: 'finalization-failed';
+          }
+        | {
+            checks: CatalogMutationCheckResult[];
+            kind: 'moved';
+            result: Awaited<ReturnType<typeof executePlannedMove>>;
+          }
+        | undefined;
+      let mutationStarted = false;
+      try {
+        confirmation = await withLock(async () => {
+          const plan = await planPromote(exampleId);
+          const move = plan.operations[0];
+          if (!move || move.kind !== 'move-directory') {
+            throw new Error('Promotion plan has no directory move');
+          }
+          if ((await promotionRevision(move)) !== revision) {
+            return undefined;
+          }
+          const checks: NonNullable<typeof confirmation>['checks'] = [];
+          const declaredChecks = adapter.promotionChecks ?? [];
+          for (const [index, check] of declaredChecks.entries()) {
+            let outcome: Awaited<ReturnType<typeof check.run>>;
+            try {
+              outcome = await check.run({
+                direction: 'promote',
+                exampleId,
+              });
+            } catch (error) {
+              throw new CatalogMutationRefusalError(
+                'check-failed',
+                `${check.id}: ${error instanceof Error ? error.message : 'check failed'}`,
+              );
+            }
+            checks.push({
+              ...outcome,
+              id: check.id,
+              label: check.label,
+              severity: check.severity,
+            });
+            if (outcome.status === 'failed' && check.severity === 'blocking') {
+              checks.push(
+                ...declaredChecks
+                  .slice(index + 1)
+                  .map(({ id, label, severity }) => ({
+                    id,
+                    label,
+                    severity,
+                    status: 'not-reached' as const,
+                  })),
+              );
+              return { checks, kind: 'blocked' as const };
+            }
+          }
+          try {
+            await renderGeneratedArtifacts();
+          } catch (error) {
+            throw new CatalogMutationRefusalError(
+              'generation-failed',
+              error instanceof Error ? error.message : 'Generation failed',
+            );
+          }
+          const currentPlan = await planPromote(exampleId);
+          const currentMove = currentPlan.operations[0];
+          if (!currentMove || currentMove.kind !== 'move-directory') {
+            throw new Error('Promotion plan has no directory move');
+          }
+          if (await pathExists(await safeAbsolutePath(currentMove.to))) {
+            throw new Error(
+              `Promotion destination already exists: ${currentMove.to}`,
+            );
+          }
+          if ((await promotionRevision(currentMove)) !== revision) {
+            return undefined;
+          }
+          mutationStarted = true;
+          const result = await executePlannedMove(currentPlan, 'Promotion');
+          try {
+            await adapter.finalizePromotion?.({
+              direction: 'promote',
+              exampleId,
+            });
+          } catch {
+            return { checks, kind: 'finalization-failed' as const };
+          }
+          return { checks, kind: 'moved' as const, result };
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : '';
+        if (error instanceof CatalogCommittedFinalizationError) {
+          return {
+            direction: 'promote' as const,
+            filesystem: 'changed' as const,
+            reason: 'committed-finalization-failed' as const,
+            recovery: 'committed' as const,
+            recoveryEvidence: error.recoveryEvidence,
+            status: 'failed' as const,
+          };
+        }
+        if (error instanceof CatalogMutationRefusalError) {
+          return {
+            detail: message.replaceAll(await rootDirectory, '<repository>'),
+            direction: 'promote' as const,
+            reason: error.reason,
+            status: 'refused' as const,
+          };
+        }
+        const fileError = error as NodeJS.ErrnoException & { dest?: string };
+        const reason = message.startsWith(
+          'Promotion destination already exists:',
+        )
+          ? 'destination-conflict'
+          : message === 'Another catalog mutation is already in progress'
+            ? 'catalog-busy'
+            : message.includes('recovery lock') ||
+                (fileError.code === 'ENOTDIR' &&
+                  `${fileError.path ?? ''}${fileError.dest ?? ''}`.includes(
+                    '.catalog.lock.recovery',
+                  ))
+              ? 'recovery-refused'
+              : undefined;
+        if (reason) {
+          return {
+            direction: 'promote' as const,
+            reason,
+            status: 'refused' as const,
+          };
+        }
+        if (message === 'Catalog crash recovery was incomplete') {
+          return {
+            direction: 'promote' as const,
+            filesystem: 'may-have-changed' as const,
+            reason: 'recovery-incomplete' as const,
+            recovery: 'incomplete' as const,
+            status: 'failed' as const,
+          };
+        }
+        if (mutationStarted) {
+          if (isIndeterminateFilesystemError(error)) {
+            return {
+              direction: 'promote' as const,
+              filesystem: 'unknown' as const,
+              reason: 'outcome-unknown' as const,
+              recovery: 'unknown' as const,
+              status: 'failed' as const,
+            };
+          }
+          const recoveryIncomplete = message.includes(
+            'rollback was incomplete',
+          );
+          return {
+            direction: 'promote' as const,
+            filesystem: recoveryIncomplete ? 'may-have-changed' : 'restored',
+            reason: recoveryIncomplete
+              ? ('recovery-incomplete' as const)
+              : ('execution-failed' as const),
+            recovery: recoveryIncomplete
+              ? ('incomplete' as const)
+              : ('rolled-back' as const),
+            status: 'failed' as const,
+          };
+        }
+        return {
+          direction: 'promote' as const,
+          filesystem: 'unknown' as const,
+          reason: 'outcome-unknown' as const,
+          recovery: 'unknown' as const,
+          status: 'failed' as const,
+        };
+      }
+      if (!confirmation) {
+        return {
+          direction: 'promote' as const,
+          reason: 'stale-preview' as const,
+          status: 'refused' as const,
+        };
+      }
+      if (confirmation.kind === 'blocked') {
+        return {
+          checks: confirmation.checks,
+          direction: 'promote' as const,
+          reason: 'check-blocked' as const,
+          status: 'refused' as const,
+        };
+      }
+      if (confirmation.kind === 'finalization-failed') {
+        return {
+          direction: 'promote' as const,
+          filesystem: 'changed' as const,
+          reason: 'finalization-failed' as const,
+          recovery: 'committed' as const,
+          status: 'failed' as const,
+        };
+      }
+      return {
+        ...(confirmation.checks.length ? { checks: confirmation.checks } : {}),
+        direction: 'promote' as const,
+        commit: 'durable' as const,
+        result: confirmation.result,
+        status: 'succeeded' as const,
+      };
     },
   };
 };
@@ -1234,7 +1942,16 @@ export const runCatalogCli = async ({
   dev,
   worker,
 }: {
-  authoring: ReturnType<typeof createCatalogAuthoring>;
+  authoring: Pick<
+    ReturnType<typeof createCatalogAuthoring>,
+    | 'demote'
+    | 'generate'
+    | 'planDemote'
+    | 'planPromote'
+    | 'promote'
+    | 'scaffold'
+    | 'verify'
+  >;
   argv: readonly string[];
   io: {
     writeError: (message: string) => void;


### PR DESCRIPTION
## Summary
Build the revision-bound Promote contract for Workflow Catalog examples.

## Stack
Foundation 1 of 2; UI-103 follows.

Linear: https://linear.app/temporal/issue/UI-104/build-a-revision-bound-promote-contract

## Test plan
- Focused tests: 72 passed
- Full suite: 3047 passed, 2 skipped
- Check, lint, build, catalog verify, diff, and architect verification completed