### PR TITLE
Make only keyboard focus pin Tooltip open

### DIFF
--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -125,7 +125,7 @@
     }
   }
 
-  function isKeyboardFocus(target: EventTarget | null) {
+  function isFocusVisible(target: EventTarget | null) {
     if (!(target instanceof Element)) return true;
 
     try {
@@ -136,7 +136,7 @@
   }
 
   function handleFocusIn(event: FocusEvent) {
-    if (!isKeyboardFocus(event.target)) return;
+    if (!isFocusVisible(event.target)) return;
 
     isFocused = true;
   }

--- a/src/lib/holocene/tooltip.svelte
+++ b/src/lib/holocene/tooltip.svelte
@@ -125,7 +125,19 @@
     }
   }
 
-  function handleFocusIn() {
+  function isKeyboardFocus(target: EventTarget | null) {
+    if (!(target instanceof Element)) return true;
+
+    try {
+      return target.matches(':focus-visible');
+    } catch {
+      return true;
+    }
+  }
+
+  function handleFocusIn(event: FocusEvent) {
+    if (!isKeyboardFocus(event.target)) return;
+
     isFocused = true;
   }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
`handleFocusIn` previously set `isFocused = true` for any focus. In Chrome and Firefox, clicking a `<button>` focuses it, so a click left `isFocused` stuck `true` and the Tooltip stayed up until focus moved elsewhere. 

`:focus-visible` is `true` for tab and other keyboard focus but `false` for a plain mouse click on a button. The `isKeyboardFocus` guard forwards keyboard focus, but drops mouse focus and still meets requirements for WCAG 1.4.13 (Content on Hover or Focus). 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

* Go to a button with a tooltip (e.g. Saved Views buttons in the collapsed view) > click the button
   - [ ] Verify tooltip goes away without having to click focus away from the button
* Tab to the button
   - [ ] Verify tooltip shoes up on button

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
