### PR TITLE
Fix paginated table height and mobile scrolling

### DIFF
--- a/src/lib/components/top-nav.svelte
+++ b/src/lib/components/top-nav.svelte
@@ -29,7 +29,7 @@
       'flex-row',
       'items-center justify-end',
       'border-b border-subtle',
-      'px-8 py-1',
+      'h-[var(--top-nav-height)] px-8',
       className,
     )}
     data-testid="top-nav"

--- a/src/lib/holocene/main-content-container.svelte
+++ b/src/lib/holocene/main-content-container.svelte
@@ -12,11 +12,11 @@
 
 <div
   id="content-wrapper"
-  class="relative h-full w-max flex-auto overflow-auto"
+  class="relative flex h-full w-max flex-auto flex-col overflow-auto"
   style="scroll-padding-top: var(--scroll-inset-top); scroll-padding-bottom: var(--scroll-inset-bottom);"
 >
   {@render children?.()}
-  <main id="content" tabindex="-1" class="pb-16 md:pb-0">
+  <main id="content" tabindex="-1" class="pb-16 md:min-h-0 md:flex-1 md:pb-0">
     {@render main?.()}
   </main>
   {@render footer?.()}

--- a/src/lib/holocene/table/paginated-table/api-paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/api-paginated.svelte
@@ -262,7 +262,8 @@
   loading={$store.loading}
   updating={$store.updating}
   visibleItems={$store.visibleItems}
-  maxHeight={maximizable && $maximized ? '100%' : maxHeight}
+  {maxHeight}
+  verticalScroll={maximizable && $maximized ? 'table' : 'responsive'}
   class={merge(maximizable && $maximized && 'border-x-0 border-b-0')}
   {id}
   {caption}
