### PR TITLE
Update SAA heartbeat info

### DIFF
--- a/src/lib/components/standalone-activities/activity-header.svelte
+++ b/src/lib/components/standalone-activities/activity-header.svelte
@@ -40,6 +40,10 @@
       `ActivityType="${activityType}"`,
     ),
   );
+  const billableActions = $derived(
+    (activityExecutionInfo.attempt ?? 0) +
+      Number(activityExecutionInfo.totalHeartbeatCount ?? 0),
+  );
   const taskQueueFilterLink = $derived(
     routeForStandaloneActivitiesWithQuery(
       { namespace },
@@ -138,7 +142,7 @@
         <DetailListLabel
           >{translate('workflows.billable-actions')}</DetailListLabel
         >
-        <DetailListTextValue text={String(activityExecutionInfo.attempt)} />
+        <DetailListTextValue text={String(billableActions)} />
       {:else}
         <DetailListLabel
           >{translate('workflows.state-transitions')}</DetailListLabel

--- a/src/lib/i18n/locales/en/standalone-activities.ts
+++ b/src/lib/i18n/locales/en/standalone-activities.ts
@@ -109,6 +109,7 @@ export const Strings = {
   'execution-time': 'Execution Time',
   'execution-duration': 'Execution Duration',
   'last-heartbeat': 'Last Heartbeat',
+  'total-heartbeats': 'Total Heartbeats',
   'heartbeat-timeout': 'Heartbeat Timeout',
   'current-retry-interval': 'Current Retry Interval',
   'last-attempt-complete-time': 'Last Attempted Complete Time',

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -41,6 +41,18 @@
       ($activityExecution?.info?.attempt ?? 0) > 1,
   );
 
+  const hasLastHeartbeatTime = $derived(
+    !!$activityExecution?.info?.lastHeartbeatTime,
+  );
+
+  const hasHeartbeatTimeout = $derived(
+    !!$activityExecution?.info?.heartbeatTimeout,
+  );
+
+  const heartbeatRowCount = $derived(
+    (hasLastHeartbeatTime ? 1 : 0) + (hasHeartbeatTimeout ? 1 : 0),
+  );
+
   const hasCodeBlocks = $derived(
     !!(
       $activityExecution?.info?.lastFailure ||
@@ -195,31 +207,35 @@
             {/if}
           </DetailList>
         </div>
-        {#if !isClosed}
+        {#if heartbeatRowCount > 0}
           <div class="space-y-2">
             <h5>
               {translate('standalone-activities.health')}
             </h5>
             <DetailList
-              rowCount={2}
+              rowCount={heartbeatRowCount}
               aria-label={translate('standalone-activities.health')}
             >
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.last-heartbeat',
-                )}</DetailListLabel
-              >
-              <DetailListTimestampValue
-                timestamp={$activityExecution.info.lastHeartbeatTime}
-              />
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.heartbeat-timeout',
-                )}</DetailListLabel
-              >
-              <DetailListTextValue
-                text={fromSeconds($activityExecution.info.heartbeatTimeout)}
-              />
+              {#if hasLastHeartbeatTime}
+                <DetailListLabel
+                  >{translate(
+                    'standalone-activities.last-heartbeat',
+                  )}</DetailListLabel
+                >
+                <DetailListTimestampValue
+                  timestamp={$activityExecution.info.lastHeartbeatTime}
+                />
+              {/if}
+              {#if hasHeartbeatTimeout}
+                <DetailListLabel
+                  >{translate(
+                    'standalone-activities.heartbeat-timeout',
+                  )}</DetailListLabel
+                >
+                <DetailListTextValue
+                  text={fromSeconds($activityExecution.info.heartbeatTimeout)}
+                />
+              {/if}
             </DetailList>
           </div>
         {/if}

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -45,12 +45,20 @@
     !!$activityExecution?.info?.lastHeartbeatTime,
   );
 
-  const hasHeartbeatTimeout = $derived(
-    !!$activityExecution?.info?.heartbeatTimeout,
+  const hasTotalHeartbeatCount = $derived(
+    $activityExecution?.info?.totalHeartbeatCount != undefined,
   );
 
+  const heartbeatTimeout = $derived(
+    $activityExecution?.info?.heartbeatTimeout ?? '',
+  );
+
+  const hasHeartbeatTimeout = $derived(!!heartbeatTimeout);
+
   const heartbeatRowCount = $derived(
-    (hasLastHeartbeatTime ? 1 : 0) + (hasHeartbeatTimeout ? 1 : 0),
+    (hasLastHeartbeatTime ? 1 : 0) +
+      (hasTotalHeartbeatCount ? 1 : 0) +
+      (hasHeartbeatTimeout ? 1 : 0),
   );
 
   const hasCodeBlocks = $derived(
@@ -233,7 +241,17 @@
                   )}</DetailListLabel
                 >
                 <DetailListTextValue
-                  text={fromSeconds($activityExecution.info.heartbeatTimeout)}
+                  text={fromSeconds(heartbeatTimeout) || heartbeatTimeout}
+                />
+              {/if}
+              {#if hasTotalHeartbeatCount}
+                <DetailListLabel
+                  >{translate(
+                    'standalone-activities.total-heartbeats',
+                  )}</DetailListLabel
+                >
+                <DetailListTextValue
+                  text={$activityExecution.info.totalHeartbeatCount ?? ''}
                 />
               {/if}
             </DetailList>

--- a/src/lib/types/activity-execution.ts
+++ b/src/lib/types/activity-execution.ts
@@ -63,6 +63,7 @@ export interface ActivityExecutionInfo extends Omit<
   | 'heartbeatTimeout'
   | 'executionDuration'
   | 'stateTransitionCount'
+  | 'totalHeartbeatCount'
   | 'currentRetryInterval'
   | 'executionTime'
   | 'startDelay'
@@ -75,6 +76,7 @@ export interface ActivityExecutionInfo extends Omit<
   heartbeatTimeout: string;
   executionDuration?: string;
   stateTransitionCount: string;
+  totalHeartbeatCount?: string;
   currentRetryInterval: string;
   searchAttributes: WorkflowSearchAttributes;
   sdkName?: string;


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Lists heartbeat values (e.g. heartbeat timeout) under the "Health" section on the Standalone Activity details page if the values exist instead of only showing them if the Standalone Activity is running. Adds "Total Heartbeats" under "Health" if a count exists. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
