### PR TITLE
Support secondary text on Combobox options

### DIFF
--- a/src/lib/holocene/combobox/combobox-option.svelte
+++ b/src/lib/holocene/combobox/combobox-option.svelte
@@ -6,6 +6,12 @@
 
   interface BaseProps {
     label: string;
+    /**
+     * Optional secondary line rendered beneath the label. Use it for context
+     * that helps disambiguate options — a description, an owner, a region.
+     * Filtering still matches on `label` only.
+     */
+    description?: string;
     class?: ClassNameValue;
     onclick?: () => void;
     leading?: Snippet;
@@ -31,6 +37,7 @@
     selected = false,
     disabled = false,
     label,
+    description = undefined,
     class: className = '',
     onclick,
     leading,
@@ -47,6 +54,7 @@
   {active}
   {selected}
   {disabled}
+  {description}
   {leading}
   {trailing}
 >

--- a/src/lib/holocene/combobox/combobox.stories.svelte
+++ b/src/lib/holocene/combobox/combobox.stories.svelte
@@ -15,11 +15,17 @@
 
   type ComboboxArgs = Omit<
     Partial<ComponentProps<typeof Combobox>>,
-    'options' | 'value' | 'optionLabelKey' | 'optionValueKey' | 'multiselect'
+    | 'options'
+    | 'value'
+    | 'optionLabelKey'
+    | 'optionValueKey'
+    | 'optionDescriptionKey'
+    | 'multiselect'
   > & {
     options?: readonly (string | Record<string, unknown>)[];
     optionLabelKey?: string;
     optionValueKey?: string;
+    optionDescriptionKey?: string;
     multiselect?: boolean;
     allowCustomValue?: boolean;
     showChevron?: boolean;
@@ -65,6 +71,7 @@
       noResultsText: { name: 'No Results Text', control: 'text' },
       optionValueKey: { control: 'text', table: { disable: true } },
       optionLabelKey: { control: 'text', table: { disable: true } },
+      optionDescriptionKey: { control: 'text', table: { disable: true } },
 
       options: { table: { disable: true } },
     },
@@ -154,6 +161,60 @@
     const menu = await canvas.findByRole('listbox');
 
     expect(menu).toBeInTheDocument();
+  }}
+/>
+
+<Story
+  name="Custom Options With Descriptions"
+  args={{
+    label: 'Select a Namespace',
+    options: [
+      {
+        label: 'billing-prod',
+        value: 'billing-prod',
+        description: 'Invoicing and payment workflows',
+      },
+      {
+        label: 'billing-staging',
+        value: 'billing-staging',
+        description: 'Pre-release verification',
+      },
+      {
+        label: 'search-prod',
+        value: 'search-prod',
+        description: 'Indexing pipeline',
+      },
+      { label: 'internal-tools', value: 'internal-tools' },
+    ],
+    optionLabelKey: 'label',
+    optionValueKey: 'value',
+    optionDescriptionKey: 'description',
+  }}
+  play={async ({ canvasElement, id }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByTestId(id);
+
+    await userEvent.type(combobox, 'billing');
+
+    const menu = await canvas.findByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    // Descriptions render as a secondary line beneath the label.
+    expect(
+      canvas.getByText('Invoicing and payment workflows'),
+    ).toBeInTheDocument();
+
+    // An option without a description still renders, with no secondary line.
+    await userEvent.clear(combobox);
+    await userEvent.type(combobox, 'internal');
+    expect(canvas.getByText('internal-tools')).toBeInTheDocument();
+
+    // Filtering matches the label only — never the description.
+    await userEvent.clear(combobox);
+    await userEvent.type(combobox, 'Indexing');
+    await waitFor(() => {
+      expect(canvas.getByText('No Results')).toBeInTheDocument();
+    });
   }}
 />
 

--- a/src/lib/holocene/combobox/combobox.svelte
+++ b/src/lib/holocene/combobox/combobox.svelte
@@ -134,12 +134,18 @@
     options: string[];
     optionValueKey?: never;
     optionLabelKey?: never;
+    optionDescriptionKey?: never;
   }
 
   interface CustomOptionProps {
     options: T[];
     optionValueKey: keyof T;
     optionLabelKey?: keyof T;
+    /**
+     * Optional key whose value renders as a secondary line beneath each
+     * option's label. Filtering still matches on the label only.
+     */
+    optionDescriptionKey?: keyof T;
   }
 
   type Props =
@@ -165,6 +171,7 @@
     showChevron = false,
     optionValueKey = undefined,
     optionLabelKey = optionValueKey,
+    optionDescriptionKey = undefined,
     minSize = 0,
     maxSize = 120,
     hintText = '',
@@ -329,6 +336,18 @@
     }
 
     return '';
+  }
+
+  function getOptionDescription(option: string | T): string | undefined {
+    if (optionDescriptionKey == null) return undefined;
+    if (option === null) return undefined;
+    if (isStringOption(option)) return undefined;
+    if (!isObjectOption(option)) return undefined;
+    if (!(optionDescriptionKey in option)) return undefined;
+
+    const description = option[optionDescriptionKey];
+
+    return description == null ? undefined : String(description);
   }
 
   function getSelectedOption(options: (string | T)[]) {
@@ -701,6 +720,7 @@
         onclick={() => handleSelectOption(option)}
         selected={isSelected(option, value)}
         label={getDisplayValue(option)}
+        description={getOptionDescription(option)}
         class={optionClass}
       />
     {:else}


### PR DESCRIPTION
Adds an optional secondary line to combobox options, so an option can carry disambiguating context beneath its label.

## What changed

- `ComboboxOption` takes an optional `description`, passed straight through to `MenuItem`.
- `Combobox` takes an optional `optionDescriptionKey` for custom (object) options, mirroring the existing `optionValueKey` / `optionLabelKey` pair. String options don't accept it — there's nothing to derive it from.
- New `Custom Options With Descriptions` story.

`MenuItem` already renders a styled `description` line (`.menu-item-description`), so this threads the existing primitive through rather than introducing new rendering. Styling, spacing and truncation come along for free.

## Decisions worth a look

- **Filtering still matches the label only**, never the description. That keeps `getDisplayValue` as the single source of what a user is typing against. The new story asserts it, so if we ever want description-aware filtering it'll be a deliberate change with a failing test to update.
- **Naming follows `MenuItem`** (`description`) rather than something like `secondaryText`, so the prop means the same thing at both layers.
- **Secondary text stays in the accessible name.** It's meaningful content, and the axe run over the story reports no violations.

## Verification

- `pnpm check` — 0 errors
- `pnpm test -- --run` — 3026 passed
- `test-storybook` scoped to Combobox — 15/15 play tests pass, no accessibility violations
- eslint, stylelint, prettier clean on the changed files

## Context

Needed by [FE-224](https://linear.app/temporal/issue/FE-224/show-description-on-namespace-selector-dropdown-menu) (namespace description in the cloud-ui namespace selector), but useful on its own. Tracked as [FE-435](https://linear.app/temporal/issue/FE-435/support-secondary-text-on-holocene-comboboxoption).

Draft until reviewed — cloud-ui can't consume it until it's packed.

Note: `fix/combobox-hint-text` also touches `combobox.svelte` and `combobox.stories.svelte`. Different concern (hint text under the input), but worth landing in a deliberate order.