### PR TITLE
fix(catalog): keep isolated test fixtures out of the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,11 @@ go.work.sum
 /.catalog.journal.json
 /.catalog.transaction-*/
 
+# Isolated catalog fixtures. The tests copy the repo into these roots so the
+# copied CLI still resolves the root node_modules, so they cannot live in the
+# system temp directory.
+/.catalog-tmp/
+
 # Legacy Catalog state stays ignored so upgrades cannot expose credentials or
 # abandoned mutation state. The CLI migrates only local content and credentials;
 # old locks and journals are deliberately not resumed under canonical names.

--- a/scripts/catalog/catalog-artifacts.test.ts
+++ b/scripts/catalog/catalog-artifacts.test.ts
@@ -24,6 +24,7 @@ import {
   verifyCatalogProjectBoundaries,
 } from './catalog-artifacts';
 import { catalogWorkerEntry, runCatalogWorkerDevelopment } from './catalog-cli';
+import { createInRepoTemporaryDirectory } from './test-temp-root';
 import { catalogRegistrationSource as localRegistrationFallback } from '../../src/lib/catalog/worker/local-registration-fallback';
 import { createCatalogRegistry } from '../../src/lib/catalog/worker/registry';
 import { requireCatalogRoutingFromEnvironment } from '../../src/lib/catalog/worker/routing-config';
@@ -35,7 +36,7 @@ const packageConsumerTest =
   process.env.CATALOG_PACKAGE_TEST === '1' ? it : it.skip;
 
 const createTemporaryDirectory = async () => {
-  const directory = await mkdtemp(join(process.cwd(), '.catalog-test-'));
+  const directory = await createInRepoTemporaryDirectory('catalog-test-');
   temporaryDirectories.push(directory);
   return directory;
 };

--- a/scripts/catalog/project-artifacts.test.ts
+++ b/scripts/catalog/project-artifacts.test.ts
@@ -1,16 +1,17 @@
-import { cp, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { verifyProjectCatalogBoundaries } from './project-artifacts';
+import { createInRepoTemporaryDirectory } from './test-temp-root';
 import type { CatalogRegistrationSource } from '../../src/lib/catalog/worker/registration-source';
 
 const temporaryDirectories: string[] = [];
 
 const createIsolatedCatalogRoot = async () => {
-  const rootDirectory = await mkdtemp(
-    join(process.cwd(), '.catalog-project-artifacts-'),
+  const rootDirectory = await createInRepoTemporaryDirectory(
+    'catalog-project-artifacts-',
   );
   temporaryDirectories.push(rootDirectory);
   await Promise.all([

--- a/scripts/catalog/test-temp-root.ts
+++ b/scripts/catalog/test-temp-root.ts
@@ -1,0 +1,18 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const IN_REPO_TEMPORARY_ROOT = '.catalog-tmp';
+
+const inRepoTemporaryRoot = () => join(process.cwd(), IN_REPO_TEMPORARY_ROOT);
+
+export const createInRepoTemporaryDirectory = async (
+  prefix: string,
+): Promise<string> => {
+  const parentDirectory = inRepoTemporaryRoot();
+  await mkdir(parentDirectory, { recursive: true });
+  return mkdtemp(join(parentDirectory, prefix));
+};
+
+export const clearInRepoTemporaryRoot = async (): Promise<void> => {
+  await rm(inRepoTemporaryRoot(), { force: true, recursive: true });
+};

--- a/scripts/catalog/ui-authoring.test.ts
+++ b/scripts/catalog/ui-authoring.test.ts
@@ -1,18 +1,19 @@
 import { execFile } from 'node:child_process';
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { createInRepoTemporaryDirectory } from './test-temp-root';
 import { createUiCatalogAuthoring } from './ui-authoring';
 
 const temporaryDirectories: string[] = [];
 const execFileAsync = promisify(execFile);
 
 const createIsolatedCatalogRoot = async () => {
-  const rootDirectory = await mkdtemp(
-    join(process.cwd(), '.catalog-ui-authoring-'),
+  const rootDirectory = await createInRepoTemporaryDirectory(
+    'catalog-ui-authoring-',
   );
   temporaryDirectories.push(rootDirectory);
   await Promise.all([
@@ -25,8 +26,8 @@ const createIsolatedCatalogRoot = async () => {
 };
 
 const createIsolatedCatalogCliRoot = async () => {
-  const rootDirectory = await mkdtemp(
-    join(process.cwd(), '.catalog-ui-authoring-cli-'),
+  const rootDirectory = await createInRepoTemporaryDirectory(
+    'catalog-ui-authoring-cli-',
   );
   temporaryDirectories.push(rootDirectory);
   await Promise.all([

--- a/vitest-global-setup.ts
+++ b/vitest-global-setup.ts
@@ -1,0 +1,5 @@
+import { clearInRepoTemporaryRoot } from './scripts/catalog/test-temp-root';
+
+export default async function setup(): Promise<void> {
+  await clearInRepoTemporaryRoot();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,9 @@ export default defineConfig({
       'e2e',
       'tests',
       '.svelte-kit',
+      '.catalog-tmp/**',
     ],
+    globalSetup: ['./vitest-global-setup.ts'],
     environment: 'jsdom',
     setupFiles: ['./vitest-setup.ts', 'vitest-localstorage-mock'],
     deps: {


### PR DESCRIPTION
## Summary

- create the isolated catalog test fixtures under a single ignored `.catalog-tmp` directory instead of the repo root
- add `.catalog-tmp` to `.gitignore` and to the vitest `exclude` list
- clear `.catalog-tmp` once per run in a vitest global setup, so an interrupted run recovers by itself

## Why

The catalog tests build isolated fixtures with `mkdtemp` in the repo root. They must stay inside the repo so the copied CLI resolves the root `node_modules`, but nothing scoped or ignored them. An `afterEach` removes them, so they only survive a run that never reaches teardown, which is easy to cause with an agent that cancels or times out a long test run. Four prefixes leak this way: `.catalog-ui-authoring-`, `.catalog-ui-authoring-cli-`, `.catalog-project-artifacts-`, and `.catalog-test-`.

Two effects follow:

1. The directories are not in `.gitignore`, unlike the sibling catalog temp paths, so they show in the file tree and in `git status`, and they can be committed by accident.
2. Vitest collects `**/*.test.ts` and excludes only `package`, `build`, `e2e`, `tests`, and `.svelte-kit`. `createIsolatedCatalogCliRoot` copies all of `scripts/catalog` recursively, so one stale `.catalog-ui-authoring-cli-*` adds 11 copied catalog test files to the next run.

## Test plan

- [x] Full unit suite: 232 files, 3026 passed, 2 skipped
- [x] Repo root stays clean after the run, and `git status` reports only the intended changes
- [x] A planted stale copy in `.catalog-tmp` is not collected, and the next run removes it
- [x] `pnpm lint`: 0 errors
- [x] `pnpm check`: 0 errors