### PR TITLE
Add Rust SDK to worker heartbeats SDK warning

### DIFF
--- a/src/lib/components/workers/workers-table/worker-heartbeats-sdk-warning.svelte
+++ b/src/lib/components/workers/workers-table/worker-heartbeats-sdk-warning.svelte
@@ -37,6 +37,11 @@
       version: '1.35.0',
       href: 'https://github.com/temporalio/sdk-java/releases',
     },
+    {
+      sdk: 'Rust',
+      version: '0.70.0',
+      href: 'https://github.com/temporalio/sdk-rust/releases',
+    },
   ];
   const currentSdk = $derived(
     supportedVersions.find(

--- a/src/lib/components/workers/workers-table/worker-heartbeats-sdk-warning.svelte
+++ b/src/lib/components/workers/workers-table/worker-heartbeats-sdk-warning.svelte
@@ -10,32 +10,32 @@
     {
       sdk: 'Go',
       version: '1.41.0',
-      href: 'https://github.com/temporalio/sdk-go/releases/tag/v1.41.0',
+      href: 'https://github.com/temporalio/sdk-go/releases',
     },
     {
       sdk: 'Python',
       version: '1.20.0',
-      href: 'https://github.com/temporalio/sdk-python/releases/tag/1.20.0',
+      href: 'https://github.com/temporalio/sdk-python/releases',
     },
     {
       sdk: 'TypeScript',
       version: '1.14.0',
-      href: 'https://github.com/temporalio/sdk-typescript/releases/tag/v1.14.0',
+      href: 'https://github.com/temporalio/sdk-typescript/releases',
     },
     {
       sdk: '.NET',
       version: '1.10.0',
-      href: 'https://github.com/temporalio/sdk-dotnet/releases/tag/1.10.0',
+      href: 'https://github.com/temporalio/sdk-dotnet/releases',
     },
     {
       sdk: 'Ruby',
       version: '1.1.0',
-      href: 'https://github.com/temporalio/sdk-ruby/releases/tag/v1.1.0',
+      href: 'https://github.com/temporalio/sdk-ruby/releases',
     },
     {
       sdk: 'Java',
       version: '1.35.0',
-      href: 'https://github.com/temporalio/sdk-java/releases/tag/v1.35.0',
+      href: 'https://github.com/temporalio/sdk-java/releases',
     },
   ];
   const currentSdk = $derived(


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

<img width="1033" height="368" alt="Screenshot 2026-08-25 at 11 19 41 AM" src="https://github.com/user-attachments/assets/7eafa478-1990-42ae-a76b-e0fbd05f3893" />


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
