### PR TITLE
Fix full-capacity Worker slot display

### DIFF
--- a/src/lib/components/workers/worker-details/worker-details-child-test-double.svelte
+++ b/src/lib/components/workers/worker-details/worker-details-child-test-double.svelte
@@ -1,0 +1,7 @@
+<script module lang="ts">
+  import { readable } from 'svelte/store';
+
+  export const timestamp = readable(() => '');
+</script>
+
+<span></span>

--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -299,8 +299,9 @@
   slots: WorkerSlotsInfo | null | undefined,
   poller: WorkerPollerInfo | null | undefined,
 )}
-  {@const noSlotsConfigured =
-    !slots?.currentUsedSlots && !slots?.currentAvailableSlots}
+  {@const usedSlots = slots?.currentUsedSlots ?? 0}
+  {@const availableSlots = slots?.currentAvailableSlots ?? 0}
+  {@const noSlotsConfigured = !usedSlots && !availableSlots}
   <Card class="flex flex-col gap-2">
     <h5 class="mb-2">{title}</h5>
     <dl class="grid grid-cols-1 gap-4 lg:grid-cols-3 lg:grid-rows-1">
@@ -314,10 +315,10 @@
               {#if noSlotsConfigured}
                 -
               {:else}
-                {slots?.currentUsedSlots ?? 0}
+                {usedSlots}
               {/if}
-            </span>{#if slots?.currentAvailableSlots && slots.currentAvailableSlots >= 0}
-              /{slots.currentAvailableSlots + (slots?.currentUsedSlots ?? 0)}
+            </span>{#if !noSlotsConfigured && availableSlots >= 0}
+              /{availableSlots + usedSlots}
             {/if}
           </p>
           {#if slots?.slotSupplierKind}

--- a/src/lib/components/workers/worker-details/worker-details.svelte.test.ts
+++ b/src/lib/components/workers/worker-details/worker-details.svelte.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment node
+
+import path from 'node:path';
+
+import type { render } from 'svelte/server';
+
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import type { Component } from 'svelte';
+import { createServer } from 'vite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startIsolatedViteServer } from '$lib/test-utilities/isolated-vite-server';
+import type { WorkerInfo, WorkerSlotsInfo } from '$lib/types';
+
+let workerDetails: Component<Record<string, unknown>>;
+let renderComponent: typeof render;
+let createRawSnippet: typeof import('svelte').createRawSnippet;
+let closeViteServer: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  const projectRoot = process.cwd();
+  const lifecycle = await startIsolatedViteServer(
+    createServer,
+    {
+      root: projectRoot,
+      configFile: false,
+      appType: 'custom',
+      plugins: [svelte({ hot: false })],
+      resolve: {
+        alias: {
+          '$lib/components/lines-and-dots/sdk-logo.svelte': path.resolve(
+            projectRoot,
+            'src/lib/components/workers/worker-details/worker-details-child-test-double.svelte',
+          ),
+          '$lib/components/timestamp.svelte': path.resolve(
+            projectRoot,
+            'src/lib/components/workers/worker-details/worker-details-child-test-double.svelte',
+          ),
+          $lib: path.resolve(projectRoot, 'src/lib'),
+          $types: path.resolve(projectRoot, 'src/types'),
+          $app: path.resolve(projectRoot, 'src/lib/svelte-mocks/app'),
+        },
+      },
+      server: { hmr: false, middlewareMode: true },
+    },
+    async (server) => ({
+      workerDetails: (
+        await server.ssrLoadModule(
+          '/src/lib/components/workers/worker-details/worker-details.svelte',
+        )
+      ).default,
+      renderComponent: (await server.ssrLoadModule('svelte/server')).render,
+      createRawSnippet: (await server.ssrLoadModule('svelte')).createRawSnippet,
+    }),
+  );
+  closeViteServer = lifecycle.close;
+  ({ createRawSnippet, renderComponent, workerDetails } = lifecycle.value);
+});
+
+afterAll(async () => closeViteServer?.());
+
+const renderSlots = (slots?: WorkerSlotsInfo): string => {
+  const worker: WorkerInfo = {
+    workerHeartbeat: slots ? { workflowTaskSlotsInfo: slots } : {},
+  };
+  const { body } = renderComponent(workerDetails, {
+    props: {
+      breadcrumb: createRawSnippet(() => ({ render: () => '' })),
+      worker,
+      onrefresh: () => {},
+    },
+  });
+  return (
+    body
+      .match(
+        /<dt id="slots-[^"]*"[\s\S]*?<\/dt>\s*<dd>[\s\S]*?<p[^>]*>([\s\S]*?)<\/p>/,
+      )?.[1]
+      .replaceAll(/<[^>]*>/g, '')
+      .replaceAll(/\s/g, '') ?? ''
+  );
+};
+
+describe('Worker slot display', () => {
+  it.each([
+    [0, 3, '0/3'],
+    [1, 2, '1/3'],
+    [2, 1, '2/3'],
+    [3, 0, '3/3'],
+    [0, 0, '-'],
+    [2, -1, '2'],
+  ])(
+    'renders used=%s and available=%s as %s',
+    (currentUsedSlots, currentAvailableSlots, expected) => {
+      expect(renderSlots({ currentUsedSlots, currentAvailableSlots })).toBe(
+        expected,
+      );
+    },
+  );
+
+  it.each([null, undefined])(
+    'uses the protobuf zero default when available slots are %s',
+    (currentAvailableSlots) => {
+      expect(renderSlots({ currentUsedSlots: 2, currentAvailableSlots })).toBe(
+        '2/2',
+      );
+    },
+  );
+
+  it('preserves the empty state when slots are missing', () => {
+    expect(renderSlots()).toBe('-');
+  });
+});


### PR DESCRIPTION
## Description and motivation

#3833 fixed the total slot calculation to use available slots plus used slots. One edge case remained: a zero available-slot count failed the existing truthiness check, so a Worker at full capacity rendered as 3 instead of 3/3.

Worker slot counts are proto3 scalar fields. The UI Server JSON marshaler omits zero-valued scalars, so currentAvailableSlots can also arrive as undefined when its protobuf value is zero. This change restores the protobuf zero defaults before rendering, while keeping -1 as unknown capacity and preserving the empty state when slot data is absent or both counts are zero.

### Screenshots

Not applicable. The rendered states are covered by component tests.

### Design considerations

The fallback applies only to counts within the existing slot display. A missing slot record still renders the existing empty state.

## Testing

Added unit coverage for:

- 0/3, 1/3, 2/3, and 3/3
- nullish available counts using the protobuf zero default
- the zero-slot empty state
- unknown availability with -1
- missing slot data

### How was this tested

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Validation completed:

- pnpm exec vitest run src/lib/components/workers/worker-details/worker-details.svelte.test.ts: 9 tests passed
- pnpm test --run: 3,142 tests passed and 2 skipped
- pnpm lint:ci: passed with no errors
- pnpm check: passed with no errors

### Steps for others to test

Run:

pnpm exec vitest run src/lib/components/workers/worker-details/worker-details.svelte.test.ts

## Checklists

### Draft checklist

Ready for review.

### Merge checklist

No follow-up changes are required.

### Issues closed

None.

## Docs

### Any docs updates needed?

No.