### PR TITLE
Fix Local Activity event history filter showing no events

### DIFF
--- a/src/lib/models/event-groups/create-event-group.test.ts
+++ b/src/lib/models/event-groups/create-event-group.test.ts
@@ -193,21 +193,17 @@ describe('groupIsPending', () => {
 });
 
 describe('groupCategory', () => {
-  it('reports local-activity for a local-activity marker', () => {
-    const marker = {
-      eventType: 'MarkerRecorded',
-      category: 'marker',
-      markerRecordedEventAttributes: { markerName: 'LocalActivity' },
-    } as unknown as WorkflowEvent;
-    expect(groupCategory(marker)).toBe('local-activity');
-  });
-
-  it('reports the head event category otherwise', () => {
-    const marker = {
-      eventType: 'MarkerRecorded',
-      category: 'marker',
-      markerRecordedEventAttributes: { markerName: 'Version' },
-    } as unknown as WorkflowEvent;
-    expect(groupCategory(marker)).toBe('marker');
-  });
+  // The local-activity split lives in toEvent, so a group just mirrors its head
+  // event — that is what keeps GroupRecord and EventGroup in agreement.
+  it.each(['local-activity', 'other', 'activity'])(
+    'mirrors a head event category of %s',
+    (category) => {
+      const head = {
+        eventType: 'MarkerRecorded',
+        category,
+        markerRecordedEventAttributes: { markerName: 'LocalActivity' },
+      } as unknown as WorkflowEvent;
+      expect(groupCategory(head)).toBe(category);
+    },
+  );
 });

