### PR TITLE
fix(ci): correct the provenance claim in the remediation PR body

### DIFF
--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -470,7 +470,22 @@ jobs:
             git push --force-with-lease origin "HEAD:refs/heads/${BRANCH}"
           fi
 
-          body="This draft is maintained by the weekly dependency-security review.\n\nClaude authored the package.json remediation from read-only Dependabot evidence. The trusted workflow regenerated pnpm-lock.yaml, rejected changes outside those two files, and passed the candidate through the full validation and hash-attestation boundary before this separate publishing job received write credentials. The workflow does not dismiss Dependabot alerts; merging this PR is the resolution path.\n\nWorkflow evidence: ${RUN_URL}"
+          body="$(cat <<EOF
+          The weekly dependency-security review maintains this draft.
+
+          A deterministic planner read the Dependabot evidence and wrote the dependency
+          change. No model authored any part of it. The trusted workflow then rebuilt
+          the lockfile, refused every change outside the approved dependency files,
+          proved that each remediated alert no longer matches its advisory range, and
+          attested the file hashes. This separate publishing job received the write
+          credential only after those checks passed.
+
+          The workflow does not dismiss a Dependabot alert. Merging this pull request
+          is the way an alert resolves.
+
+          Workflow evidence: ${RUN_URL}
+          EOF
+          )"
           pr_url="$(gh pr list --repo "$REPOSITORY" --head "$BRANCH" --base main --state open --json url --jq '.[0].url')"
           if [ -n "$pr_url" ]; then
             gh pr edit "$pr_url" --repo "$REPOSITORY" --title 'fix: weekly Dependabot security remediation' --body "$body"


### PR DESCRIPTION
## Description & motivation 💭

The first real `apply` run published draft pull request #3846. Its body holds two faults.

**It misattributes authorship.** The body states that Claude authored the change. #3845 moved that work to the deterministic planner, and no model touches the manifest now. A security remediation must not make a false claim about who wrote it.

**The newlines are literal.** The body was built as `body="...\n\n..."` inside double quotes. Bash reads no escape there, so GitHub received one long line holding a backslash and an n. #3846 shows this.

### The change

The body now comes from a quoted heredoc, so the text holds real newlines. Its lines carry the indentation of the `run` block, which YAML strips, so the shell receives the heredoc at column zero.

The new text names the deterministic planner, states that no model authored the change, and lists the checks that ran before the publishing job received a write credential.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

The workflow file parses and prettier reports no problem. 77 tests pass, unaffected.

The body was extracted from the parsed workflow and run through bash with `RUN_URL` set. The output holds real line breaks, expands the run URL, and contains no literal backslash and n.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

After this merges, open Actions, select **Weekly On-Call Review**, and run it with the mode `apply` and the channel `C0BPXR260DA`. The run updates #3846 in place, so the body should render as paragraphs.

## Checklists

### Merge Checklist

- [ ] Confirm the updated body renders as paragraphs on #3846.

### Issue(s) closed

Part of UI-138. The per-alert table with advisory links and resolved versions is still open.

## Docs

### Any docs updates needed?

No.
