### PR TITLE
 Wrap long filter chips instead of overflowing the filter bar

### DIFF
--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -345,20 +345,23 @@
   </ToggleButtons>
 {/snippet}
 
-<MenuContainer {open}>
+<MenuContainer {open} class="min-w-0 max-w-full">
   <MenuButton
     size="xs"
     controls={controlsId}
     hasIndicator
-    class="min-w-0 max-w-full bg-secondary"
+    class="h-auto min-h-8 min-w-0 max-w-full whitespace-normal bg-secondary"
     title="{getDisplayKeyWithConditional(localFilter)} {getDisplayValue(
       localFilter,
     )}"
   >
-    <span class="truncate">{getDisplayKeyWithConditional(localFilter)}</span
-    ><span class="max-w-[160px] truncate pl-1 text-brand lg:max-w-full"
-      >{getDisplayValue(localFilter)}</span
-    >
+    <div class="min-w-0 text-left">
+      <span class="break-words"
+        >{getDisplayKeyWithConditional(localFilter)}</span
+      ><span class="break-all pl-1 text-brand"
+        >{getDisplayValue(localFilter)}</span
+      >
+    </div>
   </MenuButton>
 
   <Menu id={controlsId} class="max-h-fit w-64 p-4 lg:max-w-fit">

--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -358,9 +358,8 @@
     <div class="min-w-0 text-left">
       <span class="break-words"
         >{getDisplayKeyWithConditional(localFilter)}</span
-      ><span class="break-all pl-1 text-brand"
-        >{getDisplayValue(localFilter)}</span
       >
+      <span class="break-all text-brand">{getDisplayValue(localFilter)}</span>
     </div>
   </MenuButton>
 

--- a/src/lib/components/search-attribute-filter/filter-bar.svelte
+++ b/src/lib/components/search-attribute-filter/filter-bar.svelte
@@ -6,6 +6,7 @@
 
   import Button from '$lib/holocene/button.svelte';
   import Tooltip from '$lib/holocene/tooltip.svelte';
+  import { translate } from '$lib/i18n/translate';
   import { IconCode } from '$lib/io/icon';
   import type { SearchAttributeFilter } from '$lib/models/search-attribute-filters';
   import type { SearchAttributeOption } from '$lib/stores/search-attributes';
@@ -53,7 +54,7 @@
 
 <div>
   <div
-    class="flex w-full flex-wrap items-center justify-between gap-2 border border-b-0 border-subtle bg-primary p-1.5"
+    class="flex w-full flex-wrap items-end justify-between gap-2 border border-b-0 border-subtle bg-primary p-1.5"
   >
     <Filter
       {filters}
@@ -62,9 +63,11 @@
       {statusAttribute}
       {includeNullConditions}
     />
-    <div class="flex items-center gap-1">
+    <div class="flex shrink-0 items-center gap-1">
       <Tooltip
-        text={viewManualQuery ? 'Hide raw query' : 'View raw query'}
+        text={viewManualQuery
+          ? translate('common.hide-raw-query')
+          : translate('common.view-raw-query')}
         left
       >
         <Button

--- a/src/lib/components/search-attribute-filter/filter-list.svelte
+++ b/src/lib/components/search-attribute-filter/filter-list.svelte
@@ -100,7 +100,7 @@
 </script>
 
 {#if visibleFilters.length > 0}
-  <div class="flex flex-wrap items-center gap-2">
+  <div class="flex min-w-0 flex-wrap items-center gap-2">
     {#each visibleFilters as filterItem, i (filterItem.id)}
       {#if statusAttribute && isStatusFilter(filterItem) && i === firstExecutionStatusIndex}
         <StatusFilterChip

--- a/src/lib/components/search-attribute-filter/filter.svelte
+++ b/src/lib/components/search-attribute-filter/filter.svelte
@@ -87,7 +87,7 @@
   }
 </script>
 
-<div class="flex shrink flex-wrap items-center justify-start gap-2">
+<div class="flex min-w-0 shrink flex-wrap items-center justify-start gap-2">
   <DropdownFilterList {filters} {statusAttribute} />
   <SearchAttributeMenu {options} {filters} {statusAttribute} />
 </div>

--- a/src/lib/components/search-attribute-filter/filter.svelte
+++ b/src/lib/components/search-attribute-filter/filter.svelte
@@ -87,7 +87,7 @@
   }
 </script>
 
-<div class="flex min-w-0 shrink flex-wrap items-center justify-start gap-2">
+<div class="flex min-w-0 flex-1 flex-wrap items-center justify-start gap-2">
   <DropdownFilterList {filters} {statusAttribute} />
   <SearchAttributeMenu {options} {filters} {statusAttribute} />
 </div>

--- a/src/lib/components/search-attribute-filter/status-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/status-filter-chip.svelte
@@ -117,18 +117,19 @@
   });
 </script>
 
-<MenuContainer {open}>
+<MenuContainer {open} class="min-w-0 max-w-full">
   <MenuButton
     size="xs"
     controls={controlsId}
     hasIndicator
-    class="min-w-0 max-w-full bg-secondary"
+    class="h-auto min-h-8 min-w-0 max-w-full whitespace-normal bg-secondary"
     title="{attribute} = {statusValues}"
   >
-    <span class="truncate">{attribute} =</span><span
-      class="max-w-[160px] truncate pl-1 text-brand lg:max-w-full"
-      >{statusValues}</span
-    >
+    <div class="min-w-0 text-left">
+      <span class="break-words">{attribute} =</span><span
+        class="break-all pl-1 text-brand">{statusValues}</span
+      >
+    </div>
   </MenuButton>
 
   <Menu id={controlsId} class="max-h-fit w-80 max-w-fit p-4" keepOpen>

--- a/src/lib/components/search-attribute-filter/status-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/status-filter-chip.svelte
@@ -126,9 +126,8 @@
     title="{attribute} = {statusValues}"
   >
     <div class="min-w-0 text-left">
-      <span class="break-words">{attribute} =</span><span
-        class="break-all pl-1 text-brand">{statusValues}</span
-      >
+      <span class="break-words">{attribute} =</span>
+      <span class="break-all text-brand">{statusValues}</span>
     </div>
   </MenuButton>
 

--- a/src/lib/i18n/locales/en/common.ts
+++ b/src/lib/i18n/locales/en/common.ts
@@ -9,6 +9,8 @@ export const Strings = {
   apply: 'Apply',
   remove: 'Remove',
   query: 'Query',
+  'view-raw-query': 'View raw query',
+  'hide-raw-query': 'Hide raw query',
   ago: 'ago',
   'all-time': 'All Time',
   time: 'Time',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

A filter chip with a long value ran past the right edge of the filter bar instead of staying inside it. The raw-query toggle also got pushed onto its own line whenever a chip filled the row.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="1201" height="329" alt="Screenshot 2026-09-02 at 9 53 16 PM" src="https://github.com/user-attachments/assets/28969d47-1aa2-4e68-8fab-fa43b1934850" />|<img width="1204" height="280" alt="Screenshot 2026-09-02 at 9 38 14 PM" src="https://github.com/user-attachments/assets/3c683c0d-4f70-4923-afc0-c1f70bcbb816" />|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. On Workflows, add a `WorkflowId` filter whose value is ~300 characters.
2. Confirm the chip stays inside the filter bar and wraps, with `WorkflowId =` unbroken on the first line and the value continuing on the same line.
3. Confirm the raw-query toggle stays on the same row as "Clear all" instead of dropping to its own line.
4. Narrow the window to mobile width and repeat.
5. Select several execution statuses and confirm the status chip behaves the same way.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`FE-556`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
