### PR TITLE
Fix duplicate schedule action keys

### DIFF
--- a/src/lib/components/schedule/schedules-list/schedules-table-row.svelte
+++ b/src/lib/components/schedule/schedules-list/schedules-table-row.svelte
@@ -98,7 +98,7 @@
       </TableCellWithFilterOrCopyButtons>
     {:else if label === translate('schedules.recent-runs')}
       <td class="cell truncate">
-        {#each sortRecentActions(schedule?.info?.recentActions ?? []) as run (run?.actualTime)}
+        {#each sortRecentActions(schedule?.info?.recentActions ?? []) as run (run)}
           {@const startWorkflowResult = run?.startWorkflowResult}
           <p>
             {#if startWorkflowResult && startWorkflowResult.workflowId && startWorkflowResult.runId}


### PR DESCRIPTION
## Description & motivation 💭

Fixes a potential server-rendering error in the schedules table when multiple recent actions have the same actual time, such as with the AllowAll overlap policy.

Use each schedule action object as the keyed-each identity instead of actualTime so concurrent actions cannot produce duplicate Svelte keys.

### Screenshots (if applicable) 📸

Not applicable.

### Design Considerations 🎨

None.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added
- `pnpm lint`
- `pnpm check`
- `pnpm test -- --run`

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Configure a schedule with the AllowAll overlap policy.
2. Produce multiple recent actions with the same actual time.
3. Open the schedules list and verify it renders without a duplicate-key error.

## Checklists

### Draft Checklist

None.

### Merge Checklist

None.

### Issue(s) closed

FE-438

## Docs

### Any docs updates needed?

No.
