### PR TITLE
 Make system saved views additive on custom saved views

### DIFF
--- a/src/lib/components/saved-query-views/saved-views.svelte
+++ b/src/lib/components/saved-query-views/saved-views.svelte
@@ -181,11 +181,7 @@
       narrowsActiveView(view) && isSystemViewActive(view);
     const addsToActiveView =
       narrowsActiveView(view) && onCustomView && !removesActiveView;
-    const baseQuery = activeUserView
-      ? systemViewBaseQuery
-      : addedSystemView
-        ? addedSystemViewBase
-        : query;
+    const baseQuery = addedSystemView ? addedSystemViewBase : query;
     const nextQuery = removesActiveView
       ? addedSystemView === view.id
         ? addedSystemViewBase

--- a/src/lib/components/saved-query-views/saved-views.svelte
+++ b/src/lib/components/saved-query-views/saved-views.svelte
@@ -19,6 +19,7 @@
   } from '$lib/stores/saved-queries';
   import type { SearchAttributes } from '$lib/types/workflows';
   import { copyToClipboard } from '$lib/utilities/copy-to-clipboard';
+  import { combineQueries } from '$lib/utilities/query/combine-queries';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
   import { sortAlphabetically } from '$lib/utilities/sort-alphabetically';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
@@ -47,6 +48,9 @@
   }: Props = $props();
 
   let activeQueryView: SavedQuery | undefined = $state();
+  let addedSystemViewId: string | undefined = $state();
+  let addedSystemViewBase = $state('');
+  let addedSystemViewQuery = $state('');
   let saveViewModalOpen = $state(false);
   let editViewModalOpen = $state(false);
   let pendingQueryTarget: string | undefined = $state();
@@ -69,6 +73,18 @@
   const savedQueryView = $derived(
     query && namespaceSavedQueries.find((q) => q.query === query),
   );
