### PR TITLE
fix(pagination): honor the url page when the store is rebuilt (FE-538)

### DIFF
--- a/src/lib/holocene/table/paginated-table/paginated.svelte
+++ b/src/lib/holocene/table/paginated-table/paginated.svelte
@@ -11,9 +11,11 @@
   import {
     currentPageKey,
     defaultItemsPerPage,
+    getStartingIndexForPage,
     MAX_PAGE_SIZE,
     options,
     pagination,
+    perPageFromSearchParameter,
     perPageKey,
   } from '$lib/stores/pagination';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
@@ -71,7 +73,18 @@
   const currentPageParam = $derived(
     url.searchParams.get(currentPageKey) || '1',
   );
-  const store = $derived(pagination(items, perPageParam, currentPageParam));
+  // pagination() takes a starting index, not a page number, so convert before
+  // constructing it. Passing the page straight through made every rebuild start
+  // at index 0, flashing page 1 and destroying expanded rows before the $effect
+  // below could jump back.
+  const startingIndex = $derived(
+    getStartingIndexForPage(
+      parseInt(currentPageParam, 10),
+      perPageFromSearchParameter(perPageParam),
+      items,
+    ),
+  );
+  const store = $derived(pagination(items, perPageParam, startingIndex));
 
   // keep the 'page-size' url search param within the supported options
   $effect(() => {

--- a/src/lib/holocene/table/paginated-table/paginated.svelte.test.ts
+++ b/src/lib/holocene/table/paginated-table/paginated.svelte.test.ts
@@ -1,0 +1,76 @@
+import { mount, unmount } from 'svelte';
+import { describe, expect, it } from 'vitest';
+
+import { page } from '$app/state';
+
+import Paginated from './paginated.svelte';
+
+// jsdom has no ResizeObserver; index.svelte binds element size.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver ??=
+  ResizeObserverStub as unknown as typeof ResizeObserver;
+
+const makeItems = () => Array.from({ length: 500 }, (_, i) => i);
+
+const mountPaginated = (search: string, items = makeItems()) => {
+  page.url = new URL(`http://localhost:3000/history${search}`);
+  const target = document.createElement('div');
+  document.body.appendChild(target);
+  const component = mount(Paginated, {
+    target,
+    props: {
+      items,
+      perPageLabel: 'Per page',
+      pageButtonLabel: (p: number) => `Page ${p}`,
+      nextPageButtonLabel: 'Next',
+      previousPageButtonLabel: 'Previous',
+    },
+  });
+  return { target, component };
+};
+
+const activePage = (target: HTMLElement): string | undefined =>
+  Array.from(target.querySelectorAll('button[aria-label^="Page "]'))
+    .find((b) => b.className.includes('bg-interactive-secondary-active'))
+    ?.textContent?.trim();
+
+const renderedPageFor = (search: string, items = makeItems()) => {
+  const { target, component } = mountPaginated(search, items);
+  const rendered = activePage(target);
+  unmount(component);
+  target.remove();
+  return rendered;
+};
+
+describe('Paginated', () => {
+  it('renders the page named by the url on first paint', () => {
+    expect(renderedPageFor('?page=3&per-page=100')).toBe('3');
+  });
+
+  it('honors the page across page sizes', () => {
+    expect(renderedPageFor('?page=2&per-page=250')).toBe('2');
+  });
+
+  it('still renders page 1 when the url asks for it', () => {
+    expect(renderedPageFor('?page=1&per-page=100')).toBe('1');
+  });
+
+  it('defaults to page 1 when the url omits a page', () => {
+    expect(renderedPageFor('?per-page=100')).toBe('1');
+  });
+
+  it('clamps a page beyond the last one', () => {
+    expect(renderedPageFor('?page=99&per-page=100')).toBe('5');
+  });
+
+  it('keeps the page when items are rebuilt with a new identity', () => {
+    // A data refresh replaces `items` with a fresh array, reconstructing the
+    // pagination store. That reconstruction must not move the user to page 1.
+    expect(renderedPageFor('?page=4&per-page=100', makeItems())).toBe('4');
+    expect(renderedPageFor('?page=4&per-page=100', makeItems())).toBe('4');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,13 +9,35 @@ import { catalogLocalPlugin } from './plugins/vite-plugin-catalog-local';
 export default defineConfig({
   plugins: [catalogLocalPlugin(), svelte({ hot: false })],
   resolve: {
-    alias: {
-      $lib: path.resolve(__dirname, './src/lib'),
-      $types: path.resolve(__dirname, './src/types'),
-      $components: path.resolve(__dirname, './src/lib/components/'),
-      $app: path.resolve(__dirname, './src/lib/svelte-mocks/app/'),
-      $fixtures: path.resolve(__dirname, './src/fixtures/'),
-    },
+    alias: [
+      // Component tests mount Svelte client-side. Left alone, the bare `svelte`
+      // specifier resolves to index-server.js and mount() throws
+      // lifecycle_function_unavailable. Scoped to an exact match so that
+      // `svelte/store` and friends still resolve normally, and so Node-side
+      // dependencies (prettier in scripts/catalog) keep their server builds —
+      // a global resolve.conditions: ['browser'] breaks those.
+      {
+        find: /^svelte$/,
+        replacement: path.resolve(
+          __dirname,
+          './node_modules/svelte/src/index-client.js',
+        ),
+      },
+      { find: '$lib', replacement: path.resolve(__dirname, './src/lib') },
+      { find: '$types', replacement: path.resolve(__dirname, './src/types') },
+      {
+        find: '$components',
+        replacement: path.resolve(__dirname, './src/lib/components/'),
+      },
+      {
+        find: '$app',
+        replacement: path.resolve(__dirname, './src/lib/svelte-mocks/app/'),
+      },
+      {
+        find: '$fixtures',
+        replacement: path.resolve(__dirname, './src/fixtures/'),
+      },
+    ],
   },
   test: {
     include: ['**/*.test.ts', '**/*.spec.ts'],


### PR DESCRIPTION
## Description & motivation 💭

`pagination()` takes a **starting index** as its third argument — `src/lib/stores/pagination.test.ts:248-262` documents that contract, and `holocene/pagination.svelte:94` honors it. `paginated-table/paginated.svelte:74` was passing it the **page number** from the URL instead.

With the default `per-page=100`, `getNearestStartingIndex(P, 100, items)` reduces to `getStartingIndexForPage(Math.floor(P/100) + 1, …)`, which returns index `0` for every page from 1 to 99. So a freshly constructed store always sat on page 1.

That store is `$derived`, so it is rebuilt whenever `items` changes identity. On a running workflow that happens every 10s: the interval at `workflow-run-layout.svelte:378` refetches pending activities, which flows through `setPendingMetadata`, bumps the event buffer revision, and produces a new `items` array even when no new events arrived.

The *end state* was always correct — the `$effect` at `paginated.svelte:117-120` calls `store.jumpToPage(currentPageParam)` and restores the URL page. But it runs after the DOM has already been mutated to show page 1. That intervening flush destroys and remounts every row, and an expanded event's detail is local component state (`event-summary-row.svelte:79`) with no resync, so it comes back collapsed. Page 1 was immune because there the wrong start index equals the right one, so the flash renders an identical slice and the keyed `{#each}` reuses the row instances.

Fix converts page → index at the call site, reusing the already-tested `getStartingIndexForPage`.

**`pagination()`'s signature is deliberately untouched.** `package.json:284-298` publishes wildcard exports (`"./*.svelte"`, `"./*"`) across `src/lib`, so `$lib/stores/pagination` is public package API and downstream consumers such as cloud-ui can call it positionally. Renaming or re-typing that parameter would be a breaking change. The `$effect` at `:117-120` also stays — it is load-bearing, being the only code that applies later URL changes.

This predates the Svelte 5 migration; `git show b19c43a01^` shows the same shape with `$:` statements.

### Also affected

`paginated.svelte` has three real consumers, all mis-paging today, and there is no way to fix one without forking the component:

- **Event history** — items churn every 10s on a running workflow. This is the reported bug.
- **`pages/nexus-endpoint.svelte`** — no polling; `endpoint` comes from a SvelteKit load. No user-visible change.
- **`pages/deployment.svelte`** — items change identity on user actions (set-current, set-ramping, validate, delete), never a timer. Removes a one-flush flash.

### Verified non-risks

- No filter path depends on the reset. `updateEventFilterParams` passes no `clearParameters`, so `page` already survived every filter change.
- No stale-page hazard while loading — `getStartingIndexForPage(7, 100, [])` returns `0`.
- No scroll jump — `scrollToTop()` fires only from `handlePageChange`.
- No keyboard-nav regression — `activeRowIndex` is dead state on this path; `paginated.svelte` never calls `nextRow`/`previousRow`.

## Testing 🧪

### How was this tested 👻

- [x] Unit tests added
- [ ] Manual testing
- [ ] E2E tests added

`paginated.svelte.test.ts` covers six cases: the URL's page rendered on first paint, across page sizes, page 1, an omitted page, a page beyond the last, and a rebuild with a fresh `items` array. **Confirmed to fail on unfixed code** (renders `1`, expects `3`) — the assertion observes first paint, so a settled-state test would not have caught this.

Full suite: 243 files / 3154 tests pass. `pnpm lint` exits 0. Cold `svelte-check` (cache bypassed, `dist/` moved aside) reports 0 errors.

#### Note on `vitest.config.ts`

Making plain `mount()` work needed two things:

- The bare `svelte` specifier resolved to `index-server.js`, so `mount()` threw `lifecycle_function_unavailable`. Fixed with an **exact-match** alias (`/^svelte$/` → `svelte/src/index-client.js`), which required converting `resolve.alias` to array form. A global `resolve.conditions: ['browser']` also fixes it **but breaks 20 tests in `scripts/catalog/*`**, because Prettier then resolves to its browser build and loses `resolveConfig`. Please keep the alias rather than the condition.
- jsdom has no `ResizeObserver`, which `paginated-table/index.svelte:182` binds. Stubbed locally in the test file.

No dev server is involved, and CI needs no changes. Worth noting the existing `group-details-row-client-test-runner.ts` pattern builds an in-process `ViteDevServer` to get Svelte's client build; with this alias in place, that runner could likely be simplified where it isn't relying on import-level test doubles. Not touched here.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Start a workflow that runs long enough to produce 100+ history events.
2. Open its Event History on the **All** tab while it is still running.
3. Page to 2 or beyond.
4. Click an event to expand its details and wait through a 10s refresh tick.
5. The details stay open, and the table no longer flickers to page 1.

## Checklists

### Merge Checklist

- [ ] Manual verification against a running workflow (step-by-step above)

### Issue(s) closed

Closes FE-538

## Docs

### Any docs updates needed?

None.
