### PR TITLE
feat(catalog): add a schedule manager to the catalog worker

### DIFF
--- a/.env.catalog
+++ b/.env.catalog
@@ -7,3 +7,5 @@
 # the UI even when another process publishes 7233 on IPv6 (for example Docker).
 TEMPORAL_ADDRESS=127.0.0.1:7233
 TEMPORAL_NAMESPACE=default
+# The schedule manager is off by default. Set CATALOG_SCHEDULES=enabled in
+# .env.catalog.local to let the worker create the schedules examples declare.

--- a/.env.catalog.local.example
+++ b/.env.catalog.local.example
@@ -35,3 +35,8 @@
 
 # Run only one catalog target instead of all of them:
 # CATALOG_TARGET_ID=shared-workflows
+
+# --- Declared schedules ---
+# The schedule manager is disabled by default. Enable it to let the worker
+# reconcile the schedules examples declare. It only writes schedules it owns.
+# CATALOG_SCHEDULES=enabled

--- a/agent-plugins/temporal-ui-catalog/skills/catalog/SKILL.md
+++ b/agent-plugins/temporal-ui-catalog/skills/catalog/SKILL.md
@@ -89,6 +89,33 @@ Each declared endpoint becomes a required readiness check. On a plaintext local 
 
 For manual steps no check can verify, add `setupMarkdown` to the example. It renders as a Setup card on the example page and travels in the generated artifact, so agents read the same guidance a person sees.
 
