### PR TITLE
fix(copyable): pin the copy icon to 16px

### DIFF
--- a/src/lib/holocene/copyable/button.svelte
+++ b/src/lib/holocene/copyable/button.svelte
@@ -36,5 +36,5 @@
   data-track-text={copyIconTitle}
   {...rest}
 >
-  <Glyph title={copied ? copySuccessIconTitle : copyIconTitle} />
+  <Glyph class="size-4" title={copied ? copySuccessIconTitle : copyIconTitle} />
 </button>


### PR DESCRIPTION
Restores the copy button's 16px icon, which grew with the surrounding font-size after the Io icon migration.

- Holocene's `Icon` hard-coded a 16px svg; Io icons size at `1.143em` so they track font-size.
- That is right for inline use, but the copy button is a fixed `h-6 p-1` control — beside a heading the glyph rendered at 27px and spilled out of its 24px hover surface.
- Verified in Storybook: header glyph 27x27 -> 16x16, matching the body-text one.

Reported on the cloud-ui side: https://github.com/temporalio/cloud-ui/pull/3124#discussion_r3825309950