### PR TITLE
[UI-103] Implement the complete confined example tree

### DIFF
--- a/scripts/catalog/ui-authoring.test.ts
+++ b/scripts/catalog/ui-authoring.test.ts
@@ -1,11 +1,27 @@
 import { execFile } from 'node:child_process';
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  cp,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
 
-import { createUiCatalogAuthoring } from './ui-authoring';
+import {
+  createUiCatalogAuthoring,
+  uiCatalogAuthoringLimits,
+} from './ui-authoring';
+import type { CatalogLoadedExample } from '../../src/lib/catalog/authoring';
 
 const temporaryDirectories: string[] = [];
 const execFileAsync = promisify(execFile);
@@ -145,6 +161,863 @@ describe('UI catalog authoring adapter', () => {
         'utf8',
       ),
     ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('loads one supported file as a revision-bound editable snapshot', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/snapshot-example',
+    );
+    const filePath = join(exampleDirectory, 'workflow.ts');
+    const content = "export const greeting = 'Hej, Temporal π';\n";
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(filePath, content);
+    await chmod(filePath, 0o640);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'snapshotExample',
+            },
+            id: 'snapshot-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+
+    const examples = await authoring.loadExamples();
+
+    expectTypeOf(examples).toEqualTypeOf<readonly CatalogLoadedExample[]>();
+    expect(examples).toEqual([
+      {
+        id: 'snapshot-example',
+        sourceFiles: [
+          {
+            content,
+            editable: true,
+            mode: 0o640,
+            path: 'workflow.ts',
+          },
+        ],
+        sourceId: 'oss',
+        sourceSnapshot: {
+          baseRevision: expect.stringMatching(/^[a-f\d]{64}$/),
+          limits: {
+            maxDepth: 8,
+            maxFileBytes: 256 * 1024,
+            maxFiles: 64,
+            maxTotalBytes: 1024 * 1024,
+          },
+        },
+        targetId: 'shared-workflows',
+        workflowType: 'snapshotExample',
+      },
+    ]);
+  });
+
+  it('derives a stable revision from file paths, contents, and modes', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/stable-revision',
+    );
+    const sourcePath = join(exampleDirectory, 'workflow.ts');
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(sourcePath, 'export const version = 1;\n');
+    await chmod(sourcePath, 0o640);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'stable-revision',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const loadRevision = async () =>
+      (await authoring.loadExamples())[0]!.sourceSnapshot.baseRevision;
+
+    const original = await loadRevision();
+    expect(await loadRevision()).toBe(original);
+
+    await writeFile(sourcePath, 'export const version = 2;\n');
+    const contentChanged = await loadRevision();
+    expect(contentChanged).not.toBe(original);
+
+    await chmod(sourcePath, 0o600);
+    const modeChanged = await loadRevision();
+    expect(modeChanged).not.toBe(contentChanged);
+
+    const nestedDirectory = join(exampleDirectory, 'nested');
+    await mkdir(nestedDirectory);
+    await rename(sourcePath, join(nestedDirectory, 'workflow.ts'));
+    expect(await loadRevision()).not.toBe(modeChanged);
+  });
+
+  it('rejects an unsafe descriptor ID before resolving its source directory', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: '../outside',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      createUiCatalogAuthoring(rootDirectory).loadExamples(),
+    ).rejects.toThrow('Catalog descriptor has an invalid example ID');
+  });
+
+  it('reports a busy catalog instead of loading while a mutation owns the revision lock', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    await writeFile(
+      join(rootDirectory, '.catalog.lock'),
+      `${JSON.stringify({ createdAt: Date.now(), pid: process.pid })}\n`,
+    );
+
+    await expect(
+      createUiCatalogAuthoring(rootDirectory).loadExamples(),
+    ).rejects.toThrow('Another catalog mutation is already in progress');
+  });
+
+  it('keeps new scaffolds focused while loading every file in an existing example tree', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+
+    await authoring.scaffold('new-example');
+    expect(
+      (
+        await readdir(join(rootDirectory, 'catalog.local/examples/new-example'))
+      ).sort(),
+    ).toEqual(['example.ts', 'workflow.ts']);
+
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/complete-tree',
+    );
+    await mkdir(join(exampleDirectory, 'notes'), { recursive: true });
+    await Promise.all([
+      writeFile(
+        join(exampleDirectory, 'example.ts'),
+        'export const catalogExample = true;\n',
+      ),
+      writeFile(
+        join(exampleDirectory, 'notes/context.md'),
+        '# Why this example exists\n',
+      ),
+      writeFile(
+        join(exampleDirectory, 'workflow.ts'),
+        'export async function completeTree() {}\n',
+      ),
+    ]);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'completeTree',
+            },
+            id: 'complete-tree',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+
+    const examples = await authoring.loadExamples();
+
+    expect(
+      examples
+        .find(({ id }) => id === 'complete-tree')
+        ?.sourceFiles.map(({ content, path }) => ({ content, path })),
+    ).toEqual([
+      {
+        content: 'export const catalogExample = true;\n',
+        path: 'example.ts',
+      },
+      {
+        content: '# Why this example exists\n',
+        path: 'notes/context.md',
+      },
+      {
+        content: 'export async function completeTree() {}\n',
+        path: 'workflow.ts',
+      },
+    ]);
+  });
+
+  it('adds one confined file to the buffered example without writing it to disk', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/buffered-example',
+    );
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(
+      join(exampleDirectory, 'workflow.ts'),
+      'export async function bufferedExample() {}\n',
+    );
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'bufferedExample',
+            },
+            id: 'buffered-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const [example] = await authoring.loadExamples();
+
+    const buffered = authoring.addFile(example!, {
+      content: '# Buffered notes\n',
+      path: 'notes/context.md',
+    });
+
+    expect(buffered.sourceFiles).toContainEqual({
+      content: '# Buffered notes\n',
+      editable: true,
+      mode: 0o644,
+      path: 'notes/context.md',
+    });
+    expect(example!.sourceFiles.map(({ path }) => path)).toEqual([
+      'workflow.ts',
+    ]);
+    expect(() =>
+      authoring.addFile(buffered, {
+        content: '# Replacement notes\n',
+        path: 'notes/context.md',
+      }),
+    ).toThrow('Catalog file already exists: notes/context.md');
+    await expect(
+      readFile(join(exampleDirectory, 'notes/context.md'), 'utf8'),
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('marks an existing buffered file for removal and restores it without changing disk', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/removable-example',
+    );
+    const filePath = join(exampleDirectory, 'workflow.ts');
+    const content = 'export async function removableExample() {}\n';
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(filePath, content);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'removableExample',
+            },
+            id: 'removable-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const [example] = await authoring.loadExamples();
+
+    const pendingRemoval = authoring.removeFile(example!, 'workflow.ts');
+
+    expect(pendingRemoval.sourceFiles).toContainEqual({
+      content,
+      editable: true,
+      mode: 0o644,
+      path: 'workflow.ts',
+      removed: true,
+    });
+    expect(await readFile(filePath, 'utf8')).toBe(content);
+
+    const restored = authoring.restoreFile(pendingRemoval, 'workflow.ts');
+
+    expect(restored.sourceFiles).toContainEqual({
+      content,
+      editable: true,
+      mode: 0o644,
+      path: 'workflow.ts',
+    });
+    expect(await readFile(filePath, 'utf8')).toBe(content);
+  });
+
+  it('preserves loaded modes and refuses a client-supplied mode for a new buffered file', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/mode-example',
+    );
+    const filePath = join(exampleDirectory, 'workflow.ts');
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(filePath, 'export async function modeExample() {}\n');
+    await chmod(filePath, 0o640);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'modeExample',
+            },
+            id: 'mode-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const [example] = await authoring.loadExamples();
+
+    const buffered = authoring.addFile(example!, {
+      content: '# Notes\n',
+      mode: 0o777,
+      path: 'notes.md',
+    } as Parameters<typeof authoring.addFile>[1]);
+
+    expect(buffered.sourceFiles).toEqual([
+      {
+        content: '# Notes\n',
+        editable: true,
+        mode: 0o644,
+        path: 'notes.md',
+      },
+      {
+        content: 'export async function modeExample() {}\n',
+        editable: true,
+        mode: 0o640,
+        path: 'workflow.ts',
+      },
+    ]);
+  });
+
+  it('excludes files that cannot safely participate in the editable fileset', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/confined-example',
+    );
+    const externalPath = join(rootDirectory, 'outside.ts');
+    await mkdir(exampleDirectory, { recursive: true });
+    await Promise.all([
+      writeFile(
+        join(exampleDirectory, 'workflow.ts'),
+        'export async function confinedExample() {}\n',
+      ),
+      writeFile(
+        join(exampleDirectory, 'asset.bin'),
+        Buffer.from([0xff, 0xd8, 0xff]),
+      ),
+      writeFile(join(exampleDirectory, 'nul.bin'), Buffer.from([0, 1, 2])),
+      writeFile(join(exampleDirectory, 'catalog.generated.json'), '{}\n'),
+      writeFile(join(exampleDirectory, 'unsafe\\name.ts'), 'export {};\n'),
+      writeFile(externalPath, 'export const outside = true;\n'),
+    ]);
+    await symlink(externalPath, join(exampleDirectory, 'linked.ts'));
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: {
+              targetId: 'shared-workflows',
+              workflowType: 'confinedExample',
+            },
+            id: 'confined-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+
+    const [example] =
+      await createUiCatalogAuthoring(rootDirectory).loadExamples();
+
+    expect(example?.sourceFiles.map(({ path }) => path)).toEqual([
+      'workflow.ts',
+    ]);
+  });
+
+  it('does not follow a source file replaced by a symlink immediately before open', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/replaced-entry',
+    );
+    const victimPath = join(exampleDirectory, 'victim.ts');
+    const outsidePath = join(rootDirectory, 'outside.ts');
+    await mkdir(exampleDirectory, { recursive: true });
+    await Promise.all([
+      writeFile(victimPath, 'export const original = true;\n'),
+      writeFile(outsidePath, 'export const secret = true;\n'),
+      writeFile(
+        join(exampleDirectory, 'workflow.ts'),
+        'export async function replacedEntry() {}\n',
+      ),
+    ]);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'replaced-entry',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory, {
+      beforeOpenSourceFile: async (path) => {
+        if (path !== victimPath) return;
+        await unlink(victimPath);
+        await symlink(outsidePath, victimPath);
+      },
+    });
+
+    const [example] = await authoring.loadExamples();
+
+    expect(example?.sourceFiles.map(({ path }) => path)).toEqual([
+      'workflow.ts',
+    ]);
+  });
+
+  it('rejects an example directory entry that is a symbolic link', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const externalDirectory = join(rootDirectory, 'external-example');
+    const linkedDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/linked-directory',
+    );
+    await mkdir(externalDirectory);
+    await writeFile(join(externalDirectory, 'workflow.ts'), 'export {};\n');
+    await symlink(externalDirectory, linkedDirectory, 'dir');
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'linked-directory',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      createUiCatalogAuthoring(rootDirectory).loadExamples(),
+    ).rejects.toThrow('source directory must be a real directory');
+  });
+
+  it('rejects a configured examples ancestor that is a symbolic link', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const examplesDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples',
+    );
+    const externalExamplesDirectory = join(rootDirectory, 'outside-examples');
+    const exampleId = 'linked-ancestor';
+    await rm(examplesDirectory, { recursive: true });
+    await mkdir(join(externalExamplesDirectory, exampleId), {
+      recursive: true,
+    });
+    await writeFile(
+      join(externalExamplesDirectory, exampleId, 'workflow.ts'),
+      'export const outside = true;\n',
+    );
+    await symlink(externalExamplesDirectory, examplesDirectory, 'dir');
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: exampleId,
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      createUiCatalogAuthoring(rootDirectory).loadExamples(),
+    ).rejects.toThrow('source root cannot traverse symbolic links');
+  });
+
+  it('rejects a parent directory replaced while opening a source file', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/replaced-parent',
+    );
+    const nestedDirectory = join(exampleDirectory, 'nested');
+    const victimPath = join(nestedDirectory, 'victim.ts');
+    const outsideDirectory = join(rootDirectory, 'outside-parent');
+    await Promise.all([
+      mkdir(nestedDirectory, { recursive: true }),
+      mkdir(outsideDirectory, { recursive: true }),
+    ]);
+    await Promise.all([
+      writeFile(victimPath, 'export const original = true;\n'),
+      writeFile(
+        join(outsideDirectory, 'victim.ts'),
+        'export const outside = true;\n',
+      ),
+    ]);
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'replaced-parent',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory, {
+      beforeOpenSourceFile: async (path) => {
+        if (path !== victimPath) return;
+        await rm(nestedDirectory, { recursive: true });
+        await symlink(outsideDirectory, nestedDirectory, 'dir');
+      },
+    });
+
+    await expect(authoring.loadExamples()).rejects.toThrow(
+      'source tree changed while loading',
+    );
+  });
+
+  it('bounds a source read and rejects a file that grows after opening', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/growing-source',
+    );
+    const sourcePath = join(exampleDirectory, 'workflow.ts');
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(sourcePath, 'x');
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'growing-source',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory, {
+      beforeReadSourceFile: async (path) => {
+        if (path === sourcePath) {
+          await writeFile(path, 'x'.repeat(256 * 1024 + 1));
+        }
+      },
+    });
+
+    await expect(authoring.loadExamples()).rejects.toThrow(
+      'maximum file size of 262144 bytes',
+    );
+  });
+
+  it('rejects editable trees that exceed the declared snapshot limits', async () => {
+    const loadLimitedExample = async (
+      exampleId: string,
+      createFiles: (directory: string) => Promise<void>,
+    ) => {
+      const rootDirectory = await createIsolatedCatalogRoot();
+      const exampleDirectory = join(
+        rootDirectory,
+        `src/lib/catalog/worker/examples/${exampleId}`,
+      );
+      await mkdir(exampleDirectory, { recursive: true });
+      await createFiles(exampleDirectory);
+      await writeFile(
+        join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+        JSON.stringify({
+          descriptors: [
+            {
+              execution: { targetId: 'shared-workflows' },
+              id: exampleId,
+              source: { id: 'oss' },
+            },
+          ],
+        }),
+      );
+      return createUiCatalogAuthoring(rootDirectory).loadExamples();
+    };
+    const results = await Promise.allSettled([
+      loadLimitedExample('deep-example', async (directory) => {
+        const deepDirectory = join(directory, 'a/b/c/d/e/f/g/h');
+        await mkdir(deepDirectory, { recursive: true });
+        await writeFile(join(deepDirectory, 'too-deep.ts'), 'export {};\n');
+      }),
+      loadLimitedExample('large-file-example', (directory) =>
+        writeFile(join(directory, 'large.ts'), 'x'.repeat(256 * 1024 + 1)),
+      ),
+      loadLimitedExample('many-files-example', async (directory) => {
+        await Promise.all(
+          Array.from({ length: 65 }, (_, index) =>
+            writeFile(join(directory, `${index}.ts`), 'export {};\n'),
+          ),
+        );
+      }),
+      loadLimitedExample('large-tree-example', async (directory) => {
+        await Promise.all(
+          Array.from({ length: 5 }, (_, index) =>
+            writeFile(join(directory, `${index}.ts`), 'x'.repeat(220 * 1024)),
+          ),
+        );
+      }),
+    ]);
+
+    expect(
+      results.map((result) =>
+        result.status === 'rejected' ? String(result.reason) : 'loaded',
+      ),
+    ).toEqual([
+      expect.stringContaining('maximum depth of 8'),
+      expect.stringContaining('maximum file size of 262144 bytes'),
+      expect.stringContaining('maximum file count of 64'),
+      expect.stringContaining('maximum total size of 1048576 bytes'),
+    ]);
+  });
+
+  it('keeps ordinary verification independent from editor snapshot limits', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    await authoring.scaffold('verify-large-source');
+    await writeFile(
+      join(
+        rootDirectory,
+        'catalog.local/examples/verify-large-source/notes.md',
+      ),
+      'x'.repeat(256 * 1024 + 1),
+    );
+    await authoring.generate();
+
+    await expect(authoring.verify()).resolves.toBeUndefined();
+    await expect(authoring.loadExamples()).rejects.toThrow(
+      'maximum file size of 262144 bytes',
+    );
+  });
+
+  it('refuses unsupported or over-limit files before adding them to the buffered fileset', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/add-limits-example',
+    );
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(join(exampleDirectory, 'workflow.ts'), 'abc');
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'add-limits-example',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const [loaded] = await authoring.loadExamples();
+    const example = {
+      ...loaded!,
+      sourceSnapshot: {
+        ...loaded!.sourceSnapshot,
+        limits: {
+          maxDepth: Number.MAX_SAFE_INTEGER,
+          maxFileBytes: Number.MAX_SAFE_INTEGER,
+          maxFiles: Number.MAX_SAFE_INTEGER,
+          maxTotalBytes: Number.MAX_SAFE_INTEGER,
+        },
+      },
+    };
+    const file = (path: string, content = '') => ({
+      content,
+      editable: true,
+      mode: 0o644,
+      path,
+    });
+    const additions = [
+      () => authoring.addFile(example, { content: '\0', path: 'binary.ts' }),
+      () =>
+        authoring.addFile(example, {
+          content: 'abc',
+          path: 'notes.generated.ts',
+        }),
+      () =>
+        authoring.addFile(example, {
+          content: 'a',
+          path: 'a/b/c/d/e/f/g/h/i.ts',
+        }),
+      () =>
+        authoring.addFile(example, {
+          content: 'x'.repeat(256 * 1024 + 1),
+          path: 'large.ts',
+        }),
+      () =>
+        authoring.addFile(
+          {
+            ...example,
+            sourceFiles: Array.from({ length: 64 }, (_, index) =>
+              file(`${index}.ts`),
+            ),
+          },
+          { content: '', path: 'extra.ts' },
+        ),
+      () =>
+        authoring.addFile(
+          {
+            ...example,
+            sourceFiles: Array.from({ length: 4 }, (_, index) =>
+              file(`${index}.ts`, 'x'.repeat(256 * 1024)),
+            ),
+          },
+          { content: 'a', path: 'total.ts' },
+        ),
+    ];
+
+    expect(
+      additions.map((add) => {
+        try {
+          add();
+          return 'added';
+        } catch (error) {
+          return String(error);
+        }
+      }),
+    ).toEqual([
+      expect.stringContaining('binary content'),
+      expect.stringContaining('generated file'),
+      expect.stringContaining('maximum depth of 8'),
+      expect.stringContaining('maximum file size of 262144 bytes'),
+      expect.stringContaining('maximum file count of 64'),
+      expect.stringContaining('maximum total size of 1048576 bytes'),
+    ]);
+  });
+
+  it('refuses Restore when intervening additions would exceed server-owned limits', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const exampleDirectory = join(
+      rootDirectory,
+      'src/lib/catalog/worker/examples/restore-limits',
+    );
+    await mkdir(exampleDirectory, { recursive: true });
+    await writeFile(join(exampleDirectory, 'workflow.ts'), 'export {};\n');
+    await writeFile(
+      join(rootDirectory, 'src/lib/catalog/browser/catalog.generated.json'),
+      JSON.stringify({
+        descriptors: [
+          {
+            execution: { targetId: 'shared-workflows' },
+            id: 'restore-limits',
+            source: { id: 'oss' },
+          },
+        ],
+      }),
+    );
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const [loaded] = await authoring.loadExamples();
+    const file = (path: string, content = '') => ({
+      content,
+      editable: true,
+      mode: 0o644,
+      path,
+    });
+    const fullByCount = {
+      ...loaded!,
+      sourceFiles: Array.from({ length: 64 }, (_, index) =>
+        file(`${index}.ts`),
+      ),
+    };
+    const countPending = authoring.removeFile(fullByCount, '0.ts');
+    const countWithAddition = authoring.addFile(countPending, {
+      content: '',
+      path: 'added.ts',
+    });
+    const fullByBytes = {
+      ...loaded!,
+      sourceFiles: Array.from({ length: 4 }, (_, index) =>
+        file(`${index}.ts`, 'x'.repeat(256 * 1024)),
+      ),
+    };
+    const bytesPending = authoring.removeFile(fullByBytes, '0.ts');
+    const bytesWithAddition = authoring.addFile(bytesPending, {
+      content: 'a',
+      path: 'added.ts',
+    });
+
+    expect(() => authoring.restoreFile(countWithAddition, '0.ts')).toThrow(
+      'maximum file count of 64',
+    );
+    expect(() => authoring.restoreFile(bytesWithAddition, '0.ts')).toThrow(
+      'maximum total size of 1048576 bytes',
+    );
+  });
+
+  it('keeps production loader limits immutable and server-owned', async () => {
+    const rootDirectory = await createIsolatedCatalogRoot();
+    const authoring = createUiCatalogAuthoring(rootDirectory);
+    const example = {
+      id: 'immutable-limits',
+      sourceFiles: Array.from({ length: 64 }, (_, index) => ({
+        content: '',
+        editable: true,
+        mode: 0o644,
+        path: `${index}.ts`,
+      })),
+      sourceId: 'oss',
+      sourceSnapshot: {
+        baseRevision: 'revision',
+        limits: {
+          maxDepth: Number.MAX_SAFE_INTEGER,
+          maxFileBytes: Number.MAX_SAFE_INTEGER,
+          maxFiles: Number.MAX_SAFE_INTEGER,
+          maxTotalBytes: Number.MAX_SAFE_INTEGER,
+        },
+      },
+      targetId: 'shared-workflows',
+    };
+
+    expect(Object.isFrozen(uiCatalogAuthoringLimits)).toBe(true);
+    expect(() =>
+      authoring.addFile(example, { content: '', path: 'added.ts' }),
+    ).toThrow('maximum file count of 64');
   });
 
   it('regenerates and verifies the canonical UI catalog', async () => {

--- a/scripts/catalog/ui-authoring.ts
+++ b/scripts/catalog/ui-authoring.ts
@@ -1,8 +1,19 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isUtf8 } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import {
+  type FileHandle,
+  lstat,
+  open,
+  readdir,
+  readFile,
+} from 'node:fs/promises';
+import { isAbsolute, join, posix, resolve } from 'node:path';
 
 import {
   type CatalogAuthoringArtifact,
+  type CatalogAuthoringFile,
+  type CatalogAuthoringLimits,
   composeCatalogArtifacts,
   createCatalogAuthoring,
   defineCatalogArtifact,
@@ -37,8 +48,319 @@ export const uiCatalogGeneratedPaths = [
   'src/lib/catalog/browser/catalog.generated.ts',
 ] as const;
 
-export const createUiCatalogAuthoring = (rootDirectory = getProjectRoot()) => {
+export const uiCatalogAuthoringLimits = Object.freeze({
+  maxDepth: 8,
+  maxFileBytes: 256 * 1024,
+  maxFiles: 64,
+  maxTotalBytes: 1024 * 1024,
+} as const) satisfies CatalogAuthoringLimits;
+
+const compareCodePoints = (left: string, right: string) =>
+  left < right ? -1 : left > right ? 1 : 0;
+
+const assertDescriptorExampleId = (exampleId: string) => {
+  if (!/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(exampleId)) {
+    throw new Error('Catalog descriptor has an invalid example ID');
+  }
+};
+
+const isEditableRelativePath = (path: string) =>
+  path.length > 0 &&
+  !isAbsolute(path) &&
+  !path.includes('\\') &&
+  !/^[a-z][a-z+.-]*:/i.test(path) &&
+  posix.normalize(path) === path &&
+  path !== '..' &&
+  !path.startsWith('../') &&
+  !posix.basename(path).includes('.generated.');
+
+type DirectoryIdentity = {
+  dev: number;
+  ino: number;
+  path: string;
+};
+
+const captureRealDirectory = async (
+  directory: string,
+  error: string,
+): Promise<DirectoryIdentity> => {
+  const metadata = await lstat(directory);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new Error(error);
+  }
+  return { dev: metadata.dev, ino: metadata.ino, path: directory };
+};
+
+const assertUnchangedDirectoryChain = async (
+  identities: readonly DirectoryIdentity[],
+) => {
+  // Node has no portable openat2-style API for fd-relative traversal. Identity
+  // checks ensure an observed parent replacement is rejected before content is
+  // returned. A same-user swap and restore entirely between checks cannot be
+  // excluded without platform-specific native code.
+  try {
+    for (const identity of identities) {
+      const current = await captureRealDirectory(
+        identity.path,
+        'Catalog source tree changed while loading',
+      );
+      if (current.dev !== identity.dev || current.ino !== identity.ino) {
+        throw new Error('Catalog source tree changed while loading');
+      }
+    }
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message === 'Catalog source tree changed while loading'
+    ) {
+      throw error;
+    }
+    throw new Error('Catalog source tree changed while loading', {
+      cause: error,
+    });
+  }
+};
+
+const captureConfinedSourceRoot = async (
+  rootDirectory: string,
+  examplesPath: string,
+): Promise<DirectoryIdentity[]> => {
+  if (
+    isAbsolute(examplesPath) ||
+    posix.normalize(examplesPath) !== examplesPath ||
+    examplesPath === '..' ||
+    examplesPath.startsWith('../')
+  ) {
+    throw new Error('Catalog source root must be confined');
+  }
+  let directory = resolve(rootDirectory);
+  const identities = [
+    await captureRealDirectory(
+      directory,
+      'Catalog source root cannot traverse symbolic links',
+    ),
+  ];
+  for (const component of examplesPath.split('/')) {
+    directory = join(directory, component);
+    identities.push(
+      await captureRealDirectory(
+        directory,
+        'Catalog source root cannot traverse symbolic links',
+      ),
+    );
+  }
+  return identities;
+};
+
+const readAtMost = async (handle: FileHandle, maxBytes: number) => {
+  const buffer = Buffer.allocUnsafe(maxBytes + 1);
+  let offset = 0;
+  while (offset < buffer.byteLength) {
+    const { bytesRead } = await handle.read(
+      buffer,
+      offset,
+      buffer.byteLength - offset,
+      null,
+    );
+    if (bytesRead === 0) break;
+    offset += bytesRead;
+  }
+  return buffer.subarray(0, offset);
+};
+
+const loadExampleSourceFiles = async (
+  directory: string,
+  relativeDirectory = '',
+  totals = { bytes: 0, files: 0 },
+  beforeOpenSourceFile?: (path: string) => void | Promise<void>,
+  beforeReadSourceFile?: (path: string) => void | Promise<void>,
+  ancestorIdentities: readonly DirectoryIdentity[] = [],
+  limits: CatalogAuthoringLimits = uiCatalogAuthoringLimits,
+): Promise<CatalogAuthoringFile[]> => {
+  const directoryIdentity = await captureRealDirectory(
+    directory,
+    `Catalog source directory must be a real directory: ${directory}`,
+  );
+  const directoryIdentities = [...ancestorIdentities, directoryIdentity];
+  await assertUnchangedDirectoryChain(directoryIdentities);
+  const entries = (await readdir(directory, { withFileTypes: true })).sort(
+    (left, right) => compareCodePoints(left.name, right.name),
+  );
+  await assertUnchangedDirectoryChain(directoryIdentities);
+  const files: CatalogAuthoringFile[] = [];
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    const relativePath = relativeDirectory
+      ? `${relativeDirectory}/${entry.name}`
+      : entry.name;
+    const depth = relativePath.split('/').length;
+    if (depth > limits.maxDepth) {
+      throw new Error(
+        `Catalog editable tree exceeds maximum depth of ${limits.maxDepth}: ${relativePath}`,
+      );
+    }
+    if (entry.isDirectory()) {
+      files.push(
+        ...(await loadExampleSourceFiles(
+          path,
+          relativePath,
+          totals,
+          beforeOpenSourceFile,
+          beforeReadSourceFile,
+          directoryIdentities,
+          limits,
+        )),
+      );
+      continue;
+    }
+    if (!entry.isFile() || !isEditableRelativePath(relativePath)) continue;
+    await beforeOpenSourceFile?.(path);
+    await assertUnchangedDirectoryChain(directoryIdentities);
+    const handle = await open(
+      path,
+      constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
+    ).catch((error) => {
+      if (
+        ['ELOOP', 'ENOENT'].includes(
+          (error as NodeJS.ErrnoException).code ?? '',
+        )
+      ) {
+        return;
+      }
+      throw error;
+    });
+    if (!handle) continue;
+    const { buffer, metadata } = await (async () => {
+      try {
+        const metadata = await handle.stat();
+        if (!metadata.isFile()) return { buffer: undefined, metadata };
+        if (metadata.size > limits.maxFileBytes) {
+          throw new Error(
+            `Catalog editable tree exceeds maximum file size of ${limits.maxFileBytes} bytes: ${relativePath}`,
+          );
+        }
+        await beforeReadSourceFile?.(path);
+        return {
+          buffer: await readAtMost(handle, limits.maxFileBytes),
+          metadata,
+        };
+      } finally {
+        await handle.close();
+      }
+    })();
+    await assertUnchangedDirectoryChain(directoryIdentities);
+    if (!buffer) continue;
+    const currentFileMetadata = await lstat(path).catch(() => undefined);
+    if (
+      !currentFileMetadata?.isFile() ||
+      currentFileMetadata.isSymbolicLink() ||
+      currentFileMetadata.dev !== metadata.dev ||
+      currentFileMetadata.ino !== metadata.ino
+    ) {
+      throw new Error('Catalog source tree changed while loading');
+    }
+    if (!isUtf8(buffer) || buffer.includes(0)) continue;
+    if (buffer.byteLength > limits.maxFileBytes) {
+      throw new Error(
+        `Catalog editable tree exceeds maximum file size of ${limits.maxFileBytes} bytes: ${relativePath}`,
+      );
+    }
+    totals.files += 1;
+    if (totals.files > limits.maxFiles) {
+      throw new Error(
+        `Catalog editable tree exceeds maximum file count of ${limits.maxFiles}`,
+      );
+    }
+    totals.bytes += buffer.byteLength;
+    if (totals.bytes > limits.maxTotalBytes) {
+      throw new Error(
+        `Catalog editable tree exceeds maximum total size of ${limits.maxTotalBytes} bytes`,
+      );
+    }
+    files.push({
+      content: buffer.toString('utf8'),
+      editable: true,
+      mode: metadata.mode & 0o777,
+      path: relativePath,
+    });
+  }
+  await assertUnchangedDirectoryChain(directoryIdentities);
+  return files;
+};
+
+export const createUiCatalogAuthoring = (
+  rootDirectory = getProjectRoot(),
+  hooks: {
+    beforeOpenSourceFile?: (path: string) => void | Promise<void>;
+    beforeReadSourceFile?: (path: string) => void | Promise<void>;
+  } = {},
+) => {
+  const loaderLimits = Object.freeze({
+    ...uiCatalogAuthoringLimits,
+  });
+  const sources = [
+    {
+      examplesPath: 'src/lib/catalog/worker/examples',
+      id: 'oss',
+      label: 'OSS',
+      registrationOutputPath: 'src/lib/catalog/worker/shared-registrations.ts',
+      registrationTypePath: 'src/lib/catalog/worker/registration-source.ts',
+    },
+    {
+      examplesPath: 'catalog.local/examples',
+      id: 'local',
+      label: 'Local',
+      registrationOutputPath: 'catalog.local/registration.ts',
+      registrationTypePath: 'src/lib/catalog/worker/registration-source.ts',
+    },
+  ];
   let renderGenerated: () => Promise<readonly CatalogAuthoringArtifact[]>;
+  const loadDescriptors = async () => {
+    const artifacts = await Promise.all(
+      [
+        'src/lib/catalog/browser/catalog.generated.json',
+        'catalog.local/catalog.generated.json',
+      ].map((path) =>
+        readFile(join(rootDirectory, path), 'utf8')
+          .then((content) => JSON.parse(content) as { descriptors?: unknown[] })
+          .catch((error) => {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+            throw error;
+          }),
+      ),
+    );
+    return artifacts.flatMap((artifact) =>
+      (artifact?.descriptors ?? []).map((descriptor) => {
+        const value = descriptor as {
+          execution?: { targetId?: unknown; workflowType?: unknown };
+          id?: unknown;
+          source?: { id?: unknown };
+        };
+        if (
+          typeof value.id !== 'string' ||
+          typeof value.source?.id !== 'string' ||
+          typeof value.execution?.targetId !== 'string'
+        ) {
+          throw new Error('Catalog descriptor graph is invalid');
+        }
+        assertDescriptorExampleId(value.id);
+        const source = sources.find(({ id }) => id === value.source?.id);
+        if (!source) {
+          throw new Error('Catalog descriptor graph is invalid');
+        }
+        return {
+          id: value.id,
+          source,
+          sourceId: value.source.id,
+          targetId: value.execution.targetId,
+          workflowType:
+            typeof value.execution.workflowType === 'string'
+              ? value.execution.workflowType
+              : undefined,
+        };
+      }),
+    );
+  };
   return createCatalogAuthoring({
     graph: {
       boundaries: {
@@ -89,23 +411,7 @@ export const createUiCatalogAuthoring = (rootDirectory = getProjectRoot()) => {
           path: 'src/lib/catalog/worker/shared-registrations.ts',
         },
       ],
-      sources: [
-        {
-          examplesPath: 'src/lib/catalog/worker/examples',
-          id: 'oss',
-          label: 'OSS',
-          registrationOutputPath:
-            'src/lib/catalog/worker/shared-registrations.ts',
-          registrationTypePath: 'src/lib/catalog/worker/registration-source.ts',
-        },
-        {
-          examplesPath: 'catalog.local/examples',
-          id: 'local',
-          label: 'Local',
-          registrationOutputPath: 'catalog.local/registration.ts',
-          registrationTypePath: 'src/lib/catalog/worker/registration-source.ts',
-        },
-      ],
+      sources,
       targets: [
         {
           defaultNamespace: 'default',
@@ -145,48 +451,51 @@ export const createUiCatalogAuthoring = (rootDirectory = getProjectRoot()) => {
     generatedPaths: uiCatalogGeneratedPaths,
     scaffold: ({ exampleId }) =>
       renderDirectoryCatalogScaffold({ exampleId, rootDirectory }),
-    loadExamples: async () => {
-      const artifacts = await Promise.all(
-        [
-          'src/lib/catalog/browser/catalog.generated.json',
-          'catalog.local/catalog.generated.json',
-        ].map((path) =>
-          readFile(join(rootDirectory, path), 'utf8')
-            .then(
-              (content) => JSON.parse(content) as { descriptors?: unknown[] },
-            )
-            .catch((error) => {
-              if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
-              throw error;
-            }),
-        ),
-      );
-      return artifacts.flatMap((artifact) =>
-        (artifact?.descriptors ?? []).map((descriptor) => {
-          const value = descriptor as {
-            execution?: { targetId?: unknown; workflowType?: unknown };
-            id?: unknown;
-            source?: { id?: unknown };
-          };
-          if (
-            typeof value.id !== 'string' ||
-            typeof value.source?.id !== 'string' ||
-            typeof value.execution?.targetId !== 'string'
-          ) {
-            throw new Error('Catalog descriptor graph is invalid');
-          }
-          return {
-            id: value.id,
-            sourceFiles: [],
-            sourceId: value.source.id,
-            targetId: value.execution.targetId,
-            workflowType:
-              typeof value.execution.workflowType === 'string'
-                ? value.execution.workflowType
-                : undefined,
-          };
+    loadExamples: async () =>
+      (await loadDescriptors()).map(
+        ({ id, sourceId, targetId, workflowType }) => ({
+          id,
+          sourceFiles: [],
+          sourceId,
+          targetId,
+          workflowType,
         }),
-      );
+      ),
+    editor: {
+      limits: loaderLimits,
+      loadExamples: async () =>
+        Promise.all(
+          (await loadDescriptors()).map(
+            async ({ id, source, sourceId, targetId, workflowType }) => {
+              const sourceRootIdentities = await captureConfinedSourceRoot(
+                rootDirectory,
+                source.examplesPath,
+              );
+              const sourceFiles = await loadExampleSourceFiles(
+                join(rootDirectory, source.examplesPath, id),
+                '',
+                { bytes: 0, files: 0 },
+                hooks.beforeOpenSourceFile,
+                hooks.beforeReadSourceFile,
+                sourceRootIdentities,
+                loaderLimits,
+              );
+              return {
+                id,
+                sourceFiles,
+                sourceId,
+                sourceSnapshot: {
+                  baseRevision: createHash('sha256')
+                    .update(JSON.stringify(sourceFiles))
+                    .digest('hex'),
+                  limits: { ...loaderLimits },
+                },
+                targetId,
+                workflowType,
+              };
+            },
+          ),
+        ),
     },
     validatePromotion: ({ exampleId }) =>
       planDirectoryCatalogPromotion({ exampleId, rootDirectory }),

--- a/src/lib/catalog/authoring.test.ts
+++ b/src/lib/catalog/authoring.test.ts
@@ -17,10 +17,11 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
   type CatalogAuthoringAdapter,
+  type CatalogComposedExample,
   composeCatalogArtifacts,
   createCatalogAuthoring as createCatalogAuthoringSdk,
   createCatalogLocalArtifactVitePlugin,
@@ -2941,5 +2942,68 @@ try {
         [example],
       ),
     ).toThrow('browser boundary must declare a browser consumer');
+  });
+
+  it('preserves mutable dry-run plan operations for existing consumers', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    await mkdir(join(rootDirectory, 'local/examples/mutable-plan'), {
+      recursive: true,
+    });
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    const plan = await authoring.planPromote('mutable-plan');
+
+    expectTypeOf(plan.operations).toEqualTypeOf<
+      (
+        | { from: string; kind: 'move-directory'; to: string }
+        | { kind: 'generate' | 'verify' }
+      )[]
+    >();
+    plan.operations.push({ kind: 'verify' });
+    expect(plan.operations.at(-1)).toEqual({ kind: 'verify' });
+  });
+
+  it('does not expose rename or folder management in the v1 authoring contract', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    expectTypeOf(authoring).not.toHaveProperty('renameFile');
+    expectTypeOf(authoring).not.toHaveProperty('createFolder');
+    expect(authoring).not.toHaveProperty('renameFile');
+    expect(authoring).not.toHaveProperty('createFolder');
+  });
+
+  it('keeps editor operations off the base authoring contract', async () => {
+    const rootDirectory = await createTemporaryDirectory();
+    const authoring = createCatalogAuthoring({
+      rootDirectory,
+      localExamplesPath: 'local/examples',
+      trackedExamplesPath: 'tracked/examples',
+      generatedPaths: [],
+      scaffold: () => [],
+      generate: () => [],
+    });
+
+    expectTypeOf(authoring).not.toHaveProperty('loadExamples');
+    expectTypeOf(authoring).not.toHaveProperty('addFile');
+    expectTypeOf<
+      Awaited<ReturnType<CatalogAuthoringAdapter['loadExamples']>>
+    >().toEqualTypeOf<readonly CatalogComposedExample[]>();
+    expect(authoring).not.toHaveProperty('loadExamples');
+    expect(authoring).not.toHaveProperty('addFile');
   });
 });

--- a/src/lib/catalog/authoring.ts
+++ b/src/lib/catalog/authoring.ts
@@ -70,6 +70,32 @@ export type CatalogComposedExample = {
   workflowType?: string;
 };
 
+export type CatalogAuthoringFile = {
+  content: string;
+  editable: boolean;
+  mode: number;
+  path: string;
+  removed?: true;
+};
+
+export type CatalogAuthoringLimits = {
+  maxDepth: number;
+  maxFileBytes: number;
+  maxFiles: number;
+  maxTotalBytes: number;
+};
+
+export type CatalogLoadedExample = Omit<
+  CatalogComposedExample,
+  'sourceFiles'
+> & {
+  sourceFiles: readonly CatalogAuthoringFile[];
+  sourceSnapshot: {
+    baseRevision: string;
+    limits: CatalogAuthoringLimits;
+  };
+};
+
 export type CatalogSavedState =
   | { durability: 'durable'; status: 'saved' }
   | { status: 'dirty' | 'failed' | 'stale' };
@@ -287,6 +313,86 @@ export type CatalogAuthoringAdapter = {
   }) => void | Promise<void>;
   verifyGenerated?: () => void | Promise<void>;
 };
+
+export type CatalogEditorAdapter = CatalogAuthoringAdapter & {
+  editor: {
+    limits: CatalogAuthoringLimits;
+    loadExamples: () =>
+      | readonly CatalogLoadedExample[]
+      | Promise<readonly CatalogLoadedExample[]>;
+  };
+};
+
+type CatalogAuthoringPlan = {
+  operations: (
+    | { from: string; kind: 'move-directory'; to: string }
+    | { kind: 'generate' | 'verify' }
+  )[];
+};
+
+type CatalogPromotionDescription = ReturnType<
+  NonNullable<CatalogAuthoringAdapter['describePromotion']>
+>;
+
+export type CatalogPromotionPreview =
+  | {
+      reason:
+        | 'preview-not-supported'
+        | 'save-failed'
+        | 'saved-revision-stale'
+        | 'unsaved-changes';
+      status: 'unavailable';
+    }
+  | (CatalogPromotionDescription & {
+      checks?: readonly {
+        id: string;
+        label: string;
+        severity: 'advisory' | 'blocking';
+        status: 'pending';
+      }[];
+      exampleId: string;
+      revision: string;
+      status: 'available';
+    });
+
+export type CatalogAuthoring = {
+  confirmPromote: (options: {
+    exampleId: string;
+    revision: string;
+    saveState: CatalogSavedState;
+  }) => Promise<CatalogMutationOutcome>;
+  demote: (exampleId: string) => Promise<CatalogMutationMoveResult>;
+  generate: () => Promise<readonly CatalogAuthoringArtifact[]>;
+  planDemote: (exampleId: string) => Promise<CatalogAuthoringPlan>;
+  planPromote: (exampleId: string) => Promise<CatalogAuthoringPlan>;
+  previewPromote: (options: {
+    exampleId: string;
+    saveState: CatalogSavedState;
+  }) => Promise<CatalogPromotionPreview>;
+  promote: (exampleId: string) => Promise<CatalogMutationMoveResult>;
+  scaffold: (exampleId: string) => Promise<void>;
+  verify: () => Promise<void>;
+};
+
+export type CatalogEditor = {
+  addFile: (
+    example: CatalogLoadedExample,
+    file: Pick<CatalogAuthoringFile, 'content' | 'path'>,
+  ) => CatalogLoadedExample;
+  loadExamples: () => Promise<readonly CatalogLoadedExample[]>;
+  removeFile: (
+    example: CatalogLoadedExample,
+    path: string,
+  ) => CatalogLoadedExample;
+  restoreFile: (
+    example: CatalogLoadedExample,
+    path: string,
+  ) => CatalogLoadedExample;
+};
+
+type CatalogAuthoringFor<Adapter> = Adapter extends CatalogEditorAdapter
+  ? CatalogAuthoring & CatalogEditor
+  : CatalogAuthoring;
 
 const pathExists = async (path: string) => {
   try {
@@ -585,7 +691,9 @@ export const renderCatalogSourceAssembly = ({
   ]);
 };
 
-export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
+export const createCatalogAuthoring = <Adapter extends CatalogAuthoringAdapter>(
+  adapter: Adapter,
+): CatalogAuthoringFor<Adapter> => {
   validateCatalogAuthoringGraph(adapter.graph, []);
   const declaredOutputs = new Set(
     adapter.graph.outputs.map((output) => output.path),
@@ -1615,7 +1723,97 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
     };
   };
 
-  return {
+  const editor =
+    'editor' in adapter ? (adapter as CatalogEditorAdapter).editor : undefined;
+  const editorLimits = editor ? Object.freeze({ ...editor.limits }) : undefined;
+  const assertRetainedAggregateLimits = (
+    files: readonly CatalogAuthoringFile[],
+  ) => {
+    if (!editorLimits) return;
+    const retainedFiles = files.filter(({ removed }) => !removed);
+    if (retainedFiles.length > editorLimits.maxFiles) {
+      throw new Error(
+        `Catalog editable fileset exceeds maximum file count of ${editorLimits.maxFiles}`,
+      );
+    }
+    const totalBytes = retainedFiles.reduce(
+      (total, file) => total + Buffer.byteLength(file.content),
+      0,
+    );
+    if (totalBytes > editorLimits.maxTotalBytes) {
+      throw new Error(
+        `Catalog editable fileset exceeds maximum total size of ${editorLimits.maxTotalBytes} bytes`,
+      );
+    }
+  };
+  const editorAuthoring: CatalogEditor | undefined = editor
+    ? {
+        addFile: (
+          example: CatalogLoadedExample,
+          file: Pick<CatalogAuthoringFile, 'content' | 'path'>,
+        ): CatalogLoadedExample => {
+          assertExplicitRelativePath(file.path);
+          if (posix.basename(file.path).includes('.generated.')) {
+            throw new Error(
+              `Catalog editable fileset cannot include a generated file: ${file.path}`,
+            );
+          }
+          if (file.content.includes('\0')) {
+            throw new Error(
+              `Catalog editable fileset cannot include binary content: ${file.path}`,
+            );
+          }
+          const limits = editorLimits!;
+          if (file.path.split('/').length > limits.maxDepth) {
+            throw new Error(
+              `Catalog editable fileset exceeds maximum depth of ${limits.maxDepth}: ${file.path}`,
+            );
+          }
+          const fileBytes = Buffer.byteLength(file.content);
+          if (fileBytes > limits.maxFileBytes) {
+            throw new Error(
+              `Catalog editable fileset exceeds maximum file size of ${limits.maxFileBytes} bytes: ${file.path}`,
+            );
+          }
+          if (example.sourceFiles.some(({ path }) => path === file.path)) {
+            throw new Error(`Catalog file already exists: ${file.path}`);
+          }
+          const addedFile = { ...file, editable: true, mode: 0o644 };
+          assertRetainedAggregateLimits([...example.sourceFiles, addedFile]);
+          return {
+            ...example,
+            sourceFiles: [...example.sourceFiles, addedFile].sort(
+              (left, right) =>
+                left.path < right.path ? -1 : left.path > right.path ? 1 : 0,
+            ),
+          };
+        },
+        loadExamples: () =>
+          withLock(() => Promise.resolve(editor.loadExamples())),
+        removeFile: (
+          example: CatalogLoadedExample,
+          path: string,
+        ): CatalogLoadedExample => ({
+          ...example,
+          sourceFiles: example.sourceFiles.map((file) =>
+            file.path === path ? { ...file, removed: true } : file,
+          ),
+        }),
+        restoreFile: (
+          example: CatalogLoadedExample,
+          path: string,
+        ): CatalogLoadedExample => {
+          const sourceFiles = example.sourceFiles.map((file) => {
+            if (file.path !== path) return file;
+            const { removed: _, ...restored } = file;
+            return restored;
+          });
+          assertRetainedAggregateLimits(sourceFiles);
+          return { ...example, sourceFiles };
+        },
+      }
+    : undefined;
+  const authoring: CatalogAuthoring = {
     demote: async (exampleId: string) => {
       assertExampleId(exampleId);
       return withLock(() =>
@@ -1897,6 +2095,9 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
       };
     },
   };
+  return (
+    editorAuthoring ? { ...authoring, ...editorAuthoring } : authoring
+  ) as CatalogAuthoringFor<Adapter>;
 };
 
 export const catalogHelp = `Usage: catalog <command>


### PR DESCRIPTION
## Summary
Implement the complete confined example tree for Workflow Catalog examples.

## Stack
Depends on UI-104 only for shared-file review ordering; UI-105 follows.

Linear: https://linear.app/temporal/issue/UI-103/implement-the-complete-confined-example-tree

## Test plan
- Combined focused tests: 86 passed
- Full suite: 3069 passed, 2 skipped
- Check, lint, build, catalog verify, diff, and architect verification completed