+## Schedules
+
+An example may declare one schedule beside its execution:
+
+```ts
+execution: {
+  kind: 'workflow',
+  workflowType: 'hello',
+  workflow: hello,
+  activities: { greet },
+  schedule: {
+    id: 'ui-catalog-hello-hourly',
+    spec: { cronExpressions: ['0 * * * *'] },
+    paused: false,
+    note: 'Declared by the hello catalog example',
+  },
+}
+```
+
+The spec takes `cronExpressions`, `intervals`, or both, and needs at least one entry. Add `input` to run the schedule with different arguments; without it the schedule uses the same input the Run button uses. Schedule ids must be unique across every registered example.
+
+Nothing is created until you turn the manager on. It is **disabled by default**; set `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. When it is off, the worker prints one line saying so.
+
+When it is on, the worker creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once. That schedule runs the `schedule-sync` example, which reconciles every declared schedule.
+
+The manager stamps a `uiCatalog` memo on each schedule it creates and only writes schedules carrying that memo. An owned schedule that no example declares any more is deleted. An existing id without the memo is reported as blocked and is never updated or deleted.
+
 ## Promote a local example into the shared catalog
 
 Promotion is deliberate and never automatic:

--- a/agent-plugins/temporal-ui-catalog/skills/catalog/SKILL.md
+++ b/agent-plugins/temporal-ui-catalog/skills/catalog/SKILL.md
@@ -116,6 +116,8 @@ When it is on, the worker creates its own hourly `ui-catalog-schedule-sync` sche
 
 The manager stamps a `uiCatalog` memo on each schedule it creates and only writes schedules carrying that memo. An owned schedule that no example declares any more is deleted. An existing id without the memo is reported as blocked and is never updated or deleted.
 
+To stop a declared schedule without editing code, pause it. A running state that disagrees with the declaration is reported as held, and the manager writes nothing to that schedule — spec, action, and state are all left alone — until it is resumed. Pausing `ui-catalog-schedule-sync` stops reconciliation entirely, including at worker startup, so it works as a kill switch that survives restarts.
+
 ## Promote a local example into the shared catalog
 
 Promotion is deliberate and never automatic:

--- a/scripts/catalog/dev.ts
+++ b/scripts/catalog/dev.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { Client, Connection, ScheduleNotFoundError } from '@temporalio/client';
+import { Connection } from '@temporalio/client';
 import {
   DefaultLogger,
   NativeConnection,
@@ -17,17 +17,12 @@ import {
   declaredNexusEndpoints,
   ensureDeclaredNexusEndpoints,
 } from '../../src/lib/catalog/worker/endpoint-provisioning';
-import { toScheduleSpec } from '../../src/lib/catalog/worker/examples/schedule-sync/activities';
-import {
-  catalogScheduleMemoKey,
-  catalogScheduleOwnership,
-} from '../../src/lib/catalog/worker/examples/schedule-sync/ownership';
 import type { CatalogTarget } from '../../src/lib/catalog/worker/registry';
 import { requireCatalogRoutingFromEnvironment } from '../../src/lib/catalog/worker/routing-config';
 import type { CatalogRunnerEvent } from '../../src/lib/catalog/worker/runner';
 import { bootstrapCatalogScheduleSync } from '../../src/lib/catalog/worker/schedule-bootstrap';
 import { parseCatalogScheduleConfig } from '../../src/lib/catalog/worker/schedule-config';
-import type { CatalogDesiredSchedule } from '../../src/lib/catalog/worker/schedule-declarations';
+import { catalogScheduleManagerOperations } from '../../src/lib/catalog/worker/schedule-manager-client';
 import {
   formatCatalogBanner,
   supportsAnsiColor,
@@ -166,58 +161,15 @@ try {
           `Waiting for the Temporal server at ${connectionConfig.address}… (attempt ${attempt})`,
         ),
     });
-    const managerHandle = ({ id, namespace }: CatalogDesiredSchedule) =>
-      new Client({ connection, namespace }).schedule.getHandle(id);
-
     try {
       await bootstrapCatalogScheduleSync({
-        bindings: selectedBindings,
-        describeManager: async (entry) => {
-          try {
-            const { state } = await managerHandle(entry).describe();
-            return { exists: true, paused: state.paused };
-          } catch (error) {
-            if (error instanceof ScheduleNotFoundError)
-              return { exists: false, paused: false };
-            throw error;
-          }
-        },
-        createManager: async (entry) => {
-          await new Client({
-            connection,
-            namespace: entry.namespace,
-          }).schedule.create({
-            scheduleId: entry.id,
-            spec: toScheduleSpec(entry.spec),
-            action: {
-              type: 'startWorkflow',
-              workflowType: entry.workflowType,
-              taskQueue: entry.taskQueue,
-              args: entry.args,
-            },
-            state: { paused: entry.paused, note: entry.note },
-            memo: {
-              [catalogScheduleMemoKey]: catalogScheduleOwnership(
-                entry.exampleId,
-              ),
-            },
-          });
-        },
-        updateManagerArgs: async (entry) => {
-          await managerHandle(entry).update((previous) => ({
-            ...previous,
-            action: {
-              ...previous.action,
-              type: 'startWorkflow',
-              workflowType: entry.workflowType,
-              taskQueue: entry.taskQueue,
-              args: entry.args,
-            },
-          }));
-        },
-        triggerManager: async (entry) => {
-          await managerHandle(entry).trigger();
-        },
+        // Every registered target, never the CATALOG_TARGET_ID subset: the
+        // reconciler deletes owned schedules that are not in the desired list,
+        // so a narrowed set would delete the other targets' schedules.
+        bindings: workerBindings,
+        registeredTargetIds: workerBindings.map(({ target }) => target.id),
+        runningTargetIds: selectedBindings.map(({ target }) => target.id),
+        ...catalogScheduleManagerOperations(connection),
         onEvent: (event) => {
           if (event.state === 'skipped') {
             console.info(`Schedule manager skipped: ${event.reason}`);

--- a/scripts/catalog/dev.ts
+++ b/scripts/catalog/dev.ts
@@ -174,11 +174,11 @@ try {
         bindings: selectedBindings,
         describeManager: async (entry) => {
           try {
-            await managerHandle(entry).describe();
-            return { exists: true };
+            const { state } = await managerHandle(entry).describe();
+            return { exists: true, paused: state.paused };
           } catch (error) {
             if (error instanceof ScheduleNotFoundError)
-              return { exists: false };
+              return { exists: false, paused: false };
             throw error;
           }
         },
@@ -221,6 +221,10 @@ try {
         onEvent: (event) => {
           if (event.state === 'skipped') {
             console.info(`Schedule manager skipped: ${event.reason}`);
+          } else if (event.state === 'held') {
+            console.info(
+              `Schedule "${event.scheduleId}" is held: ${event.reason}. No schedule was created, updated, or deleted.`,
+            );
           } else if (event.state === 'blocked') {
             console.info(
               `Cannot reconcile schedule "${event.scheduleId}": ${event.error instanceof Error ? event.error.message : String(event.error)}`,

--- a/scripts/catalog/dev.ts
+++ b/scripts/catalog/dev.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { Connection } from '@temporalio/client';
+import { Client, Connection, ScheduleNotFoundError } from '@temporalio/client';
 import {
   DefaultLogger,
   NativeConnection,
@@ -17,9 +17,17 @@ import {
   declaredNexusEndpoints,
   ensureDeclaredNexusEndpoints,
 } from '../../src/lib/catalog/worker/endpoint-provisioning';
+import { toScheduleSpec } from '../../src/lib/catalog/worker/examples/schedule-sync/activities';
+import {
+  catalogScheduleMemoKey,
+  catalogScheduleOwnership,
+} from '../../src/lib/catalog/worker/examples/schedule-sync/ownership';
 import type { CatalogTarget } from '../../src/lib/catalog/worker/registry';
 import { requireCatalogRoutingFromEnvironment } from '../../src/lib/catalog/worker/routing-config';
 import type { CatalogRunnerEvent } from '../../src/lib/catalog/worker/runner';
+import { bootstrapCatalogScheduleSync } from '../../src/lib/catalog/worker/schedule-bootstrap';
+import { parseCatalogScheduleConfig } from '../../src/lib/catalog/worker/schedule-config';
+import type { CatalogDesiredSchedule } from '../../src/lib/catalog/worker/schedule-declarations';
 import {
   formatCatalogBanner,
   supportsAnsiColor,
@@ -41,6 +49,7 @@ const loadEnvironment = (
 ).loadEnvFile;
 const runningTargetIds = new Set<string>();
 let announcedTargets: readonly { target: CatalogTarget }[] = [];
+let schedulesEnabled = false;
 
 const emitCatalogEvent = ({ type, ...details }: CatalogRunnerEvent) => {
   console.info(
@@ -60,6 +69,7 @@ const emitCatalogEvent = ({ type, ...details }: CatalogRunnerEvent) => {
         isTTY: Boolean(process.stdout.isTTY),
         environment: process.env,
       }),
+      schedulesEnabled,
     }),
   );
 };
@@ -83,6 +93,8 @@ try {
     : workerBindings;
   announcedTargets = selectedBindings;
   const connectionConfig = parseCatalogConnectionConfig(process.env);
+  const scheduleConfig = parseCatalogScheduleConfig(process.env);
+  schedulesEnabled = scheduleConfig.enabled;
 
   if (
     declaredNexusEndpoints(selectedBindings).length > 0 &&
@@ -132,6 +144,96 @@ try {
       });
     } finally {
       await client.close();
+    }
+  }
+
+  if (!scheduleConfig.enabled) {
+    console.info(
+      'Schedule manager disabled; set CATALOG_SCHEDULES=enabled in .env.catalog.local to create declared schedules.',
+    );
+  } else {
+    const connection = await connectWithRetry({
+      connect: () =>
+        Connection.connect({
+          address: connectionConfig.address,
+          ...(connectionConfig.apiKey
+            ? { apiKey: connectionConfig.apiKey }
+            : {}),
+          ...(connectionConfig.tls ? { tls: connectionConfig.tls } : {}),
+        }),
+      onWaiting: ({ attempt }) =>
+        console.info(
+          `Waiting for the Temporal server at ${connectionConfig.address}… (attempt ${attempt})`,
+        ),
+    });
+    const managerHandle = ({ id, namespace }: CatalogDesiredSchedule) =>
+      new Client({ connection, namespace }).schedule.getHandle(id);
+
+    try {
+      await bootstrapCatalogScheduleSync({
+        bindings: selectedBindings,
+        describeManager: async (entry) => {
+          try {
+            await managerHandle(entry).describe();
+            return { exists: true };
+          } catch (error) {
+            if (error instanceof ScheduleNotFoundError)
+              return { exists: false };
+            throw error;
+          }
+        },
+        createManager: async (entry) => {
+          await new Client({
+            connection,
+            namespace: entry.namespace,
+          }).schedule.create({
+            scheduleId: entry.id,
+            spec: toScheduleSpec(entry.spec),
+            action: {
+              type: 'startWorkflow',
+              workflowType: entry.workflowType,
+              taskQueue: entry.taskQueue,
+              args: entry.args,
+            },
+            state: { paused: entry.paused, note: entry.note },
+            memo: {
+              [catalogScheduleMemoKey]: catalogScheduleOwnership(
+                entry.exampleId,
+              ),
+            },
+          });
+        },
+        updateManagerArgs: async (entry) => {
+          await managerHandle(entry).update((previous) => ({
+            ...previous,
+            action: {
+              ...previous.action,
+              type: 'startWorkflow',
+              workflowType: entry.workflowType,
+              taskQueue: entry.taskQueue,
+              args: entry.args,
+            },
+          }));
+        },
+        triggerManager: async (entry) => {
+          await managerHandle(entry).trigger();
+        },
+        onEvent: (event) => {
+          if (event.state === 'skipped') {
+            console.info(`Schedule manager skipped: ${event.reason}`);
+          } else if (event.state === 'blocked') {
+            console.info(
+              `Cannot reconcile schedule "${event.scheduleId}": ${event.error instanceof Error ? event.error.message : String(event.error)}`,
+            );
+          } else {
+            console.info(
+              `Schedule "${event.scheduleId}" ${event.state} in ${event.namespace}/${event.taskQueue} with ${event.declaredCount} declared schedules.`,
+            );
+          }
+        },
+      });
+    } finally {
+      await connection.close();
     }
   }
 

--- a/src/lib/catalog/README.md
+++ b/src/lib/catalog/README.md
@@ -31,6 +31,7 @@ Copy the example file to `.env.catalog.local` and uncomment what you need. Only 
 | `TEMPORAL_ADDRESS`           | Server address. Defaults to `127.0.0.1:7233`.                       |
 | `TEMPORAL_NAMESPACE`         | Namespace the worker registers and polls in. Defaults to `default`. |
 | `CATALOG_TARGET_ID` | Optional. Run one target instead of all of them.                    |
+| `CATALOG_SCHEDULES` | Optional. `enabled` or `disabled`. Defaults to `disabled`.          |
 
 Prefer `127.0.0.1` over `localhost`. On some machines `localhost` resolves to IPv6 and reaches a different Temporal server than the UI is reading — for example a container publishing the same port — which appears as a healthy worker the catalog cannot see.
 
@@ -71,6 +72,33 @@ A target is a worker specification: a namespace, a task queue, a workflow bundle
 The worker waits for the server rather than exiting if it starts first, printing progress while it retries. Non-connection failures, such as an invalid API key, still fail immediately.
 
 On a plaintext local connection, the worker creates any Nexus endpoints its examples declare. When it lacks the authority to do so — any credentialed connection, including Temporal Cloud — it prints the exact `temporal operator nexus endpoint create` command instead, and the catalog page shows the same command as copyable text.
+
+## Schedules
+
+An example may declare one schedule beside its execution:
+
+```ts
+execution: {
+  kind: 'workflow',
+  workflowType: 'hello',
+  workflow: hello,
+  activities: { greet },
+  schedule: {
+    id: 'ui-catalog-hello-hourly',
+    spec: { cronExpressions: ['0 * * * *'] },
+    paused: false,
+    note: 'Declared by the hello catalog example',
+  },
+}
+```
+
+The spec accepts `cronExpressions`, `intervals`, or both, and needs at least one entry. `input` is optional: without it the schedule starts the workflow with the same input the Run button uses. Schedule ids must be unique across every registered example.
+
+The schedule manager is **disabled by default**. Set `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` to turn it on. When it is off, the worker prints one line saying so and creates nothing.
+
+When it is on, the worker creates its own `ui-catalog-schedule-sync` schedule, points it at the `schedule-sync` example, and triggers it once. That workflow reconciles every declared schedule on an hourly cadence.
+
+Ownership comes from a memo. The manager stamps `uiCatalog` on every schedule it creates and only ever updates or deletes a schedule carrying that memo. An owned schedule that no example declares any more is deleted. A schedule id that already exists without the memo is reported as blocked and is never touched.
 
 ## Generated artifacts
 

--- a/src/lib/catalog/README.md
+++ b/src/lib/catalog/README.md
@@ -100,6 +100,14 @@ When it is on, the worker creates its own `ui-catalog-schedule-sync` schedule, p
 
 Ownership comes from a memo. The manager stamps `uiCatalog` on every schedule it creates and only ever updates or deletes a schedule carrying that memo. An owned schedule that no example declares any more is deleted. A schedule id that already exists without the memo is reported as blocked and is never touched.
 
+### Stopping a schedule without a deploy
+
+Pause it in the UI. The manager treats a running state that disagrees with the declaration as a decision somebody made, reports the schedule as held, and writes nothing to it — not the spec, not the action, not the state. Resume it and the next sync reconciles it normally.
+
+Pausing `ui-catalog-schedule-sync` itself stops all reconciliation, including at worker startup: the bootstrap sees the pause and skips both the argument rewrite and the trigger.
+
+A held schedule can drift arbitrarily far from its declaration while it is held, because nothing is rewriting it. Resuming it hands it back to the reconciler, which rewrites all of that on the next pass. A hold is a pause button, not a place to keep hand edits.
+
 ## Generated artifacts
 
 The browser reads generated artifacts rather than importing worker code. `catalog.generated.json`, `catalog.generated.ts`, and the local assemblies under `catalog.local/` are all generated: never edit them by hand.

--- a/src/lib/catalog/README.md
+++ b/src/lib/catalog/README.md
@@ -100,6 +100,12 @@ When it is on, the worker creates its own `ui-catalog-schedule-sync` schedule, p
 
 Ownership comes from a memo. The manager stamps `uiCatalog` on every schedule it creates and only ever updates or deletes a schedule carrying that memo. An owned schedule that no example declares any more is deleted. A schedule id that already exists without the memo is reported as blocked and is never touched.
 
+### Reconciliation is always whole-catalog
+
+The desired list is built from every registered target, and the reconciler deletes any catalog-owned schedule that is not on it. A partial list therefore does not reconcile a subset — it deletes what the missing targets declare. The bootstrap refuses a binding set that does not cover every registered target rather than acting on one.
+
+`CATALOG_TARGET_ID` narrows which workers this process runs; it never narrows the desired list. If it excludes the target the `schedule-sync` example is registered on, the bootstrap reports that it skipped, because a triggered sync would wait for a worker this process is not starting.
+
 ### Stopping a schedule without a deploy
 
 Pause it in the UI. The manager treats a running state that disagrees with the declaration as a decision somebody made, reports the schedule as held, and writes nothing to it — not the spec, not the action, not the state. Resume it and the next sync reconciles it normally.

--- a/src/lib/catalog/browser/catalog-client-test-runner-entry.ts
+++ b/src/lib/catalog/browser/catalog-client-test-runner-entry.ts
@@ -38,6 +38,22 @@ const descriptor: BrowserCatalogDescriptor = {
   },
 };
 
+const scheduledDescriptor: BrowserCatalogDescriptor = {
+  ...descriptor,
+  id: 'hourly-order',
+  title: 'Hourly order',
+  execution: {
+    ...descriptor.execution,
+    kind: 'workflow',
+    workflowType: 'OrderLifecycle',
+    schedule: {
+      id: 'ui-catalog-hello-hourly',
+      spec: { cronExpressions: ['0 * * * *'] },
+      paused: true,
+    },
+  },
+};
+
 const localDescriptor: BrowserCatalogDescriptor = {
   ...descriptor,
   id: 'payment-reminder',
@@ -113,6 +129,7 @@ export async function cleanup() {
 export async function renderDetail({
   deferReadiness = false,
   pinExecutionId = true,
+  withSchedule = false,
   readinessResponses = [
     [
       {
@@ -126,6 +143,7 @@ export async function renderDetail({
 }: {
   deferReadiness?: boolean;
   pinExecutionId?: boolean;
+  withSchedule?: boolean;
   readinessResponses?: ReadinessCheck[][];
 } = {}) {
   readinessCallCount = 0;
@@ -144,15 +162,16 @@ export async function renderDetail({
         );
   });
   const target = document.body.appendChild(document.createElement('div'));
+  const rendered = withSchedule ? scheduledDescriptor : descriptor;
   mounted.push(
     mount(CatalogDetail, {
       target,
       props: {
         descriptor: pinExecutionId
-          ? descriptor
+          ? rendered
           : {
-              ...descriptor,
-              startOptions: { ...descriptor.startOptions, defaultValue: {} },
+              ...rendered,
+              startOptions: { ...rendered.startOptions, defaultValue: {} },
             },
         host,
         sessionStore: createCatalogSessionStore(host),

--- a/src/lib/catalog/browser/catalog-detail.client.test.ts
+++ b/src/lib/catalog/browser/catalog-detail.client.test.ts
@@ -93,6 +93,69 @@ describe('CatalogDetail client interactions', () => {
     );
   });
 
+  it('shows the declared schedule check and how to enable the schedule manager', async () => {
+    const target = await client.renderDetail({
+      withSchedule: true,
+      readinessResponses: [
+        [
+          { kind: 'worker', required: false, state: 'ready', taskQueueType: 1 },
+          {
+            kind: 'schedule',
+            required: false,
+            state: 'unavailable',
+            scheduleId: 'ui-catalog-hello-hourly',
+            paused: true,
+          },
+        ],
+      ],
+    });
+    await client.flush();
+    const readinessPanel = target.querySelector('[aria-label="Readiness"]');
+
+    expect(readinessPanel?.textContent).toContain('Declared schedule exists');
+    expect(readinessPanel?.textContent).toContain('0 * * * *');
+    expect(readinessPanel?.textContent).toContain('Paused');
+    expect(readinessPanel?.textContent).toContain(
+      'Enable the schedule manager, then restart the worker:',
+    );
+    expect(readinessPanel?.textContent).toContain('CATALOG_SCHEDULES=enabled');
+    expect(readinessPanel?.textContent).toContain(
+      'Add it to .env.catalog.local, then run pnpm catalog worker.',
+    );
+    expect(readinessPanel?.querySelector('a[href*="/schedules/"]')).toBeNull();
+    expect(
+      target.querySelector<HTMLButtonElement>('button[data-variant="primary"]')
+        ?.disabled,
+    ).toBe(false);
+  });
+
+  it('links to the schedule page once the declared schedule exists', async () => {
+    const target = await client.renderDetail({
+      withSchedule: true,
+      readinessResponses: [
+        [
+          { kind: 'worker', required: false, state: 'ready', taskQueueType: 1 },
+          {
+            kind: 'schedule',
+            required: false,
+            state: 'ready',
+            scheduleId: 'ui-catalog-hello-hourly',
+            paused: false,
+          },
+        ],
+      ],
+    });
+    await client.flush();
+    const scheduleLink = target
+      .querySelector('[aria-label="Readiness"]')
+      ?.querySelector('a[href*="/schedules/"]');
+
+    expect(scheduleLink?.textContent?.trim()).toBe('Open schedule');
+    expect(scheduleLink?.getAttribute('href')).toContain(
+      'ui-catalog-hello-hourly',
+    );
+  });
+
   it('runs the execution id it shows and then shows the next one', async () => {
     const target = await client.renderDetail({ pinExecutionId: false });
     await client.flush();

--- a/src/lib/catalog/browser/catalog-detail.client.test.ts
+++ b/src/lib/catalog/browser/catalog-detail.client.test.ts
@@ -105,6 +105,7 @@ describe('CatalogDetail client interactions', () => {
             state: 'unavailable',
             scheduleId: 'ui-catalog-hello-hourly',
             paused: true,
+            held: false,
           },
         ],
       ],
@@ -141,6 +142,7 @@ describe('CatalogDetail client interactions', () => {
             state: 'ready',
             scheduleId: 'ui-catalog-hello-hourly',
             paused: false,
+            held: false,
           },
         ],
       ],
@@ -154,6 +156,34 @@ describe('CatalogDetail client interactions', () => {
     expect(scheduleLink?.getAttribute('href')).toContain(
       'ui-catalog-hello-hourly',
     );
+  });
+
+  it('explains a held schedule and still links to it', async () => {
+    const target = await client.renderDetail({
+      withSchedule: true,
+      readinessResponses: [
+        [
+          { kind: 'worker', required: false, state: 'ready', taskQueueType: 1 },
+          {
+            kind: 'schedule',
+            required: false,
+            state: 'ready',
+            scheduleId: 'ui-catalog-hello-hourly',
+            paused: false,
+            held: true,
+          },
+        ],
+      ],
+    });
+    await client.flush();
+    const readinessPanel = target.querySelector('[aria-label="Readiness"]');
+
+    expect(readinessPanel?.textContent).toContain('Held');
+    expect(readinessPanel?.textContent).toContain('paused by hand');
+    expect(readinessPanel?.textContent).toContain('Resume');
+    expect(
+      readinessPanel?.querySelector('a[href*="/schedules/"]'),
+    ).not.toBeNull();
   });
 
   it('runs the execution id it shows and then shows the next one', async () => {

--- a/src/lib/catalog/browser/catalog-detail.svelte
+++ b/src/lib/catalog/browser/catalog-detail.svelte
@@ -30,6 +30,43 @@
     tooltip: string;
   };
 
+  type ReadinessCopy = {
+    label: string;
+    subject: string;
+    loading: string;
+    ready: string;
+    unavailable: (taskQueue: string) => string;
+    unknown: string;
+  };
+
+  const readinessCopy: Record<HostReadinessCheck['kind'], ReadinessCopy> = {
+    worker: {
+      label: 'Handler worker is polling',
+      subject: 'Worker readiness',
+      loading: 'Checking for workers…',
+      ready: 'A Worker is polling.',
+      unavailable: (taskQueue) =>
+        `This run will wait for a Worker to poll the ${taskQueue} Task Queue. Run "pnpm catalog worker" to start one.`,
+      unknown: 'Worker status couldn’t be checked.',
+    },
+    'nexus-endpoint': {
+      label: 'Endpoint matches the declared target and policy',
+      subject: 'Nexus endpoint readiness',
+      loading: 'Checking Nexus endpoint readiness…',
+      ready: 'Nexus endpoint is ready.',
+      unavailable: () => 'Nexus endpoint is unavailable.',
+      unknown: 'Nexus endpoint status couldn’t be checked.',
+    },
+    schedule: {
+      label: 'Declared schedule exists',
+      subject: 'Schedule readiness',
+      loading: 'Checking schedule readiness…',
+      ready: 'The declared schedule exists.',
+      unavailable: () => 'The declared schedule is missing.',
+      unknown: 'Schedule status couldn’t be checked.',
+    },
+  };
+
   export const readinessPresentation = ({
     kind,
     state,
@@ -39,23 +76,16 @@
     state: WorkerReadinessDisplayState | 'loading';
     taskQueue: string;
   }): ReadinessPresentation => {
-    const label =
-      kind === 'worker'
-        ? 'Handler worker is polling'
-        : 'Endpoint matches the declared target and policy';
-    const iconSubject =
-      kind === 'worker' ? 'Worker readiness' : 'Nexus endpoint readiness';
+    const copy = readinessCopy[kind];
+    const { label, subject } = copy;
 
     if (state === 'loading') {
       return {
         Icon: IconSpinner,
         iconClass: 'animate-spin text-secondary',
-        iconLabel: `${iconSubject} is checking`,
+        iconLabel: `${subject} is checking`,
         label,
-        tooltip:
-          kind === 'worker'
-            ? 'Checking for workers…'
-            : 'Checking Nexus endpoint readiness…',
+        tooltip: copy.loading,
       };
     }
 
@@ -63,12 +93,9 @@
       return {
         Icon: IconCheckCircle,
         iconClass: 'text-success',
-        iconLabel: `${iconSubject} is ready`,
+        iconLabel: `${subject} is ready`,
         label,
-        tooltip:
-          kind === 'worker'
-            ? 'A Worker is polling.'
-            : 'Nexus endpoint is ready.',
+        tooltip: copy.ready,
       };
     }
 
@@ -76,25 +103,31 @@
       return {
         Icon: IconWarning,
         iconClass: 'text-warning',
-        iconLabel: `${iconSubject} is unavailable`,
+        iconLabel: `${subject} is unavailable`,
         label,
-        tooltip:
-          kind === 'worker'
-            ? `This run will wait for a Worker to poll the ${taskQueue} Task Queue. Run "pnpm catalog worker" to start one.`
-            : 'Nexus endpoint is unavailable.',
+        tooltip: copy.unavailable(taskQueue),
       };
     }
 
     return {
       Icon: IconQuestionCircle,
       iconClass: 'text-secondary',
-      iconLabel: `${iconSubject} status is unknown`,
+      iconLabel: `${subject} status is unknown`,
       label,
-      tooltip:
-        kind === 'worker'
-          ? 'Worker status couldn’t be checked.'
-          : 'Nexus endpoint status couldn’t be checked.',
+      tooltip: copy.unknown,
     };
+  };
+
+  export const scheduleSpecSummary = (spec: BrowserScheduleSpec): string => {
+    if (spec.cronExpressions?.length) return spec.cronExpressions.join(', ');
+
+    if (spec.intervals?.length) {
+      return spec.intervals
+        .map((interval) => `every ${interval.every}`)
+        .join(', ');
+    }
+
+    return '';
   };
 
   export const nexusEndpointCreateCommand = ({
@@ -122,6 +155,7 @@
   } from '$lib/holocene/duration-input/duration-input.svelte';
   import Input from '$lib/holocene/input/input.svelte';
   import Label from '$lib/holocene/label.svelte';
+  import Link from '$lib/holocene/link.svelte';
   import MarkdownEditor from '$lib/holocene/markdown-editor/markdown-editor.svelte';
   import Markdown from '$lib/holocene/markdown-editor/preview.svelte';
   import TableHeaderRow from '$lib/holocene/table/table-header-row.svelte';
@@ -141,6 +175,7 @@
   } from '$lib/io/icon';
   import type { SearchAttributesSchema } from '$lib/stores/search-attributes';
   import { formatDistanceAbbreviated } from '$lib/utilities/format-time';
+  import { routeForSchedule } from '$lib/utilities/route-for';
 
   import { launchOutcomeExplanation } from './launch-outcome-presentation';
   import { createReadinessLoader } from './readiness-loader';
@@ -152,7 +187,11 @@
   } from './session-store';
   import { declaredExecutionId, startFromEditors } from './start-example';
   import { catalogSharedStartOptionNames } from './start-options';
-  import type { BrowserCatalogDescriptor, JsonValue } from './types';
+  import type {
+    BrowserCatalogDescriptor,
+    BrowserScheduleSpec,
+    JsonValue,
+  } from './types';
   import type { ReadinessCheck, WorkbenchHost } from './workbench-host';
 
   type FixedExecutionField = {
@@ -313,6 +352,11 @@
   );
   let prerequisiteReadiness = $derived(
     readiness.filter((check) => check.kind !== 'worker'),
+  );
+  let declaredScheduleSpec = $derived(
+    descriptor.execution.kind === 'workflow' && descriptor.execution.schedule
+      ? scheduleSpecSummary(descriptor.execution.schedule.spec)
+      : '',
   );
   let readinessAnnouncement = $derived(
     [
@@ -847,7 +891,45 @@
                     </span>
                   </Tooltip>
                   <span>{presentation.label}</span>
+                  {#if check.kind === 'schedule'}
+                    {#if declaredScheduleSpec}
+                      <span class="font-mono text-xs text-secondary"
+                        >{declaredScheduleSpec}</span
+                      >
+                    {/if}
+                    {#if check.paused}
+                      <Badge type="subtle" class="px-1 py-0 text-xs leading-4"
+                        >Paused</Badge
+                      >
+                    {/if}
+                  {/if}
                 </div>
+                {#if check.kind === 'schedule' && check.state === 'unavailable'}
+                  <p class="mt-2 text-xs text-secondary">
+                    Enable the schedule manager, then restart the worker:
+                  </p>
+                  <Copyable
+                    visible
+                    clickAllToCopy
+                    content="CATALOG_SCHEDULES=enabled"
+                    copyIconTitle="Copy the schedule manager setting"
+                    copySuccessIconTitle="Copied the schedule manager setting"
+                    container-class="mt-1"
+                    class="font-mono text-xs"
+                  />
+                  <p class="mt-1 text-xs text-secondary">
+                    Add it to .env.catalog.local, then run pnpm catalog worker.
+                  </p>
+                {/if}
+                {#if check.kind === 'schedule' && check.state === 'ready'}
+                  <Link
+                    class="mt-2 inline-block text-xs"
+                    href={routeForSchedule({
+                      namespace: descriptor.execution.namespace,
+                      scheduleId: check.scheduleId,
+                    })}>Open schedule</Link
+                  >
+                {/if}
                 {#if check.kind === 'nexus-endpoint' && check.state === 'unavailable'}
                   <p class="mt-2 text-xs text-secondary">
                     Create the declared endpoint, then run the example again:

--- a/src/lib/catalog/browser/catalog-detail.svelte
+++ b/src/lib/catalog/browser/catalog-detail.svelte
@@ -902,6 +902,11 @@
                         >Paused</Badge
                       >
                     {/if}
+                    {#if check.held}
+                      <Badge type="warning" class="px-1 py-0 text-xs leading-4"
+                        >Held</Badge
+                      >
+                    {/if}
                   {/if}
                 </div>
                 {#if check.kind === 'schedule' && check.state === 'unavailable'}
@@ -919,6 +924,14 @@
                   />
                   <p class="mt-1 text-xs text-secondary">
                     Add it to .env.catalog.local, then run pnpm catalog worker.
+                  </p>
+                {/if}
+                {#if check.kind === 'schedule' && check.held}
+                  <p class="mt-2 text-xs text-secondary">
+                    This schedule was {check.paused ? 'resumed' : 'paused'} by hand,
+                    so the manager is leaving it alone. {check.paused
+                      ? 'Pause'
+                      : 'Resume'} it to hand it back.
                   </p>
                 {/if}
                 {#if check.kind === 'schedule' && check.state === 'ready'}

--- a/src/lib/catalog/browser/catalog-detail.test.ts
+++ b/src/lib/catalog/browser/catalog-detail.test.ts
@@ -44,7 +44,7 @@ let isCurrentCatalogDetailRequest: (request: {
   requestEpoch: number;
 }) => boolean;
 let readinessPresentation: (config: {
-  kind: 'nexus-endpoint' | 'worker';
+  kind: 'nexus-endpoint' | 'schedule' | 'worker';
   state:
     | 'error'
     | 'indeterminate'
@@ -65,6 +65,10 @@ let nexusEndpointCreateCommand: (config: {
   endpoint: string;
   namespace: string;
   taskQueue: string;
+}) => string;
+let scheduleSpecSummary: (spec: {
+  cronExpressions?: string[];
+  intervals?: { every: string; offset?: string }[];
 }) => string;
 
 beforeAll(async () => {
@@ -109,6 +113,7 @@ beforeAll(async () => {
         isCurrentCatalogDetailRequest: module.isCurrentCatalogDetailRequest,
         nexusEndpointCreateCommand: module.nexusEndpointCreateCommand,
         readinessPresentation: module.readinessPresentation,
+        scheduleSpecSummary: module.scheduleSpecSummary,
         renderComponent: (await server.ssrLoadModule('svelte/server')).render,
       };
     },
@@ -120,6 +125,7 @@ beforeAll(async () => {
     nexusEndpointCreateCommand,
     renderComponent,
     readinessPresentation,
+    scheduleSpecSummary,
   } = lifecycle.value);
 }, catalogHarnessSetupTimeoutMs);
 
@@ -393,6 +399,81 @@ describe('CatalogDetail', () => {
         ...expected,
       });
     }
+  });
+
+  it('uses the same static-label presentation for schedule readiness rows', () => {
+    for (const [state, expected] of [
+      [
+        'loading',
+        {
+          iconLabel: 'Schedule readiness is checking',
+          tooltip: 'Checking schedule readiness…',
+        },
+      ],
+      [
+        'ready',
+        {
+          Icon: iconNamed(IconCheckCircle),
+          iconLabel: 'Schedule readiness is ready',
+          tooltip: 'The declared schedule exists.',
+        },
+      ],
+      [
+        'unavailable',
+        {
+          Icon: iconNamed(IconWarning),
+          iconLabel: 'Schedule readiness is unavailable',
+          tooltip: 'The declared schedule is missing.',
+        },
+      ],
+      [
+        'indeterminate',
+        {
+          Icon: iconNamed(IconQuestionCircle),
+          iconLabel: 'Schedule readiness status is unknown',
+          tooltip: 'Schedule status couldn’t be checked.',
+        },
+      ],
+    ] as const) {
+      expect(
+        readinessPresentation({
+          kind: 'schedule',
+          state,
+          taskQueue: 'catalog-tasks',
+        }),
+      ).toMatchObject({
+        label: 'Declared schedule exists',
+        ...expected,
+      });
+    }
+  });
+
+  it('summarizes a declared schedule spec compactly', () => {
+    expect(
+      scheduleSpecSummary({ cronExpressions: ['0 * * * *', '@daily'] }),
+    ).toBe('0 * * * *, @daily');
+    expect(scheduleSpecSummary({ intervals: [{ every: '1h' }] })).toBe(
+      'every 1h',
+    );
+    expect(scheduleSpecSummary({})).toBe('');
+  });
+
+  it('hands off the schedule manager setting when the declared schedule is missing', () => {
+    const source = readFileSync(
+      resolve('src/lib/catalog/browser/catalog-detail.svelte'),
+      'utf8',
+    );
+
+    expect(source).toContain(
+      "check.kind === 'schedule' && check.state === 'unavailable'",
+    );
+    expect(source).toContain('content="CATALOG_SCHEDULES=enabled"');
+    expect(source).toContain('Enable the schedule manager');
+    expect(source).toContain(
+      'Add it to .env.catalog.local, then run pnpm catalog worker.',
+    );
+    expect(source).toContain('href={routeForSchedule({');
+    expect(source).toContain('>Open schedule</Link');
   });
 
   it('hands off the exact endpoint create command when the Nexus endpoint is unavailable', () => {

--- a/src/lib/catalog/browser/catalog-list.svelte
+++ b/src/lib/catalog/browser/catalog-list.svelte
@@ -246,6 +246,13 @@
               <p class="hidden truncate text-xs text-secondary sm:block">
                 {descriptor.description}
               </p>
+              {#if descriptor.execution.kind === 'workflow' && descriptor.execution.schedule}
+                <Badge
+                  type="subtle"
+                  class="mt-1 inline-block px-1 py-0.5 text-xs leading-none"
+                  >Scheduled</Badge
+                >
+              {/if}
               <div
                 class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs sm:hidden"
               >

--- a/src/lib/catalog/browser/catalog-list.test.ts
+++ b/src/lib/catalog/browser/catalog-list.test.ts
@@ -80,6 +80,22 @@ const descriptor: BrowserCatalogDescriptor = {
   },
 };
 
+const scheduledDescriptor: BrowserCatalogDescriptor = {
+  ...descriptor,
+  id: 'hourly-order',
+  title: 'Hourly order',
+  execution: {
+    ...descriptor.execution,
+    kind: 'workflow',
+    workflowType: 'OrderLifecycle',
+    schedule: {
+      id: 'ui-catalog-hello-hourly',
+      spec: { cronExpressions: ['0 * * * *'] },
+      paused: true,
+    },
+  },
+};
+
 const host: WorkbenchHost = {
   start: vi.fn(),
   checkReadiness: vi.fn(async () => []),
@@ -100,6 +116,21 @@ describe('CatalogList', () => {
     expect(body).toContain('aria-label="Workflow examples"');
     expect(body).toContain('colspan="5"');
     expect(body).toContain('No examples match the current filters.');
+  });
+
+  it('marks rows whose workflow declares a schedule', () => {
+    const sessionStore = createCatalogSessionStore(host);
+    const { body } = renderComponent(catalogList, {
+      props: {
+        descriptors: [descriptor, scheduledDescriptor],
+        host,
+        sessionStore,
+        exampleHref,
+      },
+    });
+
+    expect(body).toContain('Scheduled');
+    expect(body.match(/>Scheduled</g)).toHaveLength(1);
   });
 
   it('renders catalog examples in a compact native table with fixed actions', () => {

--- a/src/lib/catalog/browser/catalog.generated.json
+++ b/src/lib/catalog/browser/catalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "sourceHash": "d7f2464b31a33221a79aee1b28edb90c8bf32a6aaf8d0bd990a1cf6a95c984ee",
+  "sourceHash": "4782f0f1f2739f078ce1da9817f4115367bd74d187d77421106d728e3949135b",
   "descriptors": [
     {
       "id": "activity-heartbeat",
@@ -211,7 +211,13 @@
         "targetId": "shared-workflows",
         "namespace": "default",
         "taskQueue": "ui-catalog",
-        "workflowType": "hello"
+        "workflowType": "hello",
+        "schedule": {
+          "id": "ui-catalog-hello-hourly",
+          "spec": { "cronExpressions": ["0 * * * *"] },
+          "paused": false,
+          "note": "Declared by the hello catalog example"
+        }
       },
       "source": { "id": "oss", "label": "OSS" }
     },
@@ -490,6 +496,52 @@
         "namespace": "default",
         "taskQueue": "ui-catalog",
         "workflowType": "priorityFairnessWorkflow"
+      },
+      "source": { "id": "oss", "label": "OSS" }
+    },
+    {
+      "id": "schedule-sync",
+      "title": "Schedule sync",
+      "description": "Reconciles the schedules declared by catalog examples against the server.",
+      "capabilityTags": ["schedules", "activities", "terminal-outcome"],
+      "expectedEvidence": [
+        "A completed workflow whose result lists the created, updated, and deleted schedule ids."
+      ],
+      "input": {
+        "defaultValue": [[]],
+        "schema": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "title": "Declared schedules",
+              "type": "array",
+              "items": { "type": "object" }
+            }
+          ],
+          "items": false,
+          "maxItems": 1
+        }
+      },
+      "startOptions": {
+        "defaultValue": {},
+        "schema": {
+          "type": "object",
+          "properties": {
+            "details": { "type": "string" },
+            "searchAttributes": { "type": "object" },
+            "summary": { "type": "string" },
+            "workflowStartDelay": { "type": "string" },
+            "workflowId": { "type": "string", "minLength": 1 }
+          }
+        }
+      },
+      "setupMarkdown": "The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.",
+      "execution": {
+        "kind": "workflow",
+        "targetId": "shared-workflows",
+        "namespace": "default",
+        "taskQueue": "ui-catalog",
+        "workflowType": "catalogScheduleSync"
       },
       "source": { "id": "oss", "label": "OSS" }
     },

--- a/src/lib/catalog/browser/catalog.generated.json
+++ b/src/lib/catalog/browser/catalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "sourceHash": "4782f0f1f2739f078ce1da9817f4115367bd74d187d77421106d728e3949135b",
+  "sourceHash": "d3d3b81019103ad0310ce49f73087cc9448814d7cbee87ed863341dc0da05a90",
   "descriptors": [
     {
       "id": "activity-heartbeat",
@@ -535,7 +535,7 @@
           }
         }
       },
-      "setupMarkdown": "The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.",
+      "setupMarkdown": "The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.\n\nTo stop a declared schedule without changing code, pause it. A running state that disagrees with the declaration is reported as held, and the manager writes nothing to that schedule until you resume it. Pausing this schedule stops reconciliation altogether, including at worker startup.",
       "execution": {
         "kind": "workflow",
         "targetId": "shared-workflows",

--- a/src/lib/catalog/browser/catalog.generated.json
+++ b/src/lib/catalog/browser/catalog.generated.json
@@ -1,5 +1,5 @@
 {
-  "sourceHash": "d3d3b81019103ad0310ce49f73087cc9448814d7cbee87ed863341dc0da05a90",
+  "sourceHash": "0612cb154faf145ec1a85a752e137666ac6b31abd8ad75d76c7b56dafd707b10",
   "descriptors": [
     {
       "id": "activity-heartbeat",

--- a/src/lib/catalog/browser/catalog.generated.ts
+++ b/src/lib/catalog/browser/catalog.generated.ts
@@ -2,7 +2,7 @@ import type { BrowserCatalogArtifact } from './types';
 
 export const catalogArtifact: BrowserCatalogArtifact = {
   sourceHash:
-    '4782f0f1f2739f078ce1da9817f4115367bd74d187d77421106d728e3949135b',
+    'd3d3b81019103ad0310ce49f73087cc9448814d7cbee87ed863341dc0da05a90',
   descriptors: [
     {
       id: 'activity-heartbeat',
@@ -537,7 +537,7 @@ export const catalogArtifact: BrowserCatalogArtifact = {
         },
       },
       setupMarkdown:
-        'The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.',
+        'The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.\n\nTo stop a declared schedule without changing code, pause it. A running state that disagrees with the declaration is reported as held, and the manager writes nothing to that schedule until you resume it. Pausing this schedule stops reconciliation altogether, including at worker startup.',
       execution: {
         kind: 'workflow',
         targetId: 'shared-workflows',

--- a/src/lib/catalog/browser/catalog.generated.ts
+++ b/src/lib/catalog/browser/catalog.generated.ts
@@ -2,7 +2,7 @@ import type { BrowserCatalogArtifact } from './types';
 
 export const catalogArtifact: BrowserCatalogArtifact = {
   sourceHash:
-    'd7f2464b31a33221a79aee1b28edb90c8bf32a6aaf8d0bd990a1cf6a95c984ee',
+    '4782f0f1f2739f078ce1da9817f4115367bd74d187d77421106d728e3949135b',
   descriptors: [
     {
       id: 'activity-heartbeat',
@@ -214,6 +214,12 @@ export const catalogArtifact: BrowserCatalogArtifact = {
         namespace: 'default',
         taskQueue: 'ui-catalog',
         workflowType: 'hello',
+        schedule: {
+          id: 'ui-catalog-hello-hourly',
+          spec: { cronExpressions: ['0 * * * *'] },
+          paused: false,
+          note: 'Declared by the hello catalog example',
+        },
       },
       source: { id: 'oss', label: 'OSS' },
     },
@@ -490,6 +496,54 @@ export const catalogArtifact: BrowserCatalogArtifact = {
         namespace: 'default',
         taskQueue: 'ui-catalog',
         workflowType: 'priorityFairnessWorkflow',
+      },
+      source: { id: 'oss', label: 'OSS' },
+    },
+    {
+      id: 'schedule-sync',
+      title: 'Schedule sync',
+      description:
+        'Reconciles the schedules declared by catalog examples against the server.',
+      capabilityTags: ['schedules', 'activities', 'terminal-outcome'],
+      expectedEvidence: [
+        'A completed workflow whose result lists the created, updated, and deleted schedule ids.',
+      ],
+      input: {
+        defaultValue: [[]],
+        schema: {
+          type: 'array',
+          prefixItems: [
+            {
+              title: 'Declared schedules',
+              type: 'array',
+              items: { type: 'object' },
+            },
+          ],
+          items: false,
+          maxItems: 1,
+        },
+      },
+      startOptions: {
+        defaultValue: {},
+        schema: {
+          type: 'object',
+          properties: {
+            details: { type: 'string' },
+            searchAttributes: { type: 'object' },
+            summary: { type: 'string' },
+            workflowStartDelay: { type: 'string' },
+            workflowId: { type: 'string', minLength: 1 },
+          },
+        },
+      },
+      setupMarkdown:
+        'The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.\n\nSet `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.\n\nThe manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.',
+      execution: {
+        kind: 'workflow',
+        targetId: 'shared-workflows',
+        namespace: 'default',
+        taskQueue: 'ui-catalog',
+        workflowType: 'catalogScheduleSync',
       },
       source: { id: 'oss', label: 'OSS' },
     },

