### PR TITLE
feat(ci): post the weekly review only when it needs a person

### DIFF
--- a/.github/scripts/apply-weekly-dependency-remediation.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.mjs
@@ -435,8 +435,36 @@ function highestPatchedVersion(alerts) {
   );
 }
 
+/** The resolved versions that an alert of this group still covers. */
+function vulnerableResolvedVersions(alerts, resolvedVersions) {
+  return (resolvedVersions ?? []).filter((version) =>
+    alerts.some((item) => isVersionVulnerable(version, item.vulnerableRange)),
+  );
+}
+
 function classifyPackage(alerts, packageJson, resolvedVersions) {
   const result = classifyPackageStatus(alerts, packageJson, resolvedVersions);
+  const stillVulnerable = vulnerableResolvedVersions(alerts, resolvedVersions);
+
+  // The manifest satisfies the advisory and the planner therefore has no work
+  // to do, but the lockfile still holds a version the advisory covers. The
+  // floor does not take effect, so a person must find out why. Without this a
+  // run reports success, creates no pull request, and leaves the alert open,
+  // because the verification step only reads an alert that an action names.
+  if (
+    result.status === 'safe' &&
+    !result.action &&
+    stillVulnerable.length > 0
+  ) {
+    return classification({
+      packageName: alerts[0]?.packageName,
+      alertIds: alerts.map((alert) => alert.id),
+      status: 'manual',
+      reason: `${result.reason} The lockfile still resolves ${stillVulnerable.join(', ')}, so that floor does not take effect.`,
+      resolvedVersions,
+    });
+  }
+
   if (!resolvedVersions?.length || result.resolvedVersions) return result;
   return { ...result, resolvedVersions };
 }
@@ -477,8 +505,9 @@ function classifyPackageStatus(alerts, packageJson, resolvedVersions) {
     });
   }
 
-  const vulnerableResolved = (resolvedVersions ?? []).filter((version) =>
-    alerts.some((item) => isVersionVulnerable(version, item.vulnerableRange)),
+  const vulnerableResolved = vulnerableResolvedVersions(
+    alerts,
+    resolvedVersions,
   );
   if (resolvedVersions?.length && vulnerableResolved.length === 0) {
     return classification({

--- a/.github/scripts/apply-weekly-dependency-remediation.test.mjs
+++ b/.github/scripts/apply-weekly-dependency-remediation.test.mjs
@@ -1013,3 +1013,72 @@ test('names no resolver when a plan holds no action', async () => {
   assert.equal(report.applied, false);
   assert.equal(report.resolver, undefined);
 });
+
+const vulnerableLockfile = (entry) => `lockfileVersion: '9.0'
+
+packages:
+
+  ${entry}:
+    resolution: {integrity: sha512-aaa}
+`;
+
+test('refuses an override whose floor meets the patch while the lockfile stays vulnerable', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 61,
+        name: 'cookie',
+        patched: '0.7.0',
+        vulnerable: '< 0.7.0',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { cookie: '>=0.7.0' } }),
+    lockfile: vulnerableLockfile('cookie@0.6.0'),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.deepEqual(plan.classifications[0].resolvedVersions, ['0.6.0']);
+  assert.match(plan.classifications[0].reason, /0\.6\.0/);
+  assert.match(plan.classifications[0].reason, /does not take effect/);
+});
+
+test('refuses a direct dependency whose floor meets the patch while the lockfile stays vulnerable', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 62,
+        name: 'axios',
+        patched: '1.7.0',
+        vulnerable: '< 1.7.0',
+        manifestPath: 'package.json',
+      }),
+    ],
+    packageJson: manifest({ dependencies: { axios: '^1.8.0' } }),
+    lockfile: vulnerableLockfile('axios@1.6.0'),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'manual');
+  assert.match(plan.classifications[0].reason, /1\.6\.0/);
+});
+
+test('still reports an already patched tree as already safe', () => {
+  const plan = planRemediation({
+    audit: [
+      alert({
+        number: 63,
+        name: 'cookie',
+        patched: '0.7.0',
+        vulnerable: '< 0.7.0',
+        manifestPath: 'pnpm-lock.yaml',
+      }),
+    ],
+    packageJson: manifest({ overrides: { cookie: '>=0.7.0' } }),
+    lockfile: vulnerableLockfile('cookie@0.7.0'),
+  });
+
+  assert.equal(plan.actions.length, 0);
+  assert.equal(plan.classifications[0].status, 'alreadySafe');
+});

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -194,11 +194,19 @@ const unresolvedItems = ({ audit, remediation }) => {
           : Array.isArray(item.alertIds) && item.alertIds.length > 0
             ? item.alertIds.map((id) => `#${id}`).join(', ')
             : null;
+        // The name is escaped first, then wrapped. Backticks keep a scoped
+        // package name from rendering as a Slack mention, and the escape still
+        // stops the name itself from carrying formatting.
+        const code = name
+          ? `\`${escapeSlackMrkdwn(truncateText(String(name)))}\``
+          : null;
         const label = item.number
-          ? `${alertReference} ${name ?? 'alert'}`
-          : (name ?? alertReference ?? 'unidentified alert');
-        const reason = item.reason ? ` — ${item.reason}` : '';
-        return `• ${escapeSlackMrkdwn(truncateText(label))}${escapeSlackMrkdwn(truncateText(reason))}`;
+          ? `${alertReference} ${code ?? 'alert'}`
+          : (code ?? alertReference ?? 'unidentified alert');
+        const reason = item.reason
+          ? ` — ${escapeSlackMrkdwn(truncateText(item.reason))}`
+          : '';
+        return `• ${label}${reason}`;
       }),
       omittedCount: Math.max(unresolved.length - DEFAULT_UNRESOLVED_LIMIT, 0),
     };
@@ -354,6 +362,78 @@ const contextBlock = (mrkdwn) => ({
   elements: [{ type: 'mrkdwn', text: mrkdwn }],
 });
 
