### PR TITLE
fix: don't render an empty selected-count badge in combobox

### DIFF
--- a/src/lib/holocene/combobox/combobox.stories.svelte
+++ b/src/lib/holocene/combobox/combobox.stories.svelte
@@ -203,6 +203,34 @@
 />
 
 <Story
+  name="Multiselect Without Count Label"
+  args={{
+    options: ['English', 'German', 'French'],
+    multiselect: true,
+    displayChips: false,
+    value: ['English'],
+    numberOfItemsSelectedLabel: () => '',
+  }}
+  play={async ({ canvasElement }) => {
+    expect(canvasElement.querySelectorAll('.rounded-sm.p-1')).toHaveLength(0);
+  }}
+/>
+
+<Story
+  name="Multiselect With Count Label"
+  args={{
+    options: ['English', 'German', 'French'],
+    multiselect: true,
+    displayChips: false,
+    value: ['English'],
+  }}
+  play={async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    expect(canvas.getByText('1 option selected')).toBeInTheDocument();
+  }}
+/>
+
+<Story
   name="Async Select"
   play={async ({ canvasElement, id, step }) => {
     const canvas = within(canvasElement);

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -274,6 +274,10 @@
     return Array.isArray(value);
   };
 
+  const selectedCountLabel = $derived(
+    isArrayValue(value) ? numberOfItemsSelectedLabel(value.length) : '',
+  );
+
   const addCustomValue = () => {
     if (!trimmedFilterValue) return;
     if (isArrayValue(value) && value.includes(trimmedFilterValue)) return;
@@ -541,8 +545,8 @@
             {#if value.length > chipLimit}
               <p>+{value.slice(chipLimit).length}</p>
             {/if}
-          {:else}
-            <Badge>{numberOfItemsSelectedLabel(value.length)}</Badge>
+          {:else if selectedCountLabel}
+            <Badge>{selectedCountLabel}</Badge>
           {/if}
         {/if}
         <input


### PR DESCRIPTION
## Description & motivation 💭

In multiselect mode with `displayChips` off, the combobox always rendered a `Badge` for the selected count:

```svelte
<Badge>{numberOfItemsSelectedLabel(value.length)}</Badge>
```

If a consumer supplies a `numberOfItemsSelectedLabel` that returns an empty string — reasonable when the count is already shown elsewhere on the page — the badge has no content. `Badge` is a `div` with `p-1`, `rounded-sm` and a light `bg-slate-100` fill, so with nothing inside it collapses to roughly an 8×8 light square. That is the stray dot reported between the leading search icon and the "Select a namespace" placeholder.

This skips the badge when the label is empty. The default label is never empty, so existing consumers see no change.

### Screenshots (if applicable) 📸

None — no browser was available in this environment. The artifact was confirmed from the rendered DOM instead.

### Design Considerations 🎨

The guard lives in the shared Holocene component rather than at the call site, so any screen that opts out of the in-field count is protected.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [x] Unit tests added
- [ ] E2E tests added

Two stories added under `Combobox`:

- **Multiselect Without Count Label** — blank label with a selection; asserts no badge element is rendered. This is the regression case.
- **Multiselect With Count Label** — same setup with the default label; asserts "1 option selected" still shows.

Verified locally by mounting the combobox and inspecting the DOM in those states. Before the fix the blank-label case emits `<div class="… rounded-sm p-1 … bg-slate-100"></div>` — the artifact; after, that element is gone.

Storybook builds and both stories register in the index. I could not execute the play functions here: `pnpm stories:test` needs a chromium binary and the Playwright CDN is unreachable from this environment, so the assertions are unverified by a real run — worth a glance when CI picks them up.

`pnpm lint` and `pnpm check` are clean; the existing unit suite passes unchanged (232 files, 3026 tests).

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

```
pnpm stories:dev
```

Open **Combobox → Multiselect Without Count Label**. There should be no small light square between the search icon and the placeholder. Checking out `main` and reloading shows the dot.

## Checklists

### Draft Checklist

- [ ] Confirm the Cloud UI namespace picker is in fact passing an empty `numberOfItemsSelectedLabel`. The Cloud UI repo wasn't reachable from this environment, so that last link is unverified — the empty `Badge` is the only element in this component that renders as a small featureless light box in that position (an empty `Chip` is ruled out, since it always draws a close X).