--- a/src/lib/catalog/browser/catalog.generated.ts
+++ b/src/lib/catalog/browser/catalog.generated.ts
@@ -2,7 +2,7 @@ import type { BrowserCatalogArtifact } from './types';
 
 export const catalogArtifact: BrowserCatalogArtifact = {
   sourceHash:
-    'd3d3b81019103ad0310ce49f73087cc9448814d7cbee87ed863341dc0da05a90',
+    '0612cb154faf145ec1a85a752e137666ac6b31abd8ad75d76c7b56dafd707b10',
   descriptors: [
     {
       id: 'activity-heartbeat',

--- a/src/lib/catalog/browser/start-example.test.ts
+++ b/src/lib/catalog/browser/start-example.test.ts
@@ -184,6 +184,7 @@ describe('catalog example start', () => {
           state: 'unavailable',
           scheduleId: 'ui-catalog-hello-hourly',
           paused: true,
+          held: false,
         },
       ],
     });

--- a/src/lib/catalog/browser/start-example.test.ts
+++ b/src/lib/catalog/browser/start-example.test.ts
@@ -174,6 +174,24 @@ describe('catalog example start', () => {
     expect(catalogHost.start).not.toHaveBeenCalled();
   });
 
+  it('runs despite an unavailable advisory schedule check', async () => {
+    const catalogHost = host({
+      readiness: [
+        { kind: 'worker', required: false, state: 'ready', taskQueueType: 1 },
+        {
+          kind: 'schedule',
+          required: false,
+          state: 'unavailable',
+          scheduleId: 'ui-catalog-hello-hourly',
+          paused: true,
+        },
+      ],
+    });
+
+    await expect(run(catalogHost)).resolves.toEqual({ started: true });
+    expect(catalogHost.start).toHaveBeenCalledOnce();
+  });
+
   it('reports readiness failures without dispatch', async () => {
     const catalogHost = host();
     catalogHost.checkReadiness = vi.fn(async () => {

--- a/src/lib/catalog/browser/types.ts
+++ b/src/lib/catalog/browser/types.ts
@@ -32,10 +32,24 @@ export type BrowserExecutionTarget = {
   taskQueue: string;
 };
 
+export type BrowserScheduleSpec = {
+  cronExpressions?: string[];
+  intervals?: { every: string; offset?: string }[];
+};
+
+export type BrowserScheduleDeclaration = {
+  id: string;
+  spec: BrowserScheduleSpec;
+  input?: JsonValue[];
+  paused: boolean;
+  note?: string;
+};
+
 export type BrowserWorkflowExecution = BrowserExecutionTarget & {
   kind: 'workflow';
   workflowType: string;
   nexusEndpoints?: string[];
+  schedule?: BrowserScheduleDeclaration;
 };
 
 export type BrowserStandaloneActivityExecution = BrowserExecutionTarget & {

--- a/src/lib/catalog/browser/workbench-host.ts
+++ b/src/lib/catalog/browser/workbench-host.ts
@@ -100,7 +100,18 @@ export type NexusEndpointReadinessCheck = {
   endpoint: string;
 };
 
-export type ReadinessCheck = NexusEndpointReadinessCheck | WorkerReadinessCheck;
+export type ScheduleReadinessCheck = {
+  kind: 'schedule';
+  required: false;
+  state: ReadinessState;
+  scheduleId: string;
+  paused: boolean;
+};
+
+export type ReadinessCheck =
+  | NexusEndpointReadinessCheck
+  | ScheduleReadinessCheck
+  | WorkerReadinessCheck;
 
 export type EvidenceLink = {
   href: string;

--- a/src/lib/catalog/browser/workbench-host.ts
+++ b/src/lib/catalog/browser/workbench-host.ts
@@ -105,7 +105,13 @@ export type ScheduleReadinessCheck = {
   required: false;
   state: ReadinessState;
   scheduleId: string;
+  /** What the example declares. */
   paused: boolean;
+  /**
+   * The schedule's running state on the server diverges from the declaration,
+   * so the manager is leaving it alone until the two agree again.
+   */
+  held: boolean;
 };
 
 export type ReadinessCheck =

--- a/src/lib/catalog/host/ui-services.test.ts
+++ b/src/lib/catalog/host/ui-services.test.ts
@@ -365,7 +365,7 @@ describe('createApiWorkbenchHost', () => {
       if (url.includes('/task-queues/')) {
         return jsonResponse({ pollers: [{ identity: 'worker' }] });
       }
-      return jsonResponse({ schedule: { spec: {} } });
+      return jsonResponse({ schedule: { spec: {}, state: { paused: true } } });
     });
     const host = createApiWorkbenchHost({
       descriptors: [scheduledDescriptor],
@@ -378,10 +378,34 @@ describe('createApiWorkbenchHost', () => {
       state: 'ready',
       scheduleId: 'ui-catalog-hello-hourly',
       paused: true,
+      held: false,
     });
     expect(request.mock.calls.at(-1)?.[0]).toMatch(
       /\/api\/v1\/namespaces\/catalog-demo\/schedules\/ui-catalog-hello-hourly\?$/,
     );
+  });
+
+  it('holds the schedule when the server disagrees with the declaration', async () => {
+    const request = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/task-queues/')) {
+        return jsonResponse({ pollers: [{ identity: 'worker' }] });
+      }
+      // Declared paused: true, running on the server.
+      return jsonResponse({ schedule: { spec: {}, state: { paused: false } } });
+    });
+    const host = createApiWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      request,
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'ready',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+      held: true,
+    });
   });
 
   it('reports a missing schedule as unavailable without failing readiness', async () => {
@@ -402,6 +426,7 @@ describe('createApiWorkbenchHost', () => {
       state: 'unavailable',
       scheduleId: 'ui-catalog-hello-hourly',
       paused: true,
+      held: false,
     });
   });
 

--- a/src/lib/catalog/host/ui-services.test.ts
+++ b/src/lib/catalog/host/ui-services.test.ts
@@ -58,6 +58,21 @@ const nexusDescriptor: BrowserCatalogDescriptor = {
   },
 };
 
+const scheduledDescriptor: BrowserCatalogDescriptor = {
+  ...descriptor,
+  id: 'hourly-order',
+  execution: {
+    ...descriptor.execution,
+    kind: 'workflow',
+    workflowType: 'orderWorkflow',
+    schedule: {
+      id: 'ui-catalog-hello-hourly',
+      spec: { cronExpressions: ['0 * * * *'] },
+      paused: true,
+    },
+  },
+};
+
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
     status,
@@ -343,6 +358,51 @@ describe('createApiWorkbenchHost', () => {
         /\/api\/v1\/nexus\/endpoints\?name=greeting-endpoint$/,
       ),
     ]);
+  });
+
+  it('describes the declared schedule and reports it as ready', async () => {
+    const request = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/task-queues/')) {
+        return jsonResponse({ pollers: [{ identity: 'worker' }] });
+      }
+      return jsonResponse({ schedule: { spec: {} } });
+    });
+    const host = createApiWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      request,
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'ready',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+    });
+    expect(request.mock.calls.at(-1)?.[0]).toMatch(
+      /\/api\/v1\/namespaces\/catalog-demo\/schedules\/ui-catalog-hello-hourly\?$/,
+    );
+  });
+
+  it('reports a missing schedule as unavailable without failing readiness', async () => {
+    const request = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('/task-queues/')) {
+        return jsonResponse({ pollers: [{ identity: 'worker' }] });
+      }
+      return jsonResponse({ message: 'schedule not found' }, 404);
+    });
+    const host = createApiWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      request,
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'unavailable',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+    });
   });
 
   it('classifies a known HTTP conflict as rejected', async () => {

--- a/src/lib/catalog/host/ui-services.ts
+++ b/src/lib/catalog/host/ui-services.ts
@@ -443,15 +443,20 @@ export const createApiWorkbenchHost = ({
       const route = routeForApi('schedule', { namespace, scheduleId });
 
       try {
-        const response = await requestFromAPI<{ schedule?: unknown }>(route, {
+        const response = await requestFromAPI<{
+          schedule?: { state?: { paused?: boolean } };
+        }>(route, {
           request,
           notifyOnError: false,
           options: { signal },
         });
 
-        return Boolean(response?.schedule);
+        return {
+          exists: Boolean(response?.schedule),
+          paused: Boolean(response?.schedule?.state?.paused),
+        };
       } catch {
-        return false;
+        return { exists: false, paused: false };
       }
     },
     createEvidenceHref: evidenceHref,

--- a/src/lib/catalog/host/ui-services.ts
+++ b/src/lib/catalog/host/ui-services.ts
@@ -439,6 +439,21 @@ export const createApiWorkbenchHost = ({
         response?.endpoints?.some((item) => item.spec?.name === endpoint),
       );
     },
+    checkSchedule: async ({ namespace, scheduleId }, signal) => {
+      const route = routeForApi('schedule', { namespace, scheduleId });
+
+      try {
+        const response = await requestFromAPI<{ schedule?: unknown }>(route, {
+          request,
+          notifyOnError: false,
+          options: { signal },
+        });
+
+        return Boolean(response?.schedule);
+      } catch {
+        return false;
+      }
+    },
     createEvidenceHref: evidenceHref,
   });
 };

--- a/src/lib/catalog/host/workbench-host.test.ts
+++ b/src/lib/catalog/host/workbench-host.test.ts
@@ -556,7 +556,9 @@ describe('OSS WorkbenchHost', () => {
   });
 
   it('reports a declared schedule as an advisory check after the Nexus checks', async () => {
-    const checkSchedule = vi.fn().mockResolvedValue(true);
+    const checkSchedule = vi
+      .fn()
+      .mockResolvedValue({ exists: true, paused: true });
     const host = assembleWorkbenchHost({
       descriptors: [scheduledDescriptor],
       launch: vi.fn(),
@@ -579,12 +581,56 @@ describe('OSS WorkbenchHost', () => {
         state: 'ready',
         scheduleId: 'ui-catalog-hello-hourly',
         paused: true,
+        held: false,
       },
     ]);
     expect(checkSchedule).toHaveBeenCalledWith(
       { namespace: 'catalog-demo', scheduleId: 'ui-catalog-hello-hourly' },
       undefined,
     );
+  });
+
+  it('reports a schedule held when its running state diverges from the declaration', async () => {
+    const host = assembleWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      launch: vi.fn(),
+      checkWorker: vi.fn().mockResolvedValue(true),
+      checkNexusEndpoint: vi.fn(),
+      // The example declares paused: true; somebody resumed it.
+      checkSchedule: vi.fn().mockResolvedValue({ exists: true, paused: false }),
+      createEvidenceHref: vi.fn(),
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'ready',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+      held: true,
+    });
+  });
+
+  it('does not hold a schedule that is missing from the server', async () => {
+    const host = assembleWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      launch: vi.fn(),
+      checkWorker: vi.fn().mockResolvedValue(true),
+      checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi
+        .fn()
+        .mockResolvedValue({ exists: false, paused: false }),
+      createEvidenceHref: vi.fn(),
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'unavailable',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+      held: false,
+    });
   });
 
   it('leaves a schedule check indeterminate when the lookup throws', async () => {
@@ -603,6 +649,7 @@ describe('OSS WorkbenchHost', () => {
       state: 'indeterminate',
       scheduleId: 'ui-catalog-hello-hourly',
       paused: true,
+      held: false,
     });
   });
 

