### PR TITLE
feat(deployments): show worker deployment connection status by default

### DIFF
--- a/src/lib/components/deployments/deployment-client-test-runner-entry.ts
+++ b/src/lib/components/deployments/deployment-client-test-runner-entry.ts
@@ -50,7 +50,7 @@ export async function renderDeployment({
 }: {
   fetchDeployment: unknown;
   fetchDeploymentVersion: unknown;
-  showConnectionStatus: boolean;
+  showConnectionStatus?: boolean;
 }) {
   setPageState();
   resetDeploymentsServiceMock({ fetchDeployment, fetchDeploymentVersion });
@@ -59,7 +59,7 @@ export async function renderDeployment({
   mounted.push(
     mount(Deployment, {
       target,
-      props: { showConnectionStatus },
+      props: showConnectionStatus === undefined ? {} : { showConnectionStatus },
     }),
   );
   await Promise.resolve();
@@ -90,7 +90,7 @@ export function openMenu(controls: string) {
 
 export function renderRows({
   computeStatuses,
-  showConnectionStatus = false,
+  showConnectionStatus,
 }: {
   computeStatuses: Record<string, ComputeStatus>;
   showConnectionStatus?: boolean;
@@ -106,7 +106,9 @@ export function renderRows({
         props: {
           deployment: deployment(status.toLowerCase(), computeStatus),
           columns: [{ label: 'Current Version' }],
-          showConnectionStatus,
+          ...(showConnectionStatus === undefined
+            ? {}
+            : { showConnectionStatus }),
         },
       }),
     );

--- a/src/lib/components/deployments/deployment-table-row.svelte
+++ b/src/lib/components/deployments/deployment-table-row.svelte
@@ -35,7 +35,7 @@
   let {
     deployment,
     columns,
-    showConnectionStatus = false,
+    showConnectionStatus = true,
     onChange,
   }: Props = $props();
 

--- a/src/lib/components/deployments/deployment-table-row.svelte.test.ts
+++ b/src/lib/components/deployments/deployment-table-row.svelte.test.ts
@@ -77,24 +77,24 @@ describe('deployment list connection status visibility', () => {
 
   afterAll(closeDeploymentClientTestRunner);
 
-  test('keeps providers visible while hiding statuses by default and restores statuses when enabled', async () => {
-    const hidden = client.renderRows({ computeStatuses });
-
-    expect(hidden.textContent?.match(/Lambda/g)).toHaveLength(3);
-    for (const status of Object.keys(computeStatuses)) {
-      expect(hidden.textContent).not.toContain(status);
-    }
-
-    await client.cleanup();
-
-    const visible = client.renderRows({
-      computeStatuses,
-      showConnectionStatus: true,
-    });
+  test('shows every connection status alongside the provider by default', async () => {
+    const visible = client.renderRows({ computeStatuses });
 
     expect(visible.textContent?.match(/Lambda/g)).toHaveLength(3);
     for (const status of Object.keys(computeStatuses)) {
       expect(visible.textContent).toContain(status);
+    }
+  });
+
+  test('keeps providers visible while hiding statuses when the consumer opts out', async () => {
+    const hidden = client.renderRows({
+      computeStatuses,
+      showConnectionStatus: false,
+    });
+
+    expect(hidden.textContent?.match(/Lambda/g)).toHaveLength(3);
+    for (const status of Object.keys(computeStatuses)) {
+      expect(hidden.textContent).not.toContain(status);
     }
   });
 });

--- a/src/lib/components/deployments/validate-connection-modal.svelte
+++ b/src/lib/components/deployments/validate-connection-modal.svelte
@@ -2,13 +2,18 @@
   import Button from '$lib/holocene/button.svelte';
   import Modal from '$lib/holocene/modal.svelte';
   import { translate } from '$lib/i18n/translate';
-  import { IconCheckCircleSolid, IconWarning } from '$lib/io/icon';
+  import {
+    IconCheckCircleSolid,
+    IconQuestionCircle,
+    IconWarning,
+  } from '$lib/io/icon';
+  import type { ValidationOutcome } from '$lib/utilities/connection-status';
 
   interface Props {
     buildId: string;
     open: boolean;
     loading: boolean;
-    result: { message?: string } | null;
+    result: ValidationOutcome | null;
     onClose: () => void;
     onRetry: () => void;
   }
@@ -22,9 +27,27 @@
     onRetry,
   }: Props = $props();
 
-  const isValid = $derived(!result?.message);
+  const state = $derived(result?.state);
 
-  const Glyph = $derived(isValid ? IconCheckCircleSolid : IconWarning);
+  const Glyph = $derived.by(() => {
+    if (state === 'valid') return IconCheckCircleSolid;
+    if (state === 'invalid') return IconWarning;
+    return IconQuestionCircle;
+  });
+
+  const tone = $derived.by(() => {
+    if (state === 'valid') return 'text-success';
+    if (state === 'invalid') return 'text-danger';
+    return 'text-secondary';
+  });
+
+  const heading = $derived.by(() => {
+    if (state === 'valid')
+      return translate('deployments.validate-connection-valid');
+    if (state === 'invalid')
+      return translate('deployments.validate-connection-invalid');
+    return translate('deployments.validate-connection-incomplete');
+  });
 </script>
 
 <Modal
@@ -62,22 +85,19 @@
         </div>
       {:else if result}
         <div class="flex items-start gap-2">
-          <Glyph
-            class="mt-0.5 h-4 w-4 shrink-0 {isValid
-              ? 'text-success'
-              : 'text-danger'}"
-          />
+          <Glyph class="mt-0.5 h-4 w-4 shrink-0 {tone}" />
           <div class="flex flex-col gap-1">
-            <p
-              class="text-sm font-medium {isValid
-                ? 'text-success'
-                : 'text-danger'}"
-            >
-              {isValid
-                ? translate('deployments.validate-connection-valid')
-                : translate('deployments.validate-connection-invalid')}
+            <p class="text-sm font-medium {tone}">
+              {heading}
             </p>
-            {#if result.message}
+            {#if state === 'indeterminate'}
+              <p class="text-xs text-secondary">
+                {translate(
+                  'deployments.validate-connection-incomplete-description',
+                )}
+              </p>
+            {/if}
+            {#if result.state !== 'valid' && result.message}
               <p class="text-xs text-secondary">{result.message}</p>
             {/if}
           </div>

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -20,6 +20,10 @@
     type RoutingConfig,
     type VersionSummary,
   } from '$lib/types/deployments';
+  import {
+    resolveValidationOutcome,
+    type ValidationOutcome,
+  } from '$lib/utilities/connection-status';
   import { parseVersionStatus } from '$lib/utilities/deployments';
   import {
     getBuildIdFromVersion,
@@ -177,7 +181,7 @@
   let deleteVersionError = $state('');
   let showValidateModal = $state(false);
   let validateLoading = $state(false);
-  let validateResult = $state<{ message?: string } | null>(null);
+  let validateResult = $state<ValidationOutcome | null>(null);
   let showSetRampingModal = $state(false);
   let setRampingError = $state('');
   let setRampingLoading = $state(false);
@@ -190,27 +194,24 @@
     validateLoading = true;
     showValidateModal = true;
     try {
-      let errorMessage: string | undefined;
+      let outcome: ValidationOutcome | undefined;
       await validateCurrentWorkerDeploymentVersionComputeConfig(
         { namespace, deploymentName, buildId: versionBuildId },
         (error) => {
-          errorMessage =
-            (error.body as { message?: string })?.message ??
-            translate('deployments.validate-connection-error');
+          outcome = resolveValidationOutcome(error);
         },
       );
-      validateResult = { message: errorMessage };
-
-      // A handled provider error still completes validation and may update the
-      // persisted connection status, so refresh once for either resolved result.
-      onValidationComplete?.();
+      validateResult = outcome ?? { state: 'valid' };
     } catch {
-      validateResult = {
-        message: translate('deployments.validate-connection-error'),
-      };
+      // A request that never returned tells us nothing about the connection.
+      validateResult = { state: 'indeterminate' };
     } finally {
       validateLoading = false;
     }
+
+    // A completed check persists the connection status, and a check that did
+    // not return to us can still finish, so refresh for every outcome.
+    onValidationComplete?.();
   }
 
   async function handleSetCurrentVersion() {

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -58,7 +58,7 @@
     namespace,
     deploymentName,
     conflictToken,
-    showConnectionStatus = false,
+    showConnectionStatus = true,
     onChange,
     onValidationComplete,
   }: Props = $props();

--- a/src/lib/components/deployments/version-table-row.svelte
+++ b/src/lib/components/deployments/version-table-row.svelte
@@ -23,6 +23,8 @@
   import {
     resolveValidationOutcome,
     type ValidationOutcome,
+    versionComputeProviderType,
+    versionShowsConnectionStatus,
   } from '$lib/utilities/connection-status';
   import { parseVersionStatus } from '$lib/utilities/deployments';
   import {
@@ -133,19 +135,10 @@
   }
   const statusLabel = $derived(resolveVersionStatusLabel());
 
-  const computeScalingGroup = $derived(
-    isVersionSummaryNew(version) && version.computeConfig
-      ? Object.values(version.computeConfig.scalingGroups ?? {})[0]
-      : undefined,
-  );
-  const computeProviderType = $derived(
-    computeScalingGroup?.providerType ?? computeScalingGroup?.provider?.type,
-  );
+  const computeProviderType = $derived(versionComputeProviderType(version));
 
   const connectionVisible = $derived(
-    isCurrent ||
-      isRamping ||
-      parseVersionStatus(drainageStatus).status === 'Draining',
+    versionShowsConnectionStatus(version, routingConfig),
   );
 
   const workflowHref = $derived(
@@ -369,7 +362,7 @@
   </td>
   {#if showConnectionStatus}
     <td class="text-left">
-      {#if connectionVisible && isVersionSummaryNew(version) && computeProviderType}
+      {#if connectionVisible && isVersionSummaryNew(version)}
         <ConnectionBadge computeStatus={version.computeStatus} />
       {:else}
         <span class="text-secondary">—</span>

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -144,7 +144,7 @@ export const Strings = {
   'connection-failed': 'Failed',
   'connection-pending': 'Pending',
   'connection-tooltip-pending':
-    'Not validated yet. First automatic check runs within 6h.',
+    'Not validated yet. The first automatic check runs within 6h. To check now, use Validate Connection.',
   'connection-tooltip-checked': 'Checked {{ time }}',
   'connection-checked-recently': 'less than an hour ago',
   'connection-checked-hour': '{{ hours }} hour ago',

--- a/src/lib/i18n/locales/en/deployments.ts
+++ b/src/lib/i18n/locales/en/deployments.ts
@@ -117,6 +117,9 @@ export const Strings = {
   'validate-connection-error': 'Failed to validate connection',
   'validate-connection-valid': 'Connection is valid',
   'validate-connection-invalid': 'Connection is invalid',
+  'validate-connection-incomplete': 'Could not complete the check',
+  'validate-connection-incomplete-description':
+    'The connection status is unknown. The check can still complete in the background. Retry, or refresh to see the current status.',
   'validate-connection-no-task-queue':
     "This Worker Deployment Version's Task Queue is not registered. The serverless function may be failing after invocation. Check the function for configuration or runtime errors, then re-run it from your cloud provider's console. Alternatively, create a new Version to retry.",
   'validate-connection-no-task-queue-pending':

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -27,7 +27,7 @@
     showConnectionStatus?: boolean;
   }
 
-  let { showInstancesLink = true, showConnectionStatus = false }: Props =
+  let { showInstancesLink = true, showConnectionStatus = true }: Props =
     $props();
 
   const { namespace } = $derived(page.params);

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -18,6 +18,7 @@
     setRampingUnversionedWorkers,
   } from '$lib/services/deployments-service';
   import type { DescribeWorkerDeploymentResponse } from '$lib/types/deployments';
+  import { deploymentShowsConnectionStatus } from '$lib/utilities/connection-status';
   import { deploymentHasComputeConfig } from '$lib/utilities/deployment-has-compute-config';
   import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
   import { routeForWorkerDeployments } from '$lib/utilities/route-for';
@@ -131,6 +132,8 @@
   {/if}
   {@const info = deployment.workerDeploymentInfo}
   {@const hasComputeConfig = deploymentHasComputeConfig(info)}
+  {@const connectionColumnVisible =
+    showConnectionStatus && deploymentShowsConnectionStatus(info)}
   {@const unversionedRampingPercentage =
     !info.routingConfig?.rampingDeploymentVersion &&
     info.routingConfig?.rampingVersionPercentage != null
@@ -179,7 +182,7 @@
           <th>{translate('deployments.build-id')}</th>
           <th>{translate('deployments.lifecycle')}</th>
           <th>{translate('deployments.compute')}</th>
-          {#if showConnectionStatus}
+          {#if connectionColumnVisible}
             <th>{translate('deployments.connection')}</th>
           {/if}
           <th>{translate('deployments.deployed')}</th>
@@ -194,7 +197,7 @@
             {namespace}
             {deploymentName}
             conflictToken={deployment.conflictToken}
-            {showConnectionStatus}
+            showConnectionStatus={connectionColumnVisible}
             onChange={reload}
             onValidationComplete={reload}
           />

--- a/src/lib/pages/deployment.svelte.test.ts
+++ b/src/lib/pages/deployment.svelte.test.ts
@@ -49,6 +49,36 @@ const deployment = {
   },
 } satisfies DescribeWorkerDeploymentResponse;
 
+const pendingDeployment = {
+  conflictToken: 'token',
+  workerDeploymentInfo: {
+    name: 'deployment',
+    createTime: '',
+    routingConfig: {
+      currentDeploymentVersion: {
+        deploymentName: 'deployment',
+        buildId: 'build-id',
+      },
+    },
+    lastModifierIdentity: 'test',
+    versionSummaries: [
+      {
+        version: 'deployment.build-id',
+        createTime: '',
+        deploymentVersion: {
+          deploymentName: 'deployment',
+          buildId: 'build-id',
+        },
+        status: 'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+        computeConfig: {
+          scalingGroups: { default: { providerType: 'aws-lambda' } },
+        },
+        computeStatus: { providerValidation: {} },
+      },
+    ],
+  },
+} satisfies DescribeWorkerDeploymentResponse;
+
 const selfHostedDeployment = {
   conflictToken: 'token',
   workerDeploymentInfo: {
@@ -149,20 +179,19 @@ describe('deployment connection status visibility', () => {
 
   afterAll(closeDeploymentClientTestRunner);
 
-  test('hides the connection header and cell by default', async () => {
+  test('renders the connection header and cell by default', async () => {
     const target = await client.renderDeployment({
       fetchDeployment: deployment,
       fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
-      showConnectionStatus: false,
     });
 
     expect(target.querySelector('th:nth-child(4)')?.textContent).toBe(
-      'Deployed At',
+      'Connection',
     );
-    expect(target.textContent).not.toContain('Connected');
+    expect(target.textContent).toContain('Connected');
     const details = client.expandDetails(target);
     expect(details).not.toBeNull();
-    expect(details?.getAttribute('colspan')).toBe('5');
+    expect(details?.getAttribute('colspan')).toBe('6');
   });
 
   test('renders the matching connection header and cell when enabled', async () => {
@@ -179,6 +208,35 @@ describe('deployment connection status visibility', () => {
     const details = client.expandDetails(target);
     expect(details).not.toBeNull();
     expect(details?.getAttribute('colspan')).toBe('6');
+  });
+
+  test('hides the connection header and cell when the consumer opts out', async () => {
+    const target = await client.renderDeployment({
+      fetchDeployment: deployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+      showConnectionStatus: false,
+    });
+
+    expect(target.querySelector('th:nth-child(4)')?.textContent).toBe(
+      'Deployed At',
+    );
+    expect(target.textContent).not.toContain('Connected');
+    const details = client.expandDetails(target);
+    expect(details).not.toBeNull();
+    expect(details?.getAttribute('colspan')).toBe('5');
+  });
+
+  test('shows the pending connection state for a version with no completed check', async () => {
+    const target = await client.renderDeployment({
+      fetchDeployment: pendingDeployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+    });
+
+    expect(target.querySelector('th:nth-child(4)')?.textContent).toBe(
+      'Connection',
+    );
+    expect(target.textContent).toContain('Pending');
+    expect(target.textContent).not.toContain('Connected');
   });
 
   test('shows compute-only deployment and version actions for deployments with compute config', async () => {

--- a/src/lib/pages/deployment.svelte.test.ts
+++ b/src/lib/pages/deployment.svelte.test.ts
@@ -226,6 +226,19 @@ describe('deployment connection status visibility', () => {
     expect(details?.getAttribute('colspan')).toBe('5');
   });
 
+  test('hides the connection column for a self-hosted deployment', async () => {
+    const target = await client.renderDeployment({
+      fetchDeployment: selfHostedDeployment,
+      fetchDeploymentVersion: { workerDeploymentVersionInfo: {} },
+    });
+
+    expect(
+      Array.from(target.querySelectorAll('th')).map((th) => th.textContent),
+    ).toEqual(['Build ID', 'Lifecycle', 'Compute', 'Deployed At', 'Actions']);
+    const details = client.expandDetails(target);
+    expect(details).toBeNull();
+  });
+
   test('shows the pending connection state for a version with no completed check', async () => {
     const target = await client.renderDeployment({
       fetchDeployment: pendingDeployment,

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -27,7 +27,7 @@
 
   let {
     canCreateServerlessDeployment = true,
-    showConnectionStatus = false,
+    showConnectionStatus = true,
   }: Props = $props();
 
   let error = $state('');

--- a/src/lib/utilities/connection-status.test.ts
+++ b/src/lib/utilities/connection-status.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   deriveConnectionStatus,
   formatConnectionCheckTime,
+  resolveValidationOutcome,
 } from './connection-status';
 
 describe('deriveConnectionStatus', () => {
@@ -91,5 +92,54 @@ describe('formatConnectionCheckTime', () => {
     expect(formatConnectionCheckTime(new Date('invalid'))).toBe(
       'less than an hour ago',
     );
+  });
+});
+
+describe('resolveValidationOutcome', () => {
+  const body = (message?: string) =>
+    ({ code: 3, message, details: [] }) as never;
+
+  it('treats an InvalidArgument as a verdict and keeps the server message', () => {
+    expect(
+      resolveValidationOutcome({ status: 400, body: body('Role not assumed') }),
+    ).toEqual({ state: 'invalid', message: 'Role not assumed' });
+  });
+
+  it('falls back to generic copy for an InvalidArgument with no message', () => {
+    expect(resolveValidationOutcome({ status: 400, body: body() })).toEqual({
+      state: 'invalid',
+      message: 'Failed to validate connection',
+    });
+  });
+
+  it('does not call a gateway timeout invalid', () => {
+    expect(
+      resolveValidationOutcome({ status: 504, body: body('Gateway Timeout') }),
+    ).toEqual({ state: 'indeterminate', message: 'Gateway Timeout' });
+  });
+
+  it.each([500, 502, 503, 504])(
+    'reports %i as indeterminate rather than invalid',
+    (status) => {
+      expect(resolveValidationOutcome({ status, body: body() }).state).toBe(
+        'indeterminate',
+      );
+    },
+  );
+
+  it.each([401, 403, 404, 429])(
+    'reports %i as indeterminate because it is not a connection verdict',
+    (status) => {
+      expect(resolveValidationOutcome({ status, body: body() }).state).toBe(
+        'indeterminate',
+      );
+    },
+  );
+
+  it('drops an empty message rather than showing a blank line', () => {
+    expect(resolveValidationOutcome({ status: 504, body: body('') })).toEqual({
+      state: 'indeterminate',
+      message: undefined,
+    });
   });
 });

--- a/src/lib/utilities/connection-status.test.ts
+++ b/src/lib/utilities/connection-status.test.ts
@@ -1,10 +1,247 @@
 import { describe, expect, it } from 'vitest';
 
+import type {
+  DescribeWorkerDeployment,
+  VersionSummary,
+} from '$lib/types/deployments';
+
 import {
+  deploymentShowsConnectionStatus,
   deriveConnectionStatus,
   formatConnectionCheckTime,
   resolveValidationOutcome,
+  versionShowsConnectionStatus,
 } from './connection-status';
+
+const computeVersion = (
+  buildId: string,
+  status: string,
+  scalingGroups: Record<string, unknown> = {
+    default: { providerType: 'aws-lambda' },
+  },
+): VersionSummary =>
+  ({
+    version: `deployment.${buildId}`,
+    createTime: '',
+    deploymentVersion: { deploymentName: 'deployment', buildId },
+    status,
+    computeConfig: { scalingGroups },
+  }) as VersionSummary;
+
+const selfHostedVersion = (buildId: string, status: string): VersionSummary =>
+  ({
+    version: `deployment.${buildId}`,
+    createTime: '',
+    deploymentVersion: { deploymentName: 'deployment', buildId },
+    status,
+  }) as VersionSummary;
+
+const describeDeployment = (
+  versionSummaries: VersionSummary[],
+  currentBuildId?: string,
+): DescribeWorkerDeployment =>
+  ({
+    name: 'deployment',
+    createTime: '',
+    lastModifierIdentity: 'test',
+    routingConfig: currentBuildId
+      ? {
+          currentDeploymentVersion: {
+            deploymentName: 'deployment',
+            buildId: currentBuildId,
+          },
+        }
+      : {},
+    versionSummaries,
+  }) as DescribeWorkerDeployment;
+
+describe('versionShowsConnectionStatus', () => {
+  it('shows the status for the current compute-backed version', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion('build-id', 'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT'),
+        {
+          currentDeploymentVersion: {
+            deploymentName: 'deployment',
+            buildId: 'build-id',
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('shows the status for the ramping compute-backed version', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion('build-id', 'WORKER_DEPLOYMENT_VERSION_STATUS_RAMPING'),
+        {
+          rampingDeploymentVersion: {
+            deploymentName: 'deployment',
+            buildId: 'build-id',
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it('shows the status for a draining compute-backed version', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion('build-id', 'WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING'),
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it('hides the status for an inactive version no longer routed to', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion('build-id', 'WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE'),
+        {},
+      ),
+    ).toBe(false);
+  });
+
+  it('hides the status for a self-hosted current version', () => {
+    expect(
+      versionShowsConnectionStatus(
+        selfHostedVersion(
+          'build-id',
+          'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+        ),
+        {
+          currentDeploymentVersion: {
+            deploymentName: 'deployment',
+            buildId: 'build-id',
+          },
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('hides the status when the scaling group names no provider', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion('build-id', 'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT', {
+          default: {},
+        }),
+        {
+          currentDeploymentVersion: {
+            deploymentName: 'deployment',
+            buildId: 'build-id',
+          },
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it('reads a provider from the nested provider field', () => {
+    expect(
+      versionShowsConnectionStatus(
+        computeVersion(
+          'build-id',
+          'WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING',
+          { default: { provider: { type: 'gcp-cloud-run' } } },
+        ),
+        {},
+      ),
+    ).toBe(true);
+  });
+
+  it('hides the status for a legacy version summary', () => {
+    expect(
+      versionShowsConnectionStatus(
+        {
+          version: 'deployment.build-id',
+          createTime: '',
+        } as VersionSummary,
+        {},
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('deploymentShowsConnectionStatus', () => {
+  it('returns false for an undefined deployment', () => {
+    expect(deploymentShowsConnectionStatus(undefined)).toBe(false);
+  });
+
+  it('returns false when every version is self-hosted', () => {
+    expect(
+      deploymentShowsConnectionStatus(
+        describeDeployment(
+          [
+            selfHostedVersion(
+              'build-id',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+            ),
+            selfHostedVersion(
+              'build-id-2',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE',
+            ),
+          ],
+          'build-id',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when the current version is compute-backed', () => {
+    expect(
+      deploymentShowsConnectionStatus(
+        describeDeployment(
+          [
+            computeVersion(
+              'build-id',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+            ),
+          ],
+          'build-id',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when only a draining version is compute-backed', () => {
+    expect(
+      deploymentShowsConnectionStatus(
+        describeDeployment(
+          [
+            selfHostedVersion(
+              'build-id',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+            ),
+            computeVersion(
+              'build-id-2',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_DRAINING',
+            ),
+          ],
+          'build-id',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when a compute-backed version is not routed to', () => {
+    expect(
+      deploymentShowsConnectionStatus(
+        describeDeployment(
+          [
+            selfHostedVersion(
+              'build-id',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_CURRENT',
+            ),
+            computeVersion(
+              'build-id-2',
+              'WORKER_DEPLOYMENT_VERSION_STATUS_CREATED',
+            ),
+          ],
+          'build-id',
+        ),
+      ),
+    ).toBe(false);
+  });
+});
 
 describe('deriveConnectionStatus', () => {
   it('returns pending for undefined computeStatus', () => {

--- a/src/lib/utilities/connection-status.ts
+++ b/src/lib/utilities/connection-status.ts
@@ -2,6 +2,7 @@ import { translate } from '$lib/i18n/translate';
 import type { ComputeStatus } from '$lib/types/deployments';
 import type { ValidTime } from '$lib/utilities/format-time';
 import { isTimestamp, timestampToDate } from '$lib/utilities/format-time';
+import type { APIErrorResponse } from '$lib/utilities/request-from-api';
 
 export type ConnectionState = 'pending' | 'connected' | 'failed';
 
@@ -61,4 +62,28 @@ export const connectionTooltip = (computeStatus?: ComputeStatus): string => {
   if (state === 'connected') return checked;
   const errorMessage = computeStatus?.providerValidation?.errorMessage ?? '';
   return (errorMessage ? `${errorMessage}. ` : '') + checked;
+};
+
+export type ValidationOutcome =
+  | { state: 'valid' }
+  | { state: 'invalid'; message: string }
+  | { state: 'indeterminate'; message?: string };
+
+/**
+ * The backend reports a completed check that found a problem as InvalidArgument,
+ * which is a verdict. Every other failure, such as a gateway timeout or a lost
+ * connection, means the check did not finish, so the connection state stays
+ * unknown.
+ */
+export const resolveValidationOutcome = (
+  error: Pick<APIErrorResponse, 'status' | 'body'>,
+): ValidationOutcome => {
+  const message = error?.body?.message || undefined;
+  if (error?.status === 400) {
+    return {
+      state: 'invalid',
+      message: message ?? translate('deployments.validate-connection-error'),
+    };
+  }
+  return { state: 'indeterminate', message };
 };

--- a/src/lib/utilities/connection-status.ts
+++ b/src/lib/utilities/connection-status.ts
@@ -1,8 +1,56 @@
 import { translate } from '$lib/i18n/translate';
-import type { ComputeStatus } from '$lib/types/deployments';
+import type {
+  ComputeStatus,
+  DescribeWorkerDeployment,
+  RoutingConfig,
+  VersionSummary,
+} from '$lib/types/deployments';
+import { isVersionSummaryNew } from '$lib/types/deployments';
+import { matchesVersion } from '$lib/utilities/deployment-has-compute-config';
+import { parseVersionStatus } from '$lib/utilities/deployments';
 import type { ValidTime } from '$lib/utilities/format-time';
 import { isTimestamp, timestampToDate } from '$lib/utilities/format-time';
 import type { APIErrorResponse } from '$lib/utilities/request-from-api';
+
+export const versionComputeProviderType = (
+  summary: VersionSummary,
+): string | undefined => {
+  if (!isVersionSummaryNew(summary)) return undefined;
+  const scalingGroup = Object.values(
+    summary.computeConfig?.scalingGroups ?? {},
+  )[0];
+  return scalingGroup?.providerType ?? scalingGroup?.provider?.type;
+};
+
+/**
+ * A connection status only exists for a version the provider currently backs,
+ * so only a current, ramping, or draining version with a compute provider has
+ * one to report.
+ */
+export const versionShowsConnectionStatus = (
+  summary: VersionSummary,
+  routingConfig: RoutingConfig = {},
+): boolean => {
+  if (!versionComputeProviderType(summary)) return false;
+  return (
+    matchesVersion(summary, routingConfig.currentDeploymentVersion) ||
+    matchesVersion(summary, routingConfig.rampingDeploymentVersion) ||
+    (isVersionSummaryNew(summary) &&
+      parseVersionStatus(summary.status).status === 'Draining')
+  );
+};
+
+/**
+ * The Connection column is only worth a column when at least one version can
+ * fill it. A self-hosted deployment has no provider to report on, so the column
+ * would hold nothing but placeholders.
+ */
+export const deploymentShowsConnectionStatus = (
+  deployment?: DescribeWorkerDeployment,
+): boolean =>
+  (deployment?.versionSummaries ?? []).some((summary) =>
+    versionShowsConnectionStatus(summary, deployment?.routingConfig ?? {}),
+  );
 
 export type ConnectionState = 'pending' | 'connected' | 'failed';
 

--- a/src/lib/utilities/deployment-has-compute-config.ts
+++ b/src/lib/utilities/deployment-has-compute-config.ts
@@ -16,7 +16,7 @@ import {
 const hasScalingGroups = (config?: ComputeConfig): boolean =>
   Object.keys(config?.scalingGroups ?? {}).length > 0;
 
-const matchesVersion = (
+export const matchesVersion = (
   summary: VersionSummary,
   version: WorkerDeploymentVersion | undefined,
 ): boolean => {

--- a/tests/integration/deployment-refresh.spec.ts
+++ b/tests/integration/deployment-refresh.spec.ts
@@ -132,6 +132,51 @@ test('shows the persisted connection status and refreshes it after validation', 
   await expect(page.getByText('Failed', { exact: true })).toBeVisible();
 });
 
+test('does not call a gateway timeout an invalid connection', async ({
+  page,
+}) => {
+  let validationRequests = 0;
+
+  await Promise.all([
+    mockClusterApi(page),
+    mockNamespaceApi(page),
+    mockNamespacesApi(page),
+    mockSearchAttributesApi(page),
+    mockSettingsApi(page),
+    mockSystemInfoApi(page, {
+      capabilities: { serverScaledDeployments: true },
+    }),
+  ]);
+  await page.route(DEPLOYMENT_API, (route) =>
+    route.fulfill({ json: deploymentResponse('pending') }),
+  );
+  await page.route(VALIDATE_API, (route) => {
+    validationRequests += 1;
+    return route.fulfill({
+      status: 504,
+      json: { message: 'upstream request timeout' },
+    });
+  });
+
+  await page.goto(deploymentUrl);
+  await page.getByRole('button', { name: 'Actions', exact: true }).click();
+  await page.getByRole('menuitem', { name: 'Validate Connection' }).click();
+
+  const modal = page.locator('#validate-connection-modal-build-1');
+  await expect(modal).toBeVisible();
+  await expect.poll(() => validationRequests).toBe(1);
+
+  await expect(modal.getByText('Could not complete the check')).toBeVisible();
+  await expect(modal.getByText('Connection is invalid')).toHaveCount(0);
+  await expect(modal.getByText('Connection is valid')).toHaveCount(0);
+  await expect(
+    modal.getByText('The connection status is unknown.', { exact: false }),
+  ).toBeVisible();
+
+  // The badge keeps the status the server last reported.
+  await expect(page.getByText('Pending', { exact: true })).toBeVisible();
+});
+
 test('leaves the connection cell empty for a version with no compute config', async ({
   page,
 }) => {

--- a/tests/integration/deployment-refresh.spec.ts
+++ b/tests/integration/deployment-refresh.spec.ts
@@ -61,7 +61,7 @@ const deploymentResponse = (connectionStatus: ConnectionStatus) => {
   };
 };
 
-test('keeps validation available while connection status is hidden', async ({
+test('shows the persisted connection status and refreshes it after validation', async ({
   page,
 }) => {
   let connectionStatus: ConnectionStatus = 'pending';
@@ -82,25 +82,26 @@ test('keeps validation available while connection status is hidden', async ({
     deploymentRequests += 1;
     return route.fulfill({ json: deploymentResponse(connectionStatus) });
   });
+  // The backend persists the outcome of an empty ValidateSpec request and
+  // reports a failed check as an error carrying the same message it stores.
   await page.route(VALIDATE_API, (route) => {
     validationRequests += 1;
-    connectionStatus = validationRequests === 1 ? 'connected' : 'failed';
-    if (validationRequests === 3) {
-      return route.fulfill({
-        status: 400,
-        json: { message: 'Connection failed' },
-      });
+    if (validationRequests === 1) {
+      connectionStatus = 'connected';
+      return route.fulfill({ json: {} });
     }
-    return route.fulfill({ json: {} });
+    connectionStatus = 'failed';
+    return route.fulfill({
+      status: 400,
+      json: { message: 'Connection failed' },
+    });
   });
 
   await page.goto(deploymentUrl);
   await expect(
     page.getByRole('columnheader', { name: 'Connection', exact: true }),
-  ).toHaveCount(0);
-  await expect(page.getByText('Pending', { exact: true })).toHaveCount(0);
-  await expect(page.getByText('Connected', { exact: true })).toHaveCount(0);
-  await expect(page.getByText('Failed', { exact: true })).toHaveCount(0);
+  ).toHaveCount(1);
+  await expect(page.getByText('Pending', { exact: true })).toBeVisible();
 
   await page.getByRole('button', { name: 'Actions', exact: true }).click();
   const validateConnection = page.getByRole('menuitem', {
@@ -114,7 +115,8 @@ test('keeps validation available while connection status is hidden', async ({
   await expect(modal.getByText('Connection is valid')).toBeVisible();
   await expect.poll(() => validationRequests).toBe(1);
   await expect.poll(() => deploymentRequests).toBeGreaterThanOrEqual(2);
-  await expect(page.getByText('Connected', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Connected', { exact: true })).toBeVisible();
+  await expect(page.getByText('Pending', { exact: true })).toHaveCount(0);
 
   const requestsBeforeRetry = deploymentRequests;
   await modal.getByRole('button', { name: 'Retry' }).click();
@@ -123,15 +125,37 @@ test('keeps validation available while connection status is hidden', async ({
   await expect
     .poll(() => deploymentRequests)
     .toBeGreaterThan(requestsBeforeRetry);
-  await expect(modal).toBeVisible();
-  await expect(modal.getByText('Connection is valid')).toBeVisible();
-  await expect(page.getByText('Failed', { exact: true })).toHaveCount(0);
-
-  await modal.getByRole('button', { name: 'Retry' }).click();
-
-  await expect.poll(() => validationRequests).toBe(3);
   await expect(modal.getByText('Connection is invalid')).toBeVisible();
   await expect(
     modal.getByText('Connection failed', { exact: true }),
   ).toBeVisible();
+  await expect(page.getByText('Failed', { exact: true })).toBeVisible();
+});
+
+test('leaves the connection cell empty for a version with no compute config', async ({
+  page,
+}) => {
+  await Promise.all([
+    mockClusterApi(page),
+    mockNamespaceApi(page),
+    mockNamespacesApi(page),
+    mockSearchAttributesApi(page),
+    mockSettingsApi(page),
+    mockSystemInfoApi(page, {
+      capabilities: { serverScaledDeployments: true },
+    }),
+  ]);
+  await page.route(DEPLOYMENT_API, (route) => {
+    const response = deploymentResponse('connected');
+    for (const version of response.workerDeploymentInfo.versionSummaries) {
+      delete (version as { computeConfig?: unknown }).computeConfig;
+    }
+    return route.fulfill({ json: response });
+  });
+
+  await page.goto(deploymentUrl);
+  await expect(
+    page.getByRole('columnheader', { name: 'Connection', exact: true }),
+  ).toHaveCount(1);
+  await expect(page.getByText('Connected', { exact: true })).toHaveCount(0);
 });

--- a/tests/integration/deployment-refresh.spec.ts
+++ b/tests/integration/deployment-refresh.spec.ts
@@ -177,7 +177,7 @@ test('does not call a gateway timeout an invalid connection', async ({
   await expect(page.getByText('Pending', { exact: true })).toBeVisible();
 });
 
-test('leaves the connection cell empty for a version with no compute config', async ({
+test('hides the connection column for a deployment with no compute config', async ({
   page,
 }) => {
   await Promise.all([
@@ -200,7 +200,47 @@ test('leaves the connection cell empty for a version with no compute config', as
 
   await page.goto(deploymentUrl);
   await expect(
+    page.getByRole('columnheader', { name: 'Build ID' }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole('columnheader', { name: 'Connection', exact: true }),
+  ).toHaveCount(0);
+  await expect(page.getByText('Connected', { exact: true })).toHaveCount(0);
+});
+
+test('keeps the connection column and empties the cell for a version with no compute config', async ({
+  page,
+}) => {
+  await Promise.all([
+    mockClusterApi(page),
+    mockNamespaceApi(page),
+    mockNamespacesApi(page),
+    mockSearchAttributesApi(page),
+    mockSettingsApi(page),
+    mockSystemInfoApi(page, {
+      capabilities: { serverScaledDeployments: true },
+    }),
+  ]);
+  await page.route(DEPLOYMENT_API, (route) => {
+    const response = deploymentResponse('connected');
+    response.workerDeploymentInfo.versionSummaries.push({
+      version: 'my-deployment.build-2',
+      deploymentVersion: {
+        deploymentName: 'my-deployment',
+        buildId: 'build-2',
+      },
+      createTime: { seconds: 0, nanos: 0 },
+      status: 'WORKER_DEPLOYMENT_VERSION_STATUS_INACTIVE',
+    } as (typeof response.workerDeploymentInfo.versionSummaries)[number]);
+    return route.fulfill({ json: response });
+  });
+
+  await page.goto(deploymentUrl);
+  await expect(
     page.getByRole('columnheader', { name: 'Connection', exact: true }),
   ).toHaveCount(1);
-  await expect(page.getByText('Connected', { exact: true })).toHaveCount(0);
+  await expect(page.getByText('Connected', { exact: true })).toBeVisible();
+
+  const inactiveRow = page.getByRole('row', { name: /build-2/ });
+  await expect(inactiveRow.getByRole('cell').nth(3)).toHaveText('—');
 });


### PR DESCRIPTION
## Summary

- show the connection status by default: the Connection column on the
  deployment detail page, and the status inside the compute pill on the
  deployments list
- keep `showConnectionStatus`, so a consumer can still hide the status without
  a release of this package
- restore the Validate Connection guidance in the Pending tooltip
- report a check that does not finish as unknown, rather than as an invalid
  connection
- extend the unit and integration tests to cover the re-exposed path, which
  includes the detail row colspan

https://github.com/user-attachments/assets/15388342-e1a3-48ac-938e-ddc3ba8c14a8

## Why

PR #3718 hid the connection status behind `showConnectionStatus`, which
defaults to false. The UI was correct. Two backend defects made the status show
a permanent Pending:

- `validateValidateSpec` rejected an empty `ValidateSpec`, so
  `handleValidateSpec` never ran.
  Fix: temporalio/temporal-auto-scaled-workers#99, merged 2026-07-25.
- `version_workflow.go` never sent `syncSummary()`, so an updated
  `ComputeStatus` never reached the deployment workflow that
  `DescribeWorkerDeployment` reads.
  Fix: temporalio/temporal#11273, merged 2026-08-03.

Both fixes are merged.

## Where the flip belongs

The prop defaults to false, and no route in this repo passes it, so the status
never appears. Three options:

1. **Flip the default here.** One change, one repo, and every consumer gets the
   status. This PR takes this option.
2. **Pass true from each consumer.** This needs a change in every consumer plus
   a package bump, and it leaves a dead prop here. It does not solve the staged
   rollout problem either, because a consumer also deploys everywhere at once.
3. **Gate on a server capability.** This is the only mechanism that lets an
   environment with the fixes show the status while an environment without them
   hides it, because the server reports its own support. No such capability
   exists. `serverScaledDeployments` is true with or without these fixes, so it
   selects the broken set rather than the fixed set. A capability that did track
   the fixes needs a change to temporalio/api and to the server, which takes
   longer than the rollout it would guard.

Option 1 with the prop kept gives the same rollback lever at lower cost: a
consumer can pass `showConnectionStatus={false}` if an environment turns out to
be behind.

## Pending tooltip copy

Commit e6efe42a9 removed "or use Validate Connection to check now" because the
on-demand validation was a dry run. temporal-auto-scaled-workers#99 makes that
statement correct again. `handleValidateSpec` now writes the validation status
and signals the version workflow when the request carries no scaling group
changes, which is what the manual action sends. The row already refreshes after
a validation, so the badge changes in place.

The 6h claim stays. The default of
`workercontroller.periodic_validation_interval_s` is 21600 seconds.

## Client contract

`validateCurrentWorkerDeploymentVersionComputeConfig` keeps its `void` return.
`ValidateWorkerDeploymentVersionComputeConfigResponse` is an empty message, so
the earlier `{ valid, message }` shape never matched the server. The verdict
does not need that shape.

## A check that does not finish is not a failed connection

The modal treated every error as a verdict:

```js
const isValid = $derived(!result?.message);
```

A gateway timeout therefore read as "Connection is invalid", which is wrong. The
check never returned a result, so the connection state is unknown. The endpoint
runs a workflow update that calls a provider activity while the caller waits, so
a slow provider producing a timeout is an ordinary outcome, not an edge case.

The modal now has three states:

| Outcome | Trigger | Modal |
| --- | --- | --- |
| valid | 200 | Connection is valid |
| invalid | 400 only | Connection is invalid, plus the server message |
| indeterminate | 5xx, transport failure, 401, 403, 404, 429 | Could not complete the check, status unknown |

`InvalidArgument`, which maps to 400, is the only status the backend uses for a
verdict, so it is the only one treated as one. `resolveValidationOutcome` holds
this mapping so it is testable away from the component.

The row now refreshes for every outcome. A check that does not return to the
browser can still finish and persist a status.

## Issue(s) closed

FE-191

## Test plan

- [x] `pnpm lint`: 0 errors
- [x] `pnpm check`: 0 errors
- [x] `pnpm test -- --run`: 3041 passed, 2 skipped
- [x] `pnpm test:integration`: 317 passed, 1 skipped
- [ ] manual check against an environment carrying both backend fixes


