### PR TITLE
feat(DT-4385): add a CLI to demo an in-progress feature

### DIFF
--- a/.claude/skills/system-nexus-operation/SKILL.md
+++ b/.claude/skills/system-nexus-operation/SKILL.md
@@ -112,8 +112,48 @@ event group to `resolveSystemNexusEvent`.
 
 ## How to see the display on your computer
 
-The Temporal server must support the operation. Read the `local-temporal` skill
-for the procedure to run a local server build.
+Do this command:
 
-You must also enable `history.enableChasm` and
-`history.enableSignalWithStartFromWorkflow` in the dynamic configuration.
+```bash
+pnpm demo start system-nexus-signal-with-start
+```
+
+The command starts the server, starts the UI, makes the two events, and shows
+the links to the workflows. `pnpm demo stop` stops it again. Read
+`demos/README.md` for the command list and the definition format.
+
+The definition does these necessary things for you:
+
+- It finds the commit that added the operation, then selects a server. If a CLI
+  release has the commit, it uses that release. If no release has it, the command
+  compiles your `temporalio/temporal` checkout into the dev server of the CLI.
+- It enables `history.enableChasm` and
+  `history.enableSignalWithStartFromWorkflow` in the dynamic configuration.
+- It starts the catalog worker against that server.
+- It sends the operation to the `__temporal_system` endpoint.
+
+The target of the operation is the `signal-handlers` catalog example. The catalog
+worker runs it. Thus the workflow that the operation starts and signals is a
+workflow that the catalog has. Read the `catalog` skill.
+
+**The demo is of the Nexus operation, not the `signalWithStart` function of the
+client.** The function of the client goes to the frontend RPC. It makes no caller
+workflow and no Nexus events.
+
+**The Go SDK cannot send this operation from a workflow.** It refuses the
+reserved `__temporal_` prefix. This is the reason that
+`TestBothWorkflowsVisibleAfterSWSFromWorkflow` in the server repository is a
+skipped test.
+
+**The TypeScript SDK can send it.** The demo scenario uses an ordinary caller
+workflow with `createNexusServiceClient` and the `__temporal_system` endpoint.
+
+The payloads are `binary/protobuf` workflowservice messages, and the SDK has no
+encoder for them yet. Therefore the scenario supplies one in
+`payload-converter.ts` and it runs the caller on a worker of its own, thus the
+Catalog worker gets no change. The converter is temporary: it goes away when the
+SDK gets the operation. The Python SDK has it as
+`workflow.signal_with_start_workflow(...)` on a branch. Read
+`utilities/demo/README.md` for the details of the converter.
+
+To use a server that is not the default, read the `local-temporal` skill.

--- a/.env.feature-demo.local.example
+++ b/.env.feature-demo.local.example
@@ -1,0 +1,9 @@
+# Machine-local settings for `pnpm demo`. Copy to .env.feature-demo.local,
+# which is gitignored, and set the paths for your own machine.
+#
+# These are only read when a definition needs a Temporal server that no CLI
+# release carries yet, so the demo has to compile your own checkout. A demo
+# whose feature is in a release never needs them.
+
+# TEMPORAL_SERVER_REPO=/path/to/temporalio/temporal
+# TEMPORAL_CLI_REPO=/path/to/temporalio/cli

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ go.work.sum
 /.workflow-catalog.lock.recovery
 /.workflow-catalog.journal.json
 /.workflow-catalog.transaction-*/
+
+# Feature demo runner output and machine-local paths (scripts/feature-demo.ts)
+/.feature-demo/
+/.env.feature-demo.local

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "stylelint:fix": "stylelint --fix \"src/**/*.{css,postcss,svelte}\"",
     "generate:locales": "esno scripts/generate-locales.ts",
     "generate:proto": "esno scripts/generate-temporal-proto.ts",
+    "demo": "esno utilities/demo/demo-cli.ts",
     "run-workflows": "esno scripts/run-workflows.ts",
     "run-workflows:long-running": "esno scripts/start-long-running.ts",
     "audit:tailwind": "esno scripts/audit-tailwind-colors",

--- a/scripts/catalog/catalog-cli.ts
+++ b/scripts/catalog/catalog-cli.ts
@@ -15,6 +15,7 @@ const isReportedCatalogCliError = (error: unknown) => {
     'Unknown catalog command',
     'Invalid arguments for catalog command',
     'Usage: catalog demote',
+    'Usage: catalog list',
     'Usage: catalog promote',
   ].some((prefix) => error.message.startsWith(prefix));
 };

--- a/src/lib/catalog/authoring.test.ts
+++ b/src/lib/catalog/authoring.test.ts
@@ -1196,6 +1196,7 @@ try {
         changedPaths: [],
         moved: { from: '', to: '' },
       }),
+      list: async () => [],
       scaffold: async () => undefined,
       generate: async () => [],
       verify: async () => undefined,
@@ -1219,6 +1220,133 @@ try {
     ).rejects.toThrow('Unknown catalog command "new"');
   });
 
+  it('lists the catalog examples the adapter knows about', async () => {
+    const output: string[] = [];
+    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+      demote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+      list: async () => [
+        {
+          id: 'signal-handlers',
+          sourceFiles: [],
+          sourceId: 'oss',
+          targetId: 'shared-workflows',
+          workflowType: 'signalWorkflow',
+        },
+        {
+          id: 'standalone-activity',
+          sourceFiles: [],
+          sourceId: 'oss',
+          targetId: 'shared-workflows',
+        },
+      ],
+      scaffold: async () => undefined,
+      generate: async () => [],
+      verify: async () => undefined,
+      planDemote: async () => ({ operations: [] }),
+      planPromote: async () => ({ operations: [] }),
+      promote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+    };
+
+    await runCatalogCli({
+      authoring,
+      argv: ['list'],
+      io: {
+        writeError: () => undefined,
+        writeOutput: (message) => output.push(message),
+      },
+    });
+
+    expect(output).toEqual([
+      [
+        'signal-handlers\toss\tshared-workflows\tsignalWorkflow',
+        'standalone-activity\toss\tshared-workflows\t-',
+      ].join('\n'),
+    ]);
+  });
+
+  it('lists the catalog examples as JSON on request', async () => {
+    const output: string[] = [];
+    const examples = [
+      {
+        id: 'hello',
+        sourceFiles: [],
+        sourceId: 'oss',
+        targetId: 'shared-workflows',
+        workflowType: 'hello',
+      },
+    ];
+    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+      demote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+      list: async () => examples,
+      scaffold: async () => undefined,
+      generate: async () => [],
+      verify: async () => undefined,
+      planDemote: async () => ({ operations: [] }),
+      planPromote: async () => ({ operations: [] }),
+      promote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+    };
+
+    await runCatalogCli({
+      authoring,
+      argv: ['list', '--json'],
+      io: {
+        writeError: () => undefined,
+        writeOutput: (message) => output.push(message),
+      },
+    });
+
+    expect(output).toEqual([JSON.stringify(examples, null, 2)]);
+  });
+
+  it('says how to make an example when the catalog has none', async () => {
+    const output: string[] = [];
+    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+      demote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+      list: async () => [],
+      scaffold: async () => undefined,
+      generate: async () => [],
+      verify: async () => undefined,
+      planDemote: async () => ({ operations: [] }),
+      planPromote: async () => ({ operations: [] }),
+      promote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+    };
+
+    await runCatalogCli({
+      authoring,
+      argv: ['list'],
+      io: {
+        writeError: () => undefined,
+        writeOutput: (message) => output.push(message),
+      },
+    });
+
+    expect(output.join('\n')).toContain('catalog scaffold <example-id>');
+  });
+
+  it('refuses an unknown flag on list', async () => {
+    const authoring: ReturnType<typeof createCatalogAuthoring> = {
+      demote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+      list: async () => [],
+      scaffold: async () => undefined,
+      generate: async () => [],
+      verify: async () => undefined,
+      planDemote: async () => ({ operations: [] }),
+      planPromote: async () => ({ operations: [] }),
+      promote: async () => ({ changedPaths: [], moved: { from: '', to: '' } }),
+    };
+
+    await expect(
+      runCatalogCli({
+        authoring,
+        argv: ['list', '--yaml'],
+        io: {
+          writeError: () => undefined,
+          writeOutput: () => undefined,
+        },
+      }),
+    ).rejects.toThrow('Usage: catalog list [--json]');
+  });
+
   it('dispatches demotion dry-run to the planner without mutating', async () => {
     const calls: string[] = [];
     const output: string[] = [];
@@ -1238,6 +1366,7 @@ try {
         calls.push('demote');
         return { changedPaths: [], moved: { from: '', to: '' } };
       },
+      list: async () => [],
       scaffold: async () => undefined,
       generate: async () => [],
       verify: async () => undefined,
@@ -1272,6 +1401,7 @@ try {
         changedPaths: [],
         moved: { from: '', to: '' },
       }),
+      list: async () => [],
       scaffold: async () => undefined,
       generate: async () => [],
       verify: async () => undefined,
@@ -1326,6 +1456,7 @@ try {
           },
         };
       },
+      list: async () => [],
       scaffold: async () => undefined,
       generate: async () => [],
       verify: async () => undefined,