--- a/src/lib/models/event-groups/create-event-group.ts
+++ b/src/lib/models/event-groups/create-event-group.ts
@@ -2,7 +2,6 @@ import type { Payload } from '$lib/types';
 import type { CommonHistoryEvent, WorkflowEvent } from '$lib/types/events';
 import {
   isActivityTaskScheduledEvent,
-  isLocalActivityMarkerEvent,
   isMarkerRecordedEvent,
   isNexusOperationScheduledEvent,
   isSignalExternalWorkflowExecutionInitiatedEvent,
@@ -27,14 +26,12 @@ import {
 } from './get-group-name';
 
 /**
- * A group's category, which is its head event's except for local-activity
- * markers. Shared with the buffer's LazyGroup so both derive it identically —
- * views filter on one and render the other.
+ * A group's category, which is its head event's — including the local-activity
+ * split, which toEvent already applied. Shared with the buffer's LazyGroup so
+ * both derive it identically — views filter on one and render the other.
  */
-export const groupCategory = (
-  head: WorkflowEvent,
-): WorkflowEvent['category'] =>
-  isLocalActivityMarkerEvent(head) ? 'local-activity' : head.category;
+export const groupCategory = (head: WorkflowEvent): WorkflowEvent['category'] =>
+  head.category;
 
 /**
  * Whether a group is still open. Depends only on its head event, how many of

--- a/src/lib/models/event-history/get-event-categorization.test.ts
+++ b/src/lib/models/event-history/get-event-categorization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type {
+  CommonHistoryEvent,
   EventType,
   EventTypeCategory,
   WorkflowEvents,
@@ -10,6 +11,7 @@ import {
   allEventTypeOptions,
   compactEventTypeOptions,
   eventTypeCategorizations,
+  getCategoryForEvent,
   getEventCategory,
   getEventsInCategory,
   isCategoryType,
@@ -340,5 +342,48 @@ describe('isCategoryType', () => {
 
   it('should return false for "bogus"', () => {
     expect(isCategoryType('bogus')).toBe(false);
+  });
+});
+
+describe('getCategoryForEvent', () => {
+  const marker = (markerName: string) =>
+    ({
+      eventType: 'MarkerRecorded',
+      markerRecordedEventAttributes: { markerName },
+    }) as unknown as CommonHistoryEvent;
+
+  it('categorizes a LocalActivity marker as local-activity', () => {
+    expect(getCategoryForEvent(marker('LocalActivity'), 'MarkerRecorded')).toBe(
+      'local-activity',
+    );
+  });
+
+  it('categorizes a core_local_activity marker as local-activity', () => {
+    expect(
+      getCategoryForEvent(marker('core_local_activity'), 'MarkerRecorded'),
+    ).toBe('local-activity');
+  });
+
+  it.each(['Version', 'SideEffect'])(
+    'leaves a %s marker in other',
+    (markerName) => {
+      expect(getCategoryForEvent(marker(markerName), 'MarkerRecorded')).toBe(
+        'other',
+      );
+    },
+  );
+
+  it('falls back to the event type for non-marker events', () => {
+    const event = {
+      eventType: 'ActivityTaskScheduled',
+      activityTaskScheduledEventAttributes: {},
+    } as unknown as CommonHistoryEvent;
+    expect(getCategoryForEvent(event, 'ActivityTaskScheduled')).toBe(
+      'activity',
+    );
+  });
+
+  it('keeps getEventCategory a type-only lookup', () => {
+    expect(getEventCategory('MarkerRecorded')).toBe('other');
   });
 });

--- a/src/lib/models/event-history/get-event-categorization.ts
+++ b/src/lib/models/event-history/get-event-categorization.ts
@@ -1,9 +1,12 @@
 import type { I18nKey } from '$lib/i18n';
 import type {
+  CommonHistoryEvent,
   EventType,
+  HistoryEvent,
   IterableEvent,
   WorkflowEvents,
 } from '$lib/types/events';
+import { isLocalActivityMarkerEvent } from '$lib/utilities/is-event-type';
 
 type Categories = typeof CATEGORIES;
 export type EventTypeCategory = Categories[keyof Categories];
@@ -159,6 +162,20 @@ export const compactEventTypeOptions: EventTypeOption[] =
 export const getEventCategory = (eventType: EventType): EventTypeCategory => {
   return eventTypeCategorizations?.[eventType] || CATEGORIES.OTHER;
 };
+
+/**
+ * An event's category. Local activities are `MarkerRecorded` events
+ * distinguished only by their marker name, so the type-only lookup above can
+ * never place them — without this they land in `other`, and the Local Activity
+ * filter matches nothing.
+ */
+export const getCategoryForEvent = (
+  event: CommonHistoryEvent | HistoryEvent,
+  eventType: EventType,
+): EventTypeCategory =>
+  isLocalActivityMarkerEvent(event)
+    ? CATEGORIES.LOCAL_ACTIVITY
+    : getEventCategory(eventType);
 
 export const isCategoryType = (value: string): value is EventTypeCategory => {
   for (const category in CATEGORIES) {

--- a/src/lib/models/event-history/index.ts
+++ b/src/lib/models/event-history/index.ts
@@ -22,7 +22,7 @@ import {
 import { toEventNameReadable } from '$lib/utilities/screaming-enums';
 
 import { getEventBillableActions } from './get-event-billable-actions';
-import { getEventCategory } from './get-event-categorization';
+import { getCategoryForEvent } from './get-event-categorization';
 import { getEventClassification } from './get-event-classification';
 import { simplifyAttributes } from './simplify-attributes';
 
@@ -70,7 +70,7 @@ export const toEvent = (
   const eventType = toEventNameReadable(historyEvent.eventType);
   const timestamp = formatDate(String(historyEvent.eventTime));
   const classification = getEventClassification(eventType);
-  const category = getEventCategory(eventType);
+  const category = getCategoryForEvent(historyEvent, eventType);
 
   const { key, attributes } = findAttributesAndKey(historyEvent);
 

--- a/src/lib/models/event-history/to-event-history.test.ts
+++ b/src/lib/models/event-history/to-event-history.test.ts
@@ -157,6 +157,34 @@ describe('toEventHistory', () => {
   }
 });
 
+describe('marker categorization', () => {
+  const markerEvent = (eventId: string, markerName: string) =>
+    ({
+      eventId,
+      eventTime: '2022-07-01T20:28:48.796369169Z',
+      eventType: 'MarkerRecorded',
+      version: '0',
+      taskId: '29887292',
+      markerRecordedEventAttributes: {
+        markerName,
+        workflowTaskCompletedEventId: '1',
+      },
+    }) as unknown as HistoryEvent;
+
+  it.each(['LocalActivity', 'core_local_activity'])(
+    'categorizes a %s marker as local-activity',
+    async (markerName) => {
+      const [event] = await toEventHistory([markerEvent('2', markerName)]);
+      expect(event.category).toBe('local-activity');
+    },
+  );
+
+  it('leaves a Version marker in other', async () => {
+    const [event] = await toEventHistory([markerEvent('2', 'Version')]);
+    expect(event.category).toBe('other');
+  });
+});
+
 describe('fromEventToRawEvent', () => {
   const additionalProperties = [
     'attributes',

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -12,7 +12,6 @@ import type {
 import { decodeURIForSvelte } from '$lib/utilities/encode-uri';
 import { getSDKandVersion } from '$lib/utilities/get-sdk-version';
 import {
-  isLocalActivityMarkerEvent,
   isResetEvent,
   isWorkflowTaskCompletedEvent,
 } from '$lib/utilities/is-event-type';
@@ -82,12 +81,7 @@ export const sdkInfo = derived(bufferVersion, () =>
 export const filteredEventHistory = derived(
   [bufferVersion, eventTypeFilter],
   ([, $types]) =>
-    getEventArray().filter((event) => {
-      if (isLocalActivityMarkerEvent(event)) {
-        return $types.includes('local-activity');
-      }
-      return $types.includes(event.category);
-    }),
+    getEventArray().filter((event) => $types.includes(event.category)),
 );
 
 export const decodeEventHistory = persistStore<boolean>(

--- a/src/lib/utilities/is-event-type.ts
+++ b/src/lib/utilities/is-event-type.ts
@@ -461,7 +461,7 @@ export const isResetEvent = (event: WorkflowEvent): boolean => {
 const localActivityMarkerNames = ['LocalActivity', 'core_local_activity'];
 
 export const isLocalActivityMarkerEvent = (
-  event: IterableEvent | CommonHistoryEvent,
+  event: IterableEvent | CommonHistoryEvent | HistoryEvent,
 ) => {
   if (!isMarkerRecordedEvent(event)) return false;
 


### PR DESCRIPTION
## Description & motivation 💭

Selecting the **Local Activity** category filter in event history showed an empty list, and the local activity events appeared under **Other** instead.

Local activities are not their own history event type — the server records them as `MarkerRecorded` events distinguished only by their marker name (`LocalActivity`, or `core_local_activity` for Core-based SDKs). `toEvent` derived `category` from the event type alone, and `eventTypeCategorizations` maps `MarkerRecorded → other`, so every local activity event was born with the wrong category. Nothing in that lookup could ever produce `local-activity`, because the distinction lives in the marker name rather than the event type.

Group-level code compensated after the fact: `groupCategory` re-derived the category for group heads. That split behavior by view —

| View | Filters on | Result |
| --- | --- | --- |
| Compact | `lazyGroup.category` | correct |
| Timeline | `lazyGroup.category` | correct |
| **Feed** | `event.category` | **broken** |

`eventViewType` defaults to `feed`, so users hit the broken path by default.

Rather than add a third per-call-site patch, this categorizes local activity markers at parse time so the event-level `category` is correct everywhere. That single change repairs every consumer that reads `event.category`:

- the feed view's filter in `workflow-history-layout.svelte`
- `getPaginatedEvents` in `events-service.ts`
- the imported-history feed and compact routes
- `getEventsInCategory`
- `effectiveCategory` in `event-summary-row.svelte`, so feed rows now render the Local Activity feather icon and color instead of the generic "Other" terminal icon

It also lets two existing workarounds go away — `groupCategory`'s branch and a duplicate of the same rule in `filteredEventHistory` — leaving one source of truth.

`isLocalActivityMarkerEvent` was widened to accept `HistoryEvent`, which the underlying `hasAttributes` guard already accepted. That removes the need for a cast at the call site rather than introducing one.

**Behavior note:** local activities are now mutually exclusive with **Other** — selecting Other no longer shows them. This matches how Compact and Timeline already behaved, so the change brings the three views into agreement.

### Screenshots (if applicable) 📸

_Screenshot to attach:_ feed view (the default) at `?category=local-activity`, where event 5 now renders as a **Local Activity** row with the feather icon and an `Activity Type: processData` detail chip — the same view that previously showed "No Events Match".

### Design Considerations 🎨

None — this reuses the existing `local-activity` category, which already had label, tooltip, icon (`CategoryIcon`), and color (`event-styles.ts`, `colors.ts`) entries.

One follow-up left out of scope: the `category.other-tooltip` string still lists "Marker Recorded" generically, which now reads a little wide since local activity markers have left that bucket.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Unit tests:

- `get-event-categorization.test.ts` — `getCategoryForEvent` for both marker names, `Version`/`SideEffect` markers staying in `other`, non-marker fallback, and `getEventCategory` keeping its type-only contract
- `to-event-history.test.ts` — integration-level assertion that `toEventHistory` produces `category: 'local-activity'`, which is what actually proves the feed filter is fixed
- `create-event-group.test.ts` — `groupCategory` rewritten to assert it mirrors its head event
- `grouped-event-buffer.test.ts` — unchanged; its lazy/materialized agreement suite already covers a local-activity group and asserts equality between the two sides, so it still guards the invariant

I confirmed the new tests are real guards: reverting just the fix makes both local-activity assertions fail while the `Version` control still passes.

Manual testing against a local server with a real `core_local_activity` marker produced by the catalog's `local-activity` example:

| Filter | Feed (default) | Compact |
| --- | --- | --- |
| `local-activity` | event 5, feather icon + label | shows it |
| `other` | empty | empty |
| no filter | all 6 events | — |

`workflow` returns 5 events and `local-activity` returns 1, totaling all 6 — the partition is exact, so events moved buckets and none were dropped.

`pnpm lint` reports 0 errors. A cold `svelte-check` run (no incremental cache) reports 0 errors.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. `pnpm catalog dev`, then run the **Local activity** example from the catalog page (or start `localActivityWorkflow` on the `ui-catalog` task queue directly).
2. Open that workflow's **Event History** in the default **All** (feed) view.
3. Filter to **Local Activity** — the marker event should appear with the feather icon and a "Local Activity" label.
4. Filter to **Other** — it should be gone; Version/SideEffect markers and Upsert Search Attributes events remain.
5. Repeat in **Compact** and **Timeline** to confirm no regression, and load `?category=local-activity` directly to confirm the deep link resolves.

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

FE-496

## Docs

### Any docs updates needed?

None.