@@ -281,7 +282,7 @@
   {/snippet}
 
   {#snippet actionsEnd()}
-    <nav class="flex shrink-0 items-center gap-2" aria-label={ariaLabel}>
+    <div class="ml-auto flex shrink-0 items-center gap-2">
       {@render actionsEndAdditional?.({
         visibleItems: $store.visibleItems,
         page: $store.index + 1,
@@ -289,6 +290,11 @@
       {#if maximizable}
         <MaximizeToggle {maximized} />
       {/if}
+    </div>
+    <nav
+      class="flex shrink-0 items-center gap-2 max-md:w-full max-md:justify-between"
+      aria-label={ariaLabel}
+    >
       <IconButton
         label={previousButtonLabel}
         disabled={!$store.hasPrevious}

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -44,7 +44,9 @@
     ...rest
   }: Props = $props();
 
-  const scrollsInTable = $derived(verticalScroll === 'table');
+  const scrollsInTable = $derived(
+    verticalScroll === 'table' || (maxHeight !== '' && maxHeight !== 'none'),
+  );
 
   let tableContainer = $state<HTMLDivElement>();
   let footerHeight = $state(0);

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -13,6 +13,7 @@
     updating?: boolean;
     maxHeight?: string;
     fixed?: boolean;
+    verticalScroll?: 'responsive' | 'table';
     class?: ClassNameValue;
     caption?: Snippet;
     headers?: Snippet<[{ visibleItems: Item[] }]>;
@@ -30,6 +31,7 @@
     updating = false,
     maxHeight = '',
     fixed = false,
+    verticalScroll = 'responsive',
     class: className = '',
     caption,
     headers,
@@ -42,15 +44,19 @@
     ...rest
   }: Props = $props();
 
+  const scrollsInTable = $derived(verticalScroll === 'table');
+
   let tableContainer = $state<HTMLDivElement>();
   let footerHeight = $state(0);
 
-  const tableOffset = $derived(
-    tableContainer?.offsetTop ? tableContainer.offsetTop + 32 : 0,
-  );
-
   export function scrollToTop() {
-    tableContainer?.scrollTo({ top: 0, behavior: 'instant' });
+    if (!tableContainer) return;
+
+    if (tableContainer.scrollHeight > tableContainer.clientHeight) {
+      tableContainer.scrollTo({ top: 0, behavior: 'instant' });
+    } else {
+      tableContainer.scrollIntoView({ block: 'start', behavior: 'instant' });
+    }
   }
 </script>
 
@@ -60,17 +66,15 @@
 
 <div
   class={merge(
-    'surface-primary min-h-[154px] grow overflow-auto border border-subtle',
+    'surface-primary flex min-h-[154px] grow flex-col overflow-auto border border-subtle',
     className,
   )}
   id="{rest['id']}-container"
   bind:this={tableContainer}
-  style="max-height: {maxHeight ||
-    `calc(100vh - var(--layout-pt) - ${tableOffset}px)`};
-  scroll-padding-top: var(--table-header-h, 2.25rem);
-  scroll-padding-bottom: {footerHeight}px;
-
-  --table-header-h: 2.25rem;"
+  style:max-height={maxHeight || null}
+  style:scroll-padding-top="var(--table-header-h, 2.25rem)"
+  style:scroll-padding-bottom="{footerHeight}px"
+  style:--table-header-h="2.25rem"
 >
   {#if loading}
     {#if loadingContent}
@@ -80,6 +84,7 @@
     {/if}
   {:else}
     <Table
+      class="shrink-0"
       bordered={false}
       {updating}
       {fixed}
@@ -91,7 +96,10 @@
     </Table>
     {#if visibleItems.length}
       <div
-        class="surface-primary sticky bottom-0 left-0 flex w-full grow items-center justify-between gap-2 border-t border-subtle px-4 py-2"
+        class={merge(
+          'surface-primary sticky left-0 flex w-full shrink-0 flex-wrap items-center justify-between gap-2 border-t border-subtle px-4 py-2',
+          scrollsInTable ? 'bottom-0 mt-auto' : 'md:bottom-0 md:mt-auto',
+        )}
         bind:clientHeight={footerHeight}
       >
         {@render actionsStart?.()}
@@ -99,7 +107,7 @@
         {@render actionsEnd?.()}
       </div>
     {:else}
-      <div style="height: calc(100% - var(--table-header-h));">
+      <div class="sticky left-0 flex w-full grow flex-col justify-center">
         {@render empty?.()}
       </div>
     {/if}

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -68,7 +68,7 @@
 
 <div
   class={merge(
-    'surface-primary flex min-h-[154px] grow flex-col overflow-auto border border-subtle',
+    'surface-primary flex grow flex-col overflow-auto border border-subtle',
     className,
   )}
   id="{rest['id']}-container"

--- a/src/lib/holocene/table/paginated-table/maximizable-view.svelte
+++ b/src/lib/holocene/table/paginated-table/maximizable-view.svelte
@@ -38,7 +38,9 @@
 
 <div
   class={merge(
-    $maximized && 'surface-primary fixed inset-0 z-40 flex flex-col',
+    'flex min-h-0 grow flex-col',
+    $maximized &&
+      'surface-primary fixed inset-0 z-40 pb-[var(--scroll-inset-bottom,0px)]',
   )}
   data-testid="maximizable-table-view"
 >

--- a/src/lib/layouts/standalone-activity-layout.svelte
+++ b/src/lib/layouts/standalone-activity-layout.svelte
@@ -138,7 +138,7 @@
   });
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex min-h-0 grow flex-col gap-4">
   <div class="flex items-center gap-2">
     <Link
       href={activitiesHref}

--- a/src/lib/layouts/standalone-nexus-operation-layout.svelte
+++ b/src/lib/layouts/standalone-nexus-operation-layout.svelte
@@ -85,7 +85,7 @@
   });
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex min-h-0 grow flex-col gap-4">
   <div class="flex items-center gap-2">
     <Link
       href={nexusOperationsHref}

--- a/src/lib/pages/deployment.svelte
+++ b/src/lib/pages/deployment.svelte
@@ -167,7 +167,6 @@
       previousPageButtonLabel={translate('common.previous-page')}
       pageButtonLabel={(p) => translate('common.go-to-page', { page: p })}
       items={info.versionSummaries ?? []}
-      maxHeight="fit-content"
     >
       {#snippet caption()}
         <caption class="sr-only">

--- a/src/lib/pages/deployments.svelte
+++ b/src/lib/pages/deployments.svelte
@@ -82,7 +82,7 @@
 </script>
 
 {#key [namespace, $refresh]}
-  <div class="flex flex-col gap-4">
+  <div class="flex min-h-0 grow flex-col gap-4">
     <PaginatedTable
       {onFetch}
       {onError}

--- a/src/lib/pages/task-queue.svelte
+++ b/src/lib/pages/task-queue.svelte
@@ -16,7 +16,7 @@
   );
 </script>
 
-<section class="flex flex-col gap-4">
+<section class="flex min-h-0 grow flex-col gap-4">
   <h1 data-testid="task-queue-title">{translate('workers.task-queue')}</h1>
   <h2 data-testid="task-queue-name">
     {taskQueue}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -436,10 +436,18 @@
       <UserMenu {logout} />
     </TopNavigation>
     {#snippet main()}
-      <div class="flex h-full w-full flex-col gap-4 p-4 md:p-8">
+      <div
+        class="flex h-full w-full flex-col gap-4 p-4 md:px-8 md:pb-0 md:pt-8"
+      >
         <ErrorBoundary>
           {@render children()}
         </ErrorBoundary>
+        <!--
+          md+ needs a definite height so tables can size against it, and an
+          overflowing box drops its padding-bottom from the scroll area. A
+          real box survives it: gap-4 (16px) + h-4 (16px) = pb-8's 32px.
+        -->
+        <div aria-hidden="true" class="hidden shrink-0 md:block md:h-4"></div>
       </div>
     {/snippet}
     {#snippet footer()}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -383,14 +383,14 @@
 <DarkMode />
 <SkipNavigation />
 
-<div class="flex h-dvh w-screen flex-row">
+<div class="flex h-[calc(100dvh-var(--layout-pt))] w-screen flex-row">
   <Toaster
     closeButtonLabel={translate('common.close')}
     pop={toaster.pop}
     toasts={toaster.toasts}
     position={toaster.position}
   />
-  <div class="sticky top-0 z-30 hidden h-screen w-auto md:block">
+  <div class="sticky top-0 z-30 hidden h-full w-auto md:block">
     <SideNavigation sections={[linkList, linkListForSecondGroup]} {isCloud}>
       {#snippet bottom()}
         {#if !isCloud}
@@ -436,7 +436,7 @@
       <UserMenu {logout} />
     </TopNavigation>
     {#snippet main()}
-      <div class="flex h-[calc(100%-2.5rem)] w-full flex-col gap-4 p-4 md:p-8">
+      <div class="flex h-full w-full flex-col gap-4 p-4 md:p-8">
         <ErrorBoundary>
           {@render children()}
         </ErrorBoundary>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Paginated tables now fill the available viewport height on desktop and scroll with the page on mobile

#### Previously
`PaginatedTable` sized itself with `max-height: calc(100vh - var(--layout-pt) - ${tableOffset}px)`, where `tableOffset = tableContainer.offsetTop + 32`.

1. `offsetTop` was a plain DOM read inside `$derived`, so it was measured once at mount and never recomputed — not on resize, not when the filter bar wrapped to a second line.
2. It compared against `100vh` instead of the actual scroll container.
3. `+ 32` hardcoded the desktop `p-8` bottom padding, which was `p-4` on smaller screens.

1. `height: calc(100% - var(--table-header-h))` on the empty state resolve to `auto`, so empty states collapsed to content height.

#### What changed

**Height comes from flexbox now, not JS.** The chain from the app shell down to the table container is a definite-height flex column, so the browser does the arithmetic and reflows on resize for free. 

**Empty states fill the table.** The original `calc()` works now that the container has a definite height, and consumers' `h-full` empty wrappers fill the page.

**Mobile scrolls the page, not the table.** The table grows to its content and the page scrolls, while horizontal scroll stays inside the table for wide column sets. 

**Footer controls wrap.** Page size and action icons share a row, pagination gets its own.

**`verticalScroll` prop** replaces the implicit `maxHeight="100%"` signal for the maximized view. `'table'` means the body scrolls and the footer pins; the default `'responsive'` scrolls the page on mobile and the body from `md` up.

**Top nav height matches its token.** The nav is now sized by `--top-nav-height` instead of the token merely describing it. This also fixes three pre-existing sticky sub-headers (`workflow-history-layout`,`workflow-timeline-layout`, `workflow-family-tree`) that offset by the token and were sitting 1px high, leaving a sliver of scrolled content under the nav.

**Inline `style` became `style:` directives.** `stylelint --fix` silently corrupts a Svelte `style` attribute that *begins*
with an interpolation, appending the property name on every run and killing the declaration after it. It had already eaten `scroll-padding-bottom`. Any `.svelte` file with `style="{...`  is exposed.

#### Known tradeoffs

- **Sticky column headers are lost on mobile.** `sticky` anchors to the nearest scrollport, and the `overflow-auto` we need for horizontal scroll makes the container one.
- **The footer isn't vertically sticky on mobile.** A sticky one collides with the fixed bottom nav.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