+  const savedQueryViewWithSystemView = $derived(
+    query &&
+      namespaceSavedQueries.find(
+        (saved) =>
+          saved.query &&
+          systemViews.some(
+            (system) =>
+              system.query &&
+              query === combineQueries(saved.query, system.query),
+          ),
+      ),
+  );
   const unsavedView: SavedQuery = $derived({
     id: 'unsaved',
     name: translate('common.unsaved-view'),
@@ -82,10 +98,35 @@
   const activeUserView = $derived(
     activeQueryView?.type === 'user' ? activeQueryView : undefined,
   );
+  const systemViewBaseQuery = $derived(activeUserView?.query ?? '');
+  const onCustomView = $derived(
+    Boolean(activeUserView) || Boolean(unsavedQuery),
+  );
+  const addedSystemView = $derived(
+    addedSystemViewId && addedSystemViewQuery === query
+      ? addedSystemViewId
+      : undefined,
+  );
+  const narrowsActiveView = (view: SavedQuery) =>
+    view.type === 'system' && view.id !== defaultView.id;
+  const isSystemViewActive = (view: SavedQuery) =>
+    narrowsActiveView(view)
+      ? addedSystemView === view.id ||
+        query === combineQueries(systemViewBaseQuery, view.query)
+      : query === view.query;
+  const appliedSystemView = $derived.by(() => {
+    if (!activeUserView) return undefined;
+    return systemViews.find(
+      (system) =>
+        system.query &&
+        query === combineQueries(systemViewBaseQuery, system.query),
+    );
+  });
   const activeUserViewDirty = $derived(
     Boolean(activeUserView) &&
       Boolean(query) &&
-      activeUserView?.query !== query,
+      activeUserView?.query !== query &&
+      !appliedSystemView,
   );
 
   onMount(() => {
@@ -109,6 +150,8 @@
       goto(url);
     } else if (savedQueryView) {
       activeQueryView = savedQueryView;
+    } else if (savedQueryViewWithSystemView) {
+      activeQueryView = savedQueryViewWithSystemView;
     } else if (systemQueryView) {
       activeQueryView = systemQueryView;
     } else if (query) {
@@ -131,6 +174,8 @@
       if (query && activeQueryView.query !== query) {
         if (savedQueryView) {
           activeQueryView = savedQueryView;
+        } else if (savedQueryViewWithSystemView) {
+          activeQueryView = savedQueryViewWithSystemView;
         } else if (systemQueryView) {
           activeQueryView = systemQueryView;
         } else {
@@ -141,18 +186,34 @@
   });
 
   const setActiveQueryView = (view: SavedQuery) => {
-    if (view.id === activeQueryView?.id) return;
-    activeQueryView = view;
-    pendingQueryTarget = view.query || '';
+    const addsToActiveView = narrowsActiveView(view) && onCustomView;
+    const baseQuery = activeUserView
+      ? systemViewBaseQuery
+      : addedSystemView
+        ? addedSystemViewBase
+        : query;
+    const nextView = addsToActiveView ? activeQueryView : view;
+    const nextQuery = addsToActiveView
+      ? combineQueries(baseQuery, view.query)
+      : view.query;
 
-    if (view.query) {
-      $filters = toListWorkflowFilters(view.query, $searchAttributes);
-    }
+    if (nextView?.id === activeQueryView?.id && nextQuery === query) return;
+
+    addedSystemViewId = addsToActiveView ? view.id : undefined;
+    addedSystemViewBase = addsToActiveView ? baseQuery : '';
+    addedSystemViewQuery = addsToActiveView ? nextQuery : '';
+
+    activeQueryView = nextView;
+    pendingQueryTarget = nextQuery || '';
+
+    $filters = nextQuery
+      ? toListWorkflowFilters(nextQuery, $searchAttributes)
+      : [];
 
     updateQueryParameters({
       url: page.url,
       parameter: 'query',
-      value: view.query,
+      value: nextQuery,
       allowEmpty: true,
       clearParameters: [currentPageKey],
     });
@@ -241,7 +302,7 @@
     {#each systemViews as view (view.id)}
       {@render queryButton({
         ...view,
-        active: query === view.query,
+        active: isSystemViewActive(view),
       })}
     {/each}
   </div>

--- a/src/lib/components/saved-query-views/saved-views.svelte
+++ b/src/lib/components/saved-query-views/saved-views.svelte
@@ -114,19 +114,10 @@
       ? addedSystemView === view.id ||
         query === combineQueries(systemViewBaseQuery, view.query)
       : query === view.query;
-  const appliedSystemView = $derived.by(() => {
-    if (!activeUserView) return undefined;
-    return systemViews.find(
-      (system) =>
-        system.query &&
-        query === combineQueries(systemViewBaseQuery, system.query),
-    );
-  });
   const activeUserViewDirty = $derived(
     Boolean(activeUserView) &&
       Boolean(query) &&
-      activeUserView?.query !== query &&
-      !appliedSystemView,
+      activeUserView?.query !== query,
   );
 
   onMount(() => {
@@ -186,16 +177,29 @@
   });
 
   const setActiveQueryView = (view: SavedQuery) => {
-    const addsToActiveView = narrowsActiveView(view) && onCustomView;
+    const removesActiveView =
+      narrowsActiveView(view) && isSystemViewActive(view);
+    const addsToActiveView =
+      narrowsActiveView(view) && onCustomView && !removesActiveView;
     const baseQuery = activeUserView
       ? systemViewBaseQuery
       : addedSystemView
         ? addedSystemViewBase
         : query;
-    const nextView = addsToActiveView ? activeQueryView : view;
-    const nextQuery = addsToActiveView
-      ? combineQueries(baseQuery, view.query)
-      : view.query;
+    const nextQuery = removesActiveView
+      ? addedSystemView === view.id
+        ? addedSystemViewBase
+        : systemViewBaseQuery
+      : addsToActiveView
+        ? combineQueries(baseQuery, view.query)
+        : view.query;
+    const nextView = removesActiveView
+      ? nextQuery
+        ? activeQueryView
+        : defaultView
+      : addsToActiveView
+        ? activeQueryView
+        : view;
 
     if (nextView?.id === activeQueryView?.id && nextQuery === query) return;
 

--- a/src/lib/stores/saved-queries.ts
+++ b/src/lib/stores/saved-queries.ts
@@ -3,7 +3,6 @@ import {
   IconCheckCircle,
   IconClock,
   type IconComponent,
-  IconExclamationCircle,
   IconExclamationOctagon,
   IconHappyLappy,
   IconHeartbeat,
@@ -152,7 +151,7 @@ export const systemActivityViews: SavedQuery[] = [
     id: 'failed',
     name: 'Failed',
     query: '`ExecutionStatus`="Failed"',
-    Icon: IconExclamationCircle,
+    Icon: IconExclamationOctagon,
     type: 'system',
   },
 ];
@@ -183,7 +182,7 @@ export const systemNexusViews: SavedQuery[] = [
   },
   {
     id: 'last-hour',
-    name: 'Last Hour',
+    name: 'Last 1h',
     query: `StartTime >= "${getLastHour()}"`,
     Icon: IconClock,
     type: 'system',

--- a/src/lib/utilities/query/combine-queries.test.ts
+++ b/src/lib/utilities/query/combine-queries.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { combineQueries } from './combine-queries';
+
+describe('combineQueries', () => {
+  it('should return the addition when there is no base query', () => {
+    expect(combineQueries('', '`ExecutionStatus`="Running"')).toBe(
+      '`ExecutionStatus`="Running"',
+    );
+  });
+
+  it('should return the base when there is no addition', () => {
+    expect(combineQueries('`WorkflowId`="abc"', '')).toBe('`WorkflowId`="abc"');
+  });
+
+  it('should return an empty query when both are empty', () => {
+    expect(combineQueries('', '')).toBe('');
+  });
+
+  it('should join both queries with AND', () => {
+    expect(
+      combineQueries('`WorkflowId`="abc"', '`ExecutionStatus`="Running"'),
+    ).toBe('`WorkflowId`="abc" AND `ExecutionStatus`="Running"');
+  });
+
+  it('should not duplicate an identical query', () => {
+    expect(
+      combineQueries(
+        '`ExecutionStatus`="Running"',
+        '`ExecutionStatus`="Running"',
+      ),
+    ).toBe('`ExecutionStatus`="Running"');
+  });
+
+  it('should trim surrounding whitespace', () => {
+    expect(
+      combineQueries('  `WorkflowId`="abc" ', ' StartTime >= "2024" '),
+    ).toBe('`WorkflowId`="abc" AND StartTime >= "2024"');
+  });
+
+  it('should group a base query containing an ungrouped OR', () => {
+    expect(
+      combineQueries(
+        '`ExecutionStatus`="Failed" OR `ExecutionStatus`="TimedOut"',
+        'StartTime >= "2024-01-01T00:00:00.000Z"',
+      ),
+    ).toBe(
+      '(`ExecutionStatus`="Failed" OR `ExecutionStatus`="TimedOut") AND StartTime >= "2024-01-01T00:00:00.000Z"',
+    );
+  });
+
+  it('should not group a base query whose OR is already grouped', () => {
+    expect(
+      combineQueries(
+        '(`ExecutionStatus`="Failed" OR `ExecutionStatus`="TimedOut") AND `TaskQueue`="a"',
+        '`ParentWorkflowId` is null',
+      ),
+    ).toBe(
+      '(`ExecutionStatus`="Failed" OR `ExecutionStatus`="TimedOut") AND `TaskQueue`="a" AND `ParentWorkflowId` is null',
+    );
+  });
+
+  it('should ignore OR inside quoted values and attribute names', () => {
+    expect(combineQueries('`WorkflowId`="or"', '`TaskQueue`="b"')).toBe(
+      '`WorkflowId`="or" AND `TaskQueue`="b"',
+    );
+    expect(combineQueries('`Or Attribute`="x"', '`TaskQueue`="b"')).toBe(
+      '`Or Attribute`="x" AND `TaskQueue`="b"',
+    );
+  });
+
+  it('should ignore words that merely start with or', () => {
+    expect(combineQueries('`Order`="x"', '`TaskQueue`="b"')).toBe(
+      '`Order`="x" AND `TaskQueue`="b"',
+    );
+  });
+
+  it('should preserve IN lists', () => {
+    expect(
+      combineQueries(
+        '`ExecutionStatus`="Running" AND `TemporalReportedProblems` IN ("category=WorkflowTaskFailed")',
+        'StartTime >= "2024-01-01T00:00:00.000Z"',
+      ),
+    ).toBe(
+      '`ExecutionStatus`="Running" AND `TemporalReportedProblems` IN ("category=WorkflowTaskFailed") AND StartTime >= "2024-01-01T00:00:00.000Z"',
+    );
+  });
+});

--- a/src/lib/utilities/query/combine-queries.ts
+++ b/src/lib/utilities/query/combine-queries.ts
@@ -1,0 +1,29 @@
+const stripLiterals = (query: string): string =>
+  query.replace(/`[^`]*`|"[^"]*"|'[^']*'/g, '');
+
+const stripGroups = (query: string): string => {
+  let result = query;
+  let previous = '';
+  while (result !== previous) {
+    previous = result;
+    result = result.replace(/\([^()]*\)/g, '');
+  }
+  return result;
+};
+
+const hasUngroupedOr = (query: string): boolean =>
+  /\bor\b/i.test(stripGroups(stripLiterals(query)));
+
+const group = (query: string): string =>
+  hasUngroupedOr(query) ? `(${query})` : query;
+
+export const combineQueries = (base: string, addition: string): string => {
+  const left = (base ?? '').trim();
+  const right = (addition ?? '').trim();
+
+  if (!left) return right;
+  if (!right) return left;
+  if (left === right) return left;
+
+  return `${group(left)} AND ${group(right)}`;
+};

--- a/tests/integration/saved-query-views.spec.ts
+++ b/tests/integration/saved-query-views.spec.ts
@@ -376,6 +376,45 @@ test.describe('Saved Query Views', () => {
     );
   });
 
+  test('System saved queries keep unsaved filter edits made on a saved view', async ({
+    page,
+  }) => {
+    const savedQuery = '`WorkflowId`="user-view-1"';
+    const edited = `${savedQuery} AND \`TaskQueue\`="queue-z"`;
+
+    await page.goto(
+      `/namespaces/default/workflows?query=${encodeURIComponent(savedQuery)}&savedQuery=My+View`,
+    );
+    await expectSelectedView(page, 'My View');
+
+    await page.locator('#workflow-search-attribute-filter-button').click();
+    await page.locator('#workflow-filter-search').fill('TaskQueue');
+    await page.getByRole('menuitem', { name: 'TaskQueue Keyword' }).click();
+    await page
+      .getByTestId('dropdown-filter-chip-TaskQueue-1-text')
+      .fill('queue-z');
+    await page.getByRole('button', { name: 'Apply' }).click();
+
+    await expect.poll(() => getQueryParam(page.url())).toBe(edited);
+    await expect(page.getByTestId('save-view-button')).toBeVisible();
+
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe(`${edited} AND \`ExecutionStatus\`="Running"`);
+    await expectSelectedView(page, 'My View');
+
+    await page.getByTestId('child-workflows').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe(`${edited} AND \`ParentWorkflowId\` is null`);
+
+    await page.getByTestId('child-workflows').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe(edited);
+    await expect(page.getByTestId('save-view-button')).toBeVisible();
+    await expectSelectedView(page, 'My View');
+  });
+
   test('All Workflows clears the active user saved view', async ({ page }) => {
     await page.locator('#workflow-search-attribute-filter-button').click();
     await page.locator('#workflow-filter-search').fill('WorkflowId');

--- a/tests/integration/saved-query-views.spec.ts
+++ b/tests/integration/saved-query-views.spec.ts
@@ -178,6 +178,132 @@ test.describe('Saved Query Views', () => {
     await expect.poll(() => getQueryParam(page.url())).toBe('');
   });
 
+  test('System saved queries narrow the active user saved view', async ({
+    page,
+  }) => {
+    await page.locator('#workflow-search-attribute-filter-button').click();
+    await page.locator('#workflow-filter-search').fill('WorkflowId');
+    await page.getByRole('menuitem', { name: 'WorkflowId Keyword' }).click();
+    await page
+      .getByTestId('dropdown-filter-chip-WorkflowId-0-text')
+      .fill('user-view-1');
+    await page.getByTestId('apply-filter-button').click();
+
+    await page.getByTestId('create-view-button').click();
+    await page.getByTestId('workflow-save-view-modal-input').fill('My View');
+    await page
+      .getByLabel('Save as New View')
+      .getByTestId('confirm-modal-button')
+      .click();
+
+    await expectSelectedView(page, 'My View');
+
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="user-view-1" AND `ExecutionStatus`="Running"');
+    await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
+
+    await page.getByTestId('child-workflows').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="user-view-1" AND `ParentWorkflowId` is null');
+    await expectSelectedView(page, 'My View');
+
+    await selectCustomView(page, 'my-view');
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="user-view-1"');
+    await expectSelectedView(page, 'My View');
+  });
+
+  test('System saved queries add to an unsaved view', async ({ page }) => {
+    await page.locator('#workflow-search-attribute-filter-button').click();
+    await page.locator('#workflow-filter-search').fill('WorkflowId');
+    await page.getByRole('menuitem', { name: 'WorkflowId Keyword' }).click();
+    await page
+      .getByTestId('dropdown-filter-chip-WorkflowId-0-text')
+      .fill('draft-1');
+    await page.getByTestId('apply-filter-button').click();
+
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="draft-1"');
+    await expectSelectedView(page, 'Unsaved view');
+
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="draft-1" AND `ExecutionStatus`="Running"');
+    await expectSelectedView(page, 'Unsaved view');
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+
+    await page.getByTestId('today').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toMatch(/^`WorkflowId`="draft-1" AND StartTime >= "\d{4}-/);
+    await expectSelectedView(page, 'Unsaved view');
+    await expect(page.getByTestId('today')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
+
+    await page.getByTestId('all').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe('');
+    await expect(page.getByTestId('today')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
+    await expect(page.getByTestId('all')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+  });
+
+  test('All Workflows clears the active user saved view', async ({ page }) => {
+    await page.locator('#workflow-search-attribute-filter-button').click();
+    await page.locator('#workflow-filter-search').fill('WorkflowId');
+    await page.getByRole('menuitem', { name: 'WorkflowId Keyword' }).click();
+    await page
+      .getByTestId('dropdown-filter-chip-WorkflowId-0-text')
+      .fill('user-view-1');
+    await page.getByTestId('apply-filter-button').click();
+
+    await page.getByTestId('create-view-button').click();
+    await page.getByTestId('workflow-save-view-modal-input').fill('My View');
+    await page
+      .getByLabel('Save as New View')
+      .getByTestId('confirm-modal-button')
+      .click();
+
+    await expectSelectedView(page, 'My View');
+
+    await page.getByTestId('all').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe('');
+    await expectSelectedView(page, 'Saved Views');
+    await expect(
+      page.getByRole('button', { name: 'WorkflowId = "user-view-1"' }),
+    ).toBeHidden();
+
+    await selectCustomView(page, 'my-view');
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="user-view-1" AND `ExecutionStatus`="Running"');
+
+    await page.getByTestId('all').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe('');
+    await expectSelectedView(page, 'Saved Views');
+  });
+
   test('User saved queries: create view from shared view query', async ({
     page,
   }) => {

--- a/tests/integration/saved-query-views.spec.ts
+++ b/tests/integration/saved-query-views.spec.ts
@@ -58,6 +58,30 @@ test.describe('Saved Query Views', () => {
     await expect.poll(() => getQueryParam(page.url())).toBe('');
   });
 
+  test('System saved queries toggle off when selected again', async ({
+    page,
+  }) => {
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`ExecutionStatus`="Running"');
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+
+    await page.getByTestId('running').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe('');
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
+    await expect(page.getByTestId('all')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+  });
+
   test('User saved queries: create new, edit view, then delete', async ({
     page,
   }) => {
@@ -197,25 +221,39 @@ test.describe('Saved Query Views', () => {
       .click();
 
     await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
 
     await page.getByTestId('running').click();
     await expect
       .poll(() => getQueryParam(page.url()))
       .toBe('`WorkflowId`="user-view-1" AND `ExecutionStatus`="Running"');
     await expectSelectedView(page, 'My View');
-    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
+    await expect(page.getByTestId('save-view-button')).toBeVisible();
 
     await page.getByTestId('child-workflows').click();
     await expect
       .poll(() => getQueryParam(page.url()))
       .toBe('`WorkflowId`="user-view-1" AND `ParentWorkflowId` is null');
     await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toBeVisible();
+
+    await page.getByTestId('child-workflows').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="user-view-1"');
+    await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
+    await expect(page.getByTestId('child-workflows')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
 
     await selectCustomView(page, 'my-view');
     await expect
       .poll(() => getQueryParam(page.url()))
       .toBe('`WorkflowId`="user-view-1"');
     await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
   });
 
   test('System saved queries add to an unsaved view', async ({ page }) => {
@@ -242,6 +280,17 @@ test.describe('Saved Query Views', () => {
       'true',
     );
 
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe('`WorkflowId`="draft-1"');
+    await expectSelectedView(page, 'Unsaved view');
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
+
+    await page.getByTestId('running').click();
     await page.getByTestId('today').click();
     await expect
       .poll(() => getQueryParam(page.url()))
@@ -265,6 +314,65 @@ test.describe('Saved Query Views', () => {
     await expect(page.getByTestId('all')).toHaveAttribute(
       'data-active',
       'true',
+    );
+  });
+
+  test('System saved queries toggle off after a reload without losing the saved view', async ({
+    page,
+  }) => {
+    const savedQuery = '`WorkflowId`="user-view-1"';
+
+    await page.goto(
+      `/namespaces/default/workflows?query=${encodeURIComponent(savedQuery)}&savedQuery=My+View`,
+    );
+    await expectSelectedView(page, 'My View');
+
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe(`${savedQuery} AND \`ExecutionStatus\`="Running"`);
+
+    await page.reload();
+    await waitForWorkflowsApis(page);
+    await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'true',
+    );
+
+    await page.getByTestId('running').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe(savedQuery);
+    await expectSelectedView(page, 'My View');
+    await expect(page.getByTestId('save-view-button')).toHaveCount(0);
+    await expect(page.getByTestId('running')).toHaveAttribute(
+      'data-active',
+      'false',
+    );
+  });
+
+  test('System saved queries toggle off on an unsaved view keep it unsaved', async ({
+    page,
+  }) => {
+    const draftQuery = '`WorkflowId`="draft-1"';
+
+    await page.goto(
+      `/namespaces/default/workflows?query=${encodeURIComponent(draftQuery)}`,
+    );
+    await waitForWorkflowsApis(page);
+    await expectSelectedView(page, 'Unsaved view');
+
+    await page.getByTestId('running').click();
+    await expect
+      .poll(() => getQueryParam(page.url()))
+      .toBe(`${draftQuery} AND \`ExecutionStatus\`="Running"`);
+
+    await page.getByTestId('running').click();
+    await expect.poll(() => getQueryParam(page.url())).toBe(draftQuery);
+    await expectSelectedView(page, 'Unsaved view');
+    await expect(page.getByTestId('create-view-button')).toBeVisible();
+    await expect(page.getByTestId('all')).toHaveAttribute(
+      'data-active',
+      'false',
     );
   });
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Selecting a system saved view (Running, Failures, Parent, Today, Last 1h, …) replaced the whole query, silently discarding the custom saved view selected. Picking "Today" while on a custom saved view dropped you to *all* workflows from today.

System views are now **additive** on top of a custom view (both saved or unsaved).

- **One system view applies at a time.** Each click rebuilds from the query the system view was applied *on top of*.
- **Clicking the highlighted view removes it**, restoring exactly what it was applied to.
- **"All" is always a reset** — clears the query, clears the filter pills, deselects the custom view.
- **Adding a system view to a saved view marks it unsaved**, so Save / Edit / Duplicate appear andre-selecting the view from the menu restores it.
- **Unsaved filter edits are preserved.** Adding `TaskQueue="queue-1"` on top of a saved view and then clicking a system view keeps the edit through the add, the swap, and the removal. Re-selecting the view from the menu restores it.
- **Unsaved filter edits are preserved.** Adding `TaskQueue="queue-2"` on top of a saved view and then clicking a system view keeps the edit through the add, the swap, and the removal.
- **Reload and shared links recover the pairing** — a URL holding `savedView AND systemView` resolves back to the saved view with the system view highlighted, rather than "Unsaved view".

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

Known limitations:
- **Duplicate query when your query already contains a system view's filter.** Dedupe is whole-string only, so Failures + Running (Failures contains `ExecutionStatus="Running"`), or a saved view that already filters on Running, yields a redundant query and the status pill renders `ExecutionStatus = Running, Running`. 
- **On an *unsaved* query the highlight doesn't survive a reload** (it does for saved views, which can be recognized from the query). Provenance lives in component state because the URL can't express "this clause came from a chip". 

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [x] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

- [ ] Verify the following on Schedules / Workers / Standalone Activities / Standalone Nexus Operations

1. On Workflows, add a filter (e.g. `WorkflowId = foo`) and save it as a view.
2. Click **Running** → query becomes `` `WorkflowId`="foo" AND `ExecutionStatus`="Running" ``, the
   view stays selected and shows as unsaved.
3. Click **Today** → Running is replaced, `WorkflowId` is kept.
4. Click **Today** again → back to the saved query, unsaved state clears.
5. Add another filter by hand, then click a system view → your filter is still there.
6. Reload with a system view applied, then click that view again → returns to the saved query with
   the view still selected.
7. Click **All** → query empties, pills clear, the menu returns to "Saved Views".
8. With no custom view selected, confirm system views still behave as before.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->



### Issue(s) closed <!-- add issue number here -->
`FE-479`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