+const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low'];
+const SEVERITY_MARK = {
+  critical: ':red_circle:',
+  high: ':red_circle:',
+  medium: ':large_orange_circle:',
+  low: ':large_yellow_circle:',
+};
+
+/** Alert number to its advisory page and severity, taken from the audit. */
+const alertIndex = (audit) => {
+  const index = new Map();
+  for (const alert of audit?.dependabot?.alerts ?? []) {
+    if (!Number.isInteger(alert.number)) continue;
+    index.set(alert.number, {
+      url:
+        alert.url ??
+        (audit.repository
+          ? `https://github.com/${audit.repository}/security/dependabot/${alert.number}`
+          : null),
+      severity: String(alert.severity ?? 'unknown').toLowerCase(),
+    });
+  }
+  return index;
+};
+
+/** Each alert number linked to its advisory page when the audit knows it. */
+const alertLinks = (alertIds, index) =>
+  (alertIds ?? [])
+    .map((id) => {
+      const url = index.get(id)?.url;
+      return url ? slackLink(url, String(id)) : String(id);
+    })
+    .join(', ');
+
+/** The worst severity across a set of alerts, with a count and a colour. */
+const severityBadge = (alertIds, index) => {
+  const severities = (alertIds ?? [])
+    .map((id) => index.get(id)?.severity)
+    .filter((value) => SEVERITY_ORDER.includes(value));
+  if (severities.length === 0) return null;
+  const worst = SEVERITY_ORDER.find((value) => severities.includes(value));
+  const count = severities.filter((value) => value === worst).length;
+  return `${SEVERITY_MARK[worst]} *${count} ${worst.toUpperCase()}*`;
+};
+
+/**
+ * The headline a reader sees first. A published change leads with READY and the
+ * number of alerts it closes. Anything else falls back to the plain line.
+ */
+const remediationHeadline = ({ audit, remediation, publishStatus }) => {
+  const line = remediationLine({ audit, remediation, publishStatus });
+  const result = remediation ?? audit.remediationResult;
+  const url = result?.pullRequestUrl;
+  if (publishStatus !== 'success' || !result?.applied || !url) return line;
+
+  const number = /\/pull\/(\d+)/.exec(url)?.[1];
+  if (!number) return line;
+  const closed = new Set(
+    (result.actions ?? []).flatMap((action) => action.alertIds ?? []),
+  ).size;
+  const alertText =
+    closed > 0 ? ` closes ${closed} alert${closed === 1 ? '' : 's'}` : '';
+  return `:white_check_mark: *READY*  ${slackLink(url, `#${number}`)}${alertText}`;
+};
+
+const fieldsBlock = (pairs) => ({
+  type: 'section',
+  fields: pairs
+    .flatMap(([label, value]) => [`*${label}*`, value])
+    .map((text) => ({ type: 'mrkdwn', text: truncateText(text, 2_000) })),
+});
+
 /** One line per authorized action, naming the range and the resolved version. */
 const changeLines = (result) => {
   const actions = Array.isArray(result?.actions) ? result.actions : [];
@@ -405,18 +485,59 @@ export const buildDependencySecurityReply = ({
   const result = remediation ?? audit.remediationResult;
   const blocks = [headerBlock('Dependency security')];
   blocks.push(
-    ...sectionBlocks(remediationLine({ audit, remediation, publishStatus })),
+    ...sectionBlocks(
+      remediationHeadline({ audit, remediation, publishStatus }),
+    ),
   );
 
-  const changes = changeLines(result);
-  if (changes.length > 0) blocks.push(...sectionBlocks(changes.join('\n')));
+  // One field grid per authorized action: what changed, what it resolves to,
+  // and every alert it closes, each linked to its advisory page.
+  const alerts = alertIndex(audit);
+  const actions = Array.isArray(result?.actions) ? result.actions : [];
+  const resolvedAfter = new Map();
+  for (const alert of result?.verification?.alerts ?? []) {
+    if (alert.packageName && alert.resolvedVersions?.length) {
+      resolvedAfter.set(alert.packageName, alert.resolvedVersions.join(', '));
+    }
+  }
+  for (const action of actions.slice(0, 3)) {
+    const range =
+      action.from && action.to
+        ? `\`${action.from}\` → \`${action.to}\``
+        : String(action.to ?? '');
+    const pairs = [
+      [
+        'Change',
+        `\`${escapeSlackMrkdwn(String(action.packageName))}\` ${range}`,
+      ],
+    ];
+    const after = resolvedAfter.get(action.packageName);
+    if (after) pairs.push(['Resolves to', `${after}, verified after install`]);
+    const links = alertLinks(action.alertIds, alerts);
+    if (links) pairs.push(['Alerts', links]);
+    blocks.push(fieldsBlock(pairs));
+  }
+  if (actions.length > 3) {
+    blocks.push(...sectionBlocks(`• …and ${actions.length - 3} more changes`));
+  }
+  if (actions.length === 0) {
+    const changes = changeLines(result);
+    if (changes.length > 0) blocks.push(...sectionBlocks(changes.join('\n')));
+  }
 
   const unresolved = unresolvedItems({ audit, remediation });
   if (unresolved.lines.length > 0) {
     blocks.push(dividerBlock());
-    blocks.push(
-      ...sectionBlocks(['*Needs a decision*', ...unresolved.lines].join('\n')),
-    );
+    const unresolvedAlertIds = (result?.classifications ?? [])
+      .filter((item) =>
+        ['manual', 'unsupported', 'alreadySafe'].includes(item.status),
+      )
+      .flatMap((item) => item.alertIds ?? []);
+    const badge = severityBadge(unresolvedAlertIds, alerts);
+    const heading = badge
+      ? `${badge}  *Needs a decision*`
+      : '*Needs a decision*';
+    blocks.push(...sectionBlocks([heading, ...unresolved.lines].join('\n')));
     if (unresolved.omittedCount > 0) {
       blocks.push(...sectionBlocks(omittedLine(unresolved.omittedCount, null)));
     }
@@ -467,15 +588,36 @@ export const buildExternalContributorReply = ({
   threadTs = null,
 }) => {
   const external = audit.externalContributors ?? {};
+  const groupHeading = (mark, label, pullRequests, totalCount) =>
+    `${mark} *${totalCount ?? pullRequests.length} ${label}*`;
   const sections = [
     [
-      '*Ready for review*',
+      groupHeading(
+        ':large_green_circle:',
+        'READY FOR REVIEW',
+        external.reviewReady ?? [],
+        external.reviewReadyCount,
+      ),
       external.reviewReady ?? [],
       external.reviewReadyCount,
     ],
-    ['*Needs triage*', external.triage ?? [], external.triageCount],
     [
-      '*Waiting on author*',
+      groupHeading(
+        ':large_orange_circle:',
+        'NEED TRIAGE',
+        external.triage ?? [],
+        external.triageCount,
+      ),
+      external.triage ?? [],
+      external.triageCount,
+    ],
+    [
+      groupHeading(
+        ':large_yellow_circle:',
+        'WAITING ON AUTHOR',
+        external.authorFollowup ?? [],
+        external.authorFollowupCount,
+      ),
       external.authorFollowup ?? [],
       external.authorFollowupCount,
     ],

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -26,8 +26,33 @@ const omittedLine = (count, runUrl) => {
   return `• …and ${count} more${suffix}`;
 };
 
+/**
+ * The last line of a group. It links to the page that holds the whole list, so
+ * a reader is never left at a dead end.
+ */
+const omittedLink = (count, url) => {
+  const text = `…and ${count} more`;
+  return `• ${url ? slackLink(url, text) : text}`;
+};
+
+/** Where a reader sees the full list for each module. */
+const moreUrl = {
+  pullRequests: (repository) =>
+    repository
+      ? `https://github.com/${repository}/pulls?q=is%3Apr+is%3Aopen`
+      : null,
+  vlnPullRequests: (repository) =>
+    repository
+      ? `https://github.com/${repository}/pulls?q=is%3Apr+is%3Aopen+VLN`
+      : null,
+  alerts: (repository) =>
+    repository
+      ? `https://github.com/${repository}/security/dependabot?q=is%3Aopen`
+      : null,
+};
+
 /** One section per group: a heading, a few items, then the omitted count. */
-const groupSection = (heading, pullRequests, totalCount, limit) => {
+const groupSection = (heading, pullRequests, totalCount, limit, url = null) => {
   const visible = pullRequests.slice(0, limit);
   if (visible.length === 0) return [];
   const lines = [heading, ...visible.map(renderPullRequest)];
@@ -35,7 +60,7 @@ const groupSection = (heading, pullRequests, totalCount, limit) => {
     (totalCount ?? pullRequests.length) - visible.length,
     0,
   );
-  if (omitted > 0) lines.push(`• …and ${omitted} more`);
+  if (omitted > 0) lines.push(omittedLink(omitted, url));
   return sectionBlocks(lines.join('\n'));
 };
 
@@ -228,17 +253,20 @@ const vlnBlocks = ({ audit, vlnLimit, runUrl }) => {
   const blocks = [headerBlock('VLN review')];
 
   const limit = Math.min(vlnLimit, LIST_GROUP_LIMIT);
+  const vlnUrl = moreUrl.vlnPullRequests(audit.repository);
   const pendingGroup = groupSection(
     '*Pending VLN PRs*',
     pending,
     pending.length,
     limit,
+    vlnUrl,
   );
   const triageGroup = groupSection(
     '*Needs triage*',
     needsTriage,
     needsTriage.length,
     limit,
+    vlnUrl,
   );
   blocks.push(...pendingGroup);
   if (pendingGroup.length > 0 && triageGroup.length > 0) {
@@ -503,7 +531,11 @@ export const buildDependencySecurityReply = ({
     blocks.push(fieldsBlock(pairs));
   }
   if (actions.length > 3) {
-    blocks.push(...sectionBlocks(`• …and ${actions.length - 3} more changes`));
+    blocks.push(
+      ...sectionBlocks(
+        omittedLink(actions.length - 3, moreUrl.alerts(audit.repository)),
+      ),
+    );
   }
   if (actions.length === 0) {
     const changes = changeLines(result);
@@ -524,7 +556,14 @@ export const buildDependencySecurityReply = ({
       : '*Needs a decision*';
     blocks.push(...sectionBlocks([heading, ...unresolved.lines].join('\n')));
     if (unresolved.omittedCount > 0) {
-      blocks.push(...sectionBlocks(omittedLine(unresolved.omittedCount, null)));
+      blocks.push(
+        ...sectionBlocks(
+          omittedLink(
+            unresolved.omittedCount,
+            moreUrl.alerts(audit.repository),
+          ),
+        ),
+      );
     }
   }
   if (runUrl) {
@@ -628,6 +667,7 @@ export const buildExternalContributorReply = ({
       pullRequests,
       totalCount,
       LIST_GROUP_LIMIT,
+      moreUrl.pullRequests(audit.repository),
     );
     if (group.length === 0) continue;
     if (!firstGroup) blocks.push(dividerBlock());

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -75,21 +75,8 @@ export const splitSlackSectionText = (
   return chunks;
 };
 
-const statusText = (pullRequest) => {
-  const parts = [];
-  if (pullRequest.draft) parts.push('draft');
-  if (pullRequest.review?.status && pullRequest.review.status !== 'pending') {
-    parts.push(pullRequest.review.status.replaceAll('_', ' '));
-  }
-  if (pullRequest.merge && pullRequest.merge !== 'mergeable') {
-    parts.push(pullRequest.merge);
-  }
-  if (pullRequest.checks?.status && pullRequest.checks.status !== 'passing') {
-    parts.push(`checks ${pullRequest.checks.status}`);
-  }
-  return parts.length > 0 ? ` — ${parts.join(', ')}` : '';
-};
-
+// The group badge already names the state of every item it holds, so a list
+// item carries no status. Repeating it made Slack collapse the whole group.
 const renderPullRequest = (pullRequest) =>
   `• ${slackLink(
     pullRequest.url,
@@ -97,7 +84,7 @@ const renderPullRequest = (pullRequest) =>
       `#${pullRequest.number}: ${pullRequest.title}`,
       LIST_TITLE_LIMIT,
     ),
-  )}${statusText(pullRequest)}`;
+  )}`;
 
 const remediationActionCount = (result) =>
   result?.summary?.actions ?? result?.actions?.length ?? null;
@@ -363,12 +350,10 @@ const contextBlock = (mrkdwn) => ({
 });
 
 const SEVERITY_ORDER = ['critical', 'high', 'medium', 'low'];
-const SEVERITY_MARK = {
-  critical: ':red_circle:',
-  high: ':red_circle:',
-  medium: ':large_orange_circle:',
-  low: ':large_yellow_circle:',
-};
+
+// Slack holds no badge primitive. A code span is the closest: the client draws
+// it as a small bordered chip, the same shape it gives a version or a package.
+const badge = (label) => `\`${label}\``;
 
 /** Alert number to its advisory page and severity, taken from the audit. */
 const alertIndex = (audit) => {
@@ -404,7 +389,7 @@ const severityBadge = (alertIds, index) => {
   if (severities.length === 0) return null;
   const worst = SEVERITY_ORDER.find((value) => severities.includes(value));
   const count = severities.filter((value) => value === worst).length;
-  return `${SEVERITY_MARK[worst]} *${count} ${worst.toUpperCase()}*`;
+  return badge(`${count} ${worst.toUpperCase()}`);
 };
 
 /**
@@ -424,7 +409,7 @@ const remediationHeadline = ({ audit, remediation, publishStatus }) => {
   ).size;
   const alertText =
     closed > 0 ? ` closes ${closed} alert${closed === 1 ? '' : 's'}` : '';
-  return `:white_check_mark: *READY*  ${slackLink(url, `#${number}`)}${alertText}`;
+  return `${badge('READY')}  *${slackLink(url, `#${number}`)}*${alertText}`;
 };
 
 const fieldsBlock = (pairs) => ({
@@ -588,12 +573,11 @@ export const buildExternalContributorReply = ({
   threadTs = null,
 }) => {
   const external = audit.externalContributors ?? {};
-  const groupHeading = (mark, label, pullRequests, totalCount) =>
-    `${mark} *${totalCount ?? pullRequests.length} ${label}*`;
+  const groupHeading = (label, pullRequests, totalCount) =>
+    badge(`${totalCount ?? pullRequests.length} ${label}`);
   const sections = [
     [
       groupHeading(
-        ':large_green_circle:',
         'READY FOR REVIEW',
         external.reviewReady ?? [],
         external.reviewReadyCount,
@@ -602,18 +586,12 @@ export const buildExternalContributorReply = ({
       external.reviewReadyCount,
     ],
     [
-      groupHeading(
-        ':large_orange_circle:',
-        'NEED TRIAGE',
-        external.triage ?? [],
-        external.triageCount,
-      ),
+      groupHeading('NEED TRIAGE', external.triage ?? [], external.triageCount),
       external.triage ?? [],
       external.triageCount,
     ],
     [
       groupHeading(
-        ':large_yellow_circle:',
         'WAITING ON AUTHOR',
         external.authorFollowup ?? [],
         external.authorFollowupCount,

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -108,8 +108,12 @@ const remediationLine = ({ audit, remediation, publishStatus }) => {
         : null;
 
   if (result?.applied && publishedPullRequest) {
-    const label = publishedPullRequest.number
-      ? `#${publishedPullRequest.number}: ${publishedPullRequest.title}`
+    const numberFromUrl = /\/pull\/(\d+)/.exec(publishedPullRequest.url ?? '');
+    const number = publishedPullRequest.number ?? numberFromUrl?.[1] ?? null;
+    const label = number
+      ? publishedPullRequest.title
+        ? `#${number}: ${publishedPullRequest.title}`
+        : `#${number}`
       : 'view draft remediation PR';
     return `Draft remediation PR: ${slackLink(publishedPullRequest.url, label)}${remediationActionText(result, true)}`;
   }
@@ -200,6 +204,34 @@ const dependencySecurityText = ({
   return lines.join('\n');
 };
 
+const vlnBlocks = ({ audit, vlnLimit, runUrl }) => {
+  const pending = audit.vln?.pending ?? [];
+  const needsTriage = audit.vln?.needsTriage ?? [];
+  const blocks = [headerBlock('VLN review')];
+
+  const group = (heading, pullRequests) => {
+    const visible = pullRequests.slice(0, vlnLimit);
+    if (visible.length === 0) return;
+    blocks.push(
+      ...sectionBlocks(
+        [`*${heading}*`, ...visible.map(renderPullRequest)].join('\n'),
+      ),
+    );
+    const omitted = pullRequests.length - visible.length;
+    if (omitted > 0) blocks.push(...sectionBlocks(omittedLine(omitted, null)));
+  };
+
+  group('Pending VLN PRs', pending);
+  if (pending.length > 0 && needsTriage.length > 0) blocks.push(dividerBlock());
+  group('Needs triage', needsTriage);
+
+  if (pending.length === 0 && needsTriage.length === 0) {
+    blocks.push(...sectionBlocks('No pending VLN pull request.'));
+  }
+  if (runUrl) blocks.push(contextBlock(slackLink(runUrl, 'workflow run')));
+  return blocks;
+};
+
 const vlnReviewText = ({ audit, vlnLimit, runUrl }) => {
   const vlns = audit.vln?.pending ?? [];
   const needsTriage = audit.vln?.needsTriage ?? [];
@@ -228,14 +260,107 @@ const vlnReviewText = ({ audit, vlnLimit, runUrl }) => {
   return lines.join('\n');
 };
 
-const asThreadReply = ({ channel = null, threadTs = null, text }) => ({
+const countOf = (value) => (Number.isInteger(value) ? value : 0);
+
+const unresolvedCount = (result) => {
+  if (Array.isArray(result?.unresolved)) return result.unresolved.length;
+  if (Array.isArray(result?.classifications)) {
+    return result.classifications.filter((item) =>
+      ['manual', 'unsupported', 'alreadySafe'].includes(item.status),
+    ).length;
+  }
+  return 0;
+};
+
+/** A person must act on the dependency module for one of these reasons. */
+export const dependencyNeedsAction = ({
+  audit,
+  remediation = null,
+  publishStatus = 'skipped',
+}) => {
+  if (publishStatus === 'failure') return true;
+  const result = remediation ?? audit.remediationResult;
+  const summary = result?.summary ?? {};
+  if (countOf(summary.actions) > 0) return true;
+  if (countOf(summary.manual) > 0) return true;
+  if (countOf(summary.unsupported) > 0) return true;
+  if (countOf(summary.alreadySafe) > 0) return true;
+  if (Array.isArray(result?.actions) && result.actions.length > 0) return true;
+  if (unresolvedCount(result) > 0) return true;
+  if (result?.pullRequest || result?.pullRequestUrl) return true;
+  if (audit.remediation) return true;
+  return countOf(audit.dependabot?.openAlertCount) > 0;
+};
+
+/** A person must act on the VLN module when a pull request waits. */
+export const vlnNeedsAction = ({ audit }) =>
+  (audit.vln?.pending ?? []).length > 0 ||
+  (audit.vln?.needsTriage ?? []).length > 0;
+
+/**
+ * A person must act on the external module when a pull request waits. A stale
+ * count alone is context, not work, so it does not make the module actionable.
+ */
+export const externalNeedsAction = ({ audit }) => {
+  const external = audit.externalContributors ?? {};
+  return (
+    (external.reviewReady ?? []).length > 0 ||
+    (external.triage ?? []).length > 0 ||
+    (external.authorFollowup ?? []).length > 0
+  );
+};
+
+const headerBlock = (text) => ({
+  type: 'header',
+  text: { type: 'plain_text', text: truncateText(text, 150) },
+});
+
+const sectionBlocks = (mrkdwn) =>
+  splitSlackSectionText(mrkdwn).map((text) => ({
+    type: 'section',
+    text: { type: 'mrkdwn', text },
+  }));
+
+const dividerBlock = () => ({ type: 'divider' });
+
+const contextBlock = (mrkdwn) => ({
+  type: 'context',
+  elements: [{ type: 'mrkdwn', text: mrkdwn }],
+});
+
+/** One line per authorized action, naming the range and the resolved version. */
+const changeLines = (result) => {
+  const actions = Array.isArray(result?.actions) ? result.actions : [];
+  const resolved = new Map();
+  for (const alert of result?.verification?.alerts ?? []) {
+    if (alert.packageName && alert.resolvedVersions?.length) {
+      resolved.set(alert.packageName, alert.resolvedVersions.join(', '));
+    }
+  }
+  return actions.map((action) => {
+    const range =
+      action.from && action.to ? ` \`${action.from}\` → \`${action.to}\`` : '';
+    const after = resolved.get(action.packageName);
+    const resolvedText = after ? `, resolves to ${after}` : '';
+    const alertIds = action.alertIds ?? [];
+    const alerts =
+      alertIds.length > 0 ? ` · alerts ${alertIds.join(', ')}` : '';
+    return `• \`${escapeSlackMrkdwn(String(action.packageName))}\`${range}${resolvedText}${alerts}`;
+  });
+};
+
+const asThreadReply = ({
+  channel = null,
+  threadTs = null,
+  text,
+  actionable = true,
+  blocks = null,
+}) => ({
   channel,
   thread_ts: threadTs,
   text,
-  blocks: splitSlackSectionText(text).map((sectionText) => ({
-    type: 'section',
-    text: { type: 'mrkdwn', text: sectionText },
-  })),
+  actionable,
+  blocks: blocks ?? sectionBlocks(text),
 });
 
 /**
@@ -251,9 +376,38 @@ export const buildDependencySecurityReply = ({
   threadTs = null,
 }) => {
   validatePublishStatus(publishStatus);
+  const result = remediation ?? audit.remediationResult;
+  const blocks = [headerBlock('Dependency security')];
+  blocks.push(
+    ...sectionBlocks(remediationLine({ audit, remediation, publishStatus })),
+  );
+
+  const changes = changeLines(result);
+  if (changes.length > 0) blocks.push(...sectionBlocks(changes.join('\n')));
+
+  const unresolved = unresolvedItems({ audit, remediation });
+  if (unresolved.lines.length > 0) {
+    blocks.push(dividerBlock());
+    blocks.push(
+      ...sectionBlocks(['*Needs a decision*', ...unresolved.lines].join('\n')),
+    );
+    if (unresolved.omittedCount > 0) {
+      blocks.push(...sectionBlocks(omittedLine(unresolved.omittedCount, null)));
+    }
+  }
+  if (runUrl) {
+    blocks.push(
+      contextBlock(
+        `${slackLink(runUrl, 'workflow run')} · the planner authored this change`,
+      ),
+    );
+  }
+
   return asThreadReply({
     channel,
     threadTs,
+    actionable: dependencyNeedsAction({ audit, remediation, publishStatus }),
+    blocks,
     text: dependencySecurityText({
       audit,
       remediation,
@@ -274,6 +428,8 @@ export const buildVlnReviewReply = ({
   asThreadReply({
     channel,
     threadTs,
+    actionable: vlnNeedsAction({ audit }),
+    blocks: vlnBlocks({ audit, vlnLimit, runUrl }),
     text: vlnReviewText({ audit, vlnLimit, runUrl }),
   });
 
@@ -318,7 +474,45 @@ export const buildExternalContributorReply = ({
     );
   }
   if (runUrl) lines.push('', `Run: ${slackLink(runUrl, 'view workflow run')}`);
-  return asThreadReply({ channel, threadTs, text: lines.join('\n') });
+  const blocks = [headerBlock('External contributor PRs')];
+  let firstGroup = true;
+  for (const [heading, pullRequests, totalCount] of sections) {
+    if (pullRequests.length === 0) continue;
+    if (!firstGroup) blocks.push(dividerBlock());
+    firstGroup = false;
+    blocks.push(
+      ...sectionBlocks(
+        [heading, ...pullRequests.map(renderPullRequest)].join('\n'),
+      ),
+    );
+    const omitted = Math.max(
+      (totalCount ?? pullRequests.length) - pullRequests.length,
+      0,
+    );
+    if (omitted > 0) blocks.push(...sectionBlocks(omittedLine(omitted, null)));
+  }
+  if (firstGroup) {
+    blocks.push(...sectionBlocks('No eligible external contributor PR.'));
+  }
+
+  const contextParts = [];
+  if (runUrl) contextParts.push(slackLink(runUrl, 'workflow run'));
+  if (external.staleCount > 0) {
+    contextParts.push(
+      `${external.staleCount} PR${external.staleCount === 1 ? '' : 's'} idle for 14+ days`,
+    );
+  }
+  if (contextParts.length > 0) {
+    blocks.push(contextBlock(contextParts.join(' · ')));
+  }
+
+  return asThreadReply({
+    channel,
+    threadTs,
+    actionable: externalNeedsAction({ audit }),
+    blocks,
+    text: lines.join('\n'),
+  });
 };
 
 // Kept as a small compatibility wrapper for callers that only need a single
@@ -401,9 +595,11 @@ export const runDigestCli = async ({
           : (() => {
               throw new Error(`Unsupported --module value: ${module}`);
             })();
-  await writeFile(output, `${JSON.stringify(payload, null, 2)}\n`);
+  const { actionable, ...slackPayload } = payload;
+  await writeFile(output, `${JSON.stringify(slackPayload, null, 2)}\n`);
   await writeGithubOutput('digest-file', output);
   await writeGithubOutput('slack-text', payload.text);
+  await writeGithubOutput('actionable', String(actionable));
   console.log(JSON.stringify(payload));
   return payload;
 };

--- a/.github/scripts/weekly-dependency-security-digest.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.mjs
@@ -5,6 +5,10 @@ import { escapeSlackMrkdwn } from './slack-utils.mjs';
 
 const DEFAULT_VLN_LIMIT = 10;
 const DEFAULT_UNRESOLVED_LIMIT = 10;
+// A list line must fit one row in Slack, and a group must stay short enough
+// that the client renders it without a Show more control.
+const LIST_TITLE_LIMIT = 72;
+const LIST_GROUP_LIMIT = 3;
 const SLACK_SECTION_TEXT_LIMIT = 3_000;
 const SLACK_DYNAMIC_TEXT_LIMIT = 800;
 const PUBLISH_STATUSES = new Set(['success', 'failure', 'skipped']);
@@ -20,6 +24,19 @@ const slackLink = (url, label) =>
 const omittedLine = (count, runUrl) => {
   const suffix = runUrl ? `; ${slackLink(runUrl, 'see workflow run')}` : '';
   return `• …and ${count} more${suffix}`;
+};
+
+/** One section per group: a heading, a few items, then the omitted count. */
+const groupSection = (heading, pullRequests, totalCount, limit) => {
+  const visible = pullRequests.slice(0, limit);
+  if (visible.length === 0) return [];
+  const lines = [heading, ...visible.map(renderPullRequest)];
+  const omitted = Math.max(
+    (totalCount ?? pullRequests.length) - visible.length,
+    0,
+  );
+  if (omitted > 0) lines.push(`• …and ${omitted} more`);
+  return sectionBlocks(lines.join('\n'));
 };
 
 export const splitSlackSectionText = (
@@ -74,7 +91,13 @@ const statusText = (pullRequest) => {
 };
 
 const renderPullRequest = (pullRequest) =>
-  `• ${slackLink(pullRequest.url, `#${pullRequest.number}: ${pullRequest.title}`)}${statusText(pullRequest)}`;
+  `• ${slackLink(
+    pullRequest.url,
+    truncateText(
+      `#${pullRequest.number}: ${pullRequest.title}`,
+      LIST_TITLE_LIMIT,
+    ),
+  )}${statusText(pullRequest)}`;
 
 const remediationActionCount = (result) =>
   result?.summary?.actions ?? result?.actions?.length ?? null;
@@ -209,21 +232,24 @@ const vlnBlocks = ({ audit, vlnLimit, runUrl }) => {
   const needsTriage = audit.vln?.needsTriage ?? [];
   const blocks = [headerBlock('VLN review')];
 
-  const group = (heading, pullRequests) => {
-    const visible = pullRequests.slice(0, vlnLimit);
-    if (visible.length === 0) return;
-    blocks.push(
-      ...sectionBlocks(
-        [`*${heading}*`, ...visible.map(renderPullRequest)].join('\n'),
-      ),
-    );
-    const omitted = pullRequests.length - visible.length;
-    if (omitted > 0) blocks.push(...sectionBlocks(omittedLine(omitted, null)));
-  };
-
-  group('Pending VLN PRs', pending);
-  if (pending.length > 0 && needsTriage.length > 0) blocks.push(dividerBlock());
-  group('Needs triage', needsTriage);
+  const limit = Math.min(vlnLimit, LIST_GROUP_LIMIT);
+  const pendingGroup = groupSection(
+    '*Pending VLN PRs*',
+    pending,
+    pending.length,
+    limit,
+  );
+  const triageGroup = groupSection(
+    '*Needs triage*',
+    needsTriage,
+    needsTriage.length,
+    limit,
+  );
+  blocks.push(...pendingGroup);
+  if (pendingGroup.length > 0 && triageGroup.length > 0) {
+    blocks.push(dividerBlock());
+  }
+  blocks.push(...triageGroup);
 
   if (pending.length === 0 && needsTriage.length === 0) {
     blocks.push(...sectionBlocks('No pending VLN pull request.'));
@@ -477,19 +503,16 @@ export const buildExternalContributorReply = ({
   const blocks = [headerBlock('External contributor PRs')];
   let firstGroup = true;
   for (const [heading, pullRequests, totalCount] of sections) {
-    if (pullRequests.length === 0) continue;
+    const group = groupSection(
+      heading,
+      pullRequests,
+      totalCount,
+      LIST_GROUP_LIMIT,
+    );
+    if (group.length === 0) continue;
     if (!firstGroup) blocks.push(dividerBlock());
     firstGroup = false;
-    blocks.push(
-      ...sectionBlocks(
-        [heading, ...pullRequests.map(renderPullRequest)].join('\n'),
-      ),
-    );
-    const omitted = Math.max(
-      (totalCount ?? pullRequests.length) - pullRequests.length,
-      0,
-    );
-    if (omitted > 0) blocks.push(...sectionBlocks(omittedLine(omitted, null)));
+    blocks.push(...group);
   }
   if (firstGroup) {
     blocks.push(...sectionBlocks('No eligible external contributor PR.'));

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -546,3 +546,61 @@ test('names the published pull request by number when only its URL is known', ()
     /view draft remediation PR/,
   );
 });
+
+const longTitlePullRequests = Array.from({ length: 9 }, (_, index) =>
+  pullRequest(
+    4000 + index,
+    `feat: Add "Contains" filter option to workflow search UI for substring matching in WorkflowId and WorkflowType fields ${index}`,
+  ),
+);
+
+test('keeps every list section short enough for Slack to render inline', () => {
+  const reply = buildExternalContributorReply({
+    audit: {
+      ...audit,
+      externalContributors: {
+        reviewReady: [],
+        triage: longTitlePullRequests,
+        triageCount: 20,
+        authorFollowup: longTitlePullRequests,
+        authorFollowupCount: 20,
+        staleCount: 3,
+      },
+    },
+    runUrl: RUN,
+  });
+
+  // Slack hides the URL of a link, so measure what a reader sees.
+  const visible = (text) => text.replaceAll(/<[^|>]+\|([^>]*)>/g, '$1');
+
+  for (const block of reply.blocks) {
+    if (block.type !== 'section') continue;
+    const shown = visible(block.text.text);
+    assert.ok(shown.length <= 600, `section shows ${shown.length} characters`);
+    for (const line of shown.split('\n')) {
+      assert.ok(line.length <= 120, `line shows ${line.length} characters`);
+    }
+  }
+});
+
+test('folds the omitted count into the group it belongs to', () => {
+  const reply = buildExternalContributorReply({
+    audit: {
+      ...audit,
+      externalContributors: {
+        reviewReady: [],
+        triage: longTitlePullRequests,
+        triageCount: 20,
+        authorFollowup: [],
+        staleCount: 0,
+      },
+    },
+    runUrl: RUN,
+  });
+
+  const withCount = reply.blocks.filter(
+    (block) => block.type === 'section' && /more/.test(block.text.text),
+  );
+  assert.equal(withCount.length, 1);
+  assert.match(withCount[0].text.text, /Needs triage/);
+});

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -6,6 +6,7 @@ import {
   buildExternalContributorReply,
   buildVlnReviewReply,
   buildWeeklySecurityDigest,
+  runDigestCli,
   splitSlackSectionText,
   validatePublishStatus,
 } from './weekly-dependency-security-digest.mjs';
@@ -46,6 +47,17 @@ const audit = {
   },
 };
 
+/** Slack limits: a header holds 150 characters, other text holds 3000. */
+const withinSlackLimits = (reply) =>
+  reply.blocks.every((block) => {
+    if (block.type === 'divider') return true;
+    if (block.type === 'header') return block.text.text.length <= 150;
+    if (block.type === 'context') {
+      return block.elements.every((element) => element.text.length <= 3_000);
+    }
+    return block.text.type === 'mrkdwn' && block.text.text.length <= 3_000;
+  });
+
 test('builds a dependency-security thread reply with escaped PR text and unresolved items', () => {
   const reply = buildDependencySecurityReply({
     audit,
@@ -65,7 +77,7 @@ test('builds a dependency-security thread reply with escaped PR text and unresol
   assert.match(reply.text, /2 alerts addressed/);
   assert.match(reply.text, /Needs human handling/);
   assert.match(reply.text, /view workflow run/);
-  assert.equal(reply.blocks[0].type, 'section');
+  assert.equal(reply.blocks[0].type, 'header');
 });
 
 test('renders the remediation planner report without requiring a published PR', () => {
@@ -91,7 +103,7 @@ test('renders the remediation planner report without requiring a published PR', 
     },
   });
   assert.match(reply.text, /2 safe changes applied/);
-  assert.match(reply.text, /view draft remediation PR/);
+  assert.match(reply.text, /#20/);
   assert.match(reply.text, /go\/pkg/);
   assert.match(reply.text, /unsupported ecosystem/);
 });
@@ -154,7 +166,11 @@ test('compatibility summary combines the two independent replies', () => {
   assert.match(digest.text, /Dependency security/);
   assert.match(digest.text, /VLN review/);
   assert.match(digest.text, /External contributor PRs/);
-  assert.equal(digest.blocks.length, 3);
+  assert.ok(digest.blocks.length >= 3);
+  assert.equal(
+    digest.blocks.filter((block) => block.type === 'header').length,
+    3,
+  );
 });
 
 test('builds external contributor replies by action bucket with stale count', () => {
@@ -196,12 +212,7 @@ test('caps long dependency findings with an omitted count and workflow link', ()
   });
   assert.match(reply.text, /…and 3 more/);
   assert.match(reply.text, /see workflow run/);
-  assert.ok(
-    reply.blocks.every(
-      (block) =>
-        block.text.type === 'mrkdwn' && block.text.text.length <= 3_000,
-    ),
-  );
+  assert.ok(withinSlackLimits(reply));
   assert.ok(reply.blocks.length > 1);
 });
 
@@ -231,7 +242,7 @@ test('bounds every VLN and external Slack section and reports omitted PRs', () =
   ]) {
     assert.match(reply.text, /…and [27] more/);
     assert.match(reply.text, /see workflow run/);
-    assert.ok(reply.blocks.every((block) => block.text.text.length <= 3_000));
+    assert.ok(withinSlackLimits(reply));
   }
 });
 
@@ -254,4 +265,284 @@ test('labels an unresolved classification that names no package', () => {
 
   assert.doesNotMatch(reply.text, /\[object Object\]/);
   assert.match(reply.text, /#77/);
+});
+
+const quietAudit = {
+  run: { url: 'https://github.com/temporalio/ui/actions/runs/99' },
+  dependabot: { openAlertCount: 0 },
+  remediation: null,
+  vln: { pending: [], needsTriage: [] },
+  externalContributors: {
+    reviewReady: [],
+    triage: [],
+    authorFollowup: [],
+    staleCount: 15,
+  },
+};
+
+test('reports no action needed when no module found anything', () => {
+  assert.equal(
+    buildDependencySecurityReply({ audit: quietAudit }).actionable,
+    false,
+  );
+  assert.equal(buildVlnReviewReply({ audit: quietAudit }).actionable, false);
+  assert.equal(
+    buildExternalContributorReply({ audit: quietAudit }).actionable,
+    false,
+  );
+});
+
+test('reports action needed for an authorized dependency change', () => {
+  const reply = buildDependencySecurityReply({
+    audit: { ...quietAudit, dependabot: { openAlertCount: 3 } },
+    publishStatus: 'success',
+    remediation: {
+      summary: { actions: 1, manual: 0, unsupported: 0, alreadySafe: 0 },
+      applied: true,
+      resolver: 'deterministic-planner',
+      pullRequestUrl: 'https://github.com/temporalio/ui/pull/3846',
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338, 300, 299],
+          type: 'pnpm-override',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+      classifications: [],
+      verification: {
+        verified: true,
+        alerts: [
+          {
+            alertId: 338,
+            packageName: 'protobufjs',
+            resolvedVersions: ['7.6.5'],
+          },
+        ],
+      },
+    },
+  });
+  assert.equal(reply.actionable, true);
+});
+
+test('reports action needed when a classification waits on a person', () => {
+  const reply = buildDependencySecurityReply({
+    audit: quietAudit,
+    remediation: {
+      summary: { actions: 0, manual: 1, unsupported: 0, alreadySafe: 0 },
+      applied: false,
+      actions: [],
+      classifications: [
+        {
+          packageName: '@grpc/grpc-js',
+          alertIds: [295, 294],
+          status: 'manual',
+          reason: 'no override exists',
+        },
+      ],
+    },
+  });
+  assert.equal(reply.actionable, true);
+});
+
+test('reports action needed when an alert covers an already patched tree', () => {
+  const reply = buildDependencySecurityReply({
+    audit: quietAudit,
+    remediation: {
+      summary: { actions: 0, manual: 0, unsupported: 0, alreadySafe: 2 },
+      applied: false,
+      actions: [],
+      classifications: [
+        {
+          packageName: 'left-pad',
+          alertIds: [7],
+          status: 'alreadySafe',
+          reason: 'the lockfile resolves 2.0.0',
+        },
+      ],
+    },
+  });
+  assert.equal(reply.actionable, true);
+});
+
+test('reports action needed when publication failed', () => {
+  const reply = buildDependencySecurityReply({
+    audit: quietAudit,
+    publishStatus: 'failure',
+    remediation: {
+      summary: { actions: 1, manual: 0, unsupported: 0, alreadySafe: 0 },
+      applied: true,
+      actions: [{ packageName: 'x', alertIds: [1], type: 'pnpm-override' }],
+      classifications: [],
+    },
+  });
+  assert.equal(reply.actionable, true);
+});
+
+test('reports action needed for a pending VLN pull request', () => {
+  assert.equal(buildVlnReviewReply({ audit }).actionable, true);
+});
+
+test('treats a stale count alone as no action needed', () => {
+  const reply = buildExternalContributorReply({ audit: quietAudit });
+  assert.equal(reply.actionable, false);
+});
+
+test('reports action needed when an external pull request waits on triage', () => {
+  assert.equal(buildExternalContributorReply({ audit }).actionable, true);
+});
+
+const RUN = 'https://github.com/temporalio/ui/actions/runs/99';
+
+const appliedRemediation = {
+  summary: { actions: 1, manual: 1, unsupported: 0, alreadySafe: 0 },
+  applied: true,
+  resolver: 'deterministic-planner',
+  pullRequestUrl: 'https://github.com/temporalio/ui/pull/3846',
+  actions: [
+    {
+      packageName: 'protobufjs',
+      alertIds: [338, 300, 299],
+      type: 'pnpm-override',
+      from: '^7.5.5',
+      to: '^7.6.5',
+    },
+  ],
+  classifications: [
+    {
+      packageName: '@grpc/grpc-js',
+      alertIds: [295, 294],
+      status: 'manual',
+      reason: 'no existing pnpm override',
+    },
+  ],
+  verification: {
+    verified: true,
+    alerts: [
+      { alertId: 338, packageName: 'protobufjs', resolvedVersions: ['7.6.5'] },
+    ],
+  },
+};
+
+const blockTypes = (reply) => reply.blocks.map((block) => block.type);
+const blockText = (reply) => JSON.stringify(reply.blocks);
+const countRunLinks = (reply) => blockText(reply).split(RUN).length - 1;
+
+test('leads every reply with a header block', () => {
+  for (const reply of [
+    buildDependencySecurityReply({
+      audit,
+      remediation: appliedRemediation,
+      publishStatus: 'success',
+      runUrl: RUN,
+    }),
+    buildVlnReviewReply({ audit, runUrl: RUN }),
+    buildExternalContributorReply({ audit, runUrl: RUN }),
+  ]) {
+    assert.equal(blockTypes(reply)[0], 'header');
+    assert.equal(reply.blocks[0].text.type, 'plain_text');
+    assert.ok(reply.blocks[0].text.text.length <= 150);
+  }
+});
+
+test('links the workflow run once, from a context block', () => {
+  for (const reply of [
+    buildDependencySecurityReply({
+      audit,
+      remediation: appliedRemediation,
+      publishStatus: 'success',
+      runUrl: RUN,
+    }),
+    buildVlnReviewReply({ audit, runUrl: RUN }),
+    buildExternalContributorReply({ audit, runUrl: RUN }),
+  ]) {
+    assert.equal(countRunLinks(reply), 1);
+    const contexts = reply.blocks.filter((b) => b.type === 'context');
+    assert.equal(contexts.length, 1);
+    assert.equal(blockTypes(reply).at(-1), 'context');
+    assert.match(JSON.stringify(contexts[0]), /runs\/99/);
+  }
+});
+
+test('names the package, the range, and the resolved version', () => {
+  const reply = buildDependencySecurityReply({
+    audit,
+    remediation: appliedRemediation,
+    publishStatus: 'success',
+    runUrl: RUN,
+  });
+  const rendered = blockText(reply);
+  assert.match(rendered, /protobufjs/);
+  assert.match(rendered, /\^7\.5\.5/);
+  assert.match(rendered, /\^7\.6\.5/);
+  assert.match(rendered, /7\.6\.5/);
+  assert.match(rendered, /3846/);
+});
+
+test('separates the decision list from the applied change', () => {
+  const reply = buildDependencySecurityReply({
+    audit,
+    remediation: appliedRemediation,
+    publishStatus: 'success',
+    runUrl: RUN,
+  });
+  assert.ok(blockTypes(reply).includes('divider'));
+});
+
+test('keeps the actionable flag out of the Slack payload it writes', async () => {
+  const { mkdtemp, readFile, writeFile } = await import('node:fs/promises');
+  const { tmpdir } = await import('node:os');
+  const nodePath = await import('node:path');
+
+  const directory = await mkdtemp(nodePath.join(tmpdir(), 'weekly-digest-'));
+  const inputPath = nodePath.join(directory, 'audit.json');
+  const outputPath = nodePath.join(directory, 'digest.json');
+  await writeFile(inputPath, JSON.stringify(quietAudit));
+
+  const payload = await runDigestCli({
+    argv: [
+      '--module',
+      'vln-review',
+      '--input',
+      inputPath,
+      '--output',
+      outputPath,
+    ],
+    env: {},
+  });
+
+  assert.equal(payload.actionable, false);
+  const written = JSON.parse(await readFile(outputPath, 'utf8'));
+  assert.equal(written.actionable, undefined);
+  assert.ok(Array.isArray(written.blocks));
+  assert.equal(typeof written.text, 'string');
+});
+
+test('names the published pull request by number when only its URL is known', () => {
+  const reply = buildDependencySecurityReply({
+    audit: { ...quietAudit, dependabot: { openAlertCount: 3 } },
+    publishStatus: 'success',
+    runUrl: RUN,
+    remediation: {
+      summary: { actions: 1, manual: 0, unsupported: 0, alreadySafe: 0 },
+      applied: true,
+      pullRequestUrl: 'https://github.com/temporalio/ui/pull/3846',
+      actions: [
+        {
+          packageName: 'protobufjs',
+          alertIds: [338],
+          type: 'pnpm-override',
+          from: '^7.5.5',
+          to: '^7.6.5',
+        },
+      ],
+      classifications: [],
+    },
+  });
+  assert.match(JSON.stringify(reply.blocks), /#3846/);
+  assert.doesNotMatch(
+    JSON.stringify(reply.blocks),
+    /view draft remediation PR/,
+  );
 });

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -786,3 +786,52 @@ test('still escapes formatting inside a package name', () => {
     .join('\n');
   assert.match(rendered, /\u200B\*/);
 });
+
+test('links the omitted items to where a reader can see them', () => {
+  const external = buildExternalContributorReply({
+    audit: {
+      ...audit,
+      repository: 'temporalio/ui',
+      externalContributors: {
+        reviewReady: [],
+        triage: longTitlePullRequests,
+        triageCount: 20,
+        authorFollowup: [],
+        staleCount: 0,
+      },
+    },
+    runUrl: RUN,
+  });
+  const externalText = JSON.stringify(external.blocks);
+  assert.match(externalText, /temporalio\/ui\/pulls/);
+  assert.match(externalText, /and 17 more/);
+
+  const vln = buildVlnReviewReply({
+    audit: {
+      ...audit,
+      repository: 'temporalio/ui',
+      vln: { pending: longTitlePullRequests, needsTriage: [] },
+    },
+    runUrl: RUN,
+  });
+  assert.match(JSON.stringify(vln.blocks), /temporalio\/ui\/pulls\?q=/);
+
+  const dependency = buildDependencySecurityReply({
+    audit: auditWithAlerts,
+    remediation: {
+      summary: { actions: 0, manual: 12, unsupported: 0, alreadySafe: 0 },
+      applied: false,
+      actions: [],
+      classifications: Array.from({ length: 12 }, (_, index) => ({
+        packageName: `package-${index}`,
+        alertIds: [index],
+        status: 'manual',
+        reason: 'needs a person',
+      })),
+    },
+  });
+  assert.match(
+    JSON.stringify(dependency.blocks),
+    /security\/dependabot\?q=is%3Aopen/,
+  );
+});

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -180,9 +180,9 @@ test('builds external contributor replies by action bucket with stale count', ()
     threadTs: '172345.000001',
   });
   assert.equal(reply.channel, 'C123');
-  assert.match(reply.text, /Ready for review/);
+  assert.match(reply.text, /READY FOR REVIEW/);
   assert.match(reply.text, /#14: Community fix/);
-  assert.match(reply.text, /Waiting on author/);
+  assert.match(reply.text, /WAITING ON AUTHOR/);
   assert.match(reply.text, /2 external PRs have not been updated in 14\+ days/);
 });
 
@@ -602,5 +602,177 @@ test('folds the omitted count into the group it belongs to', () => {
     (block) => block.type === 'section' && /more/.test(block.text.text),
   );
   assert.equal(withCount.length, 1);
-  assert.match(withCount[0].text.text, /Needs triage/);
+  assert.match(withCount[0].text.text, /NEED TRIAGE/);
+});
+
+const auditWithAlerts = {
+  repository: 'temporalio/ui',
+  run: { url: RUN },
+  dependabot: {
+    openAlertCount: 5,
+    alerts: [
+      {
+        number: 338,
+        severity: 'medium',
+        url: 'https://github.com/temporalio/ui/security/dependabot/338',
+        package: 'protobufjs',
+      },
+      {
+        number: 300,
+        severity: 'high',
+        url: 'https://github.com/temporalio/ui/security/dependabot/300',
+        package: 'protobufjs',
+      },
+      {
+        number: 299,
+        severity: 'medium',
+        url: 'https://github.com/temporalio/ui/security/dependabot/299',
+        package: 'protobufjs',
+      },
+      {
+        number: 295,
+        severity: 'high',
+        url: 'https://github.com/temporalio/ui/security/dependabot/295',
+        package: '@grpc/grpc-js',
+      },
+      {
+        number: 294,
+        severity: 'high',
+        url: 'https://github.com/temporalio/ui/security/dependabot/294',
+        package: '@grpc/grpc-js',
+      },
+    ],
+  },
+  remediation: null,
+  vln: { pending: [], needsTriage: [] },
+  externalContributors: {
+    reviewReady: [],
+    triage: [],
+    authorFollowup: [],
+    staleCount: 0,
+  },
+};
+
+const richRemediation = {
+  summary: { actions: 1, manual: 1, unsupported: 0, alreadySafe: 0 },
+  applied: true,
+  resolver: 'deterministic-planner',
+  pullRequestUrl: 'https://github.com/temporalio/ui/pull/3846',
+  actions: [
+    {
+      packageName: 'protobufjs',
+      alertIds: [338, 300, 299],
+      type: 'pnpm-override',
+      from: '^7.5.5',
+      to: '^7.6.5',
+    },
+  ],
+  classifications: [
+    {
+      packageName: '@grpc/grpc-js',
+      alertIds: [295, 294],
+      status: 'manual',
+      reason: 'no existing pnpm override',
+      resolvedVersions: ['1.14.3'],
+    },
+  ],
+  verification: {
+    verified: true,
+    alerts: [
+      { alertId: 338, packageName: 'protobufjs', resolvedVersions: ['7.6.5'] },
+    ],
+  },
+};
+
+const richReply = () =>
+  buildDependencySecurityReply({
+    audit: auditWithAlerts,
+    remediation: richRemediation,
+    publishStatus: 'success',
+    runUrl: RUN,
+  });
+
+test('links every alert number to its GitHub security page', () => {
+  const rendered = JSON.stringify(richReply().blocks);
+  for (const number of [338, 300, 299]) {
+    assert.ok(
+      rendered.includes(`security/dependabot/${number}|${number}`),
+      `alert ${number} is not linked to its advisory page`,
+    );
+  }
+});
+
+test('lays the change out as section fields', () => {
+  const withFields = richReply().blocks.filter((block) =>
+    Array.isArray(block.fields),
+  );
+  assert.equal(withFields.length, 1);
+  const fields = withFields[0].fields;
+  assert.ok(fields.length % 2 === 0);
+  assert.ok(fields.length <= 10);
+  const labels = fields
+    .filter((_, index) => index % 2 === 0)
+    .map((f) => f.text);
+  assert.deepEqual(labels, ['*Change*', '*Resolves to*', '*Alerts*']);
+  for (const field of fields) {
+    assert.equal(field.type, 'mrkdwn');
+    assert.ok(field.text.length <= 2_000);
+  }
+});
+
+test('leads a group with its highest severity and a count', () => {
+  const rendered = JSON.stringify(richReply().blocks);
+  assert.match(rendered, /2 HIGH/);
+  assert.match(rendered, /READY/);
+});
+
+test('renders a scoped package name as code, never as a mention', () => {
+  const reply = buildDependencySecurityReply({
+    audit: auditWithAlerts,
+    remediation: {
+      summary: { actions: 0, manual: 1, unsupported: 0, alreadySafe: 0 },
+      applied: false,
+      actions: [],
+      classifications: [
+        {
+          packageName: '@grpc/grpc-js',
+          alertIds: [295, 294],
+          status: 'manual',
+          reason: 'no existing pnpm override',
+        },
+      ],
+    },
+  });
+  const rendered = reply.blocks
+    .filter((block) => block.type === 'section')
+    .map((block) => block.text.text)
+    .join('\n');
+
+  assert.ok(rendered.includes('`@grpc/grpc-js`'));
+  // A zero-width space before the backtick would stop Slack rendering code.
+  assert.doesNotMatch(rendered, /\u200B`@grpc/);
+});
+
+test('still escapes formatting inside a package name', () => {
+  const reply = buildDependencySecurityReply({
+    audit: auditWithAlerts,
+    remediation: {
+      summary: { actions: 0, manual: 1, unsupported: 0, alreadySafe: 0 },
+      applied: false,
+      actions: [],
+      classifications: [
+        {
+          packageName: 'evil`*name*`',
+          alertIds: [295],
+          status: 'manual',
+          reason: 'check *this*',
+        },
+      ],
+    },
+  });
+  const rendered = reply.blocks
+    .filter((block) => block.type === 'section')
+    .map((block) => block.text.text)
+    .join('\n');
+  assert.match(rendered, /\u200B\*/);
 });

--- a/.github/scripts/weekly-dependency-security-digest.test.mjs
+++ b/.github/scripts/weekly-dependency-security-digest.test.mjs
@@ -570,16 +570,26 @@ test('keeps every list section short enough for Slack to render inline', () => {
     runUrl: RUN,
   });
 
-  // Slack hides the URL of a link, so measure what a reader sees.
+  // Slack hides the URL of a link, so measure what a reader sees. Slack
+  // collapses a whole message behind a Show more control, not one block, so
+  // the budget applies to the message. A reply of roughly 814 characters
+  // collapsed in run 32382088464.
   const visible = (text) => text.replaceAll(/<[^|>]+\|([^>]*)>/g, '$1');
-
-  for (const block of reply.blocks) {
-    if (block.type !== 'section') continue;
-    const shown = visible(block.text.text);
-    assert.ok(shown.length <= 600, `section shows ${shown.length} characters`);
-    for (const line of shown.split('\n')) {
-      assert.ok(line.length <= 120, `line shows ${line.length} characters`);
+  const shownText = (block) => {
+    if (block.type === 'divider') return '';
+    if (block.type === 'context') {
+      return block.elements.map((element) => visible(element.text)).join(' ');
     }
+    if (Array.isArray(block.fields)) {
+      return block.fields.map((field) => visible(field.text)).join(' ');
+    }
+    return visible(block.text.text);
+  };
+
+  const shown = reply.blocks.map(shownText).join('\n');
+  assert.ok(shown.length <= 600, `the reply shows ${shown.length} characters`);
+  for (const line of shown.split('\n')) {
+    assert.ok(line.length <= 120, `a line shows ${line.length} characters`);
   }
 });
 

--- a/.github/workflows/weekly-dependency-security-review.yml
+++ b/.github/workflows/weekly-dependency-security-review.yml
@@ -571,6 +571,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post dependency-security digest
+        # An unset value means the digest did not run, which is itself worth posting.
+        if: steps.payload.outputs.actionable != 'false'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage

--- a/.github/workflows/weekly-external-contributor-review.yml
+++ b/.github/workflows/weekly-external-contributor-review.yml
@@ -120,6 +120,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post external-contributor digest
+        # An unset value means the digest did not run, which is itself worth posting.
+        if: steps.payload.outputs.actionable != 'false'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -21,6 +21,11 @@ on:
         required: true
         default: C0BPXR260DA
         type: string
+      source_ref:
+        description: 'Revision the modules check out. Leave empty to use the revision this run was dispatched from.'
+        required: false
+        default: ''
+        type: string
 
 # The GitHub App token is scoped to the publishing job in the called workflow.
 # The workflow GITHUB_TOKEN never needs write access.
@@ -40,6 +45,7 @@ jobs:
       mode: ${{ steps.inputs.outputs.mode }}
       notify: ${{ steps.inputs.outputs.notify }}
       slack_channel: ${{ steps.inputs.outputs.slack_channel }}
+      source_ref: ${{ steps.inputs.outputs.source_ref }}
     steps:
       - id: inputs
         env:
@@ -47,6 +53,8 @@ jobs:
           REQUESTED_MODE: ${{ inputs.mode }}
           REQUESTED_NOTIFY: ${{ inputs.notify }}
           REQUESTED_SLACK_CHANNEL: ${{ inputs.slack_channel }}
+          REQUESTED_SOURCE_REF: ${{ inputs.source_ref }}
+          DISPATCH_REF: ${{ github.ref_name }}
           SCHEDULED_SLACK_CHANNEL: ${{ vars.ONCALL_FRONTEND_SLACK_CHANNEL }}
         run: |
           mode="$REQUESTED_MODE"
@@ -74,6 +82,11 @@ jobs:
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
           echo "notify=$notify" >> "$GITHUB_OUTPUT"
           echo "slack_channel=$slack_channel" >> "$GITHUB_OUTPUT"
+
+          # A run tests the revision it was dispatched from unless told otherwise.
+          source_ref="${REQUESTED_SOURCE_REF:-$DISPATCH_REF}"
+          if [ "$EVENT_NAME" = 'schedule' ]; then source_ref='main'; fi
+          echo "source_ref=$source_ref" >> "$GITHUB_OUTPUT"
 
   start-thread:
     needs: resolve-inputs
@@ -112,6 +125,7 @@ jobs:
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-dependency-security-review.yml
     with:
+      source_ref: ${{ needs.resolve-inputs.outputs.source_ref }}
       mode: ${{ needs.resolve-inputs.outputs.mode }}
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
       slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
@@ -126,6 +140,7 @@ jobs:
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-vln-review.yml
     with:
+      source_ref: ${{ needs.resolve-inputs.outputs.source_ref }}
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
       slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}
@@ -137,6 +152,7 @@ jobs:
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-external-contributor-review.yml
     with:
+      source_ref: ${{ needs.resolve-inputs.outputs.source_ref }}
       notify: ${{ needs.resolve-inputs.outputs.notify == 'true' }}
       slack_channel: ${{ needs.start-thread.outputs.slack_channel }}
       thread_ts: ${{ needs.start-thread.outputs.thread_ts }}

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -152,13 +152,18 @@ jobs:
         vln-review,
         external-contributor-review,
       ]
+    # Reports a module that did not succeed. A run where every module succeeded
+    # says nothing here, because each reply already carries its own outcome.
     if: >-
       always() &&
       needs.resolve-inputs.outputs.notify == 'true' &&
-      needs.start-thread.outputs.thread_ts != ''
+      needs.start-thread.outputs.thread_ts != '' &&
+      (needs.dependency-security.result != 'success' ||
+       needs.vln-review.result != 'success' ||
+       needs.external-contributor-review.result != 'success')
     runs-on: ubuntu-latest
     steps:
-      - name: Post module status
+      - name: Report the modules that did not succeed
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage
@@ -167,4 +172,4 @@ jobs:
           payload: |
             channel: "${{ needs.start-thread.outputs.slack_channel }}"
             thread_ts: "${{ needs.start-thread.outputs.thread_ts }}"
-            text: "Weekly review finished. Dependency security: ${{ needs.dependency-security.result }}. VLN review: ${{ needs.vln-review.result }}. External contributors: ${{ needs.external-contributor-review.result }}."
+            text: ":warning: A module did not succeed. Dependency security: ${{ needs.dependency-security.result }}. VLN review: ${{ needs.vln-review.result }}. External contributors: ${{ needs.external-contributor-review.result }}. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -135,10 +135,8 @@ jobs:
       TEMPORAL_CICD_APP_ID: ${{ secrets.TEMPORAL_CICD_APP_ID }}
       TEMPORAL_CICD_PRIVATE_KEY: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
-  # Waits for the dependency reply so the thread always reads in the same order.
-  # The dependency module is the critical path already, so this costs seconds.
   vln-review:
-    needs: [resolve-inputs, start-thread, dependency-security]
+    needs: [resolve-inputs, start-thread]
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-vln-review.yml
     with:
@@ -150,7 +148,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   external-contributor-review:
-    needs: [resolve-inputs, start-thread, dependency-security]
+    needs: [resolve-inputs, start-thread]
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-external-contributor-review.yml
     with:

--- a/.github/workflows/weekly-oncall-review.yml
+++ b/.github/workflows/weekly-oncall-review.yml
@@ -135,8 +135,10 @@ jobs:
       TEMPORAL_CICD_APP_ID: ${{ secrets.TEMPORAL_CICD_APP_ID }}
       TEMPORAL_CICD_PRIVATE_KEY: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
 
+  # Waits for the dependency reply so the thread always reads in the same order.
+  # The dependency module is the critical path already, so this costs seconds.
   vln-review:
-    needs: [resolve-inputs, start-thread]
+    needs: [resolve-inputs, start-thread, dependency-security]
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-vln-review.yml
     with:
@@ -148,7 +150,7 @@ jobs:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   external-contributor-review:
-    needs: [resolve-inputs, start-thread]
+    needs: [resolve-inputs, start-thread, dependency-security]
     if: always() && needs.resolve-inputs.result == 'success'
     uses: ./.github/workflows/weekly-external-contributor-review.yml
     with:

--- a/.github/workflows/weekly-vln-review.yml
+++ b/.github/workflows/weekly-vln-review.yml
@@ -120,6 +120,8 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post VLN digest
+        # An unset value means the digest did not run, which is itself worth posting.
+        if: steps.payload.outputs.actionable != 'false'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           method: chat.postMessage


### PR DESCRIPTION
## Description & motivation 💭

The thread from run 32375869189 carried four replies. Two said nothing: one reported that no VLN pull request was pending, and one reported that all three modules succeeded. The same workflow run was linked four times, a pull request title was cut in the middle of a word behind a **Show more** control, and two high severity alerts read like ordinary text.

A message that usually says nothing teaches a reader to skip the message that matters.

### What posts now

```
DEPENDENCY SECURITY
`READY`  #3846 closes 3 alerts
Change        `protobufjs` `^7.5.5` → `^7.6.5`
Resolves to   7.6.5, verified after install
Alerts        338, 300, 299          ← each links to its advisory page
──────────────────────────────────────────────
`2 HIGH`  Needs a decision
• `@grpc/grpc-js` — Transitive package has no existing pnpm override
workflow run · the planner authored this change

(no VLN reply)

EXTERNAL CONTRIBUTOR PRS
`5 NEED TRIAGE`
• #3436: fix: unset splash screen color
• #3498: feat: improve local-temporal skill score (90% → 94%)
• #3717: feat: Add server-side column sorting to the workflows table.
• …and 2 more                        ← links to the open pull requests
──────────────────────────────────────────────
`13 WAITING ON AUTHOR`
• #2271: Improve UX: Forbidden requests should not redirect to login page…
• #2725: Oauth additional claims2
• #3008: feat: Add "Contains" filter option to workflow search UI for sub…
• …and 10 more
workflow run · 15 PRs idle for 14+ days
```

`Resolves to` appears once a run has applied and verified a change. A dry run has no verified version to report.

### Each module decides whether a person must act

| module | acts when |
| -- | -- |
| dependency | an authorized change, a classification that waits on a person, an alert over an already patched tree, or a failed publication |
| VLN | a pending or untriaged pull request |
| external | a pull request in any of the three groups. A stale count alone is context, not work |

An unset value still posts, because a digest that did not run is worth reporting. The closing job now reports only a module that did not succeed.

### The replies use Block Kit

Every reply was one markdown string that a splitter chunked at 3000 characters. That single fact caused most of what looked clunky.

- A `header` block names the module. A `divider` separates each group. One `context` block at the end holds the run link, which appeared four times before.
- The change uses the `fields` of a section, which Slack lays out as a label and value grid.
- Every alert number links to its advisory page. The audit already held each alert URL and severity, so no extra API call was needed.
- A badge is a code span, because Slack holds no badge primitive. The client draws a code span as a small bordered chip, the same shape it already gives a version, a package name, and the mode in the root message. A severity badge names the worst severity across the alerts of a group and how many carry it.
- Each overflow line links to the page that holds the full list: the open Dependabot alerts, the open pull requests that name VLN, or the open pull requests.

### Two measurements that changed the design

**Slack collapses a message, not a block.** The first attempt budgeted each section and the lists still collapsed. The external reply held about 814 visible characters. A list item repeated a status that its group badge already named, so the line

```
#2271: Improve UX ... — review requested, conflicting, checks none
```

now reads

```
#2271: Improve UX ...
```

That takes the external reply to 489 visible characters and the dependency reply to 360. The test measures the whole message against a budget of 600.

**A package name must be wrapped, and escaped first.** Slack rendered `@grpc/grpc-js` as a mention. Backticks fix that, but `escapeSlackMrkdwn` puts a zero width space before every backtick on purpose, so a pull request title cannot carry formatting. The name is therefore escaped first and wrapped after. Two tests hold both halves: the scoped name renders as code, and a name holding an asterisk is still escaped.

### One decision worth confirming

An `alreadySafe` classification means Dependabot holds an alert open over a tree that is already patched, so a person should dismiss the alert. This counts as actionable. Say so if you would rather those stay quiet.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

99 tests pass, up from 77. Prettier and ESLint report no problem. All four workflow files parse.

The thread was posted to a test channel from this branch four times, and each round corrected a fault the render exposed. That was possible because of one more change in this pull request: the coordinator never passed `source_ref`, so a run dispatched from a branch used the branch workflow files with the scripts from `main`. It now runs the revision it was dispatched from, and a dispatch from `main` behaves as before.

The builders were also rendered against the evidence from runs 32375869189 and 32301219841. The output above is that render.

Assertions that changed, each because the behavior changed on purpose: `section` to `header` as the first block, the generic pull request label to its number, the group heading to a badge, and the two length checks generalized to understand every block type and to measure visible text rather than raw markup.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Run **Weekly On-Call Review** with the mode `dry-run` and the channel `C0BPXR260DA`. The VLN reply should be absent while no VLN pull request is pending.

## Checklists

### Merge Checklist

- [ ] Confirm the thread holds no VLN reply on a quiet week.
- [ ] Confirm the root message still posts. Suppressing it on a fully quiet run needs the coordinator to decide before it posts, which is the remaining part of UI-142.

### Issue(s) closed

Part of UI-142 and part of UI-138.

## Docs

### Any docs updates needed?

No. `.github/WORKFLOWS.md` does not describe the reply layout.