--- a/src/lib/catalog/authoring.ts
+++ b/src/lib/catalog/authoring.ts
@@ -1177,6 +1177,15 @@ export const createCatalogAuthoring = (adapter: CatalogAuthoringAdapter) => {
       withLock(() =>
         withJournaledFiles(adapter.generatedPaths, generateUnlocked),
       ),
+    /**
+     * The examples the catalog knows about, tracked and local alike. This is the
+     * catalog's own answer to "what can I run", so callers never read the
+     * generated artifacts to find out.
+     */
+    list: async (): Promise<readonly CatalogComposedExample[]> =>
+      [...(await adapter.loadExamples())].sort((left, right) =>
+        left.id.localeCompare(right.id),
+      ),
     verify: () => withLock(verifyUnlocked),
     planDemote,
     planPromote,
@@ -1195,6 +1204,7 @@ export const catalogHelp = `Usage: catalog <command>
 
 Commands:
   catalog help                   Show this help text.
+  catalog list [--json]          List the catalog examples.
   catalog scaffold <example-id>  Create a local catalog example.
   catalog generate               Generate catalog artifacts.
   catalog verify                 Verify catalog artifacts and boundaries.
@@ -1204,6 +1214,23 @@ Commands:
                                            Move or preview a tracked example into the local, Git-ignored catalog.
   catalog dev                    Start the catalog UI and worker.
   catalog worker                 Start the catalog worker.`;
+
+const formatCatalogList = (examples: readonly CatalogComposedExample[]) => {
+  if (!examples.length) {
+    return 'No catalog examples. Run "catalog scaffold <example-id>" to make one.';
+  }
+
+  return examples
+    .map((example) =>
+      [
+        example.id,
+        example.sourceId,
+        example.targetId,
+        example.workflowType ?? '-',
+      ].join('\t'),
+    )
+    .join('\n');
+};
 
 const formatCatalogMoveSuccess = ({
   exampleId,
@@ -1257,6 +1284,21 @@ export const runCatalogCli = async ({
     io.writeOutput(catalogHelp);
     return;
   }
+  if (command === 'list' && (argv.length === 1 || argv.length === 2)) {
+    if (argv.length === 2 && argv[1] !== '--json') {
+      fail('Usage: catalog list [--json]');
+    }
+
+    const examples = await authoring.list();
+
+    io.writeOutput(
+      argv[1] === '--json'
+        ? JSON.stringify(examples, null, 2)
+        : formatCatalogList(examples),
+    );
+    return;
+  }
+
   if (command === 'scaffold' && argv.length === 2) {
     await authoring.scaffold(argv[1]);
     io.writeOutput(
@@ -1334,6 +1376,7 @@ export const runCatalogCli = async ({
       'dev',
       'generate',
       'help',
+      'list',
       'scaffold',
       'verify',
       'worker',

--- a/utilities/demo/README.md
+++ b/utilities/demo/README.md
@@ -155,32 +155,43 @@ one. Nothing is built, so it is much faster.
 `temporalio/temporal` checkout into the CLI's dev server through a Go workspace
 held in `.feature-demo/`.
 
-Where those checkouts live belongs to your machine, not to a definition, so a
-definition does not name them. Set them once:
-
-```bash
-cp .env.feature-demo.local.example .env.feature-demo.local
-# then edit the two paths
-```
+The two checkouts are fetched, not configured. A blobless shallow fetch of one
+commit costs about a second, so the build uses `temporalio/temporal` and
+`temporalio/cli` at the refs a definition names, both `main` by default:
 
 ```
-TEMPORAL_SERVER_REPO=/path/to/temporalio/temporal
-TEMPORAL_CLI_REPO=/path/to/temporalio/cli
+· Fetching Temporal CLI at main
+· Fetching Temporal server at main
 ```
 
-Real environment variables win over that file, which is gitignored. The paths
-are read only when a build is actually needed, so a demo whose feature is in a
-release never asks for them, and a definition that does need one fails with the
-two variables to set. **Neither repository is modified**: no `replace`
-directive is added and no `go.work` file is written inside either tree. Whatever
-each repo has checked out is what gets compiled, and the resolved commits are
-recorded in the summary.
+They land in `.feature-demo/checkouts/`, which means the demo needs no
+configuration, it does not compile whatever you happen to have open, and it
+cannot pick up a `replace` directive from your own tree.
 
-This is what replaces `make start` in the server repo. It buys three things
-`make start` cannot give you: the dynamic config arrives as command-line flags
-instead of an edit to `config/dynamicconfig/development-sql.yaml`, the `default`
-namespace and the search attributes are registered for you, and the run is
-reproducible from the JSON file alone.
+**The two refs are a pair, and they have to move together.** The workspace puts
+both modules in one dependency graph, so Go resolves `go.temporal.io/api` to the
+highest requirement across the two, and both trees then have to compile against
+that one version. The repositories are not released in step, so an arbitrary pair
+fails, including the current `main` of each: today the CLI wants v1.63.4 and the
+server wants v1.63.5, and each removes something the other uses. The pair this
+scenario names agrees on v1.63.0.
+
+To move them, find a CLI commit and a server commit that name the same
+`go.temporal.io/api`, and change both refs at once. The build reports the pair it
+used when it fails.
+
+`requires.serverCommit` is a floor, not a build target. It gives the release line
+the feature needs, and the fetched server is checked to contain it:
+
+```
+.../checkouts/temporal_server_repo-main is at a31f4762, which does not contain
+01aa279c4. That commit adds the feature this scenario shows.
+```
+
+To build your own working tree instead, which is what developing the feature
+wants, point `TEMPORAL_SERVER_REPO` or `TEMPORAL_CLI_REPO` at it. An explicit
+path wins over a fetch, and only then are uncommitted changes part of the build
+cache key.
 
 ## `worker`
 

--- a/utilities/demo/README.md
+++ b/utilities/demo/README.md
@@ -15,7 +15,7 @@ pnpm demo scenarios                                # the scenarios a definition 
 pnpm demo show system-nexus-signal-with-start      # the definition with its defaults applied
 pnpm demo start system-nexus-signal-with-start     # run every stage
 pnpm demo start system-nexus-signal-with-start --skip ui
-pnpm demo start system-nexus-signal-with-start --only scenarios --no-keep-alive
+pnpm demo start system-nexus-signal-with-start --only scenarios --once
 pnpm demo stop                                     # stop what an earlier start left running
 pnpm demo new my-feature                           # a definition to edit
 ```
@@ -25,15 +25,26 @@ pnpm demo new my-feature                           # a definition to edit
 | `list`                   | Every scenario, with its stages and the examples it names         |
 | `scenarios`              | The scenario registry, with what each one does                     |
 | `show <definition>`      | The definition after defaults are applied, which runs nothing      |
-| `start <definition>`     | Runs the stages, prints the reviewer summary, holds the run open   |
+| `start <definition>`     | Runs the stages, prints the reviewer summary, and exits            |
 | `stop [<definition>]`    | Stops the processes a `start` recorded, all runs or one            |
 | `new <name> [example-id...]` | Writes a definition naming those catalog examples            |
 | `help`                   | The command list                                                   |
 
-`start` holds every process open until Ctrl-C and writes the reviewer summary to
-`.feature-demo/<name>/summary.md`. It also records the process ids in
-`.feature-demo/<name>/run.json`, which is what `stop` reads. Each stage writes
-its own log beside them, so a stage that fails to come up says where to look.
+`start` runs the stages, prints the reviewer summary, and exits. The processes it
+started are detached, so they keep running: `stop` is how they end. `--once`
+tears them down again before returning, which is what a one-shot check wants.
+
+Starting a scenario that is already recorded as running stops that run first, so
+a stale stack cannot be reused by accident. Anything unrecorded on a port belongs
+to somebody else and is reused as before.
+
+The summary lands in `.feature-demo/<name>/summary.md`, the process ids and the
+ports the run owns in `.feature-demo/<name>/run.json`, and each stage writes its
+own log beside them, so a stage that fails to come up says where to look. `stop`
+kills the recorded pids and then sweeps those ports, so a child that outlives its
+record still goes. A child that holds no port, such as the catalog worker, is
+reachable only through its recorded pid, because a sweep by process name would
+also catch a worker you started yourself.
 
 Repeat `--skip` or `--only` to name more than one stage.
 

--- a/utilities/demo/README.md
+++ b/utilities/demo/README.md
@@ -1,0 +1,280 @@
+# Feature demos
+
+One JSON file describes everything a reviewer needs to see a feature work:
+which Temporal server to run, which dynamic config to enable on it, which
+catalog examples to run against it, and what to look at afterwards.
+
+The workflows a demo runs are catalog examples, and the worker that runs them is
+the catalog worker. A demo names an example by id and takes its workflow type,
+task queue, and input schema from the catalog, so a demo cannot drift from the
+code the catalog page runs.
+
+```bash
+pnpm demo list                                     # the definitions
+pnpm demo scenarios                                # the scenarios a definition can name
+pnpm demo show system-nexus-signal-with-start      # the definition with its defaults applied
+pnpm demo start system-nexus-signal-with-start     # run every stage
+pnpm demo start system-nexus-signal-with-start --skip ui
+pnpm demo start system-nexus-signal-with-start --only scenarios --no-keep-alive
+pnpm demo stop                                     # stop what an earlier start left running
+pnpm demo new my-feature                           # a definition to edit
+```
+
+| Command                  | What it does                                                     |
+| ------------------------ | ---------------------------------------------------------------- |
+| `list`                   | Every scenario, with its stages and the examples it names         |
+| `scenarios`              | The scenario registry, with what each one does                     |
+| `show <definition>`      | The definition after defaults are applied, which runs nothing      |
+| `start <definition>`     | Runs the stages, prints the reviewer summary, holds the run open   |
+| `stop [<definition>]`    | Stops the processes a `start` recorded, all runs or one            |
+| `new <name> [example-id...]` | Writes a definition naming those catalog examples            |
+| `help`                   | The command list                                                   |
+
+`start` holds every process open until Ctrl-C and writes the reviewer summary to
+`.feature-demo/<name>/summary.md`. It also records the process ids in
+`.feature-demo/<name>/run.json`, which is what `stop` reads. Each stage writes
+its own log beside them, so a stage that fails to come up says where to look.
+
+Repeat `--skip` or `--only` to name more than one stage.
+
+## Layout
+
+A scenario is a directory, the way a catalog example is. Its definition and its
+own behaviour live together, and both are TypeScript:
+
+```
+utilities/demo/
+  demo-cli.ts        the entry point
+  cli.ts run.ts      the dispatcher and the stage runner
+  stages/            one file per stage: server, worker, ui
+  examples.ts        starts the catalog examples a demo names
+  scenarios/
+    system-nexus-signal-with-start/
+      definition.ts      what to run and what to check
+      scenario.ts        behaviour naming examples cannot express
+    catalog-signals-and-timers/
+      definition.ts      names catalog examples only, so it ships no behaviour
+```
+
+A definition is a module, not JSON, because the shape only matters at runtime
+and TypeScript checks it for free. `defineScenario` applies the defaults, and a
+definition that passes an option its scenario does not have fails to compile:
+
+```
+error TS2561: Object literal may only specify known properties, but
+'signalNaem' does not exist in type '{ ... signalName?: string ... }'.
+Did you mean to write 'signalName'?
+```
+
+A scenario declares what to run in one of two ways, and may use both:
+
+- `examples` names catalog examples to start. The workflow type, the task queue,
+  and the input schema come from the catalog.
+- `scenario.ts` beside the `definition.ts` is for behaviour that naming examples
+  cannot express. It exports `scenario`, and the definition gives it options
+  under `scenario`, checked by the compiler.
+
+## Adding a demo
+
+1. **Pick the catalog examples.** The catalog owns this, so ask the catalog:
+
+   ```bash
+   pnpm catalog list            # id, source, target, workflow type
+   pnpm catalog list --json     # the same, for scripting
+   ```
+
+   If the feature needs a workflow the catalog does not have, add it there first
+   with `pnpm catalog scaffold <id>`, then `pnpm catalog generate`. Promote it
+   with `pnpm catalog promote <id>` when the demo should work from a clean clone.
+
+2. **Scaffold the definition with those ids:**
+
+   ```bash
+   pnpm demo new order-timeout signal-handlers long-activity
+   ```
+
+   Each example arrives with its `role` and `note` filled in from the catalog's
+   own title and description. A mistyped id fails before any file is written.
+3. **Say what the server needs.** Leave `source` as `auto`. Add
+   `requires.serverCommit` when the feature depends on an unreleased server change,
+   and put whatever dynamic config it needs in `dynamicConfig`. See
+   [Which source to use](#which-source-to-use).
+4. **Write the review steps.** `preview.notes` is the checklist the reviewer
+   follows, so write each one as something that must be true.
+5. **Run it.** `pnpm demo start order-timeout`, then `pnpm demo stop`.
+
+A bad example id or an input that does not match the example's declared schema
+fails before anything starts, naming the problem.
+
+## Stages
+
+Four stages run in order. Each one is optional: turn it off with `"enabled":
+false` in the definition, or with `--skip <stage>` / `--only <stage>`. A stage
+also stands down on its own when something is already listening on its port, so
+a server or UI you started yourself is reused rather than fought over.
+
+| Stage       | What it does                                                    |
+| ----------- | --------------------------------------------------------------- |
+| `server`    | Provisions a Temporal dev server and applies the dynamic config |
+| `worker`    | Starts the catalog worker against that server                   |
+| `ui`        | Starts the ui-server API and the UI dev server                  |
+| `scenarios` | Runs the workflows that exercise the feature                    |
+
+## `server`
+
+| Field              | Meaning                                                                 |
+| ------------------ | ----------------------------------------------------------------------- |
+| `source`           | `cli`, `workspace`, or `binary`                                         |
+| `version`          | `cli` source only: a `temporal.download` release, or `latest`            |
+| `path`             | `binary` source only: a CLI binary already on disk                      |
+| `cliRepo`          | Overrides `TEMPORAL_CLI_REPO` for this definition, rarely wanted        |
+| `serverRepo`       | Overrides `TEMPORAL_SERVER_REPO` for this definition, rarely wanted     |
+| `serverRef`        | Fails the run unless the server checkout is on this branch or commit    |
+| `minServerVersion` | Fails the run early if the resolved server is older than this           |
+| `dynamicConfig`    | `--dynamic-config-value` pairs, as JSON values                          |
+| `searchAttributes` | `--search-attribute` pairs, name to type                                |
+| `port`, `uiPort`, `httpPort`, `logLevel`, `dbFilename`, `namespace` | Dev server settings |
+
+### Which source to use
+
+`cli` downloads a published release, which is right whenever the feature is in
+one. Nothing is built, so it is much faster.
+
+`workspace` is for a feature no release carries yet. It compiles your own
+`temporalio/temporal` checkout into the CLI's dev server through a Go workspace
+held in `.feature-demo/`.
+
+Where those checkouts live belongs to your machine, not to a definition, so a
+definition does not name them. Set them once:
+
+```bash
+cp .env.feature-demo.local.example .env.feature-demo.local
+# then edit the two paths
+```
+
+```
+TEMPORAL_SERVER_REPO=/path/to/temporalio/temporal
+TEMPORAL_CLI_REPO=/path/to/temporalio/cli
+```
+
+Real environment variables win over that file, which is gitignored. The paths
+are read only when a build is actually needed, so a demo whose feature is in a
+release never asks for them, and a definition that does need one fails with the
+two variables to set. **Neither repository is modified**: no `replace`
+directive is added and no `go.work` file is written inside either tree. Whatever
+each repo has checked out is what gets compiled, and the resolved commits are
+recorded in the summary.
+
+This is what replaces `make start` in the server repo. It buys three things
+`make start` cannot give you: the dynamic config arrives as command-line flags
+instead of an edit to `config/dynamicconfig/development-sql.yaml`, the `default`
+namespace and the search attributes are registered for you, and the run is
+reproducible from the JSON file alone.
+
+## `worker`
+
+| Field            | Meaning                                                     |
+| ---------------- | ----------------------------------------------------------- |
+| `targetId`       | Limit the worker to one registered catalog target           |
+| `readyTimeoutMs` | How long to wait for the worker to report a running target  |
+
+The stage runs `pnpm catalog worker` with `TEMPORAL_ADDRESS` and
+`TEMPORAL_NAMESPACE` set to whatever the server stage provisioned. Real
+environment variables win over `.env.catalog`, so the worker follows the demo's
+server without any file being edited. The stage waits for the worker's own
+`target-running` event before the scenarios start, so nothing races.
+
+Task queues always come from a catalog target's registration and are never set
+here. See the `catalog` skill.
+
+## `ui`
+
+| Field             | Meaning                                              |
+| ----------------- | ---------------------------------------------------- |
+| `uiServer`        | Start the Go ui-server that serves the HTTP API      |
+| `web`             | Start the Vite dev server that serves the UI         |
+| `apiPort`         | ui-server port, default `8081`                       |
+| `webPort`         | UI port, default `3000`                              |
+| `rebuildUiServer` | Run `make build` in `server/` even if a binary exists |
+
+The ui-server reads `temporalGrpcAddress` from YAML with no environment
+override, so the runner generates its own config directory under
+`.feature-demo/` pointed at whichever port the server stage used.
+`server/config` is left alone.
+
+If the server checkout uses a newer `go.temporal.io/api` than `server/go.mod`,
+the ui-server rejects new HTTP fields before they reach the server. See the
+`local-temporal` skill for how to bring the two into line.
+
+## `examples` and `scenario`
+
+`examples` is a list of catalog examples to start:
+
+```json
+"examples": [
+  { "id": "signal-handlers", "input": [300], "role": "signal wait" }
+]
+```
+
+Each entry takes its workflow type, task queue, and default input from
+`catalog.generated.json`. An `input` override is checked against the schema the
+example declares, so a demo cannot pass something the catalog page would reject.
+Naming an example that does not exist fails with the list of ids that do, before
+anything starts.
+
+For behaviour that naming examples cannot express, a demo puts `scenario.ts`
+beside its `definition.ts`:
+
+```ts
+export const scenario: Scenario = {
+  describe: 'what it does',
+  run: async (context, options) => ({ workflows: [], observations: [] }),
+};
+```
+
+`definition.ts` passes it options under `scenario`, and the compiler checks them. A demo may have both: the
+examples start first, then the scenario runs.
+
+### Why `system-nexus-signal-with-start` ships a scenario
+
+The demo is of the Nexus **operation**, not the client's `signalWithStart`
+function. The plain client call reaches the frontend RPC directly and produces
+no caller workflow and no Nexus events, which is why the old
+`temporal/scripts/signal-with-start.ts` was deleted. What this renders is a
+workflow invoking `SignalWithStartWorkflowExecution` through the
+`__temporal_system` endpoint.
+
+The caller is an ordinary workflow. Only the **Go** SDK refuses the reserved
+`__temporal_` prefix, which is why the server's own
+`TestBothWorkflowsVisibleAfterSWSFromWorkflow` is skipped; TypeScript has no
+such check, so `createNexusServiceClient` reaches the endpoint directly.
+
+What TypeScript does not have yet is an encoder for the operation's payloads,
+which are `binary/protobuf` workflowservice messages. The SDK's own protobuf
+converters emit `json/protobuf` and want reflection metadata that
+`@temporalio/proto`'s generated classes do not carry. `payload-converter.ts`
+supplies one for the two messages, and the caller runs on a worker of its own
+so nothing is added to the shared catalog worker. That converter is scaffolding:
+it goes away when the SDK gains the operation. The Python SDK already has it as
+`workflow.signal_with_start_workflow(...)`, on a branch.
+
+Two things to know if that converter is ever revisited:
+
+- Those generated namespaces are not constructors, so `instanceof` cannot
+  identify a message. Match on `value.constructor.name`.
+- A response crosses into the workflow sandbox, so its buffer belongs to another
+  realm and protobufjs rejects it with "illegal buffer". Re-wrap it:
+  `decode(new Uint8Array(payload.data ?? []))`.
+- A payload codec must **not** encode the outer envelope. The Python SDK has a
+  regression test for exactly this. Nothing here uses a codec, so it is untested
+  in this repository.
+
+Only the caller needs any of this. The operation's target is a catalog example,
+run by the catalog worker, so the workflow that gets started and signalled is
+one the catalog already ships. Point `targetExample` at any catalog example that
+handles the signal name you set.
+
+## `preview`
+
+`preview.notes` is an ordered checklist for the reviewer. It goes to the console
+and into the summary file, so write it as the steps someone else follows.

--- a/utilities/demo/catalog.ts
+++ b/utilities/demo/catalog.ts
@@ -1,0 +1,167 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import validateJsonSchema from '../../src/lib/catalog/browser/schema-validator';
+import type {
+  JsonSchema,
+  JsonValue,
+} from '../../src/lib/catalog/browser/types';
+
+/**
+ * The catalog's generated artifact is the source of truth for what an example
+ * is and where it runs, so a definition names an example id and nothing else.
+ */
+const SHARED_GENERATED = join(
+  'src',
+  'lib',
+  'catalog',
+  'browser',
+  'catalog.generated.json',
+);
+
+/** Local examples generate their own artifact, which the catalog page also reads. */
+const LOCAL_GENERATED = join('catalog.local', 'catalog.generated.json');
+
+export type CatalogExample = {
+  id: string;
+  title: string;
+  description: string;
+  kind: string;
+  workflowType?: string;
+  taskQueue?: string;
+  targetId?: string;
+  defaultInput: unknown[];
+  inputSchema?: JsonSchema;
+  source: string;
+};
+
+type Descriptor = {
+  id: string;
+  title: string;
+  description: string;
+  input?: { defaultValue?: unknown; schema?: JsonSchema };
+  execution?: {
+    kind?: string;
+    workflowType?: string;
+    taskQueue?: string;
+    targetId?: string;
+  };
+  source?: { label?: string };
+};
+
+const asArray = (value: unknown): unknown[] =>
+  Array.isArray(value) ? value : value === undefined ? [] : [value];
+
+const readArtifact = (path: string): Descriptor[] | null => {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as {
+      descriptors?: Descriptor[];
+    };
+
+    return parsed.descriptors ?? [];
+  } catch {
+    return null;
+  }
+};
+
+const readDescriptors = (cwd: string): Descriptor[] => {
+  const shared = readArtifact(join(cwd, SHARED_GENERATED));
+
+  if (!shared) {
+    throw new Error(
+      `Could not read ${SHARED_GENERATED}. Run "pnpm catalog generate" first.`,
+    );
+  }
+
+  // A local catalog is optional, and absent on a clean checkout.
+  return [...shared, ...(readArtifact(join(cwd, LOCAL_GENERATED)) ?? [])];
+};
+
+export const listCatalogExamples = (cwd = process.cwd()): CatalogExample[] =>
+  readDescriptors(cwd).map((descriptor) => ({
+    id: descriptor.id,
+    title: descriptor.title,
+    description: descriptor.description,
+    kind: descriptor.execution?.kind ?? 'unknown',
+    workflowType: descriptor.execution?.workflowType,
+    taskQueue: descriptor.execution?.taskQueue,
+    targetId: descriptor.execution?.targetId,
+    defaultInput: asArray(descriptor.input?.defaultValue),
+    inputSchema: descriptor.input?.schema,
+    source: descriptor.source?.label ?? 'unknown',
+  }));
+
+export const catalogExampleFor = (
+  id: string,
+  cwd = process.cwd(),
+): CatalogExample => {
+  const examples = listCatalogExamples(cwd);
+  const example = examples.find((candidate) => candidate.id === id);
+
+  if (!example) {
+    throw new Error(
+      [
+        `The catalog has no example "${id}".`,
+        'Run "pnpm catalog list" to see the ids. A local example you just',
+        'created needs "pnpm catalog generate" before a demo can name it.',
+      ].join('\n'),
+    );
+  }
+
+  return example;
+};
+
+export const requireWorkflowExample = (
+  id: string,
+  cwd = process.cwd(),
+): CatalogExample & { workflowType: string; taskQueue: string } => {
+  const example = catalogExampleFor(id, cwd);
+
+  if (
+    example.kind !== 'workflow' ||
+    !example.workflowType ||
+    !example.taskQueue
+  ) {
+    throw new Error(
+      `The catalog example "${id}" runs as "${example.kind}", so it cannot be started as a workflow.`,
+    );
+  }
+
+  return {
+    ...example,
+    workflowType: example.workflowType,
+    taskQueue: example.taskQueue,
+  };
+};
+
+export const catalogExampleUrl = (
+  base: string,
+  namespace: string,
+  id: string,
+) => `${base}/namespaces/${namespace}/catalog/${encodeURIComponent(id)}`;
+
+/**
+ * Checks input against the example's own declared schema, so a definition
+ * cannot quietly pass something the catalog page would reject.
+ */
+export const assertValidExampleInput = async (
+  example: CatalogExample,
+  input: readonly unknown[],
+) => {
+  if (!example.inputSchema) return;
+
+  const valid = await validateJsonSchema(
+    example.inputSchema,
+    input as JsonValue,
+  );
+
+  if (valid) return;
+
+  throw new Error(
+    [
+      `The input for the "${example.id}" catalog example does not match the schema the example declares.`,
+      `Given: ${JSON.stringify(input)}`,
+      `Schema: ${JSON.stringify(example.inputSchema)}`,
+    ].join('\n'),
+  );
+};

--- a/utilities/demo/cli.test.ts
+++ b/utilities/demo/cli.test.ts
@@ -7,7 +7,6 @@ import type { DefinitionSummary } from './definition';
 const definition: DefinitionSummary = {
   name: 'system-nexus-signal-with-start',
   title: 'Signal With Start through the system Nexus endpoint',
-  ticket: 'DT-4385',
   path: 'utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts',
   stages: ['server', 'worker', 'ui', 'scenarios'],
   examples: ['signal-handlers'],
@@ -71,7 +70,6 @@ describe('demo list', () => {
     await run('list');
 
     expect(output.join('\n')).toContain('system-nexus-signal-with-start');
-    expect(output.join('\n')).toContain('(DT-4385)');
     expect(output.join('\n')).toContain(
       'stages: server, worker, ui, scenarios',
     );

--- a/utilities/demo/cli.test.ts
+++ b/utilities/demo/cli.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { DemoCommands } from './cli';
+import { demoHelp, parseStartOptions, runDemoCli } from './cli';
+import type { DefinitionSummary } from './definition';
+
+const definition: DefinitionSummary = {
+  name: 'system-nexus-signal-with-start',
+  title: 'Signal With Start through the system Nexus endpoint',
+  ticket: 'DT-4385',
+  path: 'utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts',
+  stages: ['server', 'worker', 'ui', 'scenarios'],
+  examples: ['signal-handlers'],
+  ownScenario: true,
+};
+
+const setup = (overrides: Partial<DemoCommands> = {}) => {
+  const output: string[] = [];
+  const errors: string[] = [];
+
+  const commands: DemoCommands = {
+    list: vi.fn(async () => [definition]),
+    show: vi.fn(async () => 'the resolved definition'),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    create: vi.fn(
+      async () => 'utilities/demo/scenarios/new-thing/definition.ts',
+    ),
+    ...overrides,
+  };
+
+  const run = (...argv: string[]) =>
+    runDemoCli({
+      argv,
+      io: {
+        writeOutput: (message) => output.push(message),
+        writeError: (message) => errors.push(message),
+      },
+      commands,
+    });
+
+  return { commands, output, errors, run };
+};
+
+describe('demo CLI help', () => {
+  it('names every command it accepts', () => {
+    expect(demoHelp).toContain('demo help');
+    expect(demoHelp).toContain('demo list');
+    expect(demoHelp).toContain('demo show <definition>');
+    expect(demoHelp).toContain('demo start <definition>');
+    expect(demoHelp).toContain('demo stop [<definition>]');
+    expect(demoHelp).toContain('demo new <name> [example-id...]');
+  });
+
+  it.each([[[]], [['--help']], [['help']]])(
+    'shows help for %j',
+    async (argv) => {
+      const { output, run } = setup();
+
+      await run(...argv);
+
+      expect(output).toEqual([demoHelp]);
+    },
+  );
+});
+
+describe('demo list', () => {
+  it('shows each definition with its stages and scenarios', async () => {
+    const { output, run } = setup();
+
+    await run('list');
+
+    expect(output.join('\n')).toContain('system-nexus-signal-with-start');
+    expect(output.join('\n')).toContain('(DT-4385)');
+    expect(output.join('\n')).toContain(
+      'stages: server, worker, ui, scenarios',
+    );
+    expect(output.join('\n')).toContain('examples: signal-handlers');
+    expect(output.join('\n')).toContain('ships its own scenario.ts');
+  });
+
+  it('tells a person how to make the first definition', async () => {
+    const { output, run } = setup({ list: async () => [] });
+
+    await run('list');
+
+    expect(output.join('\n')).toContain('pnpm demo new <name>');
+  });
+});
+
+describe('demo show', () => {
+  it('passes the target through and prints the result', async () => {
+    const { commands, output, run } = setup();
+
+    await run('show', 'system-nexus-signal-with-start');
+
+    expect(commands.show).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+    );
+    expect(output).toEqual(['the resolved definition']);
+  });
+});
+
+describe('demo start', () => {
+  it('keeps every stage and holds the run open by default', async () => {
+    const { commands, run } = setup();
+
+    await run('start', 'system-nexus-signal-with-start');
+
+    expect(commands.start).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+      {
+        skip: [],
+        only: [],
+        keepAlive: true,
+      },
+    );
+  });
+
+  it('collects repeated stage flags', async () => {
+    const { commands, run } = setup();
+
+    await run(
+      'start',
+      'system-nexus-signal-with-start',
+      '--skip',
+      'ui',
+      '--skip',
+      'scenarios',
+      '--no-keep-alive',
+    );
+
+    expect(commands.start).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+      {
+        skip: ['ui', 'scenarios'],
+        only: [],
+        keepAlive: false,
+      },
+    );
+  });
+
+  it('accepts the worker stage', async () => {
+    const { commands, run } = setup();
+
+    await run('start', 'system-nexus-signal-with-start', '--skip', 'worker');
+
+    expect(commands.start).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+      {
+        skip: ['worker'],
+        only: [],
+        keepAlive: true,
+      },
+    );
+  });
+
+  it('collects --only stages', async () => {
+    const { commands, run } = setup();
+
+    await run('start', 'system-nexus-signal-with-start', '--only', 'server');
+
+    expect(commands.start).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+      {
+        skip: [],
+        only: ['server'],
+        keepAlive: true,
+      },
+    );
+  });
+
+  it('refuses a stage it does not have', async () => {
+    const { commands, errors, run } = setup();
+
+    await expect(
+      run('start', 'system-nexus-signal-with-start', '--skip', 'database'),
+    ).rejects.toThrow('--skip needs one of these stages');
+
+    expect(commands.start).not.toHaveBeenCalled();
+    expect(errors.join('\n')).toContain('server, worker, ui, scenarios');
+  });
+
+  it('refuses a flag it does not have', async () => {
+    const { commands, run } = setup();
+
+    await expect(
+      run('start', 'system-nexus-signal-with-start', '--fast'),
+    ).rejects.toThrow('Usage: demo start');
+
+    expect(commands.start).not.toHaveBeenCalled();
+  });
+
+  it('refuses a stage flag with no stage after it', async () => {
+    const { run } = setup();
+
+    await expect(
+      run('start', 'system-nexus-signal-with-start', '--only'),
+    ).rejects.toThrow('--only needs one of these stages');
+  });
+});
+
+describe('demo stop', () => {
+  it('stops every recorded run when given no name', async () => {
+    const { commands, run } = setup();
+
+    await run('stop');
+
+    expect(commands.stop).toHaveBeenCalledWith(undefined);
+  });
+
+  it('stops one run when given its name', async () => {
+    const { commands, run } = setup();
+
+    await run('stop', 'system-nexus-signal-with-start');
+
+    expect(commands.stop).toHaveBeenCalledWith(
+      'system-nexus-signal-with-start',
+    );
+  });
+});
+
+describe('demo new', () => {
+  it('reports the file it made and the next command', async () => {
+    const { commands, output, run } = setup();
+
+    await run('new', 'new-thing');
+
+    expect(commands.create).toHaveBeenCalledWith('new-thing', []);
+    expect(output.join('\n')).toContain('scenarios/new-thing/definition.ts');
+    expect(output.join('\n')).toContain('pnpm demo start new-thing');
+  });
+
+  it('passes catalog example ids through to the generator', async () => {
+    const { commands, run } = setup();
+
+    await run('new', 'new-thing', 'signal-handlers', 'long-activity');
+
+    expect(commands.create).toHaveBeenCalledWith('new-thing', [
+      'signal-handlers',
+      'long-activity',
+    ]);
+  });
+});
+
+describe('demo errors', () => {
+  it('refuses a command it does not have', async () => {
+    const { errors, run } = setup();
+
+    await expect(run('deploy')).rejects.toThrow(
+      'Unknown demo command "deploy"',
+    );
+
+    expect(errors.join('\n')).toContain(demoHelp);
+  });
+
+  it('refuses a known command with the wrong arguments', async () => {
+    const { commands, run } = setup();
+
+    await expect(run('list', 'everything')).rejects.toThrow(
+      'Invalid arguments for demo command "list"',
+    );
+
+    expect(commands.list).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseStartOptions', () => {
+  it('reports the usage line through fail', () => {
+    const fail = vi.fn(() => {
+      throw new Error('failed');
+    }) as unknown as (message: string) => never;
+
+    expect(() => parseStartOptions(['--nope'], fail)).toThrow('failed');
+    expect(fail).toHaveBeenCalledWith(
+      expect.stringContaining('Usage: demo start <definition>'),
+    );
+  });
+});

--- a/utilities/demo/cli.test.ts
+++ b/utilities/demo/cli.test.ts
@@ -100,7 +100,7 @@ describe('demo show', () => {
 });
 
 describe('demo start', () => {
-  it('keeps every stage and holds the run open by default', async () => {
+  it('keeps every stage and leaves the run up by default', async () => {
     const { commands, run } = setup();
 
     await run('start', 'system-nexus-signal-with-start');
@@ -110,7 +110,7 @@ describe('demo start', () => {
       {
         skip: [],
         only: [],
-        keepAlive: true,
+        once: false,
       },
     );
   });
@@ -125,7 +125,7 @@ describe('demo start', () => {
       'ui',
       '--skip',
       'scenarios',
-      '--no-keep-alive',
+      '--once',
     );
 
     expect(commands.start).toHaveBeenCalledWith(
@@ -133,7 +133,7 @@ describe('demo start', () => {
       {
         skip: ['ui', 'scenarios'],
         only: [],
-        keepAlive: false,
+        once: true,
       },
     );
   });
@@ -148,7 +148,7 @@ describe('demo start', () => {
       {
         skip: ['worker'],
         only: [],
-        keepAlive: true,
+        once: false,
       },
     );
   });
@@ -163,7 +163,7 @@ describe('demo start', () => {
       {
         skip: [],
         only: ['server'],
-        keepAlive: true,
+        once: false,
       },
     );
   });

--- a/utilities/demo/cli.ts
+++ b/utilities/demo/cli.ts
@@ -1,0 +1,159 @@
+import type { DefinitionSummary, Stage } from './definition';
+import { STAGES } from './definition';
+import type { StartOptions } from './run';
+
+export const demoHelp = `Usage: demo <command>
+
+Commands:
+  demo help                      Show this help text.
+  demo list                      List the feature definitions.
+  demo show <definition>         Show a definition with its defaults applied.
+  demo start <definition> [--skip <stage>] [--only <stage>] [--no-keep-alive]
+                                 Start the stages the definition declares.
+                                 Stages: ${STAGES.join(', ')}.
+                                 Repeat --skip or --only to name more than one.
+  demo stop [<definition>]       Stop what an earlier start left running.
+  demo new <name> [example-id...]
+                                 Create a definition naming those catalog
+                                 examples. Run "pnpm catalog list" for the ids.
+
+"pnpm demo list" shows which stages each definition turns on.`;
+
+export type DemoIo = {
+  writeError: (message: string) => void;
+  writeOutput: (message: string) => void;
+};
+
+export type DemoCommands = {
+  list: () => Promise<DefinitionSummary[]>;
+  show: (target: string) => Promise<string>;
+  start: (target: string, options: StartOptions) => Promise<unknown>;
+  stop: (name: string | undefined) => Promise<unknown>;
+  create: (name: string, exampleIds: readonly string[]) => Promise<string>;
+};
+
+const KNOWN_COMMANDS = [
+  'help',
+  'list',
+  'new',
+  'show',
+  'start',
+  'stop',
+] as const;
+
+const START_USAGE =
+  'Usage: demo start <definition> [--skip <stage>] [--only <stage>] [--no-keep-alive]';
+
+const formatDefinitions = (definitions: readonly DefinitionSummary[]) => {
+  if (!definitions.length) {
+    return 'No definitions yet. Run "pnpm demo new <name>" to make one.';
+  }
+
+  return definitions
+    .flatMap((definition) => [
+      `  ${definition.name}${definition.ticket ? `  (${definition.ticket})` : ''}`,
+      `    ${definition.title}`,
+      `    stages: ${definition.stages.join(', ') || 'none'}`,
+      ...(definition.examples.length
+        ? [`    examples: ${definition.examples.join(', ')}`]
+        : []),
+      ...(definition.ownScenario ? ['    ships its own scenario.ts'] : []),
+      '',
+    ])
+    .join('\n')
+    .trimEnd();
+};
+
+export const parseStartOptions = (
+  args: readonly string[],
+  fail: (message: string) => never,
+): StartOptions => {
+  const skip: Stage[] = [];
+  const only: Stage[] = [];
+  let keepAlive = true;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+
+    if (argument === '--no-keep-alive') {
+      keepAlive = false;
+      continue;
+    }
+
+    if (argument !== '--skip' && argument !== '--only') fail(START_USAGE);
+
+    const value = args[index + 1];
+
+    if (!value || !STAGES.includes(value as Stage)) {
+      fail(
+        `${argument} needs one of these stages: ${STAGES.join(', ')}.\n\n${START_USAGE}`,
+      );
+    }
+
+    (argument === '--skip' ? skip : only).push(value as Stage);
+    index += 1;
+  }
+
+  return { skip, only, keepAlive };
+};
+
+export const runDemoCli = async ({
+  argv,
+  io,
+  commands,
+}: {
+  argv: readonly string[];
+  io: DemoIo;
+  commands: DemoCommands;
+}) => {
+  if (argv.length === 0 || argv.includes('--help')) {
+    io.writeOutput(demoHelp);
+    return;
+  }
+
+  const command = argv[0] as string;
+  const fail = (message: string): never => {
+    io.writeError(`${message}\n\n${demoHelp}`);
+    throw new Error(message);
+  };
+
+  if (command === 'help' && argv.length === 1) {
+    io.writeOutput(demoHelp);
+    return;
+  }
+
+  if (command === 'list' && argv.length === 1) {
+    io.writeOutput(formatDefinitions(await commands.list()));
+    return;
+  }
+
+  if (command === 'show' && argv.length === 2) {
+    io.writeOutput(await commands.show(argv[1]));
+    return;
+  }
+
+  if (command === 'start' && argv.length >= 2) {
+    await commands.start(argv[1], parseStartOptions(argv.slice(2), fail));
+    return;
+  }
+
+  if (command === 'stop' && (argv.length === 1 || argv.length === 2)) {
+    await commands.stop(argv[1]);
+    return;
+  }
+
+  if (command === 'new' && argv.length >= 2) {
+    const path = await commands.create(argv[1], argv.slice(2));
+
+    io.writeOutput(
+      `Created ${path}. Replace the TODO values, then run "pnpm demo start ${argv[1]}".`,
+    );
+    return;
+  }
+
+  if ((KNOWN_COMMANDS as readonly string[]).includes(command)) {
+    fail(`Invalid arguments for demo command "${command}"`);
+  }
+
+  fail(`Unknown demo command "${command}"`);
+};

--- a/utilities/demo/cli.ts
+++ b/utilities/demo/cli.ts
@@ -8,8 +8,10 @@ Commands:
   demo help                      Show this help text.
   demo list                      List the feature definitions.
   demo show <definition>         Show a definition with its defaults applied.
-  demo start <definition> [--skip <stage>] [--only <stage>] [--no-keep-alive]
-                                 Start the stages the definition declares.
+  demo start <definition> [--skip <stage>] [--only <stage>] [--once]
+                                 Start the stages the definition declares and
+                                 leave them running. --once tears them down
+                                 again before returning.
                                  Stages: ${STAGES.join(', ')}.
                                  Repeat --skip or --only to name more than one.
   demo stop [<definition>]       Stop what an earlier start left running.
@@ -42,7 +44,7 @@ const KNOWN_COMMANDS = [
 ] as const;
 
 const START_USAGE =
-  'Usage: demo start <definition> [--skip <stage>] [--only <stage>] [--no-keep-alive]';
+  'Usage: demo start <definition> [--skip <stage>] [--only <stage>] [--once]';
 
 const formatDefinitions = (definitions: readonly DefinitionSummary[]) => {
   if (!definitions.length) {
@@ -70,13 +72,13 @@ export const parseStartOptions = (
 ): StartOptions => {
   const skip: Stage[] = [];
   const only: Stage[] = [];
-  let keepAlive = true;
+  let once = false;
 
   for (let index = 0; index < args.length; index += 1) {
     const argument = args[index];
 
-    if (argument === '--no-keep-alive') {
-      keepAlive = false;
+    if (argument === '--once') {
+      once = true;
       continue;
     }
 
@@ -94,7 +96,7 @@ export const parseStartOptions = (
     index += 1;
   }
 
-  return { skip, only, keepAlive };
+  return { skip, only, once };
 };
 
 export const runDemoCli = async ({

--- a/utilities/demo/cli.ts
+++ b/utilities/demo/cli.ts
@@ -51,7 +51,7 @@ const formatDefinitions = (definitions: readonly DefinitionSummary[]) => {
 
   return definitions
     .flatMap((definition) => [
-      `  ${definition.name}${definition.ticket ? `  (${definition.ticket})` : ''}`,
+      `  ${definition.name}`,
       `    ${definition.title}`,
       `    stages: ${definition.stages.join(', ') || 'none'}`,
       ...(definition.examples.length

--- a/utilities/demo/definition.ts
+++ b/utilities/demo/definition.ts
@@ -32,6 +32,14 @@ const serverSchema = z
     requires: z
       .object({
         serverCommit: z.string().optional(),
+        /**
+         * Refs to build the dev server from. Both default to main, because the
+         * two repositories share one dependency graph in the workspace and a
+         * pair from different times does not compile. serverCommit is a floor,
+         * not a build target: the fetched server is checked to contain it.
+         */
+        serverRef: z.string().default('main'),
+        cliRef: z.string().default('main'),
         minServerVersion: z.string().optional(),
       })
       .prefault({}),

--- a/utilities/demo/definition.ts
+++ b/utilities/demo/definition.ts
@@ -71,7 +71,6 @@ const uiSchema = z
 export const definitionSchema = z.object({
   name: z.string(),
   title: z.string(),
-  ticket: z.string().optional(),
   feature: z.string().optional(),
   summary: z.string().optional(),
   server: serverSchema,
@@ -166,7 +165,6 @@ export const loadDefinition = async (name: string, cwd = process.cwd()) => {
 export type DefinitionSummary = {
   name: string;
   title: string;
-  ticket?: string;
   path: string;
   stages: string[];
   examples: string[];
@@ -197,7 +195,6 @@ export const listDefinitions = async (
         name: data.name,
         title: data.title,
         ownScenario: hasOwnScenario(data.name, cwd),
-        ticket: data.ticket,
         path,
         stages: [
           ...(data.server.enabled ? ['server'] : []),

--- a/utilities/demo/definition.ts
+++ b/utilities/demo/definition.ts
@@ -1,0 +1,292 @@
+import { existsSync, readdirSync } from 'fs';
+import { mkdir, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+import { z } from 'zod';
+
+import { requireWorkflowExample } from './catalog';
+import { exampleEntrySchema } from './examples';
+
+export const STAGES = ['server', 'worker', 'ui', 'scenarios'] as const;
+
+export type Stage = (typeof STAGES)[number];
+
+const dynamicConfigValue = z.union([z.boolean(), z.number(), z.string()]);
+
+const serverSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    source: z.enum(['auto', 'cli', 'workspace', 'binary']).default('auto'),
+    version: z.string().default('latest'),
+    path: z.string().optional(),
+    /**
+     * Where the Temporal checkouts live. These belong to the machine, not to
+     * the feature, so they normally come from TEMPORAL_CLI_REPO and
+     * TEMPORAL_SERVER_REPO rather than from a definition.
+     */
+    cliRepo: z.string().optional(),
+    serverRepo: z.string().optional(),
+    serverRef: z.string().optional(),
+    requires: z
+      .object({
+        serverCommit: z.string().optional(),
+        minServerVersion: z.string().optional(),
+      })
+      .prefault({}),
+    port: z.number().int().default(7233),
+    uiPort: z.number().int().default(8233),
+    httpPort: z.number().int().optional(),
+    logLevel: z
+      .enum(['debug', 'info', 'warn', 'error', 'never'])
+      .default('warn'),
+    dbFilename: z.string().optional(),
+    namespace: z.string().default('default'),
+    dynamicConfig: z.record(z.string(), dynamicConfigValue).default({}),
+    searchAttributes: z.record(z.string(), z.string()).default({}),
+  })
+  .prefault({});
+
+const workerSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    /** Limit the catalog worker to one registered target. */
+    targetId: z.string().optional(),
+    readyTimeoutMs: z.number().int().default(120_000),
+  })
+  .prefault({});
+
+const uiSchema = z
+  .object({
+    enabled: z.boolean().default(true),
+    uiServer: z.boolean().default(true),
+    web: z.boolean().default(true),
+    apiPort: z.number().int().default(8081),
+    webPort: z.number().int().default(3000),
+    rebuildUiServer: z.boolean().default(false),
+  })
+  .prefault({});
+
+export const definitionSchema = z.object({
+  name: z.string(),
+  title: z.string(),
+  ticket: z.string().optional(),
+  feature: z.string().optional(),
+  summary: z.string().optional(),
+  server: serverSchema,
+  worker: workerSchema,
+  ui: uiSchema,
+  /** Catalog examples this demo starts. */
+  examples: z.array(exampleEntrySchema).default([]),
+  /** Options for this demo's own scenario.ts, when it has one. */
+  scenario: z.record(z.string(), z.unknown()).default({}),
+  preview: z.object({ notes: z.array(z.string()).default([]) }).prefault({}),
+});
+
+export type Definition = z.infer<typeof definitionSchema>;
+
+/**
+ * What a scenario's definition.ts writes. Everything with a default is
+ * optional, and the compiler checks the rest, so a definition needs no schema
+ * of its own and a mistyped key does not reach a run.
+ */
+export type DefinitionInput = z.input<typeof definitionSchema>;
+
+/** Declares a scenario. Applies the defaults and reports a bad shape at once. */
+export const defineScenario = (input: DefinitionInput): Definition => {
+  const parsed = definitionSchema.safeParse(input);
+
+  if (!parsed.success) {
+    throw new Error(
+      `"${input.name ?? 'unnamed'}" is not a valid scenario definition:\n${z.prettifyError(parsed.error)}`,
+    );
+  }
+
+  return parsed.data;
+};
+export type ServerDefinition = Definition['server'];
+export type WorkerDefinition = Definition['worker'];
+export type UiDefinition = Definition['ui'];
+export type ExampleDefinition = Definition['examples'][number];
+
+export const expandPath = (value: string): string =>
+  value.startsWith('~') ? join(homedir(), value.slice(1)) : value;
+
+/** A scenario's own behaviour file, beside its definition, if it has one. */
+export const ownScenarioPath = (name: string, cwd = process.cwd()) =>
+  join(scenarioDirectory(name, cwd), 'scenario.ts');
+
+export const hasOwnScenario = (name: string, cwd = process.cwd()) =>
+  existsSync(ownScenarioPath(name, cwd));
+
+const hasWork = (data: Definition, cwd: string) =>
+  data.examples.length > 0 || hasOwnScenario(data.name, cwd);
+
+export const SCENARIOS_DIR = join('utilities', 'demo', 'scenarios');
+
+/** A scenario is a directory holding its definition and its own behaviour. */
+export const scenarioDirectory = (name: string, cwd = process.cwd()) =>
+  resolve(cwd, SCENARIOS_DIR, name);
+
+export const definitionPath = (name: string, cwd = process.cwd()) =>
+  join(scenarioDirectory(name, cwd), 'definition.ts');
+
+const importDefinition = async (path: string): Promise<Definition> => {
+  const module = (await import(pathToFileURL(path).href)) as {
+    definition?: Definition;
+  };
+
+  if (!module.definition) {
+    throw new Error(`${path} must export a "definition".`);
+  }
+
+  return module.definition;
+};
+
+/**
+ * A definition is a module, so the compiler checks its shape and the options it
+ * passes to its scenario. Nothing here validates what the compiler already has.
+ */
+export const loadDefinition = async (name: string, cwd = process.cwd()) => {
+  const path = definitionPath(name, cwd);
+
+  if (!existsSync(path)) {
+    throw new Error(
+      [
+        `No scenario named "${name}".`,
+        `Expected ${path}. Run "pnpm demo list" to see the names.`,
+      ].join('\n'),
+    );
+  }
+
+  return { path, definition: await importDefinition(path) };
+};
+
+export type DefinitionSummary = {
+  name: string;
+  title: string;
+  ticket?: string;
+  path: string;
+  stages: string[];
+  examples: string[];
+  ownScenario: boolean;
+};
+
+const scenarioNames = (cwd: string): string[] => {
+  const directory = resolve(cwd, SCENARIOS_DIR);
+
+  if (!existsSync(directory)) return [];
+
+  return readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => existsSync(definitionPath(name, cwd)))
+    .sort();
+};
+
+export const listDefinitions = async (
+  cwd = process.cwd(),
+): Promise<DefinitionSummary[]> =>
+  Promise.all(
+    scenarioNames(cwd).map(async (name) => {
+      const path = definitionPath(name, cwd);
+      const data = await importDefinition(path);
+
+      return {
+        name: data.name,
+        title: data.title,
+        ownScenario: hasOwnScenario(data.name, cwd),
+        ticket: data.ticket,
+        path,
+        stages: [
+          ...(data.server.enabled ? ['server'] : []),
+          ...(data.worker.enabled ? ['worker'] : []),
+          ...(data.ui.enabled ? ['ui'] : []),
+          ...(hasWork(data, cwd) ? ['scenarios'] : []),
+        ],
+        examples: data.examples.map((entry) => entry.id),
+      };
+    }),
+  );
+
+const exampleEntries = (exampleIds: readonly string[], cwd: string) =>
+  exampleIds.map((id) => {
+    // Resolved now so a mistyped id fails while scaffolding, not at run time.
+    const example = requireWorkflowExample(id, cwd);
+
+    return {
+      id: example.id,
+      workflowId: `catalog-${example.id}`,
+      role: example.title,
+      note: example.description,
+    };
+  });
+
+const exampleSource = (examples: ReturnType<typeof exampleEntries>) =>
+  examples.length
+    ? examples
+        .map(
+          (example) => `    {
+      id: ${JSON.stringify(example.id)},
+      workflowId: ${JSON.stringify(example.workflowId)},
+      role: ${JSON.stringify(example.role)},
+      note: ${JSON.stringify(example.note)},
+    },`,
+        )
+        .join('\n')
+    : `    // Run "pnpm catalog list" for the ids.
+    { id: 'hello', role: 'TODO: what this one shows' },`;
+
+const template = (
+  name: string,
+  examples: ReturnType<typeof exampleEntries>,
+) => `import { defineScenario } from '../../definition';
+
+export const definition = defineScenario({
+  name: '${name}',
+  title: 'TODO: what a reviewer sees when ${name} works',
+  summary: 'TODO: what changes, and what it looked like before.',
+  server: {
+    source: 'auto',
+    // A feature no release carries yet needs the commit that added it:
+    // requires: { serverCommit: '...' },
+    dynamicConfig: {},
+    searchAttributes: {
+      CustomKeywordField: 'Keyword',
+      CustomIntField: 'Int',
+    },
+  },
+  examples: [
+${exampleSource(examples)}
+  ],
+  preview: {
+    notes: ['TODO: the first thing a reviewer must check.'],
+  },
+});
+`;
+
+export const scaffoldDefinition = async (
+  name: string,
+  exampleIds: readonly string[] = [],
+  cwd = process.cwd(),
+): Promise<string> => {
+  if (!/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(name)) {
+    throw new Error(
+      `A scenario name must be kebab-case, for example system-nexus-signal-with-start (got "${name}").`,
+    );
+  }
+
+  const path = definitionPath(name, cwd);
+
+  if (existsSync(path)) {
+    throw new Error(`${SCENARIOS_DIR}/${name}/definition.ts already exists.`);
+  }
+
+  const examples = exampleEntries(exampleIds, cwd);
+
+  await mkdir(scenarioDirectory(name, cwd), { recursive: true });
+  await writeFile(path, template(name, examples));
+
+  return path;
+};

--- a/utilities/demo/demo-cli.ts
+++ b/utilities/demo/demo-cli.ts
@@ -1,0 +1,77 @@
+/**
+ * Runs one feature definition end to end: provisions a Temporal server with the
+ * dynamic config the feature needs, stands up the UI, runs the scenarios that
+ * demonstrate the feature, then reports how a reviewer can see it.
+ *
+ *   pnpm demo list
+ *   pnpm demo start system-nexus-signal-with-start
+ *   pnpm demo start system-nexus-signal-with-start --skip ui
+ *   pnpm demo stop
+ */
+import { pathToFileURL } from 'node:url';
+
+import { demoHelp, runDemoCli } from './cli';
+import {
+  listDefinitions,
+  loadDefinition,
+  scaffoldDefinition,
+} from './definition';
+import { loadLocalEnvironment } from './paths';
+import { ReportedRunFailure, startFeatureDemo, stopFeatureDemo } from './run';
+
+export { demoHelp };
+
+const isReportedDemoCliError = (error: unknown) => {
+  if (error instanceof ReportedRunFailure) return true;
+  if (!(error instanceof Error)) return false;
+
+  return [
+    'Unknown demo command',
+    'Invalid arguments for demo command',
+    'Usage: demo start',
+    '--skip needs one of these stages',
+    '--only needs one of these stages',
+  ].some((prefix) => error.message.startsWith(prefix));
+};
+
+const showDefinition = async (target: string) => {
+  const { path, definition } = await loadDefinition(target);
+
+  return [`${path}`, '', JSON.stringify(definition, null, 2)].join('\n');
+};
+
+const main = async () => {
+  loadLocalEnvironment();
+
+  const io = {
+    writeError: (message: string) => console.error(message),
+    writeOutput: (message: string) => console.log(message),
+  };
+
+  try {
+    await runDemoCli({
+      argv: process.argv.slice(2),
+      io,
+      commands: {
+        list: () => listDefinitions(),
+        show: showDefinition,
+        start: (target, options) => startFeatureDemo(target, options, io),
+        stop: (name) => stopFeatureDemo(name, io),
+        create: (name, exampleIds) => scaffoldDefinition(name, exampleIds),
+      },
+    });
+  } catch (error) {
+    if (!isReportedDemoCliError(error)) {
+      const message = error instanceof Error ? error.message : error;
+      console.error(message);
+    }
+    process.exitCode = 1;
+  }
+};
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main();
+}

--- a/utilities/demo/examples.ts
+++ b/utilities/demo/examples.ts
@@ -1,0 +1,112 @@
+import {
+  Client,
+  Connection,
+  WorkflowExecutionAlreadyStartedError,
+} from '@temporalio/client';
+import { z } from 'zod';
+
+import { assertValidExampleInput, requireWorkflowExample } from './catalog';
+import type { ScenarioContext, ScenarioResult } from './scenario';
+
+export const exampleEntrySchema = z.object({
+  id: z.string(),
+  workflowId: z.string().optional(),
+  /** Replaces the example's own default input when given. */
+  input: z.array(z.unknown()).optional(),
+  role: z.string().optional(),
+  note: z.string().optional(),
+});
+
+export type ExampleEntry = z.infer<typeof exampleEntrySchema>;
+
+/**
+ * Starts the catalog examples a demo names. The catalog's generated artifact
+ * supplies the workflow type and task queue, so a definition never repeats them
+ * and cannot drift from the example it names. The catalog worker runs them,
+ * which the worker stage starts.
+ */
+export const startCatalogExamples = async (
+  { address, namespace, log }: ScenarioContext,
+  entries: readonly ExampleEntry[],
+): Promise<ScenarioResult> => {
+  // Resolved before connecting, so a bad example id or a bad input reports
+  // itself instead of surfacing as a connection failure.
+  const planned = [];
+
+  for (const entry of entries) {
+    const example = requireWorkflowExample(entry.id);
+    const args = entry.input ?? example.defaultInput;
+
+    await assertValidExampleInput(example, args);
+
+    planned.push({
+      entry,
+      example,
+      args,
+      workflowId: entry.workflowId ?? `catalog-${entry.id}`,
+    });
+  }
+
+  const connection = await Connection.connect({ address });
+  const client = new Client({ connection, namespace });
+
+  const workflows: ScenarioResult['workflows'] = [];
+  const observations: string[] = [];
+  const exampleIds: string[] = [];
+
+  for (const { entry, example, args, workflowId } of planned) {
+    exampleIds.push(example.id);
+
+    try {
+      const handle = await client.workflow.start(example.workflowType, {
+        taskQueue: example.taskQueue,
+        workflowId,
+        args,
+      });
+
+      workflows.push({
+        role: entry.role ?? example.title,
+        workflowId: handle.workflowId,
+        runId: handle.firstExecutionRunId,
+        note: entry.note ?? example.description,
+        catalogExampleId: example.id,
+      });
+
+      log(`Started catalog example ${example.id} as ${workflowId}`);
+    } catch (error) {
+      if (!(error instanceof WorkflowExecutionAlreadyStartedError)) throw error;
+
+      const running = await client.workflow
+        .getHandle(workflowId)
+        .describe()
+        .catch(() => undefined);
+
+      workflows.push({
+        role: entry.role ?? example.title,
+        workflowId,
+        runId: running?.runId ?? '',
+        note: entry.note ?? example.description,
+        catalogExampleId: example.id,
+      });
+
+      observations.push(
+        `${workflowId} was already running, so this run left it alone.`,
+      );
+      log(`Kept the running ${workflowId}`);
+    }
+  }
+
+  if (exampleIds.length) {
+    observations.push(
+      `These are catalog examples (${exampleIds.join(', ')}), so the catalog page runs the same code.`,
+    );
+  }
+
+  return {
+    workflows,
+    observations,
+    shutdown: async () => {
+      await connection.close();
+    },
+  };
+};

--- a/utilities/demo/paths.ts
+++ b/utilities/demo/paths.ts
@@ -1,0 +1,23 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+export type Logger = (message: string) => void;
+
+/** Everything this tool generates lives here, outside the source tree. */
+export const WORK_DIR = join(process.cwd(), '.feature-demo');
+
+export const runDirFor = (name: string) => join(WORK_DIR, name);
+
+/**
+ * Machine-local settings, in the same layering the catalog uses: a gitignored
+ * file for your own paths, with real environment variables winning over it.
+ */
+export const loadLocalEnvironment = () => {
+  const path = join(process.cwd(), '.env.feature-demo.local');
+
+  if (!existsSync(path)) return;
+
+  (
+    process as NodeJS.Process & { loadEnvFile: (path: string) => void }
+  ).loadEnvFile(path);
+};

--- a/utilities/demo/process.ts
+++ b/utilities/demo/process.ts
@@ -33,6 +33,29 @@ export const stopPid = async (pid: number) => {
  * `pnpm exec vite` would otherwise leave its real work running when only the
  * wrapper is signalled, and `demo stop` needs one pid it can rely on.
  */
+/** Whatever still listens on a port, so a stop is not limited to known pids. */
+export const listenersOn = async (port: number): Promise<number[]> => {
+  const { execFile } = await import('node:child_process');
+  const { promisify } = await import('node:util');
+
+  try {
+    const { stdout } = await promisify(execFile)('lsof', [
+      '-nP',
+      `-iTCP:${port}`,
+      '-sTCP:LISTEN',
+      '-t',
+    ]);
+
+    return stdout
+      .split('\n')
+      .map((line) => Number.parseInt(line.trim(), 10))
+      .filter((pid) => Number.isInteger(pid) && pid > 0);
+  } catch {
+    // lsof exits non-zero when nothing is listening.
+    return [];
+  }
+};
+
 export const startDetached = (
   label: string,
   command: string,

--- a/utilities/demo/process.ts
+++ b/utilities/demo/process.ts
@@ -1,0 +1,59 @@
+import { spawn } from 'node:child_process';
+import { openSync } from 'node:fs';
+
+export type Supervised = {
+  label: string;
+  pid: number;
+  logFile?: string;
+  stop: () => Promise<void>;
+};
+
+const signalGroup = (pid: number, signal: NodeJS.Signals) => {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone.
+    }
+  }
+};
+
+export const stopPid = async (pid: number) => {
+  signalGroup(pid, 'SIGINT');
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  signalGroup(pid, 'SIGKILL');
+};
+
+/**
+ * Starts a long-running child in its own process group. A wrapper such as
+ * `pnpm exec vite` would otherwise leave its real work running when only the
+ * wrapper is signalled, and `demo stop` needs one pid it can rely on.
+ */
+export const startDetached = (
+  label: string,
+  command: string,
+  args: readonly string[],
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; logFile?: string } = {},
+): Supervised => {
+  const log = options.logFile ? openSync(options.logFile, 'a') : 'ignore';
+
+  const child = spawn(command, [...args], {
+    stdio: ['ignore', log, log],
+    detached: true,
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+  });
+
+  child.unref();
+  child.on('error', () => {});
+
+  const pid = child.pid;
+
+  if (!pid) throw new Error(`Could not start ${label}.`);
+
+  return { label, pid, logFile: options.logFile, stop: () => stopPid(pid) };
+};

--- a/utilities/demo/requirements.test.ts
+++ b/utilities/demo/requirements.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CliCandidate,
+  type CommitFacts,
+  compareVersions,
+  lowestTaggedVersion,
+  pickCli,
+  planServerStrategy,
+  satisfies,
+} from './requirements';
+
+const facts = (overrides: Partial<CommitFacts> = {}): CommitFacts => ({
+  knownLocally: true,
+  inCheckout: true,
+  onMain: true,
+  ...overrides,
+});
+
+const cli = (label: string, serverVersion: string): CliCandidate => ({
+  label,
+  path: `/bin/${label}`,
+  serverVersion,
+});
+
+describe('compareVersions', () => {
+  it('orders release lines', () => {
+    expect(compareVersions('1.32.0', '1.31.2')).toBeGreaterThan(0);
+    expect(compareVersions('1.31.2', '1.32.0')).toBeLessThan(0);
+    expect(compareVersions('1.32.0', '1.32.0')).toBe(0);
+  });
+
+  it('ranks a release above any pre-release of the same line', () => {
+    expect(compareVersions('1.32.0', '1.32.0-157.0')).toBeGreaterThan(0);
+    expect(compareVersions('1.32.0-157.0', '1.31.2')).toBeGreaterThan(0);
+  });
+
+  it('orders pre-releases of one line by their numbers', () => {
+    expect(compareVersions('1.32.0-158.0', '1.32.0-157.0')).toBeGreaterThan(0);
+    expect(compareVersions('1.32.0-157.3', '1.32.0-157.10')).toBeLessThan(0);
+  });
+
+  it('lets a release satisfy a pre-release minimum', () => {
+    expect(satisfies('1.32.0', '1.32.0-157.0')).toBe(true);
+    expect(satisfies('1.32.0-100.0', '1.32.0-157.0')).toBe(false);
+  });
+});
+
+describe('satisfies', () => {
+  it('accepts anything when nothing is required', () => {
+    expect(satisfies('1.20.0')).toBe(true);
+  });
+
+  it('accepts an unknown version rather than blocking a reused server', () => {
+    expect(satisfies('unknown', '1.32.0')).toBe(true);
+  });
+
+  it('rejects a version below the minimum', () => {
+    expect(satisfies('1.31.2', '1.32.0')).toBe(false);
+  });
+});
+
+describe('lowestTaggedVersion', () => {
+  it('takes the lowest release line among the tags', () => {
+    expect(
+      lowestTaggedVersion([
+        'v1.32.0-158.0',
+        'v1.32.0-157.0',
+        'v1.33.0-1.0',
+        '',
+      ]),
+    ).toBe('1.32.0-157.0');
+  });
+
+  it('ignores tags that are not versions', () => {
+    expect(
+      lowestTaggedVersion(['nightly', 'release-candidate']),
+    ).toBeUndefined();
+  });
+
+  it('gives nothing for no tags', () => {
+    expect(lowestTaggedVersion([])).toBeUndefined();
+  });
+});
+
+describe('planServerStrategy', () => {
+  it('needs nothing in particular when the definition asks for nothing', () => {
+    expect(planServerStrategy({}, undefined)).toEqual({
+      minServerVersion: undefined,
+      mustBuildLocally: false,
+      reasons: [],
+    });
+  });
+
+  it('passes a plain minimum version through', () => {
+    const plan = planServerStrategy({ minServerVersion: '1.32.0' }, undefined);
+
+    expect(plan.mustBuildLocally).toBe(false);
+    expect(plan.minServerVersion).toBe('1.32.0');
+    expect(plan.reasons.join(' ')).toContain('1.32.0 or later');
+  });
+
+  it('derives the minimum from the tags that contain the commit', () => {
+    const plan = planServerStrategy(
+      { serverCommit: '01aa279c462fd9e7efc8e0ba6bbc4554b51557dd' },
+      facts({ firstTaggedVersion: '1.32.0-157.0' }),
+    );
+
+    expect(plan.mustBuildLocally).toBe(false);
+    expect(plan.minServerVersion).toBe('1.32.0-157.0');
+    expect(plan.reasons.join(' ')).toContain('first tagged 1.32.0-157.0');
+  });
+
+  it('keeps the definition minimum when it is higher than the derived one', () => {
+    const plan = planServerStrategy(
+      { serverCommit: 'abc1234', minServerVersion: '1.33.0' },
+      facts({ firstTaggedVersion: '1.32.0-157.0' }),
+    );
+
+    expect(plan.minServerVersion).toBe('1.33.0');
+  });
+
+  it('requires a local build for a commit that is on main but untagged', () => {
+    const plan = planServerStrategy(
+      { serverCommit: 'abc1234' },
+      facts({ firstTaggedVersion: undefined }),
+    );
+
+    expect(plan.mustBuildLocally).toBe(true);
+    expect(plan.reasons.join(' ')).toContain('no version tag yet');
+  });
+
+  it('requires a local build for a commit that is not on main', () => {
+    const plan = planServerStrategy(
+      { serverCommit: 'abc1234' },
+      facts({ onMain: false, firstTaggedVersion: undefined }),
+    );
+
+    expect(plan.mustBuildLocally).toBe(true);
+    expect(plan.reasons.join(' ')).toContain('not on main yet');
+  });
+
+  it('requires a local build when no checkout can resolve the commit', () => {
+    const plan = planServerStrategy(
+      { serverCommit: 'abc1234' },
+      facts({ knownLocally: false, inCheckout: false, onMain: false }),
+    );
+
+    expect(plan.mustBuildLocally).toBe(true);
+    expect(plan.reasons.join(' ')).toContain(
+      'could not be resolved in a server checkout',
+    );
+  });
+});
+
+describe('pickCli', () => {
+  it('takes the highest version that meets the minimum', () => {
+    const chosen = pickCli(
+      [cli('old', '1.30.0'), cli('good', '1.32.0'), cli('best', '1.33.0')],
+      '1.32.0',
+    );
+
+    expect(chosen?.label).toBe('best');
+  });
+
+  it('gives nothing when every candidate is too old', () => {
+    expect(pickCli([cli('old', '1.31.2')], '1.32.0')).toBeUndefined();
+  });
+
+  it('ignores a candidate whose version could not be read', () => {
+    expect(pickCli([cli('broken', 'unknown')], '1.32.0')).toBeUndefined();
+  });
+
+  it('takes the highest of all candidates when nothing is required', () => {
+    expect(pickCli([cli('a', '1.30.0'), cli('b', '1.31.2')])?.label).toBe('b');
+  });
+});

--- a/utilities/demo/requirements.ts
+++ b/utilities/demo/requirements.ts
@@ -122,15 +122,24 @@ export const planServerStrategy = (
   const short = requirement.serverCommit.slice(0, 9);
 
   if (!commit?.knownLocally) {
+    // A stated floor needs no git history, so it is preferred over a build.
+    if (requirement.minServerVersion) {
+      reasons.push(
+        `Commit ${short} adds the feature, and the definition states that Server ${requirement.minServerVersion} or later has it.`,
+      );
+
+      return {
+        minServerVersion: requirement.minServerVersion,
+        mustBuildLocally: false,
+        reasons,
+      };
+    }
+
     reasons.push(
-      `Commit ${short} could not be resolved in a server checkout, so its release line is unknown. Configure TEMPORAL_SERVER_REPO, fetch the commit, or set minServerVersion.`,
+      `Commit ${short} could not be resolved in a server checkout and the definition states no minServerVersion, so its release line is unknown.`,
     );
 
-    return {
-      minServerVersion: requirement.minServerVersion,
-      mustBuildLocally: true,
-      reasons,
-    };
+    return { mustBuildLocally: true, reasons };
   }
 
   if (!commit.onMain) {

--- a/utilities/demo/requirements.ts
+++ b/utilities/demo/requirements.ts
@@ -1,0 +1,189 @@
+/**
+ * Decides which Temporal server a feature needs, and the cheapest way to get
+ * it. A definition says what the feature requires; it does not have to know
+ * whether a release carries it yet.
+ */
+
+export type FeatureRequirement = {
+  serverCommit?: string;
+  minServerVersion?: string;
+};
+
+export type CommitFacts = {
+  /** The commit is in the server checkout's object store. */
+  knownLocally: boolean;
+  /** The commit is an ancestor of the checkout's HEAD, so a build here has it. */
+  inCheckout: boolean;
+  /** The commit is an ancestor of main, so a release will carry it eventually. */
+  onMain: boolean;
+  /** The lowest release line whose tags contain the commit, e.g. `1.32.0`. */
+  firstTaggedVersion?: string;
+};
+
+export type CliCandidate = {
+  label: string;
+  path: string;
+  serverVersion: string;
+};
+
+export type StrategyPlan = {
+  minServerVersion?: string;
+  mustBuildLocally: boolean;
+  reasons: string[];
+};
+
+const parseVersion = (version: string) => {
+  const [line, ...rest] = version.trim().replace(/^v/, '').split('-');
+
+  return {
+    release: line.split('.').map((part) => Number.parseInt(part, 10) || 0),
+    prerelease: rest.join('-').split('.').filter(Boolean),
+  };
+};
+
+const comparePrerelease = (a: readonly string[], b: readonly string[]) => {
+  // A release outranks any pre-release of the same line, so 1.32.0 is newer
+  // than 1.32.0-157.0 and satisfies a minimum of it.
+  if (!a.length && !b.length) return 0;
+  if (!a.length) return 1;
+  if (!b.length) return -1;
+
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const left = a[index];
+    const right = b[index];
+
+    if (left === undefined) return -1;
+    if (right === undefined) return 1;
+    if (left === right) continue;
+
+    const numeric = /^\d+$/.test(left) && /^\d+$/.test(right);
+
+    if (numeric) return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+
+    return left < right ? -1 : 1;
+  }
+
+  return 0;
+};
+
+export const compareVersions = (left: string, right: string): number => {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+
+  for (let index = 0; index < 3; index += 1) {
+    if ((a.release[index] ?? 0) !== (b.release[index] ?? 0)) {
+      return (a.release[index] ?? 0) - (b.release[index] ?? 0);
+    }
+  }
+
+  return comparePrerelease(a.prerelease, b.prerelease);
+};
+
+export const satisfies = (version: string, minimum?: string) =>
+  !minimum || version === 'unknown' || compareVersions(version, minimum) >= 0;
+
+/**
+ * The lowest release line among tags that contain a commit. A tag such as
+ * `v1.32.0-157.3` is a pre-release of `1.32.0`, so the release line is what a
+ * published CLI has to reach.
+ */
+export const lowestTaggedVersion = (tags: readonly string[]) => {
+  const versions = tags
+    .map((tag) => tag.trim().replace(/^v/, ''))
+    .filter((tag) => /^\d+\.\d+\.\d+/.test(tag));
+
+  if (!versions.length) return undefined;
+
+  return versions.reduce((lowest, candidate) =>
+    compareVersions(candidate, lowest) < 0 ? candidate : lowest,
+  );
+};
+
+export const planServerStrategy = (
+  requirement: FeatureRequirement,
+  commit: CommitFacts | undefined,
+): StrategyPlan => {
+  const reasons: string[] = [];
+
+  if (!requirement.serverCommit) {
+    if (requirement.minServerVersion) {
+      reasons.push(
+        `The definition asks for Server ${requirement.minServerVersion} or later.`,
+      );
+    }
+
+    return {
+      minServerVersion: requirement.minServerVersion,
+      mustBuildLocally: false,
+      reasons,
+    };
+  }
+
+  const short = requirement.serverCommit.slice(0, 9);
+
+  if (!commit?.knownLocally) {
+    reasons.push(
+      `Commit ${short} could not be resolved in a server checkout, so its release line is unknown. Configure TEMPORAL_SERVER_REPO, fetch the commit, or set minServerVersion.`,
+    );
+
+    return {
+      minServerVersion: requirement.minServerVersion,
+      mustBuildLocally: true,
+      reasons,
+    };
+  }
+
+  if (!commit.onMain) {
+    reasons.push(
+      `Commit ${short} is not on main yet, so no release can carry it. Only a build from the checkout will do.`,
+    );
+
+    return {
+      minServerVersion: requirement.minServerVersion,
+      mustBuildLocally: true,
+      reasons,
+    };
+  }
+
+  if (!commit.firstTaggedVersion) {
+    reasons.push(
+      `Commit ${short} is on main but carries no version tag yet, so no release has it. Only a build from the checkout will do.`,
+    );
+
+    return {
+      minServerVersion: requirement.minServerVersion,
+      mustBuildLocally: true,
+      reasons,
+    };
+  }
+
+  const derived = commit.firstTaggedVersion;
+  const minimum =
+    requirement.minServerVersion &&
+    compareVersions(requirement.minServerVersion, derived) > 0
+      ? requirement.minServerVersion
+      : derived;
+
+  reasons.push(
+    `Commit ${short} is on main and first tagged ${derived}, so any Server ${minimum} or later has it.`,
+  );
+
+  return { minServerVersion: minimum, mustBuildLocally: false, reasons };
+};
+
+/** The highest-versioned candidate that meets the minimum, if any. */
+export const pickCli = (
+  candidates: readonly CliCandidate[],
+  minimum?: string,
+): CliCandidate | undefined =>
+  candidates
+    .filter((candidate) => candidate.serverVersion !== 'unknown')
+    .filter((candidate) => satisfies(candidate.serverVersion, minimum))
+    .reduce<CliCandidate | undefined>(
+      (best, candidate) =>
+        !best ||
+        compareVersions(candidate.serverVersion, best.serverVersion) > 0
+          ? candidate
+          : best,
+      undefined,
+    );

--- a/utilities/demo/run.ts
+++ b/utilities/demo/run.ts
@@ -11,7 +11,7 @@ import {
 } from './definition';
 import { startCatalogExamples } from './examples';
 import { WORK_DIR } from './paths';
-import { stopPid, type Supervised } from './process';
+import { listenersOn, stopPid, type Supervised } from './process';
 import type { Scenario, StartedWorkflow } from './scenario';
 import { startServer } from './stages/server';
 import { startUi } from './stages/ui';
@@ -57,7 +57,8 @@ export type DemoIo = {
 export type StartOptions = {
   skip: Stage[];
   only: Stage[];
-  keepAlive: boolean;
+  /** Tear the run down before returning, rather than leaving it up. */
+  once: boolean;
 };
 
 const stageState = (
@@ -78,37 +79,6 @@ const stageState = (
   return { run: true, reason: undefined };
 };
 
-const holdUntilInterrupted = async (io: DemoIo, stop: () => Promise<void>) => {
-  io.writeOutput(
-    chalk.bold('\nHolding everything open. Press Ctrl-C to shut it all down.'),
-  );
-
-  await new Promise<void>((resolve) => {
-    let stopping = false;
-    // Signal handlers alone do not keep the event loop alive, and the child
-    // processes are unref'd, so Node would report an unsettled top-level await.
-    const keepAlive = setInterval(() => {}, 60_000);
-
-    const finish = () => {
-      // A second Ctrl-C means the person is done waiting.
-      if (stopping) {
-        io.writeOutput(chalk.yellow('\nLeaving the rest to "pnpm demo stop".'));
-        process.exit(130);
-      }
-
-      stopping = true;
-      io.writeOutput(chalk.dim('\nShutting down…'));
-      void stop().then(() => {
-        clearInterval(keepAlive);
-        resolve();
-      });
-    };
-
-    process.on('SIGINT', finish);
-    process.on('SIGTERM', finish);
-  });
-};
-
 export const startFeatureDemo = async (
   target: string,
   options: StartOptions,
@@ -118,8 +88,21 @@ export const startFeatureDemo = async (
   const log = (message: string) =>
     io.writeOutput(`${chalk.dim('·')} ${message}`);
 
+  // A recorded run of this scenario is stale by definition: starting again means
+  // wanting a fresh one. Anything unrecorded on a port is somebody else's and is
+  // reused by the stages instead.
+  const replaced = await stopFeatureDemo(definition.name, io, { quiet: true });
+
+  if (replaced) {
+    log(
+      `Stopped the previous run of this scenario (${replaced} process(es)), so this one is fresh.`,
+    );
+  }
+
   const outcomes: StageOutcome[] = [];
   const processes: Supervised[] = [];
+  /** Ports this run started, as opposed to ports it reused. */
+  const ownedPorts: number[] = [];
   const teardown: (() => Promise<void>)[] = [];
   const workflows: StartedWorkflow[] = [];
   const observations: string[] = [];
@@ -128,16 +111,19 @@ export const startFeatureDemo = async (
   let bundledUiUrl: string | undefined;
   let webUrl: string | undefined;
 
-  const stopEverything = async () => {
-    // A worker with a long activity in flight can take minutes to drain, and
-    // Ctrl-C must not leave the ports bound that long. Scenarios get a moment
-    // to finish, then the processes holding the ports go regardless.
+  // A worker with a long activity in flight can take minutes to drain, so a
+  // scenario gets a moment and then the run continues regardless.
+  const stopScenarios = async () => {
     await Promise.race([
       Promise.all(teardown.map((shutdown) => shutdown().catch(() => {}))),
       new Promise((resolve) => {
         setTimeout(resolve, TEARDOWN_GRACE_MS).unref();
       }),
     ]);
+  };
+
+  const stopEverything = async () => {
+    await stopScenarios();
 
     for (const child of processes) await child.stop().catch(() => {});
 
@@ -177,17 +163,27 @@ export const startFeatureDemo = async (
       startedAt: new Date().toISOString(),
       address,
       webUrl,
-      supervisorPid: options.keepAlive ? process.pid : undefined,
+      ports: ownedPorts,
       processes: processes.map(({ label, pid }) => ({ label, pid })),
     });
   }
 
-  if (!options.keepAlive || (!processes.length && !teardown.length)) {
+  if (options.once) {
     await stopEverything();
     return;
   }
 
-  await holdUntilInterrupted(io, stopEverything);
+  // The processes are detached and outlive this command, so it exits rather than
+  // holding a terminal to own something it does not.
+  await stopScenarios();
+
+  if (processes.length) {
+    io.writeOutput(
+      chalk.bold(
+        `\nStill running. Stop it with "pnpm demo stop ${definition.name}".`,
+      ),
+    );
+  }
 
   async function runStages() {
     const server = stageState('server', definition.server.enabled, options);
@@ -201,7 +197,15 @@ export const startFeatureDemo = async (
 
       address = provisioned.address;
       bundledUiUrl = provisioned.bundledUiUrl;
-      if (provisioned.process) processes.push(provisioned.process);
+
+      if (provisioned.process) {
+        processes.push(provisioned.process);
+        ownedPorts.push(
+          definition.server.port,
+          definition.server.uiPort,
+          definition.server.httpPort ?? definition.server.port + 1,
+        );
+      }
 
       outcomes.push({
         stage: 'server',
@@ -272,6 +276,11 @@ export const startFeatureDemo = async (
 
       webUrl = running.webUrl;
       processes.push(...running.processes);
+
+      for (const child of running.processes) {
+        if (child.label === 'ui-server') ownedPorts.push(definition.ui.apiPort);
+        if (child.label === 'ui') ownedPorts.push(definition.ui.webPort);
+      }
 
       outcomes.push({
         stage: 'ui',
@@ -357,39 +366,53 @@ const recordedRunNames = (): string[] => {
     .sort();
 };
 
-export const stopFeatureDemo = async (name: string | undefined, io: DemoIo) => {
+export const stopFeatureDemo = async (
+  name: string | undefined,
+  io: DemoIo,
+  { quiet = false }: { quiet?: boolean } = {},
+): Promise<number> => {
   const names = name ? [name] : recordedRunNames();
   let stopped = 0;
+  const say = (message: string) => {
+    if (!quiet) io.writeOutput(message);
+  };
 
   for (const candidate of names) {
     const state = await readState(candidate);
 
     if (!state) continue;
 
-    // The supervisor shuts its own children down, so it is asked first. Any
-    // child that outlives it is stopped directly below.
-    if (state.supervisorPid && isRunning(state.supervisorPid)) {
-      await stopPid(state.supervisorPid);
-      io.writeOutput(`Stopped the run holding ${candidate} open.`);
-      stopped += 1;
-    }
-
     for (const child of state.processes) {
       if (!isRunning(child.pid)) continue;
 
       await stopPid(child.pid);
-      io.writeOutput(`Stopped ${child.label} (pid ${child.pid}).`);
+      say(`Stopped ${child.label} (pid ${child.pid}).`);
       stopped += 1;
+    }
+
+    // A child that outlived its record still holds its port, and a pid list
+    // cannot see that. The ports this run started are swept as a backstop. A
+    // child that holds no port, such as the catalog worker, is reachable only
+    // through its recorded pid: a sweep by process name would also catch a
+    // worker somebody started themselves.
+    for (const port of state.ports ?? []) {
+      for (const pid of await listenersOn(port)) {
+        await stopPid(pid);
+        say(`Stopped whatever still held port ${port} (pid ${pid}).`);
+        stopped += 1;
+      }
     }
 
     await clearState(candidate);
   }
 
   if (!stopped) {
-    io.writeOutput(
+    say(
       name
         ? `Nothing recorded as running for "${name}".`
         : 'Nothing recorded as running.',
     );
   }
+
+  return stopped;
 };

--- a/utilities/demo/run.ts
+++ b/utilities/demo/run.ts
@@ -1,0 +1,395 @@
+import { existsSync, readdirSync } from 'fs';
+import { pathToFileURL } from 'url';
+
+import { chalk } from 'zx';
+
+import {
+  hasOwnScenario,
+  loadDefinition,
+  ownScenarioPath,
+  type Stage,
+} from './definition';
+import { startCatalogExamples } from './examples';
+import { WORK_DIR } from './paths';
+import { stopPid, type Supervised } from './process';
+import type { Scenario, StartedWorkflow } from './scenario';
+import { startServer } from './stages/server';
+import { startUi } from './stages/ui';
+import { startCatalogWorker } from './stages/worker';
+import { clearState, isRunning, readState, writeState } from './state';
+import {
+  printSummary,
+  type StageOutcome,
+  type SummaryInput,
+  writeSummary,
+} from './summary';
+
+/** Thrown after the failure has already been reported through `io`. */
+export class ReportedRunFailure extends Error {
+  constructor() {
+    super('The run failed.');
+    this.name = 'ReportedRunFailure';
+  }
+}
+
+/** Loads the behaviour a scenario ships beside its definition. */
+const loadOwnScenario = async (name: string): Promise<Scenario> => {
+  const path = ownScenarioPath(name);
+  const module = (await import(pathToFileURL(path).href)) as {
+    scenario?: Scenario;
+  };
+
+  if (!module.scenario) {
+    throw new Error(`${path} must export a "scenario".`);
+  }
+
+  return module.scenario;
+};
+
+/** How long a scenario gets to shut its workers down before the ports go. */
+const TEARDOWN_GRACE_MS = 3_000;
+
+export type DemoIo = {
+  writeOutput: (message: string) => void;
+  writeError: (message: string) => void;
+};
+
+export type StartOptions = {
+  skip: Stage[];
+  only: Stage[];
+  keepAlive: boolean;
+};
+
+const stageState = (
+  stage: Stage,
+  enabledInDefinition: boolean,
+  options: StartOptions,
+) => {
+  if (options.only.length && !options.only.includes(stage)) {
+    return { run: false, reason: `--only ${options.only.join(', ')}` };
+  }
+
+  if (options.skip.includes(stage)) return { run: false, reason: '--skip' };
+
+  if (!enabledInDefinition) {
+    return { run: false, reason: 'disabled in the definition' };
+  }
+
+  return { run: true, reason: undefined };
+};
+
+const holdUntilInterrupted = async (io: DemoIo, stop: () => Promise<void>) => {
+  io.writeOutput(
+    chalk.bold('\nHolding everything open. Press Ctrl-C to shut it all down.'),
+  );
+
+  await new Promise<void>((resolve) => {
+    let stopping = false;
+    // Signal handlers alone do not keep the event loop alive, and the child
+    // processes are unref'd, so Node would report an unsettled top-level await.
+    const keepAlive = setInterval(() => {}, 60_000);
+
+    const finish = () => {
+      // A second Ctrl-C means the person is done waiting.
+      if (stopping) {
+        io.writeOutput(chalk.yellow('\nLeaving the rest to "pnpm demo stop".'));
+        process.exit(130);
+      }
+
+      stopping = true;
+      io.writeOutput(chalk.dim('\nShutting down…'));
+      void stop().then(() => {
+        clearInterval(keepAlive);
+        resolve();
+      });
+    };
+
+    process.on('SIGINT', finish);
+    process.on('SIGTERM', finish);
+  });
+};
+
+export const startFeatureDemo = async (
+  target: string,
+  options: StartOptions,
+  io: DemoIo,
+) => {
+  const { path: definitionPath, definition } = await loadDefinition(target);
+  const log = (message: string) =>
+    io.writeOutput(`${chalk.dim('·')} ${message}`);
+
+  const outcomes: StageOutcome[] = [];
+  const processes: Supervised[] = [];
+  const teardown: (() => Promise<void>)[] = [];
+  const workflows: StartedWorkflow[] = [];
+  const observations: string[] = [];
+
+  let address = `127.0.0.1:${definition.server.port}`;
+  let bundledUiUrl: string | undefined;
+  let webUrl: string | undefined;
+
+  const stopEverything = async () => {
+    // A worker with a long activity in flight can take minutes to drain, and
+    // Ctrl-C must not leave the ports bound that long. Scenarios get a moment
+    // to finish, then the processes holding the ports go regardless.
+    await Promise.race([
+      Promise.all(teardown.map((shutdown) => shutdown().catch(() => {}))),
+      new Promise((resolve) => {
+        setTimeout(resolve, TEARDOWN_GRACE_MS).unref();
+      }),
+    ]);
+
+    for (const child of processes) await child.stop().catch(() => {});
+
+    await clearState(definition.name);
+  };
+
+  try {
+    await runStages();
+  } catch (error) {
+    io.writeError(
+      `\n${chalk.bgRed.white(' FAILED ')} ${error instanceof Error ? error.message : String(error)}`,
+    );
+    await stopEverything();
+    throw new ReportedRunFailure();
+  }
+
+  const summary: SummaryInput = {
+    definition,
+    definitionPath,
+    stages: outcomes,
+    workflows,
+    observations,
+    webUrl,
+    bundledUiUrl,
+    address,
+  };
+
+  printSummary(summary, io.writeOutput);
+
+  const summaryPath = await writeSummary(summary);
+
+  io.writeOutput(`\n${chalk.dim(`Summary written to ${summaryPath}`)}`);
+
+  if (processes.length) {
+    await writeState({
+      name: definition.name,
+      startedAt: new Date().toISOString(),
+      address,
+      webUrl,
+      supervisorPid: options.keepAlive ? process.pid : undefined,
+      processes: processes.map(({ label, pid }) => ({ label, pid })),
+    });
+  }
+
+  if (!options.keepAlive || (!processes.length && !teardown.length)) {
+    await stopEverything();
+    return;
+  }
+
+  await holdUntilInterrupted(io, stopEverything);
+
+  async function runStages() {
+    const server = stageState('server', definition.server.enabled, options);
+
+    if (server.run) {
+      const provisioned = await startServer(
+        definition.server,
+        log,
+        definition.name,
+      );
+
+      address = provisioned.address;
+      bundledUiUrl = provisioned.bundledUiUrl;
+      if (provisioned.process) processes.push(provisioned.process);
+
+      outcomes.push({
+        stage: 'server',
+        ran: true,
+        details: [
+          `Listening on ${provisioned.address}, namespace "${provisioned.namespace}"`,
+          ...(provisioned.reusedExisting
+            ? []
+            : [
+                `Temporal CLI ${provisioned.cliVersion}, Server ${provisioned.serverVersion}`,
+                ...provisioned.provenance,
+                ...Object.entries(definition.server.dynamicConfig).map(
+                  ([key, value]) =>
+                    `Dynamic config: ${key}=${JSON.stringify(value)}`,
+                ),
+              ]),
+          `Bundled Web UI: ${provisioned.bundledUiUrl}`,
+        ],
+      });
+    } else {
+      outcomes.push({
+        stage: 'server',
+        ran: false,
+        reason: server.reason,
+        details: [`Expecting a server on ${address}`],
+      });
+    }
+
+    const worker = stageState('worker', definition.worker.enabled, options);
+
+    if (worker.run) {
+      const running = await startCatalogWorker(
+        definition.worker,
+        address,
+        definition.server.namespace,
+        log,
+        definition.name,
+      );
+
+      if (running.process) processes.push(running.process);
+
+      outcomes.push({
+        stage: 'worker',
+        ran: true,
+        details: [
+          `The catalog worker is polling for: ${running.targets.join(', ')}`,
+          'Started with "pnpm catalog worker", so the demo runs the same code the catalog page runs.',
+        ],
+      });
+    } else {
+      outcomes.push({
+        stage: 'worker',
+        ran: false,
+        reason: worker.reason,
+        details: [],
+      });
+    }
+
+    const ui = stageState('ui', definition.ui.enabled, options);
+
+    if (ui.run) {
+      const running = await startUi(
+        definition.ui,
+        address,
+        log,
+        definition.name,
+      );
+
+      webUrl = running.webUrl;
+      processes.push(...running.processes);
+
+      outcomes.push({
+        stage: 'ui',
+        ran: true,
+        details: [
+          ...(running.apiUrl ? [`ui-server API: ${running.apiUrl}`] : []),
+          ...(running.webUrl ? [`UI: ${running.webUrl}`] : []),
+        ],
+      });
+    } else {
+      outcomes.push({
+        stage: 'ui',
+        ran: false,
+        reason: ui.reason,
+        details: [],
+      });
+    }
+
+    const scenarios = stageState(
+      'scenarios',
+      definition.examples.length > 0 || hasOwnScenario(definition.name),
+      options,
+    );
+
+    if (!scenarios.run) {
+      outcomes.push({
+        stage: 'scenarios',
+        ran: false,
+        reason: scenarios.reason,
+        details: [],
+      });
+
+      return;
+    }
+
+    const details: string[] = [];
+
+    const record = (result: Awaited<ReturnType<Scenario['run']>>) => {
+      if (result.shutdown) teardown.push(result.shutdown);
+
+      workflows.push(...result.workflows);
+      observations.push(...result.observations);
+    };
+
+    const context = {
+      address,
+      namespace: definition.server.namespace,
+      log,
+    };
+
+    if (definition.examples.length) {
+      log(`Starting ${definition.examples.length} catalog example(s)`);
+
+      const result = await startCatalogExamples(context, definition.examples);
+
+      record(result);
+      details.push(`Catalog examples: started ${result.workflows.length}`);
+    }
+
+    if (hasOwnScenario(definition.name)) {
+      const scenario = await loadOwnScenario(definition.name);
+
+      log(`Running the behaviour of the "${definition.name}" scenario`);
+
+      const result = await scenario.run(context, definition.scenario);
+
+      record(result);
+      details.push(
+        `Own scenario: started ${result.workflows.length} workflow(s)`,
+      );
+    }
+
+    outcomes.push({ stage: 'scenarios', ran: true, details });
+  }
+};
+
+const recordedRunNames = (): string[] => {
+  if (!existsSync(WORK_DIR)) return [];
+
+  return readdirSync(WORK_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+};
+
+export const stopFeatureDemo = async (name: string | undefined, io: DemoIo) => {
+  const names = name ? [name] : recordedRunNames();
+  let stopped = 0;
+
+  for (const candidate of names) {
+    const state = await readState(candidate);
+
+    if (!state) continue;
+
+    // The supervisor shuts its own children down, so it is asked first. Any
+    // child that outlives it is stopped directly below.
+    if (state.supervisorPid && isRunning(state.supervisorPid)) {
+      await stopPid(state.supervisorPid);
+      io.writeOutput(`Stopped the run holding ${candidate} open.`);
+      stopped += 1;
+    }
+
+    for (const child of state.processes) {
+      if (!isRunning(child.pid)) continue;
+
+      await stopPid(child.pid);
+      io.writeOutput(`Stopped ${child.label} (pid ${child.pid}).`);
+      stopped += 1;
+    }
+
+    await clearState(candidate);
+  }
+
+  if (!stopped) {
+    io.writeOutput(
+      name
+        ? `Nothing recorded as running for "${name}".`
+        : 'Nothing recorded as running.',
+    );
+  }
+};

--- a/utilities/demo/scenario.ts
+++ b/utilities/demo/scenario.ts
@@ -1,0 +1,35 @@
+import type { Logger } from './paths';
+
+export type StartedWorkflow = {
+  role: string;
+  workflowId: string;
+  runId: string;
+  note?: string;
+  /** Set when the workflow is a catalog example, so the summary can link to it. */
+  catalogExampleId?: string;
+};
+
+export type ScenarioContext = {
+  address: string;
+  namespace: string;
+  log: Logger;
+};
+
+export type ScenarioResult = {
+  workflows: StartedWorkflow[];
+  observations: string[];
+  shutdown?: () => Promise<void>;
+};
+
+/**
+ * Behaviour a scenario cannot express by naming catalog examples. It goes in
+ * `scenario.ts` beside the `definition.ts`, the way a catalog example puts its
+ * workflow beside its `example.ts`.
+ */
+export type Scenario = {
+  describe: string;
+  run: (
+    context: ScenarioContext,
+    options: Record<string, unknown>,
+  ) => Promise<ScenarioResult>;
+};

--- a/utilities/demo/scenarios/catalog-signals-and-timers/definition.ts
+++ b/utilities/demo/scenarios/catalog-signals-and-timers/definition.ts
@@ -1,0 +1,53 @@
+import { defineScenario } from '../../definition';
+
+export const definition = defineScenario({
+  name: 'catalog-signals-and-timers',
+  title: 'Catalog examples covering signals, timers, and pending work',
+  summary:
+    'Starts catalog examples that leave open workflows behind: a bounded signal wait, a signal collector, a long activity, and a timer-driven repetition. Each one is a catalog example, so the catalog page runs the same code and the review covers what ships.',
+  server: {
+    source: 'auto',
+    dynamicConfig: {
+      'frontend.enableUpdateWorkflowExecution': true,
+      'frontend.enableUpdateWorkflowExecutionAsyncAccepted': true,
+    },
+    searchAttributes: {
+      CustomKeywordField: 'Keyword',
+      CustomIntField: 'Int',
+    },
+  },
+  examples: [
+    {
+      id: 'signal-handlers',
+      workflowId: 'catalog-signal-handlers',
+      input: [300],
+      role: 'signal wait',
+      note: "Waits five minutes for 'test-signal', so it stays open for review.",
+    },
+    {
+      id: 'signal-collector',
+      workflowId: 'catalog-signal-collector',
+      input: [{ timeoutSeconds: 300, maxItems: 3 }],
+      role: 'signal collector',
+      note: 'Collects up to three signaled items before it processes them.',
+    },
+    {
+      id: 'long-activity',
+      workflowId: 'catalog-long-activity',
+      role: 'pending activity',
+    },
+    {
+      id: 'timer-driven-repetition',
+      workflowId: 'catalog-timer-repetition',
+      role: 'timers',
+    },
+  ],
+  preview: {
+    notes: [
+      "Open each workflow's Timeline tab. Every pending activity and timer must show a pending marker.",
+      'Leave a history page open for a minute. Auto-refresh must pick up new events without a reload.',
+      "Send 'test-signal' to catalog-signal-handlers and confirm the history records it.",
+      'Open the catalog page and confirm each example reports a worker polling its task queue.',
+    ],
+  },
+});

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/caller-workflow.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/caller-workflow.ts
@@ -1,0 +1,91 @@
+import protoPkg from '@temporalio/proto';
+import { createNexusServiceClient } from '@temporalio/workflow';
+import * as nexus from 'nexus-rpc';
+
+const { temporal } = protoPkg;
+
+type Request = InstanceType<
+  typeof temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest
+>;
+type Response = InstanceType<
+  typeof temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse
+>;
+
+/**
+ * The system endpoint serves the workflowservice contract, so the operation is
+ * named exactly as the proto names it.
+ */
+const workflowService = nexus.service(
+  'temporal.api.workflowservice.v1.WorkflowService',
+  {
+    SignalWithStartWorkflowExecution: nexus.operation<Request, Response>(),
+  },
+);
+
+export type CallerInput = {
+  targetWorkflowId: string;
+  targetWorkflowType: string;
+  targetTaskQueue: string;
+  signalName: string;
+  signalInput: unknown;
+  workflowInput: unknown[];
+  memo: Record<string, unknown>;
+};
+
+/**
+ * The inner payloads the target receives. A workflow has no payload converter
+ * of its own, and `json/plain` is what the default converter produces for these
+ * values, so the caller builds them directly.
+ */
+const jsonPayload = (value: unknown) => ({
+  metadata: { encoding: new TextEncoder().encode('json/plain') },
+  data: new TextEncoder().encode(JSON.stringify(value)),
+});
+
+export type CallerOutput = {
+  started: boolean;
+  runId: string;
+};
+
+/**
+ * Invokes SignalWithStartWorkflowExecution on the `__temporal_system` endpoint.
+ * An ordinary workflow can do this: only the Go SDK refuses the reserved
+ * `__temporal_` prefix.
+ */
+export async function SystemNexusSignalWithStartCaller(
+  input: CallerInput,
+): Promise<CallerOutput> {
+  const client = createNexusServiceClient({
+    endpoint: '__temporal_system',
+    service: workflowService,
+  });
+
+  const { SignalWithStartWorkflowExecutionRequest } =
+    temporal.api.workflowservice.v1;
+
+  const response = await client.executeOperation(
+    'SignalWithStartWorkflowExecution',
+    SignalWithStartWorkflowExecutionRequest.create({
+      workflowId: input.targetWorkflowId,
+      workflowType: { name: input.targetWorkflowType },
+      taskQueue: { name: input.targetTaskQueue },
+      signalName: input.signalName,
+      signalInput: { payloads: [jsonPayload(input.signalInput)] },
+      input: { payloads: input.workflowInput.map(jsonPayload) },
+      ...(Object.keys(input.memo).length
+        ? {
+            memo: {
+              fields: Object.fromEntries(
+                Object.entries(input.memo).map(([key, value]) => [
+                  key,
+                  jsonPayload(value),
+                ]),
+              ),
+            },
+          }
+        : {}),
+    }),
+  );
+
+  return { started: response.started, runId: response.runId };
+}

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/caller-workflow.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/caller-workflow.ts
@@ -1,5 +1,5 @@
 import protoPkg from '@temporalio/proto';
-import { createNexusServiceClient } from '@temporalio/workflow';
+import { createNexusServiceClient, workflowInfo } from '@temporalio/workflow';
 import * as nexus from 'nexus-rpc';
 
 const { temporal } = protoPkg;
@@ -30,6 +30,8 @@ export type CallerInput = {
   signalInput: unknown;
   workflowInput: unknown[];
   memo: Record<string, unknown>;
+  /** Defaults to this workflow's id. The UI shows it on the initiated event. */
+  identity?: string;
 };
 
 /**
@@ -70,6 +72,10 @@ export async function SystemNexusSignalWithStartCaller(
       workflowType: { name: input.targetWorkflowType },
       taskQueue: { name: input.targetTaskQueue },
       signalName: input.signalName,
+      // Nothing populates this for us: the server records the request as the
+      // caller sent it, and no SDK sets identity on this path yet. The UI shows
+      // it when present, so the caller names itself.
+      identity: input.identity ?? workflowInfo().workflowId,
       signalInput: { payloads: [jsonPayload(input.signalInput)] },
       input: { payloads: input.workflowInput.map(jsonPayload) },
       ...(Object.keys(input.memo).length

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
@@ -4,7 +4,6 @@ import { defineScenario } from '../../definition';
 export const definition = defineScenario({
   name: 'system-nexus-signal-with-start',
   title: 'Signal With Start through the system Nexus endpoint',
-  ticket: 'DT-4385',
   feature: 'src/lib/system-nexus-endpoints/signal-with-start-workflow',
   summary:
     'A workflow calls SignalWithStartWorkflowExecution on the __temporal_system Nexus endpoint. Both of the resulting events carry a binary/protobuf workflowservice message. Without this branch the UI shows the raw Nexus transport; with it the UI decodes the payload and shows the operation, its target, and the link back to the caller. The operation\'s target is the "signal-handlers" catalog example, so the workflow it starts and signals is one the catalog already runs.',
@@ -29,7 +28,6 @@ export const definition = defineScenario({
     signalInput: 'delivered by the system Nexus operation',
     memo: {
       demo: 'system-nexus-signal-with-start',
-      ticket: 'DT-4385',
     },
   } satisfies Options,
   preview: {

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
@@ -35,7 +35,7 @@ export const definition = defineScenario({
   preview: {
     notes: [
       'Open the caller workflow\'s History tab. The two Nexus rows must read "Signal With Start Workflow Execution Initiated" and "\u2026 Delivered", not "Nexus Operation Scheduled" and "Nexus Operation Completed".',
-      "Expand the Initiated row. It must show the target workflow ID, the signal name, and the caller's identity, and it must not show the endpoint, service, operation, or requestId transport fields.",
+      "Expand the Initiated row. It must show the target workflow ID, the signal name, and the caller's identity, and it must not show the endpoint, service, operation, or requestId transport fields. The server records the request as the caller sent it, so identity appears because the caller sets it; a 'control' row appears only for a caller that sets that field.",
       'Follow the target execution link from the Initiated row. It must land on the target workflow.',
       "Open the target workflow's History tab. Its Workflow Execution Signaled row must carry a link back to the caller.",
       "Switch the caller's history to Compact. The collapsed group row must read the operation label, not the raw Nexus event name.",

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
@@ -9,7 +9,19 @@ export const definition = defineScenario({
     'A workflow calls SignalWithStartWorkflowExecution on the __temporal_system Nexus endpoint. Both of the resulting events carry a binary/protobuf workflowservice message. Without this branch the UI shows the raw Nexus transport; with it the UI decodes the payload and shows the operation, its target, and the link back to the caller. The operation\'s target is the "signal-handlers" catalog example, so the workflow it starts and signals is one the catalog already runs.',
   server: {
     source: 'auto',
-    requires: { serverCommit: '01aa279c462fd9e7efc8e0ba6bbc4554b51557dd' },
+    requires: {
+      // The commit that adds the operation, and the release line that carries
+      // it. The floor is stated because a fetched checkout has no history to
+      // derive it from.
+      serverCommit: '01aa279c462fd9e7efc8e0ba6bbc4554b51557dd',
+      minServerVersion: '1.32.0',
+      // A verified pair, and it has to stay a pair. The workspace puts both
+      // repositories in one dependency graph, they are not released in step,
+      // and go.temporal.io/api changes under both: these two agree on v1.63.0,
+      // while the current mains disagree and do not compile. Move both together.
+      serverRef: 'a31f476255b2c7c00176f683cdce84710daaba44',
+      cliRef: '590d3a7ac8cff31673bca69e969427a34f321f7b',
+    },
     dynamicConfig: {
       'history.enableChasm': true,
       'history.enableSignalWithStartFromWorkflow': true,

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/definition.ts
@@ -1,0 +1,46 @@
+import type { Options } from './scenario';
+import { defineScenario } from '../../definition';
+
+export const definition = defineScenario({
+  name: 'system-nexus-signal-with-start',
+  title: 'Signal With Start through the system Nexus endpoint',
+  ticket: 'DT-4385',
+  feature: 'src/lib/system-nexus-endpoints/signal-with-start-workflow',
+  summary:
+    'A workflow calls SignalWithStartWorkflowExecution on the __temporal_system Nexus endpoint. Both of the resulting events carry a binary/protobuf workflowservice message. Without this branch the UI shows the raw Nexus transport; with it the UI decodes the payload and shows the operation, its target, and the link back to the caller. The operation\'s target is the "signal-handlers" catalog example, so the workflow it starts and signals is one the catalog already runs.',
+  server: {
+    source: 'auto',
+    requires: { serverCommit: '01aa279c462fd9e7efc8e0ba6bbc4554b51557dd' },
+    dynamicConfig: {
+      'history.enableChasm': true,
+      'history.enableSignalWithStartFromWorkflow': true,
+    },
+    searchAttributes: {
+      CustomKeywordField: 'Keyword',
+      CustomIntField: 'Int',
+    },
+  },
+  // The compiler checks these against the scenario beside this file, so a
+  // mistyped option is an error here rather than a default used quietly.
+  scenario: {
+    targetExample: 'signal-handlers',
+    targetWorkflowId: 'system-nexus-target',
+    signalName: 'test-signal',
+    signalInput: 'delivered by the system Nexus operation',
+    memo: {
+      demo: 'system-nexus-signal-with-start',
+      ticket: 'DT-4385',
+    },
+  } satisfies Options,
+  preview: {
+    notes: [
+      'Open the caller workflow\'s History tab. The two Nexus rows must read "Signal With Start Workflow Execution Initiated" and "\u2026 Delivered", not "Nexus Operation Scheduled" and "Nexus Operation Completed".',
+      "Expand the Initiated row. It must show the target workflow ID, the signal name, and the caller's identity, and it must not show the endpoint, service, operation, or requestId transport fields.",
+      'Follow the target execution link from the Initiated row. It must land on the target workflow.',
+      "Open the target workflow's History tab. Its Workflow Execution Signaled row must carry a link back to the caller.",
+      "Switch the caller's history to Compact. The collapsed group row must read the operation label, not the raw Nexus event name.",
+      'Open the Timeline tab on the caller. The operation must use the Nexus colour and icon.',
+      'Open the catalog page for signal-handlers. It must show a worker polling its task queue, which is the same worker that ran the target.',
+    ],
+  },
+});

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/payload-converter.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/payload-converter.ts
@@ -1,0 +1,78 @@
+import {
+  CompositePayloadConverter,
+  defaultPayloadConverter,
+  type Payload,
+  type PayloadConverterWithEncoding,
+} from '@temporalio/common';
+import protoPkg from '@temporalio/proto';
+
+const { temporal } = protoPkg;
+
+type ProtoCodec = {
+  encode: (message: unknown) => { finish: () => Uint8Array };
+  decode: (data: Uint8Array) => unknown;
+};
+
+/** The messages the system Nexus endpoint speaks for this operation. */
+const MESSAGES: Record<string, ProtoCodec> = {
+  'temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest':
+    temporal.api.workflowservice.v1
+      .SignalWithStartWorkflowExecutionRequest as unknown as ProtoCodec,
+  'temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionResponse':
+    temporal.api.workflowservice.v1
+      .SignalWithStartWorkflowExecutionResponse as unknown as ProtoCodec,
+};
+
+const encodeText = (value: string) => new TextEncoder().encode(value);
+const decodeText = (value: Uint8Array | null | undefined) =>
+  new TextDecoder().decode(value ?? new Uint8Array());
+
+/**
+ * The system Nexus endpoint speaks binary/protobuf workflowservice messages.
+ *
+ * The SDK's own protobuf converters cannot do this yet: they emit
+ * json/protobuf, and they want reflection metadata that the generated classes
+ * in `@temporalio/proto` do not carry. This converter is therefore demo-only
+ * scaffolding, and it goes away when the SDK gains the operation.
+ */
+class SystemNexusProtoConverter implements PayloadConverterWithEncoding {
+  public readonly encodingType = 'binary/protobuf';
+
+  public toPayload(value: unknown): Payload | undefined {
+    if (!value || typeof value !== 'object') return undefined;
+
+    // Those generated namespaces are not constructors, so `instanceof` cannot
+    // identify a message. Its prototype names itself instead.
+    const messageType = Object.keys(MESSAGES).find(
+      (name) => name.split('.').pop() === value.constructor?.name,
+    );
+
+    if (!messageType) return undefined;
+
+    return {
+      metadata: {
+        encoding: encodeText(this.encodingType),
+        messageType: encodeText(messageType),
+      },
+      data: MESSAGES[messageType].encode(value).finish(),
+    };
+  }
+
+  public fromPayload<T>(payload: Payload): T {
+    const messageType = decodeText(payload.metadata?.messageType);
+    const codec = MESSAGES[messageType];
+
+    if (!codec) {
+      throw new Error(`No proto codec for message type "${messageType}"`);
+    }
+
+    // A response crosses into the workflow sandbox, so its buffer belongs to
+    // another realm and protobufjs rejects it. Re-wrap it in this realm's view.
+    return codec.decode(new Uint8Array(payload.data ?? [])) as T;
+  }
+}
+
+export const payloadConverter = new CompositePayloadConverter(
+  new SystemNexusProtoConverter(),
+  ...(defaultPayloadConverter as CompositePayloadConverter).converters,
+);

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
@@ -36,6 +36,8 @@ const optionsSchema = z.strictObject({
     .default('a signal delivered by the system Nexus endpoint'),
   workflowInput: z.array(z.unknown()).optional(),
   memo: z.record(z.string(), z.unknown()).default({}),
+  /** Defaults to the caller's workflow id. */
+  identity: z.string().optional(),
 });
 
 const run = async (

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Client, Connection } from '@temporalio/client';
+import protoPkg from '@temporalio/proto';
 import {
   DefaultLogger,
   NativeConnection,
@@ -39,6 +40,73 @@ const optionsSchema = z.strictObject({
   /** Defaults to the caller's workflow id. */
   identity: z.string().optional(),
 });
+
+/** What the UI renders from the decoded request, and the target needs to run. */
+const REQUIRED_FIELDS = [
+  'workflowId',
+  'workflowType',
+  'taskQueue',
+  'signalName',
+  'identity',
+] as const;
+
+/**
+ * Fields this caller deliberately leaves unset. The server records the request
+ * as the caller sent it today, so any of these appearing means the server
+ * started populating it, which changes what the UI shows.
+ */
+const UNSET_FIELDS = ['namespace', 'requestId', 'control', 'links'] as const;
+
+/**
+ * The demo exists to prove the UI has real data to render, so it checks the
+ * recorded request rather than trusting that what was sent is what was stored.
+ * This is the guard against the operation's shape drifting underneath us.
+ */
+const checkRecordedShape = async (
+  client: Client,
+  callerWorkflowId: string,
+): Promise<string[]> => {
+  const history = await client.workflow
+    .getHandle(callerWorkflowId)
+    .fetchHistory();
+
+  const scheduled = history.events?.find(
+    (event) => event.nexusOperationScheduledEventAttributes,
+  );
+  const input = scheduled?.nexusOperationScheduledEventAttributes?.input;
+
+  if (!input?.data) {
+    throw new Error(
+      'The caller recorded no NexusOperationScheduled input, so there is nothing for the UI to decode.',
+    );
+  }
+
+  const request =
+    protoPkg.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.decode(
+      input.data,
+    ).toJSON() as Record<string, unknown>;
+
+  const missing = REQUIRED_FIELDS.filter((field) => !request[field]);
+
+  if (missing.length) {
+    throw new Error(
+      [
+        `The recorded request no longer carries: ${missing.join(', ')}.`,
+        'The UI renders signalName, identity, and control from this request, and',
+        'the target needs the rest. Either the caller stopped sending them, or the',
+        'server changed what it records. Update this scenario to match.',
+      ].join('\n'),
+    );
+  }
+
+  const appeared = UNSET_FIELDS.filter((field) => request[field]);
+
+  return appeared.length
+    ? [
+        `The server now populates ${appeared.join(', ')} on the request, which this caller does not send. The UI may show more than these review steps describe.`,
+      ]
+    : [];
+};
 
 const run = async (
   { address, namespace, log }: ScenarioContext,
@@ -103,6 +171,8 @@ const run = async (
     `The operation returned started=${result.started} for run ${result.runId}`,
   );
 
+  const shapeNotes = await checkRecordedShape(client, caller.workflowId);
+
   return {
     workflows: [
       {
@@ -128,6 +198,7 @@ const run = async (
         ? 'The operation started a new target workflow (started=true).'
         : 'The target already existed, so the operation only signaled it (started=false).',
       `The target runs the "${target.id}" catalog example on the catalog worker, so nothing here is demo-only code.`,
+      ...shapeNotes,
     ],
     shutdown: async () => {
       await connection.close();

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/scenario.ts
@@ -1,0 +1,140 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Client, Connection } from '@temporalio/client';
+import {
+  DefaultLogger,
+  NativeConnection,
+  Runtime,
+  Worker,
+} from '@temporalio/worker';
+import { z } from 'zod';
+
+import { SystemNexusSignalWithStartCaller } from './caller-workflow';
+import { assertValidExampleInput, requireWorkflowExample } from '../../catalog';
+import type { Scenario, ScenarioContext, ScenarioResult } from '../../scenario';
+
+const require = createRequire(import.meta.url);
+
+/** The options this scenario accepts, checked by the compiler in definition.ts. */
+export type Options = z.input<typeof optionsSchema>;
+
+// strict, so an option this scenario does not have is an error rather than a
+// default used quietly.
+const optionsSchema = z.strictObject({
+  /**
+   * The catalog example the operation starts and signals. Its workflow type and
+   * task queue come from the catalog, and the catalog worker runs it.
+   */
+  targetExample: z.string().default('signal-handlers'),
+  targetWorkflowId: z.string().default('system-nexus-target'),
+  /** Must be a signal the target example handles. */
+  signalName: z.string().default('test-signal'),
+  signalInput: z
+    .unknown()
+    .default('a signal delivered by the system Nexus endpoint'),
+  workflowInput: z.array(z.unknown()).optional(),
+  memo: z.record(z.string(), z.unknown()).default({}),
+});
+
+const run = async (
+  { address, namespace, log }: ScenarioContext,
+  rawOptions: Record<string, unknown>,
+): Promise<ScenarioResult> => {
+  const options = optionsSchema.parse(rawOptions);
+  const target = requireWorkflowExample(options.targetExample);
+  const targetInput = options.workflowInput ?? target.defaultInput;
+
+  await assertValidExampleInput(target, targetInput);
+
+  log(
+    `Target is the "${target.id}" catalog example: workflow type ${target.workflowType} on the "${target.taskQueue}" task queue`,
+  );
+
+  Runtime.install({ logger: new DefaultLogger('WARN') });
+
+  // The caller needs a payload converter the SDK does not ship yet, so it runs
+  // on a worker of its own. The target stays on the catalog worker.
+  const dataConverter = {
+    payloadConverterPath: join(
+      dirname(fileURLToPath(import.meta.url)),
+      'payload-converter.ts',
+    ),
+  };
+  const callerTaskQueue = `system-nexus-caller-${Date.now().toString(36)}`;
+
+  const worker = await Worker.create({
+    connection: await NativeConnection.connect({ address }),
+    workflowsPath: require.resolve('./caller-workflow'),
+    taskQueue: callerTaskQueue,
+    namespace,
+    dataConverter,
+  });
+
+  const connection = await Connection.connect({ address });
+  const client = new Client({ connection, namespace, dataConverter });
+
+  const callerWorkflowId = `system-nexus-caller-${Date.now().toString(36)}`;
+
+  const caller = await client.workflow.start(SystemNexusSignalWithStartCaller, {
+    taskQueue: callerTaskQueue,
+    workflowId: callerWorkflowId,
+    args: [
+      {
+        targetWorkflowId: options.targetWorkflowId,
+        targetWorkflowType: target.workflowType,
+        targetTaskQueue: target.taskQueue,
+        signalName: options.signalName,
+        signalInput: options.signalInput,
+        workflowInput: targetInput,
+        memo: options.memo,
+      },
+    ],
+  });
+
+  log(`Caller workflow started: ${caller.workflowId}`);
+
+  const result = await worker.runUntil(caller.result());
+
+  log(
+    `The operation returned started=${result.started} for run ${result.runId}`,
+  );
+
+  return {
+    workflows: [
+      {
+        role: 'caller',
+        workflowId: caller.workflowId,
+        runId: caller.firstExecutionRunId,
+        note: 'An ordinary workflow. Carries the two system Nexus events, both binary/protobuf.',
+      },
+      {
+        role: 'target',
+        workflowId: options.targetWorkflowId,
+        runId: result.runId,
+        note: result.started
+          ? `Started by the operation, then signaled. Runs the "${target.id}" catalog example.`
+          : `Already existed, so the operation only signaled it. Runs the "${target.id}" catalog example.`,
+        catalogExampleId: target.id,
+      },
+    ],
+    observations: [
+      'NexusOperationScheduled carries endpoint __temporal_system, service temporal.api.workflowservice.v1.WorkflowService, operation SignalWithStartWorkflowExecution.',
+      'Both payloads are binary/protobuf, so the UI must decode them to show anything useful.',
+      result.started
+        ? 'The operation started a new target workflow (started=true).'
+        : 'The target already existed, so the operation only signaled it (started=false).',
+      `The target runs the "${target.id}" catalog example on the catalog worker, so nothing here is demo-only code.`,
+    ],
+    shutdown: async () => {
+      await connection.close();
+    },
+  };
+};
+
+export const scenario: Scenario = {
+  describe:
+    'Invokes SignalWithStartWorkflowExecution through the __temporal_system Nexus endpoint from an ordinary caller workflow, so the caller history holds a NexusOperationScheduled and NexusOperationCompleted pair with binary/protobuf payloads.',
+  run,
+};

--- a/utilities/demo/scenarios/system-nexus-signal-with-start/sdk-support.test.ts
+++ b/utilities/demo/scenarios/system-nexus-signal-with-start/sdk-support.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * This scenario ships a caller workflow and a payload converter only because
+ * the TypeScript SDK cannot send this operation yet. These tests fail when that
+ * stops being true, so the scaffolding is deleted deliberately rather than
+ * carried forever.
+ *
+ * The Python SDK already has the plumbing on main, and the caller API
+ * (`workflow.signal_with_start_workflow`) on a branch, so this is a question of
+ * when rather than whether.
+ */
+describe('the reason this scenario ships its own caller', () => {
+  it('fails when the SDK gains a signal-with-start workflow API', async () => {
+    const workflow = await import('@temporalio/workflow');
+
+    const supported = Object.keys(workflow).filter((name) =>
+      /signalWithStart/i.test(name),
+    );
+
+    expect(
+      supported,
+      [
+        `@temporalio/workflow now exports ${supported.join(', ')}.`,
+        'Use it instead: delete caller-workflow.ts and payload-converter.ts,',
+        'and call the SDK from the scenario.',
+      ].join('\n'),
+    ).toEqual([]);
+  });
+
+  it('fails when the SDK can encode these messages as binary/protobuf', async () => {
+    const { DefaultPayloadConverterWithProtobufs } =
+      await import('@temporalio/common/lib/converter/protobuf-payload-converters');
+    const protoPkg = await import('@temporalio/proto');
+
+    const converter = new DefaultPayloadConverterWithProtobufs({
+      protobufRoot: protoPkg as unknown as Record<string, unknown>,
+    });
+
+    const message =
+      protoPkg.default.temporal.api.workflowservice.v1.SignalWithStartWorkflowExecutionRequest.create(
+        { workflowId: 'canary' },
+      );
+
+    // The generated classes carry no reflection metadata, so the SDK's own
+    // protobuf converters cannot serialize them. If this starts working, the
+    // converter in this directory is redundant.
+    let encoding: string | undefined;
+
+    try {
+      const payload = converter.toPayload(message);
+      encoding = new TextDecoder().decode(payload?.metadata?.encoding);
+    } catch {
+      encoding = undefined;
+    }
+
+    expect(
+      encoding,
+      [
+        `The SDK's protobuf converter now produces "${encoding}" for these messages.`,
+        'If that is binary/protobuf with a messageType, delete payload-converter.ts',
+        'and use the SDK converter.',
+      ].join('\n'),
+    ).not.toBe('binary/protobuf');
+  });
+});

--- a/utilities/demo/stages/server.ts
+++ b/utilities/demo/stages/server.ts
@@ -156,86 +156,195 @@ const downloadCli = async (version: string, log: Logger): Promise<string> => {
  * Where the Temporal checkouts live on this machine. A definition may name them,
  * but normally the environment does, so a definition stays portable.
  */
-const repoPath = (
-  fromDefinition: string | undefined,
-  variable: string,
-  label: string,
-): string => {
-  const configured = fromDefinition ?? process.env[variable];
+const CHECKOUT_DIR = join(WORK_DIR, 'checkouts');
 
-  if (!configured) {
+const REPOS = {
+  server: {
+    url: 'https://github.com/temporalio/temporal.git',
+    label: 'Temporal server',
+    variable: 'TEMPORAL_SERVER_REPO',
+  },
+  cli: {
+    url: 'https://github.com/temporalio/cli.git',
+    label: 'Temporal CLI',
+    variable: 'TEMPORAL_CLI_REPO',
+  },
+} as const;
+
+type RepoSource = {
+  path: string;
+  ref: string;
+  sha: string;
+  /** A checkout this tool owns is clean, so its commit identifies it fully. */
+  key: string;
+  provenance: string;
+};
+
+/**
+ * Fetches one commit rather than cloning a repository. GitHub serves a blobless
+ * shallow fetch of any reachable commit, so this costs seconds instead of the
+ * whole history, and the checkout belongs to this tool rather than to whatever a
+ * person happens to have open.
+ */
+const ensureCheckout = async (
+  repo: (typeof REPOS)[keyof typeof REPOS],
+  ref: string,
+  log: Logger,
+): Promise<RepoSource> => {
+  const path = join(CHECKOUT_DIR, `${repo.variable.toLowerCase()}-${ref}`);
+  const head = async () =>
+    (await $`git -C ${path} rev-parse HEAD`.quiet().nothrow()).stdout.trim();
+
+  const pinned = /^[0-9a-f]{7,40}$/.test(ref);
+  const current = existsSync(join(path, '.git')) ? await head() : '';
+
+  // A pinned commit cannot move, so an existing checkout of it is reusable. A
+  // branch can move, so it is fetched again.
+  if (!current || !pinned) {
+    log(`Fetching ${repo.label} at ${ref}`);
+
+    await mkdir(path, { recursive: true });
+    await $`git -C ${path} init -q`.quiet().nothrow();
+    await $`git -C ${path} remote add origin ${repo.url}`.quiet().nothrow();
+
+    const fetched =
+      await $`git -C ${path} fetch --depth 1 --filter=blob:none origin ${ref}`
+        .quiet()
+        .nothrow();
+
+    if (fetched.exitCode !== 0) {
+      throw new Error(
+        [
+          `Could not fetch ${ref} from ${repo.url}.`,
+          `Set ${repo.variable} to a local checkout instead, or check the ref.`,
+          fetched.stderr.trim(),
+        ].join('\n'),
+      );
+    }
+
+    await $`git -C ${path} checkout -q --force FETCH_HEAD`.quiet().nothrow();
+  }
+
+  const sha = await head();
+
+  return {
+    path,
+    ref,
+    sha,
+    key: sha,
+    provenance: `${repo.label}: ${repo.url} @ ${ref} (${sha.slice(0, 9)}), fetched into ${path}`,
+  };
+};
+
+/** A checkout somebody is working in, which may carry uncommitted changes. */
+const useLocalRepo = async (
+  repo: (typeof REPOS)[keyof typeof REPOS],
+  path: string,
+): Promise<RepoSource> => {
+  const expanded = expandPath(path);
+
+  if (!existsSync(join(expanded, 'go.mod'))) {
+    throw new Error(`${expanded} is not a Go module checkout.`);
+  }
+
+  const described = await gitDescribe(expanded);
+  const uncommitted = described.changedGoFiles
+    ? `, ${described.changedGoFiles} uncommitted Go file(s)`
+    : '';
+
+  return {
+    path: expanded,
+    ref: described.ref,
+    sha: described.sha,
+    key: `${described.sha}-${described.fingerprint}`,
+    provenance: `${repo.label}: ${expanded} @ ${described.ref} (${described.sha}${uncommitted})`,
+  };
+};
+
+/**
+ * A pinned checkout by default, so the demo needs no configuration and does not
+ * compile whatever a person has open. An explicit path wins, because somebody
+ * developing the feature wants their own working tree.
+ */
+const resolveRepo = async (
+  repo: (typeof REPOS)[keyof typeof REPOS],
+  fromDefinition: string | undefined,
+  ref: string | undefined,
+  log: Logger,
+): Promise<RepoSource> => {
+  const local = fromDefinition ?? process.env[repo.variable];
+
+  if (local) return useLocalRepo(repo, local);
+
+  if (!ref) {
     throw new Error(
       [
-        `This definition needs a local build of the Temporal server, but no ${label} checkout is configured.`,
-        `Set ${variable}, or put it in .env.feature-demo.local, which is gitignored:`,
-        '',
-        '  TEMPORAL_SERVER_REPO=/path/to/temporalio/temporal',
-        '  TEMPORAL_CLI_REPO=/path/to/temporalio/cli',
+        `A build of the ${repo.label} needs a ref to fetch, and this definition gives none.`,
+        repo.variable === 'TEMPORAL_SERVER_REPO'
+          ? 'Set requires.serverCommit in the definition, or point TEMPORAL_SERVER_REPO at a checkout.'
+          : `Set requires.cliRef in the definition, or point ${repo.variable} at a checkout.`,
       ].join('\n'),
     );
   }
 
-  return expandPath(configured);
+  return ensureCheckout(repo, ref, log);
 };
 
 const buildWorkspaceCli = async (
   server: ServerDefinition,
   log: Logger,
 ): Promise<{ binary: string; provenance: string[] }> => {
-  const cliRepo = repoPath(server.cliRepo, 'TEMPORAL_CLI_REPO', 'Temporal CLI');
-  const serverRepo = repoPath(
-    server.serverRepo,
-    'TEMPORAL_SERVER_REPO',
-    'Temporal server',
-  );
+  const [cli, temporal] = await Promise.all([
+    resolveRepo(REPOS.cli, server.cliRepo, server.requires.cliRef, log),
+    resolveRepo(
+      REPOS.server,
+      server.serverRepo,
+      server.serverRef ?? server.requires.serverRef,
+      log,
+    ),
+  ]);
 
-  for (const repo of [cliRepo, serverRepo]) {
-    if (!existsSync(join(repo, 'go.mod'))) {
-      throw new Error(`${repo} is not a Go module checkout.`);
+  const required = server.requires.serverCommit;
+
+  const shallow =
+    (
+      await $`git -C ${temporal.path} rev-parse --is-shallow-repository`
+        .quiet()
+        .nothrow()
+    ).stdout.trim() === 'true';
+
+  // A fetched checkout has one commit, so ancestry cannot be computed from it.
+  // The version floor covers that case, checked against the built binary.
+  if (required && !shallow) {
+    const contains =
+      await $`git -C ${temporal.path} merge-base --is-ancestor ${required} HEAD`
+        .quiet()
+        .nothrow();
+
+    if (contains.exitCode !== 0) {
+      throw new Error(
+        [
+          `${temporal.path} is at ${temporal.sha.slice(0, 9)}, which does not contain ${required.slice(0, 9)}.`,
+          'That commit adds the feature this scenario shows. Fetch a ref that has it,',
+          'or set requires.serverRef to one.',
+        ].join('\n'),
+      );
     }
   }
 
-  const cli = await gitDescribe(cliRepo);
-  const local = await gitDescribe(serverRepo);
-
-  if (
-    server.serverRef &&
-    server.serverRef !== local.ref &&
-    server.serverRef !== local.sha
-  ) {
-    throw new Error(
-      [
-        `This definition needs ${serverRepo} on "${server.serverRef}", but it is on "${local.ref}" (${local.sha}).`,
-        `Check it out first:  git -C ${serverRepo} checkout ${server.serverRef}`,
-      ].join('\n'),
-    );
-  }
-
-  const binary = join(
-    BIN_DIR,
-    `temporal-workspace-${cli.sha}-${local.sha}-${cli.fingerprint}-${local.fingerprint}`,
-  );
+  const binary = join(BIN_DIR, `temporal-workspace-${cli.key}-${temporal.key}`);
   const goWork = join(WORK_DIR, 'go.work');
 
   await mkdir(BIN_DIR, { recursive: true });
   await writeFile(
     goWork,
-    `go 1.26.4
-
-use (
-	${cliRepo}
-	${serverRepo}
-)
-`,
+    `go 1.26.4\n\nuse (\n\t${cli.path}\n\t${temporal.path}\n)\n`,
   );
 
-  const uncommitted = (count: number) =>
-    count ? `, ${count} uncommitted Go file(s)` : '';
-
   const provenance = [
-    `CLI repo: ${cliRepo} @ ${cli.ref} (${cli.sha}${uncommitted(cli.changedGoFiles)})`,
-    `Server repo: ${serverRepo} @ ${local.ref} (${local.sha}${uncommitted(local.changedGoFiles)})`,
-    `Go workspace: ${goWork} (neither repo modified)`,
+    cli.provenance,
+    temporal.provenance,
+    `Go workspace: ${goWork} (neither checkout modified)`,
   ];
 
   if (existsSync(binary)) {
@@ -243,17 +352,29 @@ use (
     return { binary, provenance };
   }
 
-  log('Building the CLI against the local server. This takes a few minutes.');
+  log('Building the CLI against that server. This takes a few minutes.');
 
   const build = $({
-    cwd: cliRepo,
+    cwd: cli.path,
     env: { ...process.env, GOWORK: goWork },
   })`go build -o ${binary} ./cmd/temporal`;
 
-  const { exitCode, stderr } = await build.nothrow();
+  const { exitCode, stderr, stdout } = await build.nothrow();
 
   if (exitCode !== 0) {
-    throw new Error(`The workspace build failed:\n${stderr}`);
+    // go reports compile errors on stdout as often as stderr.
+    throw new Error(
+      [
+        'The workspace build failed.',
+        'These two checkouts share one dependency graph, so they have to be a',
+        'compatible pair. Move requires.serverRef and requires.cliRef together.',
+        `${cli.provenance}`,
+        `${temporal.provenance}`,
+        '',
+        [stderr, stdout].filter(Boolean).join('\n').trim() ||
+          'The build produced no output.',
+      ].join('\n'),
+    );
   }
 
   return { binary, provenance };

--- a/utilities/demo/stages/server.ts
+++ b/utilities/demo/stages/server.ts
@@ -1,0 +1,597 @@
+import { createHash } from 'crypto';
+import { existsSync, readdirSync } from 'fs';
+import { chmod, mkdir, readFile, writeFile } from 'fs/promises';
+import zlib from 'node:zlib';
+import { join } from 'path';
+import { finished } from 'stream/promises';
+
+import fetch from 'node-fetch';
+import tar from 'tar-fs';
+import waitForPort from 'wait-port';
+import { $, chalk } from 'zx';
+
+import { expandPath, type ServerDefinition } from '../definition';
+import { type Logger, runDirFor, WORK_DIR } from '../paths';
+import { startDetached, type Supervised } from '../process';
+import {
+  type CliCandidate,
+  type CommitFacts,
+  lowestTaggedVersion,
+  pickCli,
+  planServerStrategy,
+  satisfies,
+} from '../requirements';
+
+export type ProvisionedServer = {
+  binary: string;
+  serverVersion: string;
+  cliVersion: string;
+  address: string;
+  namespace: string;
+  bundledUiUrl: string;
+  provenance: string[];
+  reusedExisting: boolean;
+  process?: Supervised;
+};
+
+const BIN_DIR = join(WORK_DIR, 'bin');
+
+const versionsFrom = (output: string) => {
+  const cli = /^temporal version (\S+)/m.exec(output)?.[1] ?? 'unknown';
+  const server =
+    /Server (\d+\.\d+\.\d+[^,)\s]*)/.exec(output)?.[1] ?? 'unknown';
+
+  return { cli, server };
+};
+
+const readVersions = async (binary: string) => {
+  const { stdout, exitCode } = await $`${binary} -v`.quiet().nothrow();
+
+  if (exitCode !== 0) {
+    throw new Error(`${binary} is not a runnable Temporal CLI.`);
+  }
+
+  return versionsFrom(stdout);
+};
+
+const GO_PATHSPEC = ['*.go', 'go.mod', 'go.sum'];
+
+const pathFromStatusLine = (line: string) => {
+  const path = line.slice(3);
+  const renamed = path.split(' -> ');
+
+  return renamed[renamed.length - 1].replace(/^"|"$/g, '');
+};
+
+/**
+ * Identifies the Go source a build would actually see: the commit, plus the
+ * content of every Go file the working tree changes or adds. A checkout that
+ * carries unrelated local changes, such as an untracked directory or a
+ * `replace` for a sibling module, keeps hitting the build cache, while a real
+ * edit to Go source misses it.
+ */
+const goFingerprint = async (repo: string, sha: string) => {
+  const status = (
+    await $`git -C ${repo} status --porcelain -- ${GO_PATHSPEC}`
+      .quiet()
+      .nothrow()
+  ).stdout;
+
+  const hash = createHash('sha256').update(sha);
+  const lines = status.split('\n').filter(Boolean).sort();
+
+  for (const line of lines) {
+    hash.update(line);
+
+    try {
+      hash.update(await readFile(join(repo, pathFromStatusLine(line))));
+    } catch {
+      // Deleted or unreadable: the status line already records the change.
+    }
+  }
+
+  return {
+    fingerprint: hash.digest('hex').slice(0, 12),
+    changedGoFiles: lines.length,
+  };
+};
+
+const gitDescribe = async (repo: string) => {
+  const sha = (
+    await $`git -C ${repo} rev-parse --short HEAD`.quiet().nothrow()
+  ).stdout.trim();
+  const ref = (
+    await $`git -C ${repo} rev-parse --abbrev-ref HEAD`.quiet().nothrow()
+  ).stdout.trim();
+  const { fingerprint, changedGoFiles } = await goFingerprint(repo, sha);
+
+  return { sha, ref, fingerprint, changedGoFiles };
+};
+
+const downloadCli = async (version: string, log: Logger): Promise<string> => {
+  const destination = join(BIN_DIR, `cli-${version}`);
+  const binary = join(destination, 'temporal');
+
+  if (existsSync(binary)) {
+    log(`Reusing the CLI already downloaded at ${binary}`);
+    return binary;
+  }
+
+  const arch = process.arch === 'x64' ? 'amd64' : process.arch;
+  const url = `https://temporal.download/cli/archive/${version}?platform=${process.platform}&arch=${arch}`;
+
+  log(`Downloading the Temporal CLI from ${url}`);
+
+  const response = await fetch(url);
+
+  if (!response.ok || !response.body) {
+    const hint =
+      response.status === 404 &&
+      version !== 'latest' &&
+      !version.startsWith('v')
+        ? ` A pinned version needs the "v" prefix, so try "v${version}".`
+        : '';
+
+    throw new Error(
+      `Could not download the Temporal CLI ${version}: ${response.status} ${response.statusText}.${hint}`,
+    );
+  }
+
+  await mkdir(destination, { recursive: true });
+  await finished(
+    response.body.pipe(zlib.createGunzip()).pipe(tar.extract(destination)),
+  );
+  await chmod(binary, 0o755);
+
+  return binary;
+};
+
+/**
+ * Compiles the CLI's dev server against a local `temporalio/temporal` checkout
+ * through a Go workspace held in the run directory. Neither repository is
+ * modified: no `replace` directive is added and no `go.work` is written inside
+ * either tree.
+ */
+/**
+ * Where the Temporal checkouts live on this machine. A definition may name them,
+ * but normally the environment does, so a definition stays portable.
+ */
+const repoPath = (
+  fromDefinition: string | undefined,
+  variable: string,
+  label: string,
+): string => {
+  const configured = fromDefinition ?? process.env[variable];
+
+  if (!configured) {
+    throw new Error(
+      [
+        `This definition needs a local build of the Temporal server, but no ${label} checkout is configured.`,
+        `Set ${variable}, or put it in .env.feature-demo.local, which is gitignored:`,
+        '',
+        '  TEMPORAL_SERVER_REPO=/path/to/temporalio/temporal',
+        '  TEMPORAL_CLI_REPO=/path/to/temporalio/cli',
+      ].join('\n'),
+    );
+  }
+
+  return expandPath(configured);
+};
+
+const buildWorkspaceCli = async (
+  server: ServerDefinition,
+  log: Logger,
+): Promise<{ binary: string; provenance: string[] }> => {
+  const cliRepo = repoPath(server.cliRepo, 'TEMPORAL_CLI_REPO', 'Temporal CLI');
+  const serverRepo = repoPath(
+    server.serverRepo,
+    'TEMPORAL_SERVER_REPO',
+    'Temporal server',
+  );
+
+  for (const repo of [cliRepo, serverRepo]) {
+    if (!existsSync(join(repo, 'go.mod'))) {
+      throw new Error(`${repo} is not a Go module checkout.`);
+    }
+  }
+
+  const cli = await gitDescribe(cliRepo);
+  const local = await gitDescribe(serverRepo);
+
+  if (
+    server.serverRef &&
+    server.serverRef !== local.ref &&
+    server.serverRef !== local.sha
+  ) {
+    throw new Error(
+      [
+        `This definition needs ${serverRepo} on "${server.serverRef}", but it is on "${local.ref}" (${local.sha}).`,
+        `Check it out first:  git -C ${serverRepo} checkout ${server.serverRef}`,
+      ].join('\n'),
+    );
+  }
+
+  const binary = join(
+    BIN_DIR,
+    `temporal-workspace-${cli.sha}-${local.sha}-${cli.fingerprint}-${local.fingerprint}`,
+  );
+  const goWork = join(WORK_DIR, 'go.work');
+
+  await mkdir(BIN_DIR, { recursive: true });
+  await writeFile(
+    goWork,
+    `go 1.26.4
+
+use (
+	${cliRepo}
+	${serverRepo}
+)
+`,
+  );
+
+  const uncommitted = (count: number) =>
+    count ? `, ${count} uncommitted Go file(s)` : '';
+
+  const provenance = [
+    `CLI repo: ${cliRepo} @ ${cli.ref} (${cli.sha}${uncommitted(cli.changedGoFiles)})`,
+    `Server repo: ${serverRepo} @ ${local.ref} (${local.sha}${uncommitted(local.changedGoFiles)})`,
+    `Go workspace: ${goWork} (neither repo modified)`,
+  ];
+
+  if (existsSync(binary)) {
+    log(`Reusing the workspace build at ${binary}`);
+    return { binary, provenance };
+  }
+
+  log('Building the CLI against the local server. This takes a few minutes.');
+
+  const build = $({
+    cwd: cliRepo,
+    env: { ...process.env, GOWORK: goWork },
+  })`go build -o ${binary} ./cmd/temporal`;
+
+  const { exitCode, stderr } = await build.nothrow();
+
+  if (exitCode !== 0) {
+    throw new Error(`The workspace build failed:\n${stderr}`);
+  }
+
+  return { binary, provenance };
+};
+
+/** Reads what a commit means for the release line, from the server checkout. */
+const readCommitFacts = async (
+  repo: string,
+  commit: string,
+): Promise<CommitFacts> => {
+  const isAncestor = async (ref: string) =>
+    (
+      await $`git -C ${repo} merge-base --is-ancestor ${commit} ${ref}`
+        .quiet()
+        .nothrow()
+    ).exitCode === 0;
+
+  const known =
+    (
+      await $`git -C ${repo} cat-file -e ${`${commit}^{commit}`}`
+        .quiet()
+        .nothrow()
+    ).exitCode === 0;
+
+  if (!known) {
+    return { knownLocally: false, inCheckout: false, onMain: false };
+  }
+
+  let onMain = false;
+
+  for (const ref of ['origin/main', 'main']) {
+    if (await isAncestor(ref)) {
+      onMain = true;
+      break;
+    }
+  }
+
+  const tags = (
+    await $`git -C ${repo} tag --contains ${commit}`.quiet().nothrow()
+  ).stdout
+    .split('\n')
+    .filter(Boolean);
+
+  return {
+    knownLocally: true,
+    inCheckout: await isAncestor('HEAD'),
+    onMain,
+    firstTaggedVersion: lowestTaggedVersion(tags),
+  };
+};
+
+const cliCandidate = async (
+  label: string,
+  path: string,
+): Promise<CliCandidate | undefined> => {
+  if (!existsSync(path)) return undefined;
+
+  try {
+    const { server } = await readVersions(path);
+
+    return { label, path, serverVersion: server };
+  } catch {
+    return undefined;
+  }
+};
+
+/** CLIs already on this machine, which cost nothing to reuse. */
+const PREPARED_CLI = join(process.cwd(), 'bin', 'cli', 'temporal');
+
+const cliCandidatesOnDisk = async (): Promise<CliCandidate[]> => {
+  const paths = [
+    ['bin/cli/temporal (from pnpm prepare)', PREPARED_CLI],
+    ...(existsSync(BIN_DIR)
+      ? readdirSync(BIN_DIR)
+          .filter((entry) => entry.startsWith('cli-'))
+          .map(
+            (entry) =>
+              [
+                `${entry} (downloaded earlier)`,
+                join(BIN_DIR, entry, 'temporal'),
+              ] as const,
+          )
+      : []),
+  ] as const;
+
+  const candidates = await Promise.all(
+    paths.map(([label, path]) => cliCandidate(label, path)),
+  );
+
+  return candidates.filter(
+    (candidate): candidate is CliCandidate => !!candidate,
+  );
+};
+
+const explicitBinary = (server: ServerDefinition) => {
+  if (!server.path) {
+    throw new Error('server.source "binary" needs server.path.');
+  }
+
+  const binary = expandPath(server.path);
+
+  if (!existsSync(binary)) throw new Error(`${binary} does not exist.`);
+
+  return { binary, provenance: [`Binary: ${binary}`] };
+};
+
+/**
+ * Picks the cheapest server that meets the feature's requirement. A CLI already
+ * on disk costs nothing, a published release costs a download, and compiling the
+ * server checkout costs minutes, so they are tried in that order. An explicit
+ * `source` skips the choice.
+ */
+const resolveBinary = async (
+  server: ServerDefinition,
+  log: Logger,
+): Promise<{
+  binary: string;
+  provenance: string[];
+  minServerVersion?: string;
+}> => {
+  if (server.source === 'binary') return explicitBinary(server);
+
+  if (server.source === 'workspace') {
+    return {
+      ...(await buildWorkspaceCli(server, log)),
+      minServerVersion: server.requires.minServerVersion,
+    };
+  }
+
+  if (server.source === 'cli') {
+    return {
+      binary: await downloadCli(server.version, log),
+      provenance: [
+        `Temporal CLI release: ${server.version} (temporal.download)`,
+      ],
+      minServerVersion: server.requires.minServerVersion,
+    };
+  }
+
+  // A server checkout is only needed to build one. Without it the plan still
+  // works from a release, and only a local build reports the missing path.
+  const serverRepo = server.serverRepo ?? process.env.TEMPORAL_SERVER_REPO;
+  const commit =
+    server.requires.serverCommit && serverRepo
+      ? await readCommitFacts(
+          expandPath(serverRepo),
+          server.requires.serverCommit,
+        )
+      : undefined;
+
+  const plan = planServerStrategy(server.requires, commit);
+
+  for (const reason of plan.reasons) log(reason);
+
+  if (!plan.mustBuildLocally) {
+    const onDisk = pickCli(await cliCandidatesOnDisk(), plan.minServerVersion);
+
+    if (onDisk) {
+      log(
+        `Reusing ${onDisk.label}: it bundles Server ${onDisk.serverVersion}.`,
+      );
+
+      return {
+        binary: onDisk.path,
+        provenance: [
+          ...plan.reasons,
+          `Server from ${onDisk.label}, which bundles Server ${onDisk.serverVersion}.`,
+        ],
+        minServerVersion: plan.minServerVersion,
+      };
+    }
+
+    // `pnpm prepare` downloads the latest release into bin/cli, so when that
+    // binary is present there is nothing new to fetch for "latest".
+    const preparedIsLatest =
+      server.version === 'latest' && existsSync(PREPARED_CLI);
+
+    const downloaded = preparedIsLatest
+      ? await cliCandidate(
+          'bin/cli/temporal (the latest release)',
+          PREPARED_CLI,
+        )
+      : await cliCandidate(
+          `Temporal CLI ${server.version}`,
+          await downloadCli(server.version, log),
+        );
+
+    if (
+      downloaded &&
+      satisfies(downloaded.serverVersion, plan.minServerVersion)
+    ) {
+      return {
+        binary: downloaded.path,
+        provenance: [
+          ...plan.reasons,
+          `Server from the ${server.version} CLI release, which bundles Server ${downloaded.serverVersion}.`,
+        ],
+        minServerVersion: plan.minServerVersion,
+      };
+    }
+
+    log(
+      `The ${server.version} CLI release bundles Server ${downloaded?.serverVersion ?? 'unknown'}, which is too old. Compiling the server checkout instead.`,
+    );
+  }
+
+  if (commit && !commit.inCheckout && serverRepo) {
+    throw new Error(
+      [
+        `Commit ${server.requires.serverCommit?.slice(0, 9)} is not an ancestor of HEAD in ${serverRepo}, so a build there would not contain the feature.`,
+        `Check out a ref that has it:  git -C ${serverRepo} log --oneline -1 ${server.requires.serverCommit}`,
+      ].join('\n'),
+    );
+  }
+
+  const built = await buildWorkspaceCli(server, log);
+
+  return {
+    ...built,
+    provenance: [...plan.reasons, ...built.provenance],
+    minServerVersion: plan.minServerVersion,
+  };
+};
+
+const dynamicConfigFlags = (values: ServerDefinition['dynamicConfig']) =>
+  Object.entries(values).flatMap(([key, value]) => [
+    '--dynamic-config-value',
+    `${key}=${JSON.stringify(value)}`,
+  ]);
+
+const searchAttributeFlags = (values: ServerDefinition['searchAttributes']) =>
+  Object.entries(values).flatMap(([key, type]) => [
+    '--search-attribute',
+    `${key}=${type}`,
+  ]);
+
+export const startServer = async (
+  server: ServerDefinition,
+  log: Logger,
+  runName: string,
+): Promise<ProvisionedServer> => {
+  const address = `127.0.0.1:${server.port}`;
+  const bundledUiUrl = `http://localhost:${server.uiPort}`;
+
+  const alreadyRunning = await waitForPort({
+    port: server.port,
+    timeout: 250,
+    output: 'silent',
+  });
+
+  if (alreadyRunning.open) {
+    log(
+      chalk.yellow(
+        `Something is already listening on ${address}. Reusing it. The dynamic config and version checks in this definition were NOT applied to it.`,
+      ),
+    );
+
+    return {
+      binary: '(existing process)',
+      serverVersion: 'unknown',
+      cliVersion: 'unknown',
+      address,
+      namespace: server.namespace,
+      bundledUiUrl,
+      provenance: [`Reused the server already listening on ${address}`],
+      reusedExisting: true,
+    };
+  }
+
+  const { binary, provenance, minServerVersion } = await resolveBinary(
+    server,
+    log,
+  );
+  const versions = await readVersions(binary);
+
+  if (!satisfies(versions.server, minServerVersion)) {
+    throw new Error(
+      [
+        `This feature needs Temporal Server ${minServerVersion} or later, but ${binary} bundles ${versions.server}.`,
+        'Set server.source to "workspace" to compile your own server checkout into the dev server.',
+      ].join('\n'),
+    );
+  }
+
+  const flags = [
+    `--port=${server.port}`,
+    `--ui-port=${server.uiPort}`,
+    `--http-port=${server.httpPort ?? server.port + 1}`,
+    `--log-level=${server.logLevel}`,
+    ...(server.dbFilename
+      ? [`--db-filename=${expandPath(server.dbFilename)}`]
+      : []),
+    ...(server.namespace === 'default'
+      ? []
+      : [`--namespace=${server.namespace}`]),
+    ...searchAttributeFlags(server.searchAttributes),
+    ...dynamicConfigFlags(server.dynamicConfig),
+  ];
+
+  log(`Starting ${binary} (Server ${versions.server}) on ${address}`);
+
+  await mkdir(runDirFor(runName), { recursive: true });
+
+  const child = startDetached(
+    'server',
+    binary,
+    ['server', 'start-dev', ...flags],
+    {
+      logFile: join(runDirFor(runName), 'server.log'),
+    },
+  );
+
+  const ready = await Promise.all([
+    waitForPort({ port: server.port, output: 'silent', timeout: 60_000 }),
+    waitForPort({ port: server.uiPort, output: 'silent', timeout: 60_000 }),
+  ]);
+
+  if (!ready.every((port) => port.open)) {
+    await child.stop();
+
+    throw new Error(
+      [
+        `The Temporal server did not come up on ${address}.`,
+        `Its log is at ${child.logFile}.`,
+        `Run this to see why:  ${binary} server start-dev ${flags.join(' ')}`,
+      ].join('\n'),
+    );
+  }
+
+  return {
+    binary,
+    serverVersion: versions.server,
+    cliVersion: versions.cli,
+    address,
+    namespace: server.namespace,
+    bundledUiUrl,
+    provenance,
+    reusedExisting: false,
+    process: child,
+  };
+};

--- a/utilities/demo/stages/ui.ts
+++ b/utilities/demo/stages/ui.ts
@@ -1,0 +1,202 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import waitForPort from 'wait-port';
+import { $, chalk } from 'zx';
+
+import type { UiDefinition } from '../definition';
+import { type Logger, runDirFor, WORK_DIR } from '../paths';
+import { startDetached, type Supervised } from '../process';
+
+export type RunningUi = {
+  apiUrl?: string;
+  webUrl?: string;
+  processes: Supervised[];
+};
+
+const CONFIG_DIR_NAME = 'ui-server-config';
+
+const replaceScalar = (yaml: string, key: string, value: string) => {
+  const pattern = new RegExp(`^${key}:.*$`, 'm');
+
+  return pattern.test(yaml)
+    ? yaml.replace(pattern, `${key}: ${value}`)
+    : `${key}: ${value}\n${yaml}`;
+};
+
+/**
+ * The ui-server reads `temporalGrpcAddress` from YAML only, with no environment
+ * override, so a demo on a non-default port needs its own config. Generating a
+ * config directory here keeps `server/config` untouched.
+ */
+const writeConfig = async (ui: UiDefinition, address: string) => {
+  const source = join(process.cwd(), 'server', 'config');
+  const destination = join(WORK_DIR, CONFIG_DIR_NAME);
+
+  await mkdir(destination, { recursive: true });
+
+  const base = replaceScalar(
+    await readFile(join(source, 'base.yaml'), 'utf8'),
+    'temporalGrpcAddress',
+    address,
+  );
+
+  const development = replaceScalar(
+    replaceScalar(
+      await readFile(join(source, 'development.yaml'), 'utf8'),
+      'port',
+      String(ui.apiPort),
+    ),
+    'enableUi',
+    'false',
+  );
+
+  await writeFile(join(destination, 'base.yaml'), base);
+  await writeFile(join(destination, 'development.yaml'), development);
+
+  return destination;
+};
+
+const startUiServer = async (
+  ui: UiDefinition,
+  address: string,
+  log: Logger,
+  runName: string,
+): Promise<Supervised> => {
+  const serverDir = join(process.cwd(), 'server');
+  const binary = join(serverDir, 'ui-server');
+  const configDir = await writeConfig(ui, address);
+
+  if (ui.rebuildUiServer || !existsSync(binary)) {
+    log('Building the ui-server binary (make build)');
+
+    const build = await $({ cwd: serverDir })`make build`.quiet().nothrow();
+
+    if (build.exitCode !== 0) {
+      throw new Error(`make build failed in server/:\n${build.stderr}`);
+    }
+  }
+
+  log(`Starting the ui-server on port ${ui.apiPort}, pointed at ${address}`);
+
+  await mkdir(runDirFor(runName), { recursive: true });
+
+  const child = startDetached(
+    'ui-server',
+    binary,
+    [
+      '--root',
+      WORK_DIR,
+      '--config',
+      CONFIG_DIR_NAME,
+      '--env',
+      'development',
+      'start',
+    ],
+    { cwd: serverDir, logFile: join(runDirFor(runName), 'ui-server.log') },
+  );
+
+  const ready = await waitForPort({
+    port: ui.apiPort,
+    output: 'silent',
+    timeout: 60_000,
+  });
+
+  if (!ready.open) {
+    await child.stop();
+
+    throw new Error(
+      [
+        `The ui-server did not come up on port ${ui.apiPort}.`,
+        `Its config is in ${configDir} and its log is at ${child.logFile}.`,
+      ].join('\n'),
+    );
+  }
+
+  return child;
+};
+
+const startWeb = async (
+  ui: UiDefinition,
+  log: Logger,
+  runName: string,
+): Promise<Supervised> => {
+  log(`Starting the UI dev server on port ${ui.webPort}`);
+
+  await mkdir(runDirFor(runName), { recursive: true });
+
+  const child = startDetached(
+    'ui',
+    'pnpm',
+    [
+      'exec',
+      'vite',
+      'dev',
+      '--mode',
+      'feature-demo',
+      '--port',
+      String(ui.webPort),
+      '--strictPort',
+    ],
+    {
+      env: {
+        ...process.env,
+        VITE_API: `http://localhost:${ui.apiPort}`,
+        VITE_MODE: 'development',
+        VITE_TEMPORAL_UI_BUILD_TARGET: 'local',
+      },
+      logFile: join(runDirFor(runName), 'ui.log'),
+    },
+  );
+
+  const ready = await waitForPort({
+    port: ui.webPort,
+    output: 'silent',
+    timeout: 120_000,
+  });
+
+  if (!ready.open) {
+    await child.stop();
+
+    throw new Error(
+      `The UI dev server did not come up on port ${ui.webPort}. Its log is at ${child.logFile}.`,
+    );
+  }
+
+  return child;
+};
+
+const reuseIfRunning = async (port: number, label: string, log: Logger) => {
+  const running = await waitForPort({ port, timeout: 250, output: 'silent' });
+
+  if (running.open) {
+    log(
+      chalk.yellow(`Reusing the ${label} already listening on port ${port}.`),
+    );
+  }
+
+  return running.open;
+};
+
+export const startUi = async (
+  ui: UiDefinition,
+  address: string,
+  log: Logger,
+  runName: string,
+): Promise<RunningUi> => {
+  const processes: Supervised[] = [];
+
+  const apiUrl = ui.uiServer ? `http://localhost:${ui.apiPort}` : undefined;
+  const webUrl = ui.web ? `http://localhost:${ui.webPort}` : undefined;
+
+  if (ui.uiServer && !(await reuseIfRunning(ui.apiPort, 'ui-server', log))) {
+    processes.push(await startUiServer(ui, address, log, runName));
+  }
+
+  if (ui.web && !(await reuseIfRunning(ui.webPort, 'UI dev server', log))) {
+    processes.push(await startWeb(ui, log, runName));
+  }
+
+  return { apiUrl, webUrl, processes };
+};

--- a/utilities/demo/stages/worker.ts
+++ b/utilities/demo/stages/worker.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'fs';
+import { mkdir } from 'fs/promises';
+import { join } from 'path';
+
+import { chalk } from 'zx';
+
+import type { WorkerDefinition } from '../definition';
+import { type Logger, runDirFor } from '../paths';
+import { startDetached, type Supervised } from '../process';
+
+export type RunningWorker = {
+  process?: Supervised;
+  targets: string[];
+  reusedExisting: boolean;
+};
+
+const READY_EVENT = '"event":"target-running"';
+
+const runningTargets = (logFile: string): string[] => {
+  try {
+    return [
+      ...new Set(
+        readFileSync(logFile, 'utf8')
+          .split('\n')
+          .filter((line) => line.includes(READY_EVENT))
+          .flatMap((line) => {
+            try {
+              const parsed = JSON.parse(line) as { targetId?: string };
+
+              return parsed.targetId ? [parsed.targetId] : [];
+            } catch {
+              return [];
+            }
+          }),
+      ),
+    ];
+  } catch {
+    return [];
+  }
+};
+
+const waitForTargets = async (logFile: string, timeoutMs: number) => {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const targets = runningTargets(logFile);
+
+    if (targets.length) return targets;
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return [];
+};
+
+/**
+ * Starts the catalog's own worker rather than a worker of our own, so a demo
+ * runs the same code the catalog page runs. The worker takes its address and
+ * namespace from the environment, which wins over `.env.catalog`, so it follows
+ * whichever server the server stage provisioned.
+ */
+export const startCatalogWorker = async (
+  worker: WorkerDefinition,
+  address: string,
+  namespace: string,
+  log: Logger,
+  runName: string,
+): Promise<RunningWorker> => {
+  const directory = runDirFor(runName);
+
+  await mkdir(directory, { recursive: true });
+
+  const logFile = join(directory, 'catalog-worker.log');
+
+  log(
+    `Starting the catalog worker against ${address}, namespace "${namespace}"`,
+  );
+
+  const child = startDetached('catalog-worker', 'pnpm', ['catalog', 'worker'], {
+    env: {
+      ...process.env,
+      TEMPORAL_ADDRESS: address,
+      TEMPORAL_NAMESPACE: namespace,
+      ...(worker.targetId ? { CATALOG_TARGET_ID: worker.targetId } : {}),
+    },
+    logFile,
+  });
+
+  const targets = await waitForTargets(logFile, worker.readyTimeoutMs);
+
+  if (!targets.length) {
+    await child.stop();
+
+    throw new Error(
+      [
+        'The catalog worker did not report a running target.',
+        `Its log is at ${logFile}.`,
+        'Run "pnpm catalog verify" if the generated artifacts may be stale.',
+      ].join('\n'),
+    );
+  }
+
+  log(
+    chalk.dim(
+      `Catalog worker polling for ${targets.length} target(s): ${targets.join(', ')}`,
+    ),
+  );
+
+  return { process: child, targets, reusedExisting: false };
+};

--- a/utilities/demo/state.ts
+++ b/utilities/demo/state.ts
@@ -9,8 +9,8 @@ export type RunState = {
   startedAt: string;
   address: string;
   webUrl?: string;
-  /** The `demo start` process holding the run open, if it is still attached. */
-  supervisorPid?: number;
+  /** Ports this run started, so a stop can sweep what outlived its pid. */
+  ports: number[];
   processes: { label: string; pid: number }[];
 };
 

--- a/utilities/demo/state.ts
+++ b/utilities/demo/state.ts
@@ -1,0 +1,47 @@
+import { existsSync } from 'fs';
+import { mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import { runDirFor } from './paths';
+
+export type RunState = {
+  name: string;
+  startedAt: string;
+  address: string;
+  webUrl?: string;
+  /** The `demo start` process holding the run open, if it is still attached. */
+  supervisorPid?: number;
+  processes: { label: string; pid: number }[];
+};
+
+const stateFile = (name: string) => join(runDirFor(name), 'run.json');
+
+export const writeState = async (state: RunState) => {
+  await mkdir(runDirFor(state.name), { recursive: true });
+  await writeFile(stateFile(state.name), `${JSON.stringify(state, null, 2)}\n`);
+};
+
+export const readState = async (name: string): Promise<RunState | null> => {
+  const path = stateFile(name);
+
+  if (!existsSync(path)) return null;
+
+  try {
+    return JSON.parse(await readFile(path, 'utf8')) as RunState;
+  } catch {
+    return null;
+  }
+};
+
+export const clearState = async (name: string) => {
+  await rm(stateFile(name), { force: true });
+};
+
+export const isRunning = (pid: number) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/utilities/demo/summary.ts
+++ b/utilities/demo/summary.ts
@@ -1,0 +1,188 @@
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+import { chalk } from 'zx';
+
+import { catalogExampleUrl } from './catalog';
+import type { Definition, Stage } from './definition';
+import { runDirFor } from './paths';
+import type { StartedWorkflow } from './scenario';
+
+export type StageOutcome = {
+  stage: Stage;
+  ran: boolean;
+  reason?: string;
+  details: string[];
+};
+
+export type SummaryInput = {
+  definition: Definition;
+  definitionPath: string;
+  stages: StageOutcome[];
+  workflows: StartedWorkflow[];
+  observations: string[];
+  webUrl?: string;
+  bundledUiUrl?: string;
+  address?: string;
+};
+
+const historyUrl = (
+  base: string,
+  namespace: string,
+  workflow: StartedWorkflow,
+) =>
+  `${base}/namespaces/${namespace}/workflows/${encodeURIComponent(workflow.workflowId)}/${workflow.runId}/history`;
+
+const previewBase = ({ webUrl, bundledUiUrl }: SummaryInput) =>
+  webUrl ?? bundledUiUrl;
+
+export const renderMarkdown = (input: SummaryInput): string => {
+  const { definition, stages, workflows, observations } = input;
+  const namespace = definition.server.namespace;
+  const base = previewBase(input);
+  const lines: string[] = [];
+
+  lines.push(`# ${definition.title}`);
+  lines.push('');
+
+  if (definition.ticket) lines.push(`**Ticket:** ${definition.ticket}  `);
+  if (definition.feature) lines.push(`**Feature:** ${definition.feature}  `);
+  lines.push(`**Definition:** \`${input.definitionPath}\``);
+  lines.push('');
+
+  if (definition.summary) {
+    lines.push(definition.summary);
+    lines.push('');
+  }
+
+  lines.push('## What this run did');
+  lines.push('');
+
+  for (const stage of stages) {
+    lines.push(
+      `### ${stage.stage} — ${stage.ran ? 'ran' : `skipped${stage.reason ? ` (${stage.reason})` : ''}`}`,
+    );
+    lines.push('');
+
+    if (stage.details.length) {
+      for (const detail of stage.details) lines.push(`- ${detail}`);
+      lines.push('');
+    }
+  }
+
+  if (workflows.length) {
+    lines.push('## Workflows to look at');
+    lines.push('');
+
+    for (const workflow of workflows) {
+      const link =
+        base && workflow.runId
+          ? `[${workflow.workflowId}](${historyUrl(base, namespace, workflow)})`
+          : `\`${workflow.workflowId}\``;
+
+      lines.push(`- **${workflow.role}** ${link}`);
+      if (workflow.runId) lines.push(`  - run: \`${workflow.runId}\``);
+      if (workflow.note) lines.push(`  - ${workflow.note}`);
+      if (base && workflow.catalogExampleId) {
+        lines.push(
+          `  - catalog example: [${workflow.catalogExampleId}](${catalogExampleUrl(base, namespace, workflow.catalogExampleId)})`,
+        );
+      }
+    }
+
+    lines.push('');
+  }
+
+  if (observations.length) {
+    lines.push('## What to look for');
+    lines.push('');
+    for (const observation of observations) lines.push(`- ${observation}`);
+    lines.push('');
+  }
+
+  if (definition.preview.notes.length) {
+    lines.push('## Review steps');
+    lines.push('');
+    definition.preview.notes.forEach((note, index) => {
+      lines.push(`${index + 1}. ${note}`);
+    });
+    lines.push('');
+  }
+
+  if (!base) {
+    lines.push(
+      '> No UI was started by this run. Start one, then open the workflows above.',
+    );
+    lines.push('');
+  }
+
+  return lines.join('\n');
+};
+
+export const printSummary = (
+  input: SummaryInput,
+  write: (message: string) => void = console.log,
+) => {
+  const { definition, stages, workflows, observations } = input;
+  const namespace = definition.server.namespace;
+  const base = previewBase(input);
+
+  const heading = (text: string) => write(`\n${chalk.bold.cyan(text)}`);
+
+  write(`\n${chalk.bold.green('▸')} ${chalk.bold(definition.title)}`);
+  if (definition.ticket) write(chalk.dim(`  ${definition.ticket}`));
+
+  heading('What this run did');
+  for (const stage of stages) {
+    const label = stage.ran
+      ? chalk.green('ran')
+      : chalk.yellow(`skipped${stage.reason ? ` (${stage.reason})` : ''}`);
+
+    write(`  ${stage.stage.padEnd(10)} ${label}`);
+    for (const detail of stage.details) write(chalk.dim(`    ${detail}`));
+  }
+
+  if (workflows.length) {
+    heading('Workflows to look at');
+    for (const workflow of workflows) {
+      write(`  ${chalk.bold(workflow.role)}  ${workflow.workflowId}`);
+      if (base && workflow.runId) {
+        write(
+          chalk.blue.underline(`    ${historyUrl(base, namespace, workflow)}`),
+        );
+      }
+      if (workflow.note) write(chalk.dim(`    ${workflow.note}`));
+      if (base && workflow.catalogExampleId) {
+        write(
+          chalk.dim(
+            `    catalog example ${workflow.catalogExampleId}: ${catalogExampleUrl(base, namespace, workflow.catalogExampleId)}`,
+          ),
+        );
+      }
+    }
+  }
+
+  if (observations.length) {
+    heading('What to look for');
+    for (const observation of observations) write(`  - ${observation}`);
+  }
+
+  if (definition.preview.notes.length) {
+    heading('Review steps');
+    definition.preview.notes.forEach((note, index) => {
+      write(`  ${index + 1}. ${note}`);
+    });
+  }
+};
+
+export const writeSummary = async (input: SummaryInput) => {
+  const directory = runDirFor(input.definition.name);
+
+  await mkdir(directory, { recursive: true });
+
+  const path = join(directory, 'summary.md');
+
+  await writeFile(path, renderMarkdown(input));
+
+  return path;
+};

--- a/utilities/demo/summary.ts
+++ b/utilities/demo/summary.ts
@@ -45,7 +45,6 @@ export const renderMarkdown = (input: SummaryInput): string => {
   lines.push(`# ${definition.title}`);
   lines.push('');
 
-  if (definition.ticket) lines.push(`**Ticket:** ${definition.ticket}  `);
   if (definition.feature) lines.push(`**Feature:** ${definition.feature}  `);
   lines.push(`**Definition:** \`${input.definitionPath}\``);
   lines.push('');
@@ -130,7 +129,6 @@ export const printSummary = (
   const heading = (text: string) => write(`\n${chalk.bold.cyan(text)}`);
 
   write(`\n${chalk.bold.green('▸')} ${chalk.bold(definition.title)}`);
-  if (definition.ticket) write(chalk.dim(`  ${definition.ticket}`));
 
   heading('What this run did');
   for (const stage of stages) {


### PR DESCRIPTION
Based on `decode-binary-protobuf-payloads`, because the demo it ships is a demo
of that branch. Review this after DT-4385, or with it.

<img width="1500" height="1250" alt="signal-with-start-system-nexus (1)" src="https://github.com/user-attachments/assets/3f3435ac-9e3c-4f22-b111-bf3b02499fb0" />

## The goal

A reviewer of an in-progress feature needs a Temporal server that has the
feature, the dynamic configuration it wants, a worker, the workflows that show
it, and a list of what to check. One command supplies all of it:

```bash
pnpm demo start system-nexus-signal-with-start
```

The command runs the stages, prints the summary, and exits. The run continues.
`pnpm demo stop` ends it, and `--once` ends it before the command returns.

This tool is for **in-progress** features. The system Nexus SignalWithStart
operation is in server 1.32.0, and the newest CLI release has server 1.31.2, thus
a release cannot show it and the tool compiles a server checkout instead.

## How a scenario is put together

Everything is in `utilities/demo`. A scenario is a directory, the way a Catalog
example is, and its files are TypeScript:

```
utilities/demo/scenarios/system-nexus-signal-with-start/
  definition.ts         what to run and what to check
  scenario.ts           behaviour that names of examples cannot give
  caller-workflow.ts    the workflow that sends the operation
  payload-converter.ts  binary/protobuf for the two messages
```

A definition is a module, not JSON, because the shape has a meaning at runtime
only and the compiler checks a module at no cost. Therefore the options that a
definition sends to its scenario are checked, and the editor shows them:

```
error TS2561: Object literal may only specify known properties, but
'signalNaem' does not exist in type '{ ... signalName?: string ... }'.
Did you mean to write 'signalName'?
```

A scenario says what to run in one of two ways, and it can use both. `examples`
names Catalog examples. A `scenario.ts` gives behaviour that names of examples
cannot give.

## Stages

Four stages run in sequence, and each one is optional. Use `"enabled": false` in
the definition, or `--skip` and `--only`.

| Stage       | What it does                                                    |
| ----------- | --------------------------------------------------------------- |
| `server`    | Supplies a Temporal dev server and applies the dynamic config   |
| `worker`    | Starts the Catalog worker against that server                   |
| `ui`        | Starts the ui-server API and the UI dev server                  |
| `scenarios` | Runs the workflows that show the feature                        |

A start stops a recorded run of the same scenario first, and it says so. Anything
on a port that no record mentions belongs to somebody else, and a stage reuses
it. A stop kills the recorded pids and then sweeps the ports that the run owns.

## The server stage

The stage selects the least costly server that has the feature. A definition
gives the commit that added it:

```json
"requires": { "serverCommit": "01aa279c462fd9e7efc8e0ba6bbc4554b51557dd" }
```

The stage finds the release line of that commit from its tags, then it tries a
CLI on disk, then a release, then a build of your server checkout. It gives the
reason:

```
Commit 01aa279c4 is on main and first tagged 1.32.0-157.0, so any Server
1.32.0-157.0 or later has it.
The latest CLI release bundles Server 1.31.2, which is too old. Compiling the
server checkout instead.
```

When a release has the operation, the same definition uses that release, with no
change and no Go tools.

The build uses a Go workspace in `.feature-demo`, thus it changes no repository:
it adds no `replace` directive and it writes no `go.work` in a checkout. A
definition gives no path to a checkout, because a path belongs to a machine. Set
`TEMPORAL_SERVER_REPO` and `TEMPORAL_CLI_REPO`, or copy
`.env.feature-demo.local.example`. The paths are read only if a build is
necessary.

## The Catalog does the work

The workflows are Catalog examples and the worker is the Catalog worker, thus a
demo shows the same code that the Catalog page runs. A definition gives an
example id only, and the workflow type, the task queue, and the input schema come
from the Catalog. An input that disagrees with the schema of an example stops the
run before anything starts.

The caller of the operation is an ordinary workflow, because the reserved
`__temporal_` prefix is refused by the Go SDK only. TypeScript has no encoder for
the payloads of the operation, which are `binary/protobuf` workflowservice
messages, thus `payload-converter.ts` supplies one and the caller runs on a
worker of its own. That converter is scaffolding: two tests fail when the SDK
makes it unnecessary, and each one says what to delete. The scenario also reads
the request that the server recorded and stops the run if a field that the UI
needs is absent.

## Also here

`pnpm catalog list` shows the Catalog examples and their ids, which a person
needs to write a definition. It is a separate commit, and it can become a
separate PR if the Catalog owners prefer.

The system Nexus skill documents that the Go SDK alone refuses the reserved
prefix, and that the true limit for TypeScript is the encoding of the payloads.

## To review

1. `pnpm demo list`, then `pnpm demo start system-nexus-signal-with-start`.
2. Follow the steps that the summary gives. They check the display that DT-4385
   adds.
3. `pnpm demo stop`.

`pnpm lint:ci`, `pnpm check`, `pnpm catalog verify`, and `pnpm test -- --run` all
pass. 44 tests cover the dispatcher, the selection of a server, and the reasons
this scenario ships a caller of its own.
