### PR TITLE
ci: run the on-call review test only for an on-call change

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -417,13 +417,20 @@ fail-safe: it uses `dry-run` mode and `ONCALL_FRONTEND_SLACK_CHANNEL`.
 `notify: false` runs the audits without posting to Slack.
 
 A separate `weekly-oncall-review-pr-test.yml` workflow validates internal pull
-requests that change the on-call workflows, their dependency-security scripts
-or tests, `package.json`, or `pnpm-lock.yaml`. It checks out the PR head SHA and
-runs the dependency module in `dry-run` mode plus the VLN and external-review
-audits. Fork and Dependabot pull requests are skipped. The PR workflow passes
-no stored repository secrets and disables every notification path, so it
-validates the audit and remediation logic without posting to Slack or
-publishing changes.
+requests that change the on-call workflows or the scripts and tests they use. It
+does not run for a change to `package.json` or `pnpm-lock.yaml`, because
+`lint-and-test.yml` and `playwright.yml` already validate a dependency change on
+every pull request. It checks out the PR head SHA and runs the dependency module
+in `dry-run` mode plus the VLN and external-review audits. Fork and Dependabot
+pull requests are skipped. The PR workflow passes no stored repository secrets
+and disables every notification path, so it validates the audit and remediation
+logic without posting to Slack or publishing changes.
+
+The same workflow also holds a manual rehearsal. A `workflow_dispatch` run
+starts the dependency module in the mode you choose, including `apply`, and sets
+the `publish` input to false. The job that holds the GitHub App token therefore
+does not run, and no pull request is touched. The publish job also refuses a
+`pull_request` event, so the rehearsal has two independent guards.
 
 After merging, use a manual `dry-run` dispatch to the default test channel
 `C0BPXR260DA` when Slack delivery itself needs validation.

--- a/.github/workflows/weekly-oncall-review-pr-test.yml
+++ b/.github/workflows/weekly-oncall-review-pr-test.yml
@@ -27,8 +27,7 @@ on:
       - .github/scripts/verify-weekly-dependency-remediation.test.mjs
       - .github/scripts/weekly-dependency-security-digest.mjs
       - .github/scripts/weekly-dependency-security-digest.test.mjs
-      - package.json
-      - pnpm-lock.yaml
+      - .github/scripts/slack-utils.mjs
 
 permissions:
   contents: read

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "validate:versions": "./scripts/validate-versions.sh",
     "knip": "knip",
     "a11y:manifest:test": "node scripts/a11y/manifest.test.mjs",
-    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/validate-claude-dependency-remediation.test.mjs .github/scripts/verify-weekly-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
+    "test:github-automation": "node --test .github/scripts/weekly-dependency-security-audit.test.mjs .github/scripts/apply-weekly-dependency-remediation.test.mjs .github/scripts/verify-weekly-dependency-remediation.test.mjs .github/scripts/weekly-dependency-security-digest.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.18.7",


### PR DESCRIPTION
## Description & motivation 💭

The on-call review test ran on every dependency change.

```diff
  paths:
    - .github/workflows/weekly-oncall-review.yml
    ...
    - .github/scripts/weekly-dependency-security-digest.test.mjs
+   - .github/scripts/slack-utils.mjs
-   - package.json
-   - pnpm-lock.yaml
```

`package.json` and `pnpm-lock.yaml` were in the filter, so every Dependabot pull request and the weekly remediation pull request itself started three audit modules, a full install, the unit tests, the type check, the lint, and a server build.

That work proves nothing about the on-call review. `lint-and-test.yml` and `playwright.yml` already validate a dependency change on every pull request, and the weekly run validates the manifest against the live alerts. Pull request 3846, which changes only those two files, is the clearest example: it started the whole on-call suite for no signal.

`slack-utils.mjs` is added because no path covered it. `weekly-dependency-security-digest.mjs` imports it, so a change there changes the digest.

The three scripts for the review-notification workflows stay out. They belong to `pr-review-notification.yml` and `pr-review-reminder.yml`, not to the on-call review.

### A stale reference, found while checking the scripts

`test:github-automation` still named `validate-claude-dependency-remediation.test.mjs`, which #3845 deleted.

```
node --test <existing.test.mjs> <deleted.test.mjs>
# tests 32
# pass 32
# fail 0
exit=0
```

`node --test` ignores a path that does not exist and exits 0, so the command kept reporting success and the reference stayed invisible. That is my error in #3845: I reverted `package.json` to drop an unrelated local line and reverted this edit with it.

The script now names four files, and each one exists.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

The workflow file parses and prettier reports no problem. `pnpm test:github-automation` reports 77 tests passing against the four files it now names.

Each referenced path was checked against the filesystem, so a future deletion of a test file cannot hide again in the same way.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Open a pull request that changes only `package.json`. The **Weekly On-Call Review PR Test** checks should not appear. Open a pull request that changes any file the filter names, and they should.

## Checklists

### Merge Checklist

- [ ] Confirm a dependency-only pull request no longer starts the on-call suite.

### Issue(s) closed

None.

## Docs

### Any docs updates needed?

Yes, and they are in this change.

The document said the pull request test runs for a change to `package.json` or `pnpm-lock.yaml`. It now says that it does not, and why.

The document also never mentioned the manual rehearsal, which is the only way to exercise the apply path without publishing. A reader who wanted to test that path had no way to learn it exists. A new paragraph describes the dispatch, the `publish` input, and the two guards that keep it from touching a pull request.

Every claim in both paragraphs was checked against the workflow files rather than trusted:

| claim | holds |
| -- | -- |
| no `package.json` or `pnpm-lock.yaml` in the paths | yes |
| checks out the pull request head SHA | yes |
| the dependency module runs `dry-run` | yes |
| fork and Dependabot pull requests are skipped | yes |
| passes no stored secret | yes |
| every notification path is disabled | yes |
| the rehearsal sets `publish` to false | yes |
| the rehearsal accepts `apply` | yes |
| the publish job refuses a `pull_request` event | yes |
| the publish job requires the `publish` input | yes |
