### PR TITLE
Adds a Contains option to the search-attribute filter dropdown that

### DIFF
--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -115,6 +115,11 @@
             label: translate('common.starts-with'),
             id: 'starts-with',
           },
+          {
+            value: 'LIKE',
+            label: translate('common.contains'),
+            id: 'contains',
+          },
         ]
       : []),
     ...defaultConditionOptions,
@@ -179,7 +184,9 @@
       const conditionText =
         conditional === 'STARTS_WITH'
           ? translate('common.starts-with').toLowerCase()
-          : conditional;
+          : conditional === 'LIKE'
+            ? translate('common.contains').toLowerCase()
+            : conditional;
       return `${attribute} ${conditionText}`;
     }
 

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -38,6 +38,7 @@ export const Strings = {
   between: 'Between',
   'in-last': 'In Last',
   'starts-with': 'Starts with',
+  contains: 'Contains',
   equals: 'Equals',
   'greater-than': 'Greater Than',
   'greater-than-or-equal-to': 'Greater than or equal to',

--- a/src/lib/utilities/is.ts
+++ b/src/lib/utilities/is.ts
@@ -43,6 +43,7 @@ const operators = [
   '(',
   ')',
   'starts_with',
+  'like',
 ] as const;
 
 const conditionals = [
@@ -57,6 +58,7 @@ const conditionals = [
   '<',
   '!',
   'starts_with',
+  'like',
   'is',
   'is not',
   'in',
@@ -185,6 +187,11 @@ export const isError = (e: unknown): e is Error => {
 export const isStartsWith = (x: unknown) => {
   if (!isString(x)) return false;
   return x.toLocaleLowerCase() === 'starts_with';
+};
+
+export const isContains = (x: unknown) => {
+  if (!isString(x)) return false;
+  return x.toLocaleLowerCase() === 'like';
 };
 
 export const isInConditional = (x: unknown) => {

--- a/src/lib/utilities/query/filter-workflow-query.test.ts
+++ b/src/lib/utilities/query/filter-workflow-query.test.ts
@@ -49,6 +49,21 @@ describe('toListWorkflowQueryFromFilters', () => {
     expect(query).toBe('`ExecutionStatus`="Running"');
   });
 
+  it('should convert a contains (LIKE) filter and wrap the value in wildcards', () => {
+    const filters = [
+      {
+        attribute: 'WorkflowId',
+        type: 'Keyword',
+        conditional: 'LIKE',
+        operator: '',
+        parenthesis: '',
+        value: 'e2d4257b',
+      },
+    ];
+    const query = toListWorkflowQueryFromFilters(filters);
+    expect(query).toBe('`WorkflowId` LIKE "%e2d4257b%"');
+  });
+
   it('should convert multiple ExecutionStatus filters', () => {
     const filters = [
       {

--- a/src/lib/utilities/query/filter-workflow-query.ts
+++ b/src/lib/utilities/query/filter-workflow-query.ts
@@ -8,7 +8,12 @@ import {
   type SearchAttributeType,
 } from '$lib/types/workflows';
 
-import { isInConditional, isNullConditional, isStartsWith } from '../is';
+import {
+  isContains,
+  isInConditional,
+  isNullConditional,
+  isStartsWith,
+} from '../is';
 import { isDuration, isDurationString, toDate, tomorrow } from '../to-duration';
 
 export type QueryKey =
@@ -118,6 +123,12 @@ const toFilterQueryStatement = (
       type,
       conditional,
     })}`;
+  }
+
+  // Contains: the user-typed value is wrapped in '%' wildcards to produce a
+  // substring-matching LIKE pattern.
+  if (isContains(conditional)) {
+    return `\`${queryKey}\` ${conditional} "%${value}%"`;
   }
 
   return `\`${queryKey}\`${conditional}${formatValue({

--- a/src/lib/utilities/query/to-list-workflow-filters.test.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.test.ts
@@ -31,6 +31,7 @@ const customAttributesWithSpacesQuery =
 const workflowQueryWithSpaces =
   '`WorkflowId`="One and Two" AND `Custom Keyword Field`="Hello = world"';
 const prefixQuery = '`WorkflowType` STARTS_WITH "hello"';
+const containsQuery = '`WorkflowId` LIKE "%hello%"';
 const isEmptyQuery = '`WorkflowType` is null';
 const isNotEmptyQuery = '`StartTime` IS NOT NULL';
 const keywordListQuery = '`CustomKeywordListField`in("Hello", "World")';
@@ -85,6 +86,21 @@ describe('toListWorkflowFilters', () => {
         attribute: 'WorkflowType',
         type: 'Keyword',
         conditional: 'STARTS_WITH',
+        operator: '',
+        parenthesis: '',
+        value: 'hello',
+      },
+    ];
+    expect(result).toMatchObject(expectedFilters);
+  });
+
+  it('should parse a query with contains (LIKE) search and strip the wildcards', () => {
+    const result = toListWorkflowFilters(containsQuery, attributes);
+    const expectedFilters = [
+      {
+        attribute: 'WorkflowId',
+        type: 'Keyword',
+        conditional: 'LIKE',
         operator: '',
         parenthesis: '',
         value: 'hello',

--- a/src/lib/utilities/query/to-list-workflow-filters.ts
+++ b/src/lib/utilities/query/to-list-workflow-filters.ts
@@ -14,6 +14,7 @@ import { isValidDate } from '../format-date';
 import {
   isBetween,
   isConditional,
+  isContains,
   isJoin,
   isNullConditional,
   isParenthesis,
@@ -138,6 +139,10 @@ export const toListWorkflowFilters = (
         } else if (isBoolStatement(filter.type)) {
           filter.value = tokenTwoAhead;
           filter.conditional = '=';
+        } else if (isContains(nextToken)) {
+          // Strip the '%' wildcards that toFilterQueryStatement wraps around
+          // a Contains value so the chip shows the raw user-typed text.
+          filter.value = tokenTwoAhead?.replace(/^%/, '').replace(/%$/, '');
         } else {
           filter.value = tokenTwoAhead;
         }


### PR DESCRIPTION
translates to a visibility LIKE query:

- is.ts: recognize `like` as a filter operator/conditional (isContains)
- filter-workflow-query / to-list-workflow-filters: build and parse `LIKE "%value%"` expressions
- dropdown-filter-chip: show the Contains option; en locale string

Requires server-side LIKE support (companion server PR).

<img width="561" height="327" alt="image" src="https://github.com/user-attachments/assets/f050b45b-f58d-47c7-a6b2-61e38afc5c18" />

## Description & motivation 💭

Adds a **Contains** option to the search-attribute filter dropdown for Keyword search attributes. Selecting it builds a visibility query using the `LIKE` operator with the value wrapped in `%` wildcards (e.g. `` `CustomKeywordField` LIKE "%payment%" ``), enabling substring filtering.

Today the dropdown only offers exact match (`=`, `!=`) and **Starts with** (`STARTS_WITH`) for Keyword attributes, so there is no way to filter by "value appears anywhere in the attribute". This is especially useful for filtering workflows/schedules whose IDs or custom Keyword attributes embed identifiers mid-string.

Changes:
- `dropdown-filter-chip.svelte` — adds the **Contains** condition option for Keyword attributes and renders the chip label as "contains" (lowercased i18n string), mirroring the existing Starts-with handling.
- `is.ts` — recognizes `like` as a valid operator/conditional and adds an `isContains` helper.
- `filter-workflow-query.ts` — builds `` `Attr` LIKE "%value%" `` statements for the Contains conditional.
- `to-list-workflow-filters.ts` — parses `LIKE` statements back into filter chips, stripping the `%` wildcards so the chip shows the raw user-typed text.
- `en/common.ts` — new `contains` locale string.

⚠️ Requires server-side `LIKE` support for Keyword attributes: <companion server PR link>. Against a server without that support, using Contains returns the standard invalid-operator query error.

### Design Considerations 🎨

- "Contains" appears directly below "Starts with" in the condition dropdown, only for Keyword attributes (same gating as Starts with).
- The chip displays the raw value (wildcards stripped), consistent with how Starts-with chips display.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Manually verified against a local server build with `LIKE` visibility support: selecting Contains produces the `LIKE "%…%"` query, results match substrings, and reloading the page parses the query back into the chip correctly. Unit tests added in `filter-workflow-query.test.ts` (statement construction, wildcard wrapping) and `to-list-workflow-filters.test.ts` (parsing `LIKE` statements, wildcard stripping).

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Run the UI against a server build that supports `LIKE` on Keyword search attributes (<companion server PR link>).
2. On the Workflows page, add a filter on a Keyword attribute (e.g. `WorkflowType` or a custom Keyword attribute) and pick **Contains** from the condition dropdown.
3. Enter a substring and apply — the query bar shows `` `Attr` LIKE "%value%" `` and only workflows containing the substring are listed.
4. Reload the page (or paste a `LIKE` query manually) — the filter chip is reconstructed showing the plain value without `%`.

## Docs

### Any docs updates needed?

The list-filter docs on docs.temporal.io (supported operators for Keyword attributes) should mention `LIKE`/Contains once the server-side support ships.