--- a/src/lib/catalog/host/workbench-host.test.ts
+++ b/src/lib/catalog/host/workbench-host.test.ts
@@ -37,6 +37,21 @@ const nexusDescriptor: BrowserCatalogDescriptor = {
   },
 };
 
+const scheduledDescriptor: BrowserCatalogDescriptor = {
+  ...workflowDescriptor,
+  id: 'hourly-order',
+  execution: {
+    ...workflowDescriptor.execution,
+    kind: 'workflow',
+    workflowType: 'orderWorkflow',
+    schedule: {
+      id: 'ui-catalog-hello-hourly',
+      spec: { cronExpressions: ['0 * * * *'] },
+      paused: true,
+    },
+  },
+};
+
 const activityDescriptor: BrowserCatalogDescriptor = {
   ...workflowDescriptor,
   id: 'priority-activity',
@@ -69,6 +84,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -115,6 +131,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -144,6 +161,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -171,6 +189,7 @@ describe('OSS WorkbenchHost', () => {
       launch: vi.fn().mockResolvedValue({ status: 'accepted', runId: 'run-1' }),
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -189,6 +208,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -214,6 +234,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -239,6 +260,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -264,6 +286,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -294,6 +317,7 @@ describe('OSS WorkbenchHost', () => {
       launch: vi.fn().mockResolvedValue({ status: 'accepted' }),
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -319,6 +343,7 @@ describe('OSS WorkbenchHost', () => {
       launch: vi.fn().mockResolvedValue({ status: 'accepted', runId: 42 }),
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -338,6 +363,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -358,6 +384,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -380,6 +407,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -402,6 +430,7 @@ describe('OSS WorkbenchHost', () => {
       launch,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -427,6 +456,7 @@ describe('OSS WorkbenchHost', () => {
       }),
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -451,6 +481,7 @@ describe('OSS WorkbenchHost', () => {
       }),
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref,
     });
     const outcome = await host.start(command);
@@ -471,6 +502,7 @@ describe('OSS WorkbenchHost', () => {
       launch: vi.fn(),
       checkWorker,
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -499,6 +531,7 @@ describe('OSS WorkbenchHost', () => {
       launch: vi.fn(),
       checkWorker: vi.fn().mockResolvedValue(true),
       checkNexusEndpoint,
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 
@@ -522,6 +555,79 @@ describe('OSS WorkbenchHost', () => {
     );
   });
 
+  it('reports a declared schedule as an advisory check after the Nexus checks', async () => {
+    const checkSchedule = vi.fn().mockResolvedValue(true);
+    const host = assembleWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      launch: vi.fn(),
+      checkWorker: vi.fn().mockResolvedValue(true),
+      checkNexusEndpoint: vi.fn(),
+      checkSchedule,
+      createEvidenceHref: vi.fn(),
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toEqual([
+      {
+        kind: 'worker',
+        required: false,
+        state: 'ready',
+        taskQueueType: 1,
+      },
+      {
+        kind: 'schedule',
+        required: false,
+        state: 'ready',
+        scheduleId: 'ui-catalog-hello-hourly',
+        paused: true,
+      },
+    ]);
+    expect(checkSchedule).toHaveBeenCalledWith(
+      { namespace: 'catalog-demo', scheduleId: 'ui-catalog-hello-hourly' },
+      undefined,
+    );
+  });
+
+  it('leaves a schedule check indeterminate when the lookup throws', async () => {
+    const host = assembleWorkbenchHost({
+      descriptors: [scheduledDescriptor],
+      launch: vi.fn(),
+      checkWorker: vi.fn().mockResolvedValue(true),
+      checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn().mockRejectedValue(new Error('unreachable')),
+      createEvidenceHref: vi.fn(),
+    });
+
+    await expect(host.checkReadiness('hourly-order')).resolves.toContainEqual({
+      kind: 'schedule',
+      required: false,
+      state: 'indeterminate',
+      scheduleId: 'ui-catalog-hello-hourly',
+      paused: true,
+    });
+  });
+
+  it('omits the schedule check when no schedule is declared', async () => {
+    const checkSchedule = vi.fn();
+    const host = assembleWorkbenchHost({
+      descriptors: [workflowDescriptor],
+      launch: vi.fn(),
+      checkWorker: vi.fn().mockResolvedValue(true),
+      checkNexusEndpoint: vi.fn(),
+      checkSchedule,
+      createEvidenceHref: vi.fn(),
+    });
+
+    await expect(host.checkReadiness('order-lifecycle')).resolves.toEqual([
+      {
+        kind: 'worker',
+        required: false,
+        state: 'ready',
+        taskQueueType: 1,
+      },
+    ]);
+    expect(checkSchedule).not.toHaveBeenCalled();
+  });
+
   it('performs one observation request with the accepted reference and signal', async () => {
     const observe = vi.fn().mockResolvedValue({
       state: 'running',
@@ -534,6 +640,7 @@ describe('OSS WorkbenchHost', () => {
       observe,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
     const controller = new AbortController();
@@ -573,6 +680,7 @@ describe('OSS WorkbenchHost', () => {
       observe,
       checkWorker: vi.fn(),
       checkNexusEndpoint: vi.fn(),
+      checkSchedule: vi.fn(),
       createEvidenceHref: vi.fn(),
     });
 

--- a/src/lib/catalog/host/workbench-host.ts
+++ b/src/lib/catalog/host/workbench-host.ts
@@ -69,6 +69,10 @@ export type WorkbenchHostDependencies = {
     request: { namespace: string; endpoint: string },
     signal?: AbortSignal,
   ) => Promise<boolean>;
+  checkSchedule: (
+    request: { namespace: string; scheduleId: string },
+    signal?: AbortSignal,
+  ) => Promise<boolean>;
   createEvidenceHref: (
     reference: LaunchReference & { runId: string },
   ) => string;
@@ -131,6 +135,7 @@ export const assembleWorkbenchHost = ({
   observe,
   checkWorker,
   checkNexusEndpoint,
+  checkSchedule,
   createEvidenceHref,
 }: WorkbenchHostDependencies): WorkbenchHost => {
   const descriptorsById = new Map(
@@ -281,6 +286,37 @@ export const assembleWorkbenchHost = ({
           required: true,
           state: endpointState,
           endpoint,
+        });
+      }
+
+      const declaredSchedule =
+        descriptor.execution.kind === 'workflow'
+          ? descriptor.execution.schedule
+          : undefined;
+
+      if (declaredSchedule) {
+        let scheduleState: ReadinessCheck['state'];
+
+        try {
+          scheduleState = (await checkSchedule(
+            {
+              namespace: descriptor.execution.namespace,
+              scheduleId: declaredSchedule.id,
+            },
+            signal,
+          ))
+            ? 'ready'
+            : 'unavailable';
+        } catch {
+          scheduleState = 'indeterminate';
+        }
+
+        checks.push({
+          kind: 'schedule',
+          required: false,
+          state: scheduleState,
+          scheduleId: declaredSchedule.id,
+          paused: declaredSchedule.paused,
         });
       }
 

--- a/src/lib/catalog/host/workbench-host.ts
+++ b/src/lib/catalog/host/workbench-host.ts
@@ -72,7 +72,7 @@ export type WorkbenchHostDependencies = {
   checkSchedule: (
     request: { namespace: string; scheduleId: string },
     signal?: AbortSignal,
-  ) => Promise<boolean>;
+  ) => Promise<{ exists: boolean; paused: boolean }>;
   createEvidenceHref: (
     reference: LaunchReference & { runId: string },
   ) => string;
@@ -296,17 +296,19 @@ export const assembleWorkbenchHost = ({
 
       if (declaredSchedule) {
         let scheduleState: ReadinessCheck['state'];
+        let held = false;
 
         try {
-          scheduleState = (await checkSchedule(
+          const { exists, paused } = await checkSchedule(
             {
               namespace: descriptor.execution.namespace,
               scheduleId: declaredSchedule.id,
             },
             signal,
-          ))
-            ? 'ready'
-            : 'unavailable';
+          );
+
+          scheduleState = exists ? 'ready' : 'unavailable';
+          held = exists && paused !== declaredSchedule.paused;
         } catch {
           scheduleState = 'indeterminate';
         }
@@ -317,6 +319,7 @@ export const assembleWorkbenchHost = ({
           state: scheduleState,
           scheduleId: declaredSchedule.id,
           paused: declaredSchedule.paused,
+          held,
         });
       }
 

--- a/src/lib/catalog/scenarios.md
+++ b/src/lib/catalog/scenarios.md
@@ -140,6 +140,16 @@ The worker creates its own hourly `ui-catalog-schedule-sync` schedule, triggers 
 
 Run it in a namespace that no other schedule manager owns. A reconciler that deletes every schedule it does not know about will remove the catalog's schedules on its next pass.
 
+### A schedule paused by hand
+
+Pause a catalog-owned schedule in the UI. The next sync reports it as held and writes nothing to it; the example page shows a Held badge naming what happened. Resume it and the following sync reconciles it again, rewriting any edits made while it was held.
+
+Pausing `ui-catalog-schedule-sync` stops reconciliation entirely. Worker startup then prints the held line instead of rewriting the manager's arguments and triggering it, so the pause survives restarts.
+
+**Unverified.** Covered by unit tests across the plan, the bootstrap, and the readiness check, but not yet exercised against a live server.
+
+### Schedule manager enabled (continued)
+
 **Verified** against a local server in a dedicated namespace. Cold start created the manager and the `hello` schedule with the ownership memo; a restart updated the manager's arguments and triggered a sync. A hand-deleted declared schedule was recreated. A hand-edited cron on an owned schedule was rewritten back. A memo-marked schedule for a removed example was deleted. A schedule without the memo was left alone, and one squatting on a declared id was reported as blocked and left untouched. The example page's schedule readiness check was covered by client tests only.
 
 ## Environment interference

--- a/src/lib/catalog/scenarios.md
+++ b/src/lib/catalog/scenarios.md
@@ -140,6 +140,16 @@ The worker creates its own hourly `ui-catalog-schedule-sync` schedule, triggers 
 
 Run it in a namespace that no other schedule manager owns. A reconciler that deletes every schedule it does not know about will remove the catalog's schedules on its next pass.
 
+### One target only, with schedules enabled
+
+```bash
+CATALOG_TARGET_ID=shared-workflows CATALOG_SCHEDULES=enabled pnpm catalog worker
+```
+
+The worker polls one target, but reconciliation still runs against every registered target's declarations. Narrowing to a target that does not register `schedule-sync` reports a skip instead of triggering a sync nothing would pick up.
+
+**Unverified.** Covered by unit tests on the bootstrap; not exercised against a live server.
+
 ### A schedule paused by hand
 
 Pause a catalog-owned schedule in the UI. The next sync reports it as held and writes nothing to it; the example page shows a Held badge naming what happened. Resume it and the following sync reconciles it again, rewriting any edits made while it was held.

--- a/src/lib/catalog/scenarios.md
+++ b/src/lib/catalog/scenarios.md
@@ -121,6 +121,27 @@ Without provisioning authority, the worker prints the `temporal operator nexus e
 
 **Verified** for the UI state and copy. The credentialed worker path is unverified.
 
+## Schedules
+
+### Schedule manager disabled
+
+The committed default. `CATALOG_SCHEDULES` is unset, so the worker prints one line naming the setting and creates no schedule. Any value other than `enabled` or `disabled` fails startup with a message naming the variable.
+
+**Verified** against a local server: the disabled line and banner appear, no schedule is created, and an invalid value fails before any target starts.
+
+### Schedule manager enabled
+
+```bash
+# .env.catalog.local
+CATALOG_SCHEDULES=enabled
+```
+
+The worker creates its own hourly `ui-catalog-schedule-sync` schedule, triggers it once, and the reconciliation workflow creates, updates, or deletes the schedules the examples declare. Only schedules carrying the `uiCatalog` memo are updated or deleted; a foreign id is reported as blocked.
+
+Run it in a namespace that no other schedule manager owns. A reconciler that deletes every schedule it does not know about will remove the catalog's schedules on its next pass.
+
+**Verified** against a local server in a dedicated namespace. Cold start created the manager and the `hello` schedule with the ownership memo; a restart updated the manager's arguments and triggered a sync. A hand-deleted declared schedule was recreated. A hand-edited cron on an owned schedule was rewritten back. A memo-marked schedule for a removed example was deleted. A schedule without the memo was left alone, and one squatting on a declared id was reported as blocked and left untouched. The example page's schedule readiness check was covered by client tests only.
+
 ## Environment interference
 
 ### A second Temporal server on the same port

--- a/src/lib/catalog/worker/endpoint-provisioning.test.ts
+++ b/src/lib/catalog/worker/endpoint-provisioning.test.ts
@@ -19,6 +19,7 @@ const binding = (
   examples: executions.map((execution, index) => ({
     id: `${targetId}-example-${index}`,
     execution,
+    inputDefault: [],
   })),
   activities: {},
   nexusServices: [],

--- a/src/lib/catalog/worker/examples/corpus.test.ts
+++ b/src/lib/catalog/worker/examples/corpus.test.ts
@@ -45,6 +45,7 @@ const proofExampleIds = [
   'priority-fairness',
   'standalone-activity',
   'nexus-greeting',
+  'schedule-sync',
 ] as const;
 
 describe('shared workflow corpus', () => {
@@ -115,6 +116,7 @@ describe('shared workflow corpus', () => {
         ...migratedWorkflowTypes,
         'priorityFairnessWorkflow',
         'nexusGreeting',
+        'catalogScheduleSync',
       ].sort(),
     );
     for (const example of registry.examples) {
@@ -512,6 +514,11 @@ describe('shared workflow corpus', () => {
         'src/lib/catalog/worker/examples/nexus-greeting/workflow.ts',
         'src/lib/catalog/worker/examples/nexus-greeting/service.ts',
         'src/lib/catalog/worker/examples/nexus-greeting/handler.ts',
+        'src/lib/catalog/worker/examples/schedule-sync/example.ts',
+        'src/lib/catalog/worker/examples/schedule-sync/workflow.ts',
+        'src/lib/catalog/worker/examples/schedule-sync/activities.ts',
+        'src/lib/catalog/worker/examples/schedule-sync/ownership.ts',
+        'src/lib/catalog/worker/examples/schedule-sync/plan.ts',
       ].sort(),
     );
   });

--- a/src/lib/catalog/worker/examples/hello/example.ts
+++ b/src/lib/catalog/worker/examples/hello/example.ts
@@ -33,5 +33,11 @@ export const catalogExample: CatalogExampleDefinition = {
     workflowType: 'hello',
     workflow: hello,
     activities: { greet },
+    schedule: {
+      id: 'ui-catalog-hello-hourly',
+      spec: { cronExpressions: ['0 * * * *'] },
+      paused: false,
+      note: 'Declared by the hello catalog example',
+    },
   },
 };

--- a/src/lib/catalog/worker/examples/index.ts
+++ b/src/lib/catalog/worker/examples/index.ts
@@ -15,12 +15,13 @@ import { catalogExample as example7 } from './long-activity/example.js';
 import { catalogExample as example8 } from './nexus-greeting/example.js';
 import { catalogExample as example9 } from './parallel-activities/example.js';
 import { catalogExample as example10 } from './priority-fairness/example.js';
-import { catalogExample as example11 } from './sequential-activities/example.js';
-import { catalogExample as example12 } from './signal-collector/example.js';
-import { catalogExample as example13 } from './signal-handlers/example.js';
-import { catalogExample as example14 } from './standalone-activity/example.js';
-import { catalogExample as example15 } from './timer-driven-repetition/example.js';
-import { catalogExample as example16 } from './workflow-patching/example.js';
+import { catalogExample as example11 } from './schedule-sync/example.js';
+import { catalogExample as example12 } from './sequential-activities/example.js';
+import { catalogExample as example13 } from './signal-collector/example.js';
+import { catalogExample as example14 } from './signal-handlers/example.js';
+import { catalogExample as example15 } from './standalone-activity/example.js';
+import { catalogExample as example16 } from './timer-driven-repetition/example.js';
+import { catalogExample as example17 } from './workflow-patching/example.js';
 
 const sharedWorkflowDefinitions = [
   example0,
@@ -40,6 +41,7 @@ const sharedWorkflowDefinitions = [
   example14,
   example15,
   example16,
+  example17,
 ] satisfies readonly CatalogExampleDefinition[];
 
 export const sharedWorkflowExamples: readonly CatalogExampleRegistration[] =
@@ -109,6 +111,11 @@ export const sharedWorkflowSourceFiles = [
   'src/lib/catalog/worker/examples/parallel-activities/workflow.ts',
   'src/lib/catalog/worker/examples/priority-fairness/example.ts',
   'src/lib/catalog/worker/examples/priority-fairness/workflow.ts',
+  'src/lib/catalog/worker/examples/schedule-sync/activities.ts',
+  'src/lib/catalog/worker/examples/schedule-sync/example.ts',
+  'src/lib/catalog/worker/examples/schedule-sync/ownership.ts',
+  'src/lib/catalog/worker/examples/schedule-sync/plan.ts',
+  'src/lib/catalog/worker/examples/schedule-sync/workflow.ts',
   'src/lib/catalog/worker/examples/sequential-activities/example.ts',
   'src/lib/catalog/worker/examples/sequential-activities/workflow.ts',
   'src/lib/catalog/worker/examples/signal-collector/activity.ts',

--- a/src/lib/catalog/worker/examples/schedule-sync/activities.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/activities.ts
@@ -1,0 +1,155 @@
+import { Client, Connection, type ScheduleSpec } from '@temporalio/client';
+import type { Duration } from '@temporalio/common';
+
+import {
+  catalogScheduleMemoKey,
+  catalogScheduleOwnership,
+  isCatalogOwned,
+} from './ownership.js';
+import type {
+  CatalogSchedulePlan,
+  CatalogSchedulePlanResult,
+  ExistingCatalogSchedule,
+} from './plan.js';
+import type { BrowserScheduleSpec } from '../../../browser/types.js';
+import { parseCatalogConnectionConfig } from '../../connection-config.js';
+
+export const toScheduleSpec = ({
+  cronExpressions,
+  intervals,
+}: BrowserScheduleSpec): ScheduleSpec => ({
+  ...(cronExpressions ? { cronExpressions: [...cronExpressions] } : {}),
+  ...(intervals
+    ? {
+        intervals: intervals.map(({ every, offset }) => ({
+          every: every as Duration,
+          ...(offset === undefined ? {} : { offset: offset as Duration }),
+        })),
+      }
+    : {}),
+});
+
+const describeError = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
+const withCatalogClient = async <Result>(
+  namespace: string,
+  use: (client: Client) => Promise<Result>,
+): Promise<Result> => {
+  const config = parseCatalogConnectionConfig(process.env);
+  const connection = await Connection.connect({
+    address: config.address,
+    ...(config.apiKey ? { apiKey: config.apiKey } : {}),
+    ...(config.tls ? { tls: config.tls } : {}),
+  });
+
+  try {
+    return await use(new Client({ connection, namespace }));
+  } finally {
+    await connection.close();
+  }
+};
+
+export const listCatalogSchedules = async ({
+  namespace,
+}: {
+  namespace: string;
+}): Promise<ExistingCatalogSchedule[]> =>
+  withCatalogClient(namespace, async (client) => {
+    const existing: ExistingCatalogSchedule[] = [];
+
+    for await (const summary of client.schedule.list()) {
+      const memo: unknown = summary.memo;
+      const owned = isCatalogOwned(memo);
+
+      existing.push({
+        id: summary.scheduleId,
+        owned,
+        ...(owned ? { exampleId: memo[catalogScheduleMemoKey].exampleId } : {}),
+      });
+    }
+
+    return existing;
+  });
+
+export const applyCatalogSchedulePlan = async ({
+  namespace,
+  plan,
+}: {
+  namespace: string;
+  plan: CatalogSchedulePlan;
+}): Promise<CatalogSchedulePlanResult> =>
+  withCatalogClient(namespace, async (client) => {
+    const result: CatalogSchedulePlanResult = {
+      created: [],
+      updated: [],
+      deleted: [],
+      blocked: plan.blocked.map(({ id }) => id),
+      errors: [],
+    };
+
+    for (const schedule of plan.create) {
+      try {
+        await client.schedule.create({
+          scheduleId: schedule.id,
+          spec: toScheduleSpec(schedule.spec),
+          action: {
+            type: 'startWorkflow',
+            workflowType: schedule.workflowType,
+            taskQueue: schedule.taskQueue,
+            args: schedule.args,
+          },
+          state: { paused: schedule.paused, note: schedule.note },
+          memo: {
+            [catalogScheduleMemoKey]: catalogScheduleOwnership(
+              schedule.exampleId,
+            ),
+          },
+        });
+        result.created.push(schedule.id);
+      } catch (error) {
+        result.errors.push(`${schedule.id}: ${describeError(error)}`);
+      }
+    }
+
+    for (const schedule of plan.update) {
+      try {
+        await client.schedule.getHandle(schedule.id).update((previous) => ({
+          ...previous,
+          spec: toScheduleSpec(schedule.spec),
+          action: {
+            ...previous.action,
+            type: 'startWorkflow',
+            workflowType: schedule.workflowType,
+            taskQueue: schedule.taskQueue,
+            args: schedule.args,
+          },
+          state: {
+            ...previous.state,
+            paused: schedule.paused,
+            note: schedule.note,
+          },
+        }));
+        result.updated.push(schedule.id);
+      } catch (error) {
+        result.errors.push(`${schedule.id}: ${describeError(error)}`);
+      }
+    }
+
+    for (const scheduleId of plan.delete) {
+      try {
+        await client.schedule.getHandle(scheduleId).delete();
+        result.deleted.push(scheduleId);
+      } catch (error) {
+        result.errors.push(`${scheduleId}: ${describeError(error)}`);
+      }
+    }
+
+    if (result.errors.length > 0) {
+      throw new Error(
+        `Catalog schedule reconciliation failed: ${result.errors.join('; ')}`,
+      );
+    }
+
+    return result;
+  });

--- a/src/lib/catalog/worker/examples/schedule-sync/activities.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/activities.ts
@@ -65,6 +65,7 @@ export const listCatalogSchedules = async ({
       existing.push({
         id: summary.scheduleId,
         owned,
+        paused: summary.state.paused,
         ...(owned ? { exampleId: memo[catalogScheduleMemoKey].exampleId } : {}),
       });
     }
@@ -85,6 +86,7 @@ export const applyCatalogSchedulePlan = async ({
       updated: [],
       deleted: [],
       blocked: plan.blocked.map(({ id }) => id),
+      held: plan.held.map(({ id }) => id),
       errors: [],
     };
 

--- a/src/lib/catalog/worker/examples/schedule-sync/activities.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/activities.ts
@@ -1,5 +1,4 @@
-import { Client, Connection, type ScheduleSpec } from '@temporalio/client';
-import type { Duration } from '@temporalio/common';
+import { Client, Connection } from '@temporalio/client';
 
 import {
   catalogScheduleMemoKey,
@@ -11,23 +10,8 @@ import type {
   CatalogSchedulePlanResult,
   ExistingCatalogSchedule,
 } from './plan.js';
-import type { BrowserScheduleSpec } from '../../../browser/types.js';
 import { parseCatalogConnectionConfig } from '../../connection-config.js';
-
-export const toScheduleSpec = ({
-  cronExpressions,
-  intervals,
-}: BrowserScheduleSpec): ScheduleSpec => ({
-  ...(cronExpressions ? { cronExpressions: [...cronExpressions] } : {}),
-  ...(intervals
-    ? {
-        intervals: intervals.map(({ every, offset }) => ({
-          every: every as Duration,
-          ...(offset === undefined ? {} : { offset: offset as Duration }),
-        })),
-      }
-    : {}),
-});
+import { toScheduleSpec } from '../../schedule-spec.js';
 
 const describeError = (error: unknown) =>
   error instanceof Error ? error.message : String(error);

--- a/src/lib/catalog/worker/examples/schedule-sync/example.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/example.ts
@@ -1,0 +1,56 @@
+import {
+  applyCatalogSchedulePlan,
+  listCatalogSchedules,
+} from './activities.js';
+import { catalogScheduleSync } from './workflow.js';
+import type { RuntimeJsonDocument } from '../../../browser/types.js';
+import type { CatalogExampleDefinition } from '../../registry.js';
+
+const input: RuntimeJsonDocument = {
+  defaultValue: [[]],
+  schema: {
+    type: 'array',
+    prefixItems: [
+      {
+        title: 'Declared schedules',
+        type: 'array',
+        items: { type: 'object' },
+      },
+    ],
+    items: false,
+    maxItems: 1,
+  },
+};
+const startOptions: RuntimeJsonDocument = {
+  defaultValue: {},
+  schema: {
+    type: 'object',
+    properties: { workflowId: { type: 'string', minLength: 1 } },
+  },
+};
+
+export const catalogExample: CatalogExampleDefinition = {
+  id: 'schedule-sync',
+  title: 'Schedule sync',
+  description:
+    'Reconciles the schedules declared by catalog examples against the server.',
+  capabilityTags: ['schedules', 'activities', 'terminal-outcome'],
+  expectedEvidence: [
+    'A completed workflow whose result lists the created, updated, and deleted schedule ids.',
+  ],
+  input,
+  startOptions,
+  setupMarkdown: [
+    'The schedule manager is disabled by default, so no catalog example creates a schedule until you turn it on.',
+    '',
+    'Set `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.',
+    '',
+    'The manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.',
+  ].join('\n'),
+  execution: {
+    kind: 'workflow',
+    workflowType: 'catalogScheduleSync',
+    workflow: catalogScheduleSync,
+    activities: { applyCatalogSchedulePlan, listCatalogSchedules },
+  },
+};

--- a/src/lib/catalog/worker/examples/schedule-sync/example.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/example.ts
@@ -46,6 +46,8 @@ export const catalogExample: CatalogExampleDefinition = {
     'Set `CATALOG_SCHEDULES=enabled` in `.env.catalog.local` and restart the worker. The worker then creates its own hourly `ui-catalog-schedule-sync` schedule and triggers it once.',
     '',
     'The manager only writes schedules it owns. Ownership comes from the `uiCatalog` memo it stamps on every schedule it creates. A schedule id that already exists without that memo is reported as blocked and is never updated or deleted.',
+    '',
+    'To stop a declared schedule without changing code, pause it. A running state that disagrees with the declaration is reported as held, and the manager writes nothing to that schedule until you resume it. Pausing this schedule stops reconciliation altogether, including at worker startup.',
   ].join('\n'),
   execution: {
     kind: 'workflow',

--- a/src/lib/catalog/worker/examples/schedule-sync/ownership.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/ownership.ts
@@ -1,0 +1,51 @@
+import type { JsonValue } from '../../../browser/types.js';
+import type { CatalogDesiredSchedule } from '../../schedule-declarations.js';
+
+export const catalogScheduleMemoKey = 'uiCatalog';
+
+export const catalogScheduleSyncExampleId = 'schedule-sync';
+
+export const catalogScheduleSyncScheduleId = 'ui-catalog-schedule-sync';
+
+export const catalogScheduleSyncCronExpression = '0 * * * *';
+
+export type CatalogScheduleOwnership = {
+  exampleId: string;
+  targetId?: string;
+};
+
+export const isCatalogOwned = (
+  memo: unknown,
+): memo is Record<string, CatalogScheduleOwnership> => {
+  if (typeof memo !== 'object' || memo === null) return false;
+
+  const ownership = (memo as Record<string, unknown>)[catalogScheduleMemoKey];
+
+  if (typeof ownership !== 'object' || ownership === null) return false;
+
+  const { exampleId } = ownership as Record<string, unknown>;
+
+  return typeof exampleId === 'string' && exampleId.length > 0;
+};
+
+export const catalogScheduleOwnership = (
+  exampleId: string,
+): CatalogScheduleOwnership => ({ exampleId });
+
+export const managerScheduleEntry = (
+  declared: readonly CatalogDesiredSchedule[],
+  {
+    namespace,
+    taskQueue,
+    workflowType,
+  }: { namespace: string; taskQueue: string; workflowType: string },
+): CatalogDesiredSchedule => ({
+  id: catalogScheduleSyncScheduleId,
+  namespace,
+  taskQueue,
+  workflowType,
+  exampleId: catalogScheduleSyncExampleId,
+  spec: { cronExpressions: [catalogScheduleSyncCronExpression] },
+  args: [declared as unknown as JsonValue],
+  paused: false,
+});

--- a/src/lib/catalog/worker/examples/schedule-sync/plan.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/plan.ts
@@ -3,6 +3,7 @@ import type { CatalogDesiredSchedule } from '../../schedule-declarations.js';
 export type ExistingCatalogSchedule = {
   id: string;
   owned: boolean;
+  paused: boolean;
   exampleId?: string;
 };
 
@@ -11,11 +12,23 @@ export type BlockedCatalogSchedule = {
   reason: 'foreign';
 };
 
+/**
+ * A schedule whose running state was changed by a person rather than by a
+ * declaration. The manager reports it and writes nothing to it until the state
+ * matches the declaration again, so pausing a misbehaving schedule in the UI is
+ * enough to stop it without editing code and restarting the worker.
+ */
+export type HeldCatalogSchedule = {
+  id: string;
+  reason: 'paused-by-hand' | 'paused-orphan' | 'resumed-by-hand';
+};
+
 export type CatalogSchedulePlan = {
   create: CatalogDesiredSchedule[];
   update: CatalogDesiredSchedule[];
   delete: string[];
   blocked: BlockedCatalogSchedule[];
+  held: HeldCatalogSchedule[];
 };
 
 export type CatalogSchedulePlanResult = {
@@ -23,6 +36,7 @@ export type CatalogSchedulePlanResult = {
   updated: string[];
   deleted: string[];
   blocked: string[];
+  held: string[];
   errors: string[];
 };
 
@@ -40,6 +54,7 @@ export const planCatalogSchedules = ({
     update: [],
     delete: [],
     blocked: [],
+    held: [],
   };
 
   for (const schedule of desired) {
@@ -50,16 +65,35 @@ export const planCatalogSchedules = ({
       continue;
     }
 
-    if (match.owned) {
-      plan.update.push(schedule);
+    if (!match.owned) {
+      plan.blocked.push({ id: schedule.id, reason: 'foreign' });
       continue;
     }
 
-    plan.blocked.push({ id: schedule.id, reason: 'foreign' });
+    // Drift in either direction is somebody's decision. The whole schedule is
+    // skipped rather than just the flag: rewriting the spec of a schedule
+    // someone paused mid-incident is the same surprise in a different form.
+    if (match.paused !== schedule.paused) {
+      plan.held.push({
+        id: schedule.id,
+        reason: match.paused ? 'paused-by-hand' : 'resumed-by-hand',
+      });
+      continue;
+    }
+
+    plan.update.push(schedule);
   }
 
   for (const entry of existing) {
     if (!entry.owned || desiredIds.has(entry.id)) continue;
+
+    // An orphan has no declaration to compare against, so a pause is the only
+    // signal available. Deleting something a person deliberately stopped is the
+    // destructive half of this pair, so a paused orphan is reported instead.
+    if (entry.paused) {
+      plan.held.push({ id: entry.id, reason: 'paused-orphan' });
+      continue;
+    }
 
     plan.delete.push(entry.id);
   }

--- a/src/lib/catalog/worker/examples/schedule-sync/plan.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/plan.ts
@@ -1,0 +1,68 @@
+import type { CatalogDesiredSchedule } from '../../schedule-declarations.js';
+
+export type ExistingCatalogSchedule = {
+  id: string;
+  owned: boolean;
+  exampleId?: string;
+};
+
+export type BlockedCatalogSchedule = {
+  id: string;
+  reason: 'foreign';
+};
+
+export type CatalogSchedulePlan = {
+  create: CatalogDesiredSchedule[];
+  update: CatalogDesiredSchedule[];
+  delete: string[];
+  blocked: BlockedCatalogSchedule[];
+};
+
+export type CatalogSchedulePlanResult = {
+  created: string[];
+  updated: string[];
+  deleted: string[];
+  blocked: string[];
+  errors: string[];
+};
+
+export const planCatalogSchedules = ({
+  desired,
+  existing,
+}: {
+  desired: readonly CatalogDesiredSchedule[];
+  existing: readonly ExistingCatalogSchedule[];
+}): CatalogSchedulePlan => {
+  const existingById = new Map(existing.map((entry) => [entry.id, entry]));
+  const desiredIds = new Set(desired.map(({ id }) => id));
+  const plan: CatalogSchedulePlan = {
+    create: [],
+    update: [],
+    delete: [],
+    blocked: [],
+  };
+
+  for (const schedule of desired) {
+    const match = existingById.get(schedule.id);
+
+    if (!match) {
+      plan.create.push(schedule);
+      continue;
+    }
+
+    if (match.owned) {
+      plan.update.push(schedule);
+      continue;
+    }
+
+    plan.blocked.push({ id: schedule.id, reason: 'foreign' });
+  }
+
+  for (const entry of existing) {
+    if (!entry.owned || desiredIds.has(entry.id)) continue;
+
+    plan.delete.push(entry.id);
+  }
+
+  return plan;
+};

--- a/src/lib/catalog/worker/examples/schedule-sync/workflow.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/workflow.ts
@@ -27,6 +27,7 @@ export async function catalogScheduleSync(
     updated: [],
     deleted: [],
     blocked: [],
+    held: [],
     errors: [],
   };
 
@@ -42,6 +43,7 @@ export async function catalogScheduleSync(
     merged.updated.push(...result.updated);
     merged.deleted.push(...result.deleted);
     merged.blocked.push(...result.blocked);
+    merged.held.push(...result.held);
     merged.errors.push(...result.errors);
   }
 

--- a/src/lib/catalog/worker/examples/schedule-sync/workflow.ts
+++ b/src/lib/catalog/worker/examples/schedule-sync/workflow.ts
@@ -1,0 +1,49 @@
+import { proxyActivities, workflowInfo } from '@temporalio/workflow';
+
+import { managerScheduleEntry } from './ownership.js';
+import {
+  type CatalogSchedulePlanResult,
+  planCatalogSchedules,
+} from './plan.js';
+import type { CatalogDesiredSchedule } from '../../schedule-declarations.js';
+
+const { applyCatalogSchedulePlan, listCatalogSchedules } = proxyActivities<
+  typeof import('./activities.js')
+>({ startToCloseTimeout: '30 seconds' });
+
+export async function catalogScheduleSync(
+  declared: CatalogDesiredSchedule[] = [],
+): Promise<CatalogSchedulePlanResult> {
+  const { namespace, taskQueue, workflowType } = workflowInfo();
+  const desired = [
+    ...declared,
+    managerScheduleEntry(declared, { namespace, taskQueue, workflowType }),
+  ];
+  const namespaces = [
+    ...new Set(desired.map((schedule) => schedule.namespace)),
+  ];
+  const merged: CatalogSchedulePlanResult = {
+    created: [],
+    updated: [],
+    deleted: [],
+    blocked: [],
+    errors: [],
+  };
+
+  for (const target of namespaces) {
+    const existing = await listCatalogSchedules({ namespace: target });
+    const plan = planCatalogSchedules({
+      desired: desired.filter((schedule) => schedule.namespace === target),
+      existing,
+    });
+    const result = await applyCatalogSchedulePlan({ namespace: target, plan });
+
+    merged.created.push(...result.created);
+    merged.updated.push(...result.updated);
+    merged.deleted.push(...result.deleted);
+    merged.blocked.push(...result.blocked);
+    merged.errors.push(...result.errors);
+  }
+
+  return merged;
+}

--- a/src/lib/catalog/worker/registry.test.ts
+++ b/src/lib/catalog/worker/registry.test.ts
@@ -195,6 +195,7 @@ describe('generateCatalog', () => {
               workflow,
               activities: { greetingActivity: activity },
             },
+            inputDefault: ['Temporal'],
           },
         ],
         activities: { greetingActivity: activity },
@@ -268,6 +269,7 @@ describe('generateCatalog', () => {
           timeouts: { scheduleToClose: '1 minute' },
           policies: { retry: { maximumAttempts: 3 } },
         },
+        inputDefault: { name: 'Temporal' },
       },
     ]);
     expect(generated.workerBindings[0]?.activities).toEqual({
@@ -343,6 +345,7 @@ describe('generateCatalog', () => {
           handler,
           policies: { scheduleToClose: '1 minute' },
         },
+        inputDefault: { name: 'Temporal' },
       },
     ]);
     expect(generated.workerBindings[0]?.activities).toEqual({});
@@ -1527,6 +1530,231 @@ describe('generateCatalog', () => {
     ).not.toHaveProperty('setupMarkdown');
     expect(() => generateCatalog(registerSetupExample(''))).toThrow(
       'invalid metadata fields',
+    );
+  });
+});
+
+describe('generateCatalog schedule declarations', () => {
+  const registerScheduledExample = (
+    schedule: unknown,
+    id = 'scheduled-example',
+  ) => {
+    const workflow = () => undefined;
+    const registry = createCatalogRegistry();
+
+    registry.registerTarget({
+      id: 'catalog',
+      namespace: 'default',
+      taskQueue: 'catalog',
+      workflowsPath: './workflows',
+      workflowExports: { scheduledWorkflow: workflow },
+    });
+    registry.registerExample({
+      id,
+      title: 'Scheduled example',
+      description: 'Declares a schedule.',
+      targetId: 'catalog',
+      capabilityTags: [],
+      expectedEvidence: [],
+      input: { defaultValue: ['Temporal'], schema: {} },
+      startOptions: { defaultValue: {}, schema: {} },
+      execution: {
+        kind: 'workflow',
+        workflowType: 'scheduledWorkflow',
+        workflow,
+        activities: {},
+        schedule: schedule as never,
+      },
+    });
+
+    return registry;
+  };
+  const validSchedule = {
+    id: 'scheduled-hourly',
+    spec: { cronExpressions: ['0 * * * *'] },
+    paused: false,
+  };
+
+  it('emits a declared schedule into the browser descriptor', () => {
+    const generated = generateCatalog(
+      registerScheduledExample({
+        ...validSchedule,
+        input: ['Scheduled'],
+        note: 'Hourly',
+        spec: {
+          cronExpressions: ['0 * * * *'],
+          intervals: [{ every: '1h', offset: '5m' }],
+        },
+      }),
+    );
+
+    expect(generated.browserDescriptors[0]?.execution).toMatchObject({
+      schedule: {
+        id: 'scheduled-hourly',
+        spec: {
+          cronExpressions: ['0 * * * *'],
+          intervals: [{ every: '1h', offset: '5m' }],
+        },
+        input: ['Scheduled'],
+        paused: false,
+        note: 'Hourly',
+      },
+    });
+  });
+
+  it('omits the schedule from the descriptor when no example declares one', () => {
+    const generated = generateCatalog(registerScheduledExample(undefined));
+
+    expect(generated.browserDescriptors[0]?.execution).not.toHaveProperty(
+      'schedule',
+    );
+  });
+
+  it('carries the example input default onto the worker binding', () => {
+    const generated = generateCatalog(registerScheduledExample(validSchedule));
+
+    expect(generated.workerBindings[0]?.examples[0]?.inputDefault).toEqual([
+      'Temporal',
+    ]);
+  });
+
+  it('rejects an unknown field on the schedule', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({ ...validSchedule, cron: '0 * * * *' }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an unknown field on the schedule spec', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { cronExpressions: ['0 * * * *'], calendars: [] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an unknown field on a schedule interval', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { intervals: [{ every: '1h', jitter: '1m' }] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an empty schedule id', () => {
+    expect(() =>
+      generateCatalog(registerScheduledExample({ ...validSchedule, id: '' })),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects a spec with neither a cron expression nor an interval', () => {
+    expect(() =>
+      generateCatalog(registerScheduledExample({ ...validSchedule, spec: {} })),
+    ).toThrow('declares an invalid schedule');
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { cronExpressions: [], intervals: [] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an empty cron expression', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { cronExpressions: [''] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an interval without a duration', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { intervals: [{ every: '' }] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an interval with an empty offset', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          spec: { intervals: [{ every: '1h', offset: '' }] },
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects a non-boolean paused flag', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({ ...validSchedule, paused: 'false' }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects input that is not a JSON-serializable array', () => {
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({ ...validSchedule, input: 'Temporal' }),
+      ),
+    ).toThrow('declares an invalid schedule');
+    expect(() =>
+      generateCatalog(
+        registerScheduledExample({
+          ...validSchedule,
+          input: [() => undefined],
+        }),
+      ),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects an empty note', () => {
+    expect(() =>
+      generateCatalog(registerScheduledExample({ ...validSchedule, note: '' })),
+    ).toThrow('declares an invalid schedule');
+  });
+
+  it('rejects two examples declaring the same schedule id', () => {
+    const registry = registerScheduledExample(validSchedule);
+    const workflow = registry.targets[0].workflowExports.scheduledWorkflow;
+
+    registry.registerExample({
+      id: 'second-scheduled-example',
+      title: 'Second scheduled example',
+      description: 'Declares the same schedule id.',
+      targetId: 'catalog',
+      capabilityTags: [],
+      expectedEvidence: [],
+      input: { defaultValue: [], schema: {} },
+      startOptions: { defaultValue: {}, schema: {} },
+      execution: {
+        kind: 'workflow',
+        workflowType: 'scheduledWorkflow',
+        workflow,
+        activities: {},
+        schedule: validSchedule,
+      },
+    });
+
+    expect(() => generateCatalog(registry)).toThrow(
+      'Duplicate catalog schedule id "scheduled-hourly" declared by example "second-scheduled-example"',
     );
   });
 });

--- a/src/lib/catalog/worker/registry.ts
+++ b/src/lib/catalog/worker/registry.ts
@@ -6,8 +6,10 @@ import { withSharedCatalogStartOptions } from '../browser/start-options.js';
 import type {
   BrowserCatalogDescriptor,
   BrowserCatalogMetadata,
+  BrowserScheduleDeclaration,
   JsonObject,
   JsonSchema,
+  JsonValue,
   RuntimeJsonDocument,
 } from '../browser/types';
 
@@ -31,6 +33,8 @@ type ExampleMetadata = BrowserCatalogMetadata & {
   targetId: string;
 };
 
+export type CatalogScheduleDeclaration = BrowserScheduleDeclaration;
+
 type WorkflowExecution = {
   kind: 'workflow';
   workflowType: string;
@@ -38,6 +42,7 @@ type WorkflowExecution = {
   activities: Readonly<Record<string, ActivityImplementation>>;
   nexusEndpoints?: readonly string[];
   nexusServices?: readonly ServiceHandler[];
+  schedule?: CatalogScheduleDeclaration;
 };
 
 type StandaloneActivityExecution = {
@@ -93,6 +98,7 @@ export type CatalogWorkerBinding = {
   examples: {
     id: string;
     execution: CatalogExampleRegistration['execution'];
+    inputDefault: JsonValue;
   }[];
   activities: Record<string, ActivityImplementation>;
   nexusServices: ServiceHandler[];
@@ -252,6 +258,71 @@ const isNexusHandler = (value: unknown): value is ServiceHandler =>
   typeof value.definition.operations === 'object' &&
   value.definition.operations !== null;
 
+const scheduleFields = new Set(['id', 'spec', 'input', 'paused', 'note']);
+
+const scheduleSpecFields = new Set(['cronExpressions', 'intervals']);
+
+const scheduleIntervalFields = new Set(['every', 'offset']);
+
+const isPlainRecord = (
+  value: unknown,
+  knownFields: ReadonlySet<string>,
+): value is Record<string, unknown> =>
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  hasOnlyEnumerableDataProperties(value) &&
+  hasOnlyKnownFields(value, knownFields);
+
+const isScheduleInterval = (value: unknown): boolean => {
+  if (!isPlainRecord(value, scheduleIntervalFields)) return false;
+
+  return (
+    isNonEmptyString(value.every) &&
+    (value.offset === undefined || isNonEmptyString(value.offset))
+  );
+};
+
+const isCatalogScheduleDeclaration = (
+  value: unknown,
+): value is CatalogScheduleDeclaration => {
+  if (!isPlainRecord(value, scheduleFields)) return false;
+
+  if (
+    !isNonEmptyString(value.id) ||
+    typeof value.paused !== 'boolean' ||
+    (value.note !== undefined && !isNonEmptyString(value.note)) ||
+    (value.input !== undefined &&
+      (!Array.isArray(value.input) || !isJsonSerializable(value.input)))
+  ) {
+    return false;
+  }
+
+  if (!isPlainRecord(value.spec, scheduleSpecFields)) return false;
+
+  const { cronExpressions, intervals } = value.spec;
+
+  if (
+    cronExpressions !== undefined &&
+    (!Array.isArray(cronExpressions) ||
+      !cronExpressions.every(isNonEmptyString))
+  ) {
+    return false;
+  }
+
+  if (
+    intervals !== undefined &&
+    (!Array.isArray(intervals) || !intervals.every(isScheduleInterval))
+  ) {
+    return false;
+  }
+
+  const cronCount = Array.isArray(cronExpressions) ? cronExpressions.length : 0;
+  const intervalCount = Array.isArray(intervals) ? intervals.length : 0;
+
+  return cronCount + intervalCount > 0;
+};
+
 const exampleFields = new Set([
   'id',
   'title',
@@ -280,6 +351,7 @@ const workflowExecutionFields = new Set([
   'activities',
   'nexusEndpoints',
   'nexusServices',
+  'schedule',
 ]);
 
 const standaloneActivityExecutionFields = new Set([
@@ -513,6 +585,16 @@ export const generateCatalog = (registry: CatalogRegistry) => {
 
     if (
       example.execution.kind === 'workflow' &&
+      example.execution.schedule !== undefined &&
+      !isCatalogScheduleDeclaration(example.execution.schedule)
+    ) {
+      throw new Error(
+        `Catalog workflow execution for example "${example.id}" declares an invalid schedule`,
+      );
+    }
+
+    if (
+      example.execution.kind === 'workflow' &&
       !hasOnlyEnumerableDataProperties(example.execution.activities)
     ) {
       throw new Error(
@@ -532,6 +614,7 @@ export const generateCatalog = (registry: CatalogRegistry) => {
   }
 
   const exampleIds = new Set<string>();
+  const scheduleIds = new Set<string>();
 
   for (const { execution, id, targetId } of registry.examples) {
     if (exampleIds.has(id)) {
@@ -539,6 +622,16 @@ export const generateCatalog = (registry: CatalogRegistry) => {
     }
 
     exampleIds.add(id);
+
+    if (execution.kind === 'workflow' && execution.schedule) {
+      if (scheduleIds.has(execution.schedule.id)) {
+        throw new Error(
+          `Duplicate catalog schedule id "${execution.schedule.id}" declared by example "${id}"`,
+        );
+      }
+
+      scheduleIds.add(execution.schedule.id);
+    }
 
     const target = registry.targets.find((target) => target.id === targetId);
 
@@ -629,7 +722,11 @@ export const generateCatalog = (registry: CatalogRegistry) => {
 
       return {
         target,
-        examples: examples.map(({ id, execution }) => ({ id, execution })),
+        examples: examples.map(({ id, execution, input }) => ({
+          id,
+          execution,
+          inputDefault: input.defaultValue,
+        })),
         activities,
         nexusServices,
       };
@@ -685,6 +782,7 @@ export const generateCatalog = (registry: CatalogRegistry) => {
           ...(execution.nexusEndpoints?.length
             ? { nexusEndpoints: [...execution.nexusEndpoints] }
             : {}),
+          ...(execution.schedule ? { schedule: execution.schedule } : {}),
         },
       };
     });

--- a/src/lib/catalog/worker/schedule-bootstrap.test.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.test.ts
@@ -55,12 +55,14 @@ const syncExamples = () => [
 const bootstrap = async ({
   examples = syncExamples(),
   exists = false,
+  paused = false,
   triggerManager = vi.fn(async () => undefined),
   createManager = vi.fn(async () => undefined),
   updateManagerArgs = vi.fn(async () => undefined),
 }: {
   examples?: CatalogWorkerBinding['examples'];
   exists?: boolean;
+  paused?: boolean;
   triggerManager?: (entry: CatalogDesiredSchedule) => Promise<void>;
   createManager?: (entry: CatalogDesiredSchedule) => Promise<void>;
   updateManagerArgs?: (entry: CatalogDesiredSchedule) => Promise<void>;
@@ -69,7 +71,7 @@ const bootstrap = async ({
 
   await bootstrapCatalogScheduleSync({
     bindings: bindings(examples),
-    describeManager: async () => ({ exists }),
+    describeManager: async () => ({ exists, paused }),
     createManager,
     updateManagerArgs,
     triggerManager,
@@ -169,5 +171,34 @@ describe('bootstrapCatalogScheduleSync', () => {
       },
     ]);
     expect(triggerManager).not.toHaveBeenCalled();
+  });
+});
+
+describe('bootstrapCatalogScheduleSync and a paused manager', () => {
+  it('writes nothing and triggers nothing when the manager is paused by hand', async () => {
+    const { events, createManager, updateManagerArgs, triggerManager } =
+      await bootstrap({ exists: true, paused: true });
+
+    expect(createManager).not.toHaveBeenCalled();
+    expect(updateManagerArgs).not.toHaveBeenCalled();
+    expect(triggerManager).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      expect.objectContaining({
+        state: 'held',
+        scheduleId: 'ui-catalog-schedule-sync',
+        reason: 'paused by hand; resume it to reconcile again',
+      }),
+    ]);
+  });
+
+  it('reconciles again once the manager is resumed', async () => {
+    const { events, updateManagerArgs, triggerManager } = await bootstrap({
+      exists: true,
+      paused: false,
+    });
+
+    expect(updateManagerArgs).toHaveBeenCalledTimes(1);
+    expect(triggerManager).toHaveBeenCalledTimes(1);
+    expect(events.map(({ state }) => state)).toEqual(['updated', 'triggered']);
   });
 });

--- a/src/lib/catalog/worker/schedule-bootstrap.test.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.test.ts
@@ -69,8 +69,12 @@ const bootstrap = async ({
 } = {}) => {
   const events: CatalogScheduleBootstrapEvent[] = [];
 
+  const workerBindings = bindings(examples);
+
   await bootstrapCatalogScheduleSync({
-    bindings: bindings(examples),
+    bindings: workerBindings,
+    registeredTargetIds: workerBindings.map(({ target }) => target.id),
+    runningTargetIds: workerBindings.map(({ target }) => target.id),
     describeManager: async () => ({ exists, paused }),
     createManager,
     updateManagerArgs,
@@ -200,5 +204,86 @@ describe('bootstrapCatalogScheduleSync and a paused manager', () => {
     expect(updateManagerArgs).toHaveBeenCalledTimes(1);
     expect(triggerManager).toHaveBeenCalledTimes(1);
     expect(events.map(({ state }) => state)).toEqual(['updated', 'triggered']);
+  });
+});
+
+describe('bootstrapCatalogScheduleSync and an incomplete binding set', () => {
+  const operations = {
+    describeManager: async () => ({ exists: false, paused: false }),
+    createManager: async () => undefined,
+    updateManagerArgs: async () => undefined,
+    triggerManager: async () => undefined,
+    onEvent: () => undefined,
+  };
+
+  it('refuses to reconcile when a registered target is missing', async () => {
+    const present = bindings(syncExamples());
+
+    await expect(
+      bootstrapCatalogScheduleSync({
+        ...operations,
+        bindings: present,
+        // The registry knows about a second target this call did not receive.
+        registeredTargetIds: ['shared-workflows', 'local-examples'],
+        runningTargetIds: ['shared-workflows'],
+      }),
+    ).rejects.toThrow(/local-examples is also registered/);
+  });
+
+  it('names the partial set in the message so the caller can see what it sent', async () => {
+    await expect(
+      bootstrapCatalogScheduleSync({
+        ...operations,
+        bindings: [],
+        registeredTargetIds: ['shared-workflows'],
+        runningTargetIds: [],
+      }),
+    ).rejects.toThrow(/given no targets/);
+  });
+
+  it('reconciles when every registered target is present', async () => {
+    const createManager = vi.fn(async () => undefined);
+    const present = bindings(syncExamples());
+
+    await bootstrapCatalogScheduleSync({
+      ...operations,
+      createManager,
+      bindings: present,
+      registeredTargetIds: ['shared-workflows'],
+      runningTargetIds: ['shared-workflows'],
+    });
+
+    expect(createManager).toHaveBeenCalledOnce();
+  });
+});
+
+describe('bootstrapCatalogScheduleSync and a narrowed run', () => {
+  it('skips when no worker in this process polls the manager target', async () => {
+    const events: CatalogScheduleBootstrapEvent[] = [];
+    const createManager = vi.fn(async () => undefined);
+    const triggerManager = vi.fn(async () => undefined);
+    const present = bindings(syncExamples());
+
+    await bootstrapCatalogScheduleSync({
+      bindings: present,
+      registeredTargetIds: ['shared-workflows'],
+      // CATALOG_TARGET_ID narrowed this process to a target that is not the
+      // manager's, so a triggered sync would sit as backlog nothing polls.
+      runningTargetIds: ['local-examples'],
+      describeManager: async () => ({ exists: false, paused: false }),
+      createManager,
+      updateManagerArgs: async () => undefined,
+      triggerManager,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(createManager).not.toHaveBeenCalled();
+    expect(triggerManager).not.toHaveBeenCalled();
+    expect(events).toEqual([
+      expect.objectContaining({
+        state: 'skipped',
+        reason: expect.stringContaining('shared-workflows'),
+      }),
+    ]);
   });
 });

--- a/src/lib/catalog/worker/schedule-bootstrap.test.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  CatalogScheduleDeclaration,
+  CatalogWorkerBinding,
+} from './registry';
+import {
+  bootstrapCatalogScheduleSync,
+  type CatalogScheduleBootstrapEvent,
+} from './schedule-bootstrap';
+import type { CatalogDesiredSchedule } from './schedule-declarations';
+
+const workflowExample = (
+  id: string,
+  workflowType: string,
+  schedule?: CatalogScheduleDeclaration,
+): CatalogWorkerBinding['examples'][number] => ({
+  id,
+  execution: {
+    kind: 'workflow',
+    workflowType,
+    workflow: () => undefined,
+    activities: {},
+    ...(schedule ? { schedule } : {}),
+  },
+  inputDefault: ['Temporal'],
+});
+
+const bindings = (
+  examples: CatalogWorkerBinding['examples'],
+): CatalogWorkerBinding[] => [
+  {
+    target: {
+      id: 'shared-workflows',
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      workflowsPath: './workflows',
+      workflowExports: {},
+    },
+    examples,
+    activities: {},
+    nexusServices: [],
+  },
+];
+
+const syncExamples = () => [
+  workflowExample('hello', 'hello', {
+    id: 'ui-catalog-hello-hourly',
+    spec: { cronExpressions: ['0 * * * *'] },
+    paused: false,
+  }),
+  workflowExample('schedule-sync', 'catalogScheduleSync'),
+];
+
+const bootstrap = async ({
+  examples = syncExamples(),
+  exists = false,
+  triggerManager = vi.fn(async () => undefined),
+  createManager = vi.fn(async () => undefined),
+  updateManagerArgs = vi.fn(async () => undefined),
+}: {
+  examples?: CatalogWorkerBinding['examples'];
+  exists?: boolean;
+  triggerManager?: (entry: CatalogDesiredSchedule) => Promise<void>;
+  createManager?: (entry: CatalogDesiredSchedule) => Promise<void>;
+  updateManagerArgs?: (entry: CatalogDesiredSchedule) => Promise<void>;
+} = {}) => {
+  const events: CatalogScheduleBootstrapEvent[] = [];
+
+  await bootstrapCatalogScheduleSync({
+    bindings: bindings(examples),
+    describeManager: async () => ({ exists }),
+    createManager,
+    updateManagerArgs,
+    triggerManager,
+    onEvent: (event) => events.push(event),
+  });
+
+  return { events, createManager, updateManagerArgs, triggerManager };
+};
+
+describe('bootstrapCatalogScheduleSync', () => {
+  it('creates the manager schedule when the server does not have it', async () => {
+    const createManager = vi.fn(async () => undefined);
+    const { events, triggerManager } = await bootstrap({ createManager });
+
+    expect(createManager).toHaveBeenCalledWith({
+      id: 'ui-catalog-schedule-sync',
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      workflowType: 'catalogScheduleSync',
+      exampleId: 'schedule-sync',
+      spec: { cronExpressions: ['0 * * * *'] },
+      args: [
+        [
+          {
+            id: 'ui-catalog-hello-hourly',
+            namespace: 'default',
+            taskQueue: 'ui-catalog',
+            workflowType: 'hello',
+            exampleId: 'hello',
+            spec: { cronExpressions: ['0 * * * *'] },
+            args: ['Temporal'],
+            paused: false,
+          },
+        ],
+      ],
+      paused: false,
+    });
+    expect(triggerManager).toHaveBeenCalledTimes(1);
+    expect(events.map(({ state }) => state)).toEqual(['created', 'triggered']);
+    expect(events[0]).toMatchObject({
+      scheduleId: 'ui-catalog-schedule-sync',
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      declaredCount: 1,
+    });
+  });
+
+  it('updates the manager arguments when the schedule already exists', async () => {
+    const updateManagerArgs = vi.fn(async () => undefined);
+    const { events, createManager } = await bootstrap({
+      exists: true,
+      updateManagerArgs,
+    });
+
+    expect(createManager).not.toHaveBeenCalled();
+    expect(updateManagerArgs).toHaveBeenCalledTimes(1);
+    expect(events.map(({ state }) => state)).toEqual(['updated', 'triggered']);
+  });
+
+  it('reports a trigger failure as blocked without throwing', async () => {
+    const { events } = await bootstrap({
+      triggerManager: vi.fn(async () => {
+        throw new Error('permission denied');
+      }),
+    });
+
+    expect(events.map(({ state }) => state)).toEqual(['created', 'blocked']);
+    expect(events[1].error).toBeInstanceOf(Error);
+  });
+
+  it('reports a create failure as blocked and never triggers', async () => {
+    const triggerManager = vi.fn(async () => undefined);
+    const { events } = await bootstrap({
+      createManager: vi.fn(async () => {
+        throw new Error('permission denied');
+      }),
+      triggerManager,
+    });
+
+    expect(events.map(({ state }) => state)).toEqual(['blocked']);
+    expect(triggerManager).not.toHaveBeenCalled();
+  });
+
+  it('skips when no target registers the schedule-sync example', async () => {
+    const triggerManager = vi.fn(async () => undefined);
+    const { events } = await bootstrap({
+      examples: [workflowExample('hello', 'hello')],
+      triggerManager,
+    });
+
+    expect(events).toEqual([
+      {
+        state: 'skipped',
+        scheduleId: 'ui-catalog-schedule-sync',
+        reason:
+          'The "schedule-sync" example is not registered as a workflow on any target',
+      },
+    ]);
+    expect(triggerManager).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/catalog/worker/schedule-bootstrap.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.ts
@@ -10,7 +10,7 @@ import {
 } from './schedule-declarations.js';
 
 export type CatalogScheduleBootstrapEvent = {
-  state: 'blocked' | 'created' | 'skipped' | 'triggered' | 'updated';
+  state: 'blocked' | 'created' | 'held' | 'skipped' | 'triggered' | 'updated';
   scheduleId: string;
   namespace?: string;
   taskQueue?: string;
@@ -30,7 +30,7 @@ export const bootstrapCatalogScheduleSync = async ({
   bindings: readonly CatalogWorkerBinding[];
   describeManager: (
     entry: CatalogDesiredSchedule,
-  ) => Promise<{ exists: boolean }>;
+  ) => Promise<{ exists: boolean; paused: boolean }>;
   createManager: (entry: CatalogDesiredSchedule) => Promise<void>;
   updateManagerArgs: (entry: CatalogDesiredSchedule) => Promise<void>;
   triggerManager: (entry: CatalogDesiredSchedule) => Promise<void>;
@@ -65,7 +65,19 @@ export const bootstrapCatalogScheduleSync = async ({
   };
 
   try {
-    const { exists } = await describeManager(entry);
+    const { exists, paused } = await describeManager(entry);
+
+    // A paused manager is the kill switch. Rewriting its args or triggering it
+    // would restart the reconciliation the pause was meant to stop, and every
+    // worker restart would do it again. Resume it to hand control back.
+    if (exists && paused) {
+      onEvent({
+        state: 'held',
+        ...details,
+        reason: 'paused by hand; resume it to reconcile again',
+      });
+      return;
+    }
 
     if (exists) {
       await updateManagerArgs(entry);

--- a/src/lib/catalog/worker/schedule-bootstrap.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.ts
@@ -1,0 +1,88 @@
+import {
+  catalogScheduleSyncExampleId,
+  catalogScheduleSyncScheduleId,
+  managerScheduleEntry,
+} from './examples/schedule-sync/ownership.js';
+import type { CatalogWorkerBinding } from './registry.js';
+import {
+  type CatalogDesiredSchedule,
+  declaredSchedules,
+} from './schedule-declarations.js';
+
+export type CatalogScheduleBootstrapEvent = {
+  state: 'blocked' | 'created' | 'skipped' | 'triggered' | 'updated';
+  scheduleId: string;
+  namespace?: string;
+  taskQueue?: string;
+  declaredCount?: number;
+  reason?: string;
+  error?: unknown;
+};
+
+export const bootstrapCatalogScheduleSync = async ({
+  bindings,
+  describeManager,
+  createManager,
+  updateManagerArgs,
+  triggerManager,
+  onEvent,
+}: {
+  bindings: readonly CatalogWorkerBinding[];
+  describeManager: (
+    entry: CatalogDesiredSchedule,
+  ) => Promise<{ exists: boolean }>;
+  createManager: (entry: CatalogDesiredSchedule) => Promise<void>;
+  updateManagerArgs: (entry: CatalogDesiredSchedule) => Promise<void>;
+  triggerManager: (entry: CatalogDesiredSchedule) => Promise<void>;
+  onEvent: (event: CatalogScheduleBootstrapEvent) => void;
+}): Promise<void> => {
+  const declared = declaredSchedules(bindings);
+  const manager = bindings
+    .flatMap(({ target, examples }) =>
+      examples.map((example) => ({ target, example })),
+    )
+    .find(({ example }) => example.id === catalogScheduleSyncExampleId);
+
+  if (!manager || manager.example.execution.kind !== 'workflow') {
+    onEvent({
+      state: 'skipped',
+      scheduleId: catalogScheduleSyncScheduleId,
+      reason: `The "${catalogScheduleSyncExampleId}" example is not registered as a workflow on any target`,
+    });
+    return;
+  }
+
+  const entry = managerScheduleEntry(declared, {
+    namespace: manager.target.namespace,
+    taskQueue: manager.target.taskQueue,
+    workflowType: manager.example.execution.workflowType,
+  });
+  const details = {
+    scheduleId: entry.id,
+    namespace: entry.namespace,
+    taskQueue: entry.taskQueue,
+    declaredCount: declared.length,
+  };
+
+  try {
+    const { exists } = await describeManager(entry);
+
+    if (exists) {
+      await updateManagerArgs(entry);
+      onEvent({ state: 'updated', ...details });
+    } else {
+      await createManager(entry);
+      onEvent({ state: 'created', ...details });
+    }
+  } catch (error) {
+    onEvent({ state: 'blocked', ...details, error });
+    return;
+  }
+
+  try {
+    await triggerManager(entry);
+    onEvent({ state: 'triggered', ...details });
+  } catch (error) {
+    onEvent({ state: 'blocked', ...details, error });
+  }
+};

--- a/src/lib/catalog/worker/schedule-bootstrap.ts
+++ b/src/lib/catalog/worker/schedule-bootstrap.ts
@@ -19,15 +19,46 @@ export type CatalogScheduleBootstrapEvent = {
   error?: unknown;
 };
 
+/**
+ * Refuses a binding set that does not cover every registered target.
+ *
+ * The desired list is built from the bindings handed in, and the reconciler
+ * deletes every catalog-owned schedule that is not on it. So a partial set does
+ * not reconcile a subset — it deletes the schedules the missing targets
+ * declare. `registeredTargetIds` comes from the registry rather than from
+ * `bindings`, which is what makes this check able to see the difference.
+ */
+const assertEveryTargetPresent = (
+  bindings: readonly CatalogWorkerBinding[],
+  registeredTargetIds: readonly string[],
+) => {
+  const present = new Set(bindings.map(({ target }) => target.id));
+  const missing = registeredTargetIds.filter((id) => !present.has(id));
+
+  if (missing.length === 0) return;
+
+  throw new Error(
+    `The schedule manager was given ${present.size === 0 ? 'no targets' : [...present].join(', ')} but ${missing.join(', ')} is also registered. ` +
+      'Reconciling from a partial set would delete the schedules the missing targets declare, so it needs every registered target.',
+  );
+};
+
 export const bootstrapCatalogScheduleSync = async ({
   bindings,
+  registeredTargetIds,
+  runningTargetIds,
   describeManager,
   createManager,
   updateManagerArgs,
   triggerManager,
   onEvent,
 }: {
+  /** Every registered target, not the subset this process will poll. */
   bindings: readonly CatalogWorkerBinding[];
+  /** Target ids the registry knows about, used to prove `bindings` is complete. */
+  registeredTargetIds: readonly string[];
+  /** Targets this process will actually poll, which may be narrower. */
+  runningTargetIds: readonly string[];
   describeManager: (
     entry: CatalogDesiredSchedule,
   ) => Promise<{ exists: boolean; paused: boolean }>;
@@ -36,6 +67,8 @@ export const bootstrapCatalogScheduleSync = async ({
   triggerManager: (entry: CatalogDesiredSchedule) => Promise<void>;
   onEvent: (event: CatalogScheduleBootstrapEvent) => void;
 }): Promise<void> => {
+  assertEveryTargetPresent(bindings, registeredTargetIds);
+
   const declared = declaredSchedules(bindings);
   const manager = bindings
     .flatMap(({ target, examples }) =>
@@ -48,6 +81,15 @@ export const bootstrapCatalogScheduleSync = async ({
       state: 'skipped',
       scheduleId: catalogScheduleSyncScheduleId,
       reason: `The "${catalogScheduleSyncExampleId}" example is not registered as a workflow on any target`,
+    });
+    return;
+  }
+
+  if (!runningTargetIds.includes(manager.target.id)) {
+    onEvent({
+      state: 'skipped',
+      scheduleId: catalogScheduleSyncScheduleId,
+      reason: `No worker in this process polls the "${manager.target.id}" target, so a triggered sync would wait for one`,
     });
     return;
   }

--- a/src/lib/catalog/worker/schedule-config.test.ts
+++ b/src/lib/catalog/worker/schedule-config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseCatalogScheduleConfig } from './schedule-config';
+
+describe('parseCatalogScheduleConfig', () => {
+  it('leaves the schedule manager disabled when the variable is unset', () => {
+    expect(parseCatalogScheduleConfig({})).toEqual({ enabled: false });
+  });
+
+  it('leaves the schedule manager disabled when the variable says disabled', () => {
+    expect(
+      parseCatalogScheduleConfig({ CATALOG_SCHEDULES: 'disabled' }),
+    ).toEqual({ enabled: false });
+  });
+
+  it('enables the schedule manager when the variable says enabled', () => {
+    expect(
+      parseCatalogScheduleConfig({ CATALOG_SCHEDULES: 'enabled' }),
+    ).toEqual({ enabled: true });
+  });
+
+  it('rejects any other value by naming the variable and both accepted values', () => {
+    expect(() =>
+      parseCatalogScheduleConfig({ CATALOG_SCHEDULES: 'true' }),
+    ).toThrow('CATALOG_SCHEDULES must be "enabled" or "disabled"');
+  });
+});

--- a/src/lib/catalog/worker/schedule-config.ts
+++ b/src/lib/catalog/worker/schedule-config.ts
@@ -1,0 +1,17 @@
+export type CatalogScheduleConfig = {
+  enabled: boolean;
+};
+
+type CatalogScheduleEnvironment = Record<string, string | undefined>;
+
+export const parseCatalogScheduleConfig = (
+  environment: CatalogScheduleEnvironment,
+): CatalogScheduleConfig => {
+  const setting = environment.CATALOG_SCHEDULES;
+
+  if (setting === undefined || setting === 'disabled')
+    return { enabled: false };
+  if (setting === 'enabled') return { enabled: true };
+
+  throw new Error('CATALOG_SCHEDULES must be "enabled" or "disabled"');
+};

--- a/src/lib/catalog/worker/schedule-declarations.test.ts
+++ b/src/lib/catalog/worker/schedule-declarations.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  CatalogScheduleDeclaration,
+  CatalogWorkerBinding,
+} from './registry';
+import { declaredSchedules } from './schedule-declarations';
+import type { JsonValue } from '../browser/types';
+
+const binding = (
+  namespace: string,
+  taskQueue: string,
+  examples: CatalogWorkerBinding['examples'],
+): CatalogWorkerBinding => ({
+  target: {
+    id: 'shared',
+    namespace,
+    taskQueue,
+    workflowsPath: './workflows',
+    workflowExports: {},
+  },
+  examples,
+  activities: {},
+  nexusServices: [],
+});
+
+const workflowExample = (
+  id: string,
+  schedule?: CatalogScheduleDeclaration,
+  inputDefault: JsonValue = ['Temporal'],
+): CatalogWorkerBinding['examples'][number] => ({
+  id,
+  execution: {
+    kind: 'workflow',
+    workflowType: `${id}Workflow`,
+    workflow: () => undefined,
+    activities: {},
+    ...(schedule ? { schedule } : {}),
+  },
+  inputDefault,
+});
+
+describe('declaredSchedules', () => {
+  it('returns nothing when no example declares a schedule', () => {
+    expect(
+      declaredSchedules([
+        binding('default', 'ui-catalog', [workflowExample('hello')]),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('resolves a declared schedule against its target routing and input default', () => {
+    expect(
+      declaredSchedules([
+        binding('default', 'ui-catalog', [
+          workflowExample('hello', {
+            id: 'ui-catalog-hello-hourly',
+            spec: { cronExpressions: ['0 * * * *'] },
+            paused: false,
+            note: 'Declared by the hello catalog example',
+          }),
+        ]),
+      ]),
+    ).toEqual([
+      {
+        id: 'ui-catalog-hello-hourly',
+        namespace: 'default',
+        taskQueue: 'ui-catalog',
+        workflowType: 'helloWorkflow',
+        exampleId: 'hello',
+        spec: { cronExpressions: ['0 * * * *'] },
+        args: ['Temporal'],
+        paused: false,
+        note: 'Declared by the hello catalog example',
+      },
+    ]);
+  });
+
+  it('prefers the declared schedule input over the example input default', () => {
+    const [schedule] = declaredSchedules([
+      binding('default', 'ui-catalog', [
+        workflowExample('hello', {
+          id: 'hello-hourly',
+          spec: { intervals: [{ every: '1h', offset: '5m' }] },
+          input: ['Scheduled'],
+          paused: true,
+        }),
+      ]),
+    ]);
+
+    expect(schedule).toEqual({
+      id: 'hello-hourly',
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      workflowType: 'helloWorkflow',
+      exampleId: 'hello',
+      spec: { intervals: [{ every: '1h', offset: '5m' }] },
+      args: ['Scheduled'],
+      paused: true,
+    });
+    expect(Object.hasOwn(schedule, 'note')).toBe(false);
+  });
+
+  it('falls back to no arguments when the example input default is not an array', () => {
+    expect(
+      declaredSchedules([
+        binding('default', 'ui-catalog', [
+          workflowExample(
+            'hello',
+            {
+              id: 'hello-hourly',
+              spec: { cronExpressions: ['0 * * * *'] },
+              paused: false,
+            },
+            { name: 'Temporal' },
+          ),
+        ]),
+      ])[0].args,
+    ).toEqual([]);
+  });
+
+  it('collects schedules across every binding and skips other execution kinds', () => {
+    const schedules = declaredSchedules([
+      binding('default', 'ui-catalog', [
+        workflowExample('hello', {
+          id: 'hello-hourly',
+          spec: { cronExpressions: ['0 * * * *'] },
+          paused: false,
+        }),
+        {
+          id: 'standalone',
+          execution: {
+            kind: 'standalone-activity',
+            activityType: 'greet',
+            activity: () => undefined,
+            timeouts: {},
+            policies: {},
+          },
+          inputDefault: [],
+        },
+      ]),
+      binding('staging', 'ui-catalog-staging', [
+        workflowExample('other', {
+          id: 'other-hourly',
+          spec: { cronExpressions: ['30 * * * *'] },
+          paused: false,
+        }),
+      ]),
+    ]);
+
+    expect(schedules.map(({ id, namespace }) => [id, namespace])).toEqual([
+      ['hello-hourly', 'default'],
+      ['other-hourly', 'staging'],
+    ]);
+  });
+});

--- a/src/lib/catalog/worker/schedule-declarations.ts
+++ b/src/lib/catalog/worker/schedule-declarations.ts
@@ -1,0 +1,44 @@
+import type { CatalogWorkerBinding } from './registry.js';
+import type { BrowserScheduleSpec, JsonValue } from '../browser/types.js';
+
+export type CatalogDesiredSchedule = {
+  id: string;
+  namespace: string;
+  taskQueue: string;
+  workflowType: string;
+  exampleId: string;
+  spec: BrowserScheduleSpec;
+  args: JsonValue[];
+  paused: boolean;
+  note?: string;
+};
+
+export const declaredSchedules = (
+  bindings: readonly CatalogWorkerBinding[],
+): CatalogDesiredSchedule[] => {
+  const declared: CatalogDesiredSchedule[] = [];
+
+  for (const { target, examples } of bindings) {
+    for (const { id, execution, inputDefault } of examples) {
+      if (execution.kind !== 'workflow' || !execution.schedule) continue;
+
+      const { schedule } = execution;
+      const args =
+        schedule.input ?? (Array.isArray(inputDefault) ? inputDefault : []);
+
+      declared.push({
+        id: schedule.id,
+        namespace: target.namespace,
+        taskQueue: target.taskQueue,
+        workflowType: execution.workflowType,
+        exampleId: id,
+        spec: schedule.spec,
+        args,
+        paused: schedule.paused,
+        ...(schedule.note === undefined ? {} : { note: schedule.note }),
+      });
+    }
+  }
+
+  return declared;
+};

--- a/src/lib/catalog/worker/schedule-manager-client.ts
+++ b/src/lib/catalog/worker/schedule-manager-client.ts
@@ -1,0 +1,82 @@
+import {
+  Client,
+  type ConnectionLike,
+  ScheduleNotFoundError,
+} from '@temporalio/client';
+
+import {
+  catalogScheduleMemoKey,
+  catalogScheduleOwnership,
+} from './examples/schedule-sync/ownership.js';
+import type { CatalogDesiredSchedule } from './schedule-declarations.js';
+import { toScheduleSpec } from './schedule-spec.js';
+
+/**
+ * The four operations {@link bootstrapCatalogScheduleSync} needs, built against
+ * an open connection.
+ *
+ * The bootstrap takes them as callbacks so its decisions stay testable without a
+ * server. They are assembled here rather than at each call site so that every
+ * caller — the local dev worker, a deploy step in another repository — writes
+ * the same schedule: the same ownership memo, the same spec conversion, and the
+ * same treatment of a missing schedule as "does not exist" rather than an error.
+ */
+export const catalogScheduleManagerOperations = (
+  connection: ConnectionLike,
+) => {
+  const handleFor = ({ id, namespace }: CatalogDesiredSchedule) =>
+    new Client({ connection, namespace }).schedule.getHandle(id);
+
+  return {
+    describeManager: async (entry: CatalogDesiredSchedule) => {
+      try {
+        const { state } = await handleFor(entry).describe();
+        return { exists: true, paused: state.paused };
+      } catch (error) {
+        if (error instanceof ScheduleNotFoundError)
+          return { exists: false, paused: false };
+        throw error;
+      }
+    },
+
+    createManager: async (entry: CatalogDesiredSchedule) => {
+      await new Client({
+        connection,
+        namespace: entry.namespace,
+      }).schedule.create({
+        scheduleId: entry.id,
+        spec: toScheduleSpec(entry.spec),
+        action: {
+          type: 'startWorkflow',
+          workflowType: entry.workflowType,
+          taskQueue: entry.taskQueue,
+          args: entry.args,
+        },
+        state: { paused: entry.paused, note: entry.note },
+        memo: {
+          [catalogScheduleMemoKey]: catalogScheduleOwnership(entry.exampleId),
+        },
+      });
+    },
+
+    // Only the action is rewritten. The spec is left alone because the manager's
+    // own cadence is not something a declaration owns, and the state is left
+    // alone because a pause is the kill switch.
+    updateManagerArgs: async (entry: CatalogDesiredSchedule) => {
+      await handleFor(entry).update((previous) => ({
+        ...previous,
+        action: {
+          ...previous.action,
+          type: 'startWorkflow',
+          workflowType: entry.workflowType,
+          taskQueue: entry.taskQueue,
+          args: entry.args,
+        },
+      }));
+    },
+
+    triggerManager: async (entry: CatalogDesiredSchedule) => {
+      await handleFor(entry).trigger();
+    },
+  };
+};

--- a/src/lib/catalog/worker/schedule-ownership.test.ts
+++ b/src/lib/catalog/worker/schedule-ownership.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  catalogScheduleMemoKey,
+  isCatalogOwned,
+  managerScheduleEntry,
+} from './examples/schedule-sync/ownership';
+import type { CatalogDesiredSchedule } from './schedule-declarations';
+
+const declared: CatalogDesiredSchedule[] = [
+  {
+    id: 'ui-catalog-hello-hourly',
+    namespace: 'default',
+    taskQueue: 'ui-catalog',
+    workflowType: 'hello',
+    exampleId: 'hello',
+    spec: { cronExpressions: ['0 * * * *'] },
+    args: ['Temporal'],
+    paused: false,
+  },
+];
+
+describe('isCatalogOwned', () => {
+  it('recognizes a schedule the catalog stamped with its memo', () => {
+    expect(
+      isCatalogOwned({ [catalogScheduleMemoKey]: { exampleId: 'hello' } }),
+    ).toBe(true);
+  });
+
+  it('rejects a memo without the catalog key', () => {
+    expect(isCatalogOwned({ other: { exampleId: 'hello' } })).toBe(false);
+  });
+
+  it('rejects a catalog memo without an example id', () => {
+    expect(
+      isCatalogOwned({ [catalogScheduleMemoKey]: { exampleId: '' } }),
+    ).toBe(false);
+    expect(isCatalogOwned({ [catalogScheduleMemoKey]: 'hello' })).toBe(false);
+  });
+
+  it('rejects a missing memo', () => {
+    expect(isCatalogOwned(undefined)).toBe(false);
+    expect(isCatalogOwned(null)).toBe(false);
+  });
+});
+
+describe('managerScheduleEntry', () => {
+  it('describes an hourly manager schedule carrying the declared schedules', () => {
+    expect(
+      managerScheduleEntry(declared, {
+        namespace: 'default',
+        taskQueue: 'ui-catalog',
+        workflowType: 'catalogScheduleSync',
+      }),
+    ).toEqual({
+      id: 'ui-catalog-schedule-sync',
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      workflowType: 'catalogScheduleSync',
+      exampleId: 'schedule-sync',
+      spec: { cronExpressions: ['0 * * * *'] },
+      args: [declared],
+      paused: false,
+    });
+  });
+});

--- a/src/lib/catalog/worker/schedule-plan.test.ts
+++ b/src/lib/catalog/worker/schedule-plan.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { managerScheduleEntry } from './examples/schedule-sync/ownership';
+import { planCatalogSchedules } from './examples/schedule-sync/plan';
+import type { CatalogDesiredSchedule } from './schedule-declarations';
+
+const desiredSchedule = (id: string): CatalogDesiredSchedule => ({
+  id,
+  namespace: 'default',
+  taskQueue: 'ui-catalog',
+  workflowType: 'hello',
+  exampleId: 'hello',
+  spec: { cronExpressions: ['0 * * * *'] },
+  args: ['Temporal'],
+  paused: false,
+});
+
+describe('planCatalogSchedules', () => {
+  it('creates a desired schedule the server does not have', () => {
+    const schedule = desiredSchedule('hello-hourly');
+
+    expect(planCatalogSchedules({ desired: [schedule], existing: [] })).toEqual(
+      {
+        create: [schedule],
+        update: [],
+        delete: [],
+        blocked: [],
+      },
+    );
+  });
+
+  it('updates a desired schedule the catalog already owns', () => {
+    const schedule = desiredSchedule('hello-hourly');
+
+    expect(
+      planCatalogSchedules({
+        desired: [schedule],
+        existing: [{ id: 'hello-hourly', owned: true, exampleId: 'hello' }],
+      }),
+    ).toEqual({
+      create: [],
+      update: [schedule],
+      delete: [],
+      blocked: [],
+    });
+  });
+
+  it('blocks a desired id that belongs to a schedule the catalog does not own', () => {
+    expect(
+      planCatalogSchedules({
+        desired: [desiredSchedule('hello-hourly')],
+        existing: [{ id: 'hello-hourly', owned: false }],
+      }),
+    ).toEqual({
+      create: [],
+      update: [],
+      delete: [],
+      blocked: [{ id: 'hello-hourly', reason: 'foreign' }],
+    });
+  });
+
+  it('deletes an owned schedule that no example declares any more', () => {
+    expect(
+      planCatalogSchedules({
+        desired: [],
+        existing: [{ id: 'retired-hourly', owned: true, exampleId: 'retired' }],
+      }),
+    ).toEqual({
+      create: [],
+      update: [],
+      delete: ['retired-hourly'],
+      blocked: [],
+    });
+  });
+
+  it('never deletes a schedule the catalog does not own', () => {
+    expect(
+      planCatalogSchedules({
+        desired: [],
+        existing: [{ id: 'someone-elses-hourly', owned: false }],
+      }),
+    ).toEqual({
+      create: [],
+      update: [],
+      delete: [],
+      blocked: [],
+    });
+  });
+
+  it('keeps the manager schedule because it is part of the desired set', () => {
+    const declared = [desiredSchedule('hello-hourly')];
+    const manager = managerScheduleEntry(declared, {
+      namespace: 'default',
+      taskQueue: 'ui-catalog',
+      workflowType: 'catalogScheduleSync',
+    });
+    const plan = planCatalogSchedules({
+      desired: [...declared, manager],
+      existing: [
+        { id: 'hello-hourly', owned: true, exampleId: 'hello' },
+        {
+          id: 'ui-catalog-schedule-sync',
+          owned: true,
+          exampleId: 'schedule-sync',
+        },
+      ],
+    });
+
+    expect(plan.delete).toEqual([]);
+    expect(plan.update.map(({ id }) => id)).toEqual([
+      'hello-hourly',
+      'ui-catalog-schedule-sync',
+    ]);
+  });
+
+  it('sorts every desired schedule into exactly one bucket', () => {
+    const created = desiredSchedule('created-hourly');
+    const updated = desiredSchedule('updated-hourly');
+    const foreign = desiredSchedule('foreign-hourly');
+    const plan = planCatalogSchedules({
+      desired: [created, updated, foreign],
+      existing: [
+        { id: 'updated-hourly', owned: true, exampleId: 'hello' },
+        { id: 'foreign-hourly', owned: false },
+        { id: 'retired-hourly', owned: true, exampleId: 'retired' },
+      ],
+    });
+
+    expect(plan).toEqual({
+      create: [created],
+      update: [updated],
+      delete: ['retired-hourly'],
+      blocked: [{ id: 'foreign-hourly', reason: 'foreign' }],
+    });
+  });
+});

--- a/src/lib/catalog/worker/schedule-plan.test.ts
+++ b/src/lib/catalog/worker/schedule-plan.test.ts
@@ -25,6 +25,7 @@ describe('planCatalogSchedules', () => {
         update: [],
         delete: [],
         blocked: [],
+        held: [],
       },
     );
   });
@@ -35,13 +36,21 @@ describe('planCatalogSchedules', () => {
     expect(
       planCatalogSchedules({
         desired: [schedule],
-        existing: [{ id: 'hello-hourly', owned: true, exampleId: 'hello' }],
+        existing: [
+          {
+            id: 'hello-hourly',
+            owned: true,
+            paused: false,
+            exampleId: 'hello',
+          },
+        ],
       }),
     ).toEqual({
       create: [],
       update: [schedule],
       delete: [],
       blocked: [],
+      held: [],
     });
   });
 
@@ -49,13 +58,14 @@ describe('planCatalogSchedules', () => {
     expect(
       planCatalogSchedules({
         desired: [desiredSchedule('hello-hourly')],
-        existing: [{ id: 'hello-hourly', owned: false }],
+        existing: [{ id: 'hello-hourly', owned: false, paused: false }],
       }),
     ).toEqual({
       create: [],
       update: [],
       delete: [],
       blocked: [{ id: 'hello-hourly', reason: 'foreign' }],
+      held: [],
     });
   });
 
@@ -63,13 +73,21 @@ describe('planCatalogSchedules', () => {
     expect(
       planCatalogSchedules({
         desired: [],
-        existing: [{ id: 'retired-hourly', owned: true, exampleId: 'retired' }],
+        existing: [
+          {
+            id: 'retired-hourly',
+            owned: true,
+            paused: false,
+            exampleId: 'retired',
+          },
+        ],
       }),
     ).toEqual({
       create: [],
       update: [],
       delete: ['retired-hourly'],
       blocked: [],
+      held: [],
     });
   });
 
@@ -77,13 +95,14 @@ describe('planCatalogSchedules', () => {
     expect(
       planCatalogSchedules({
         desired: [],
-        existing: [{ id: 'someone-elses-hourly', owned: false }],
+        existing: [{ id: 'someone-elses-hourly', owned: false, paused: false }],
       }),
     ).toEqual({
       create: [],
       update: [],
       delete: [],
       blocked: [],
+      held: [],
     });
   });
 
@@ -97,10 +116,11 @@ describe('planCatalogSchedules', () => {
     const plan = planCatalogSchedules({
       desired: [...declared, manager],
       existing: [
-        { id: 'hello-hourly', owned: true, exampleId: 'hello' },
+        { id: 'hello-hourly', owned: true, paused: false, exampleId: 'hello' },
         {
           id: 'ui-catalog-schedule-sync',
           owned: true,
+          paused: false,
           exampleId: 'schedule-sync',
         },
       ],
@@ -113,6 +133,85 @@ describe('planCatalogSchedules', () => {
     ]);
   });
 
+  it('holds a declared schedule somebody paused by hand', () => {
+    const schedule = desiredSchedule('hello-hourly');
+    const plan = planCatalogSchedules({
+      desired: [schedule],
+      existing: [
+        { id: 'hello-hourly', owned: true, paused: true, exampleId: 'hello' },
+      ],
+    });
+
+    expect(plan.held).toEqual([
+      { id: 'hello-hourly', reason: 'paused-by-hand' },
+    ]);
+    expect(plan.update).toEqual([]);
+  });
+
+  it('holds a declared schedule somebody resumed by hand', () => {
+    const schedule = { ...desiredSchedule('hello-hourly'), paused: true };
+    const plan = planCatalogSchedules({
+      desired: [schedule],
+      existing: [
+        { id: 'hello-hourly', owned: true, paused: false, exampleId: 'hello' },
+      ],
+    });
+
+    expect(plan.held).toEqual([
+      { id: 'hello-hourly', reason: 'resumed-by-hand' },
+    ]);
+    expect(plan.update).toEqual([]);
+  });
+
+  it('holds a paused schedule no example declares any more', () => {
+    const plan = planCatalogSchedules({
+      desired: [],
+      existing: [
+        {
+          id: 'retired-hourly',
+          owned: true,
+          paused: true,
+          exampleId: 'retired',
+        },
+      ],
+    });
+
+    expect(plan.held).toEqual([
+      { id: 'retired-hourly', reason: 'paused-orphan' },
+    ]);
+    expect(plan.delete).toEqual([]);
+  });
+
+  it('blocks a foreign schedule rather than holding it, whatever its state', () => {
+    const plan = planCatalogSchedules({
+      desired: [desiredSchedule('hello-hourly')],
+      existing: [{ id: 'hello-hourly', owned: false, paused: true }],
+    });
+
+    expect(plan.blocked).toEqual([{ id: 'hello-hourly', reason: 'foreign' }]);
+    expect(plan.held).toEqual([]);
+  });
+
+  it('reconciles a held schedule again once its state matches the declaration', () => {
+    const schedule = desiredSchedule('hello-hourly');
+    const held = planCatalogSchedules({
+      desired: [schedule],
+      existing: [
+        { id: 'hello-hourly', owned: true, paused: true, exampleId: 'hello' },
+      ],
+    });
+    const resumed = planCatalogSchedules({
+      desired: [schedule],
+      existing: [
+        { id: 'hello-hourly', owned: true, paused: false, exampleId: 'hello' },
+      ],
+    });
+
+    expect(held.update).toEqual([]);
+    expect(resumed.held).toEqual([]);
+    expect(resumed.update).toEqual([schedule]);
+  });
+
   it('sorts every desired schedule into exactly one bucket', () => {
     const created = desiredSchedule('created-hourly');
     const updated = desiredSchedule('updated-hourly');
@@ -120,9 +219,19 @@ describe('planCatalogSchedules', () => {
     const plan = planCatalogSchedules({
       desired: [created, updated, foreign],
       existing: [
-        { id: 'updated-hourly', owned: true, exampleId: 'hello' },
-        { id: 'foreign-hourly', owned: false },
-        { id: 'retired-hourly', owned: true, exampleId: 'retired' },
+        {
+          id: 'updated-hourly',
+          owned: true,
+          paused: false,
+          exampleId: 'hello',
+        },
+        { id: 'foreign-hourly', owned: false, paused: false },
+        {
+          id: 'retired-hourly',
+          owned: true,
+          paused: false,
+          exampleId: 'retired',
+        },
       ],
     });
 
@@ -131,6 +240,7 @@ describe('planCatalogSchedules', () => {
       update: [updated],
       delete: ['retired-hourly'],
       blocked: [{ id: 'foreign-hourly', reason: 'foreign' }],
+      held: [],
     });
   });
 });

--- a/src/lib/catalog/worker/schedule-spec.ts
+++ b/src/lib/catalog/worker/schedule-spec.ts
@@ -1,0 +1,25 @@
+import type { ScheduleSpec } from '@temporalio/client';
+import type { Duration } from '@temporalio/common';
+
+import type { BrowserScheduleSpec } from '../browser/types.js';
+
+/**
+ * Turns a declared spec into the SDK's shape. Kept apart from the reconciler's
+ * activities so a caller that only needs to describe a schedule — the startup
+ * bootstrap, a deploy step — does not pull a client in with it. Both imports
+ * here are type-only, so this module has no runtime dependency at all.
+ */
+export const toScheduleSpec = ({
+  cronExpressions,
+  intervals,
+}: BrowserScheduleSpec): ScheduleSpec => ({
+  ...(cronExpressions ? { cronExpressions: [...cronExpressions] } : {}),
+  ...(intervals
+    ? {
+        intervals: intervals.map(({ every, offset }) => ({
+          every: every as Duration,
+          ...(offset === undefined ? {} : { offset: offset as Duration }),
+        })),
+      }
+    : {}),
+});

--- a/src/lib/catalog/worker/startup-banner.test.ts
+++ b/src/lib/catalog/worker/startup-banner.test.ts
@@ -36,6 +36,15 @@ describe('formatCatalogBanner', () => {
     expect(banner).toContain('local-workflows → default / ui-catalog-local');
   });
 
+  it('states whether the schedule manager is enabled', () => {
+    expect(formatCatalogBanner({ targets })).toContain(
+      'Schedule manager: disabled',
+    );
+    expect(formatCatalogBanner({ targets, schedulesEnabled: true })).toContain(
+      'Schedule manager: enabled',
+    );
+  });
+
   it('keeps every framed line the same width', () => {
     const widths = new Set(
       formatCatalogBanner({ targets })

--- a/src/lib/catalog/worker/startup-banner.ts
+++ b/src/lib/catalog/worker/startup-banner.ts
@@ -34,10 +34,12 @@ export const formatCatalogBanner = ({
   targets,
   origin = 'http://localhost:3000',
   color = false,
+  schedulesEnabled = false,
 }: {
   targets: readonly CatalogBannerTarget[];
   origin?: string;
   color?: boolean;
+  schedulesEnabled?: boolean;
 }): string => {
   const namespaces = [...new Set(targets.map(({ namespace }) => namespace))];
   const lines: BannerLine[] = [
@@ -52,6 +54,11 @@ export const formatCatalogBanner = ({
       text: `${id} → ${namespace} / ${taskQueue}`,
       style: '',
     })),
+    { text: '', style: '' },
+    {
+      text: `Schedule manager: ${schedulesEnabled ? 'enabled' : 'disabled'}`,
+      style: GRAY,
+    },
   ];
   const contentWidth = Math.max(...lines.map(({ text }) => width(text)));
   const paint = (value: string, style: string) =>

--- a/src/lib/catalog/worker/workflows.ts
+++ b/src/lib/catalog/worker/workflows.ts
@@ -10,6 +10,7 @@ export { longActivity } from './examples/long-activity/workflow.js';
 export { nexusGreeting } from './examples/nexus-greeting/workflow.js';
 export { parallelActivities } from './examples/parallel-activities/workflow.js';
 export { priorityFairnessWorkflow } from './examples/priority-fairness/workflow.js';
+export { catalogScheduleSync } from './examples/schedule-sync/workflow.js';
 export { sequentialActivities } from './examples/sequential-activities/workflow.js';
 export { signalCollector } from './examples/signal-collector/workflow.js';
 export { signalWorkflow } from './examples/signal-handlers/workflow.js';


### PR DESCRIPTION
## What

Adds a schedule manager to the Temporal Catalog so examples can declare scheduled jobs and the catalog worker provisions them at startup.

- **Declaration on the example.** A workflow example can carry a `schedule` block: id, cron expressions or intervals, optional input, a required `paused` flag, and a note. Generation validates every field and rejects duplicate schedule ids. The `hello` example declares an hourly schedule.
- **Sync example.** A new shared `schedule-sync` example holds the reconciler. Its workflow lists schedules in the target namespace, keeps only those carrying the `uiCatalog` ownership memo, and plans create, update, and delete. Foreign schedules are never touched. One squatting on a declared id is reported as blocked. Orphaned catalog-owned schedules are deleted.
- **Startup bootstrap.** After Nexus endpoint provisioning, the dev script ensures the hourly `ui-catalog-schedule-sync` manager schedule exists, rewrites its args to the current declared list, and triggers one sync. Works over plaintext, API key, and TLS.
- **Disabled by default.** Nothing runs unless `.env.catalog.local` sets `CATALOG_SCHEDULES=enabled`. Any other value fails startup naming the variable. The banner prints the mode.
- **UI.** The example page shows an advisory schedule readiness check that never blocks Run. Missing shows the enable setting as copyable text. Present links to the schedule page. The list shows a Scheduled badge.

## Why

The catalog worker needs a way to exercise Schedules end to end, and a place to add scheduled jobs to its startup sequence. The design mirrors the existing Nexus endpoint provisioning step and keeps the catalog's rules: declared in code, validated at generation, task queues from registration only.

## Verification

- `pnpm check`, `pnpm lint`, `pnpm catalog verify`: clean.
- Catalog and scripts tests: 247 files, 3212 passed.
- End to end against a local server in a dedicated namespace: cold start, restart, hand-deleted schedule recreated, hand-edited cron rewritten, memo-marked orphan deleted, foreign schedule ignored, foreign squatter blocked, disabled default, and invalid flag value. Details in `src/lib/catalog/scenarios.md`.

## Notes for reviewers

- Run the manager in a namespace no other reconciler owns. A reconciler that deletes unknown schedules will remove the catalog's schedules on its next pass.
- Every worker restart under watch mode triggers a sync when enabled.
- Disabling the manager later leaves existing catalog schedules in place. A `pnpm catalog schedules clear` command is a natural follow-up.

