### PR TITLE
feat(workers): warn about Cloud Run deployment latency when creating a version

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.stories.svelte
+++ b/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.stories.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import CloudRunLatencyNotice from './cloud-run-latency-notice.svelte';
+  import ComputeProviderPicker from './compute-provider-picker.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Workers/Cloud Run Latency Notice',
+    component: CloudRunLatencyNotice,
+  });
+</script>
+
+<Story name="Cloud Run selected" asChild>
+  <div class="max-w-[45rem] p-4">
+    <ComputeProviderPicker
+      provider="cloud-run"
+      providers={[{ value: 'lambda' }, { value: 'cloud-run' }]}
+    >
+      <CloudRunLatencyNotice provider="cloud-run" />
+    </ComputeProviderPicker>
+  </div>
+</Story>

--- a/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.svelte
+++ b/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Alert from '$lib/holocene/alert.svelte';
+  import Link from '$lib/holocene/link.svelte';
+  import { translate } from '$lib/i18n/translate';
+
+  interface Props {
+    provider?: string;
+    class?: string;
+  }
+
+  let { provider, class: className = '' }: Props = $props();
+
+  const knownIssuesHref =
+    'https://cloud.google.com/run/docs/known-issues#deployment-latency';
+</script>
+
+{#if provider === 'cloud-run'}
+  <Alert
+    intent="warning"
+    class={className}
+    title={translate('workers.cloud-run-latency-notice-title')}
+    data-testid="cloud-run-latency-notice"
+  >
+    {translate('workers.cloud-run-latency-notice-before')}<Link
+      href={knownIssuesHref}
+      newTab>{translate('workers.cloud-run-latency-notice-link')}</Link
+    >{translate('workers.cloud-run-latency-notice-after')}
+  </Alert>
+{/if}

--- a/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.test.ts
+++ b/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment node
+
+import path from 'node:path';
+
+import type { render } from 'svelte/server';
+
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import type { Component } from 'svelte';
+import { createServer } from 'vite';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { startIsolatedViteServer } from '$lib/test-utilities/isolated-vite-server';
+
+let cloudRunLatencyNotice: Component<Record<string, unknown>>;
+let renderComponent: typeof render;
+let closeViteServer: (() => Promise<void>) | undefined;
+
+beforeAll(async () => {
+  const projectRoot = process.cwd();
+  const lifecycle = await startIsolatedViteServer(
+    createServer,
+    {
+      root: projectRoot,
+      configFile: false,
+      appType: 'custom',
+      plugins: [svelte({ hot: false })],
+      resolve: {
+        alias: [
+          {
+            find: '$lib',
+            replacement: path.resolve(projectRoot, 'src/lib'),
+          },
+          {
+            find: '$types',
+            replacement: path.resolve(projectRoot, 'src/types'),
+          },
+          {
+            find: '$app',
+            replacement: path.resolve(projectRoot, 'src/lib/svelte-mocks/app'),
+          },
+        ],
+      },
+      server: { middlewareMode: true },
+    },
+    async (server) => ({
+      cloudRunLatencyNotice: (
+        await server.ssrLoadModule(
+          '/src/lib/components/workers/serverless-worker-form/cloud-run-latency-notice.svelte',
+        )
+      ).default,
+      renderComponent: (await server.ssrLoadModule('svelte/server')).render,
+    }),
+  );
+  closeViteServer = lifecycle.close;
+  ({ cloudRunLatencyNotice, renderComponent } = lifecycle.value);
+});
+
+afterAll(async () => {
+  await closeViteServer?.();
+});
+
+const knownIssuesUrl =
+  'https://cloud.google.com/run/docs/known-issues#deployment-latency';
+
+const renderNotice = (provider: string | undefined): string =>
+  renderComponent(cloudRunLatencyNotice, { props: { provider } }).body;
+
+describe('CloudRunLatencyNotice', () => {
+  it('warns about the open Google Cloud issue when Cloud Run is selected', () => {
+    const body = renderNotice('cloud-run');
+
+    expect(body).toContain(
+      'Open Google Cloud issue: high deployment latency in some regions',
+    );
+    expect(body).toContain(
+      'Google currently reports that creating or updating Cloud Run resources takes longer than expected in some regions, including us-central1.',
+    );
+    expect(body).toContain(
+      'Google recommends deploying to another region while the issue is open.',
+    );
+    expect(body).toContain('in the Cloud Run known issues.');
+  });
+
+  it('links to the Cloud Run known issues in a new tab', () => {
+    const body = renderNotice('cloud-run');
+
+    expect(body).toContain(`href="${knownIssuesUrl}"`);
+    expect(body).toContain('target="_blank"');
+    expect(body).toContain('High deployment latency in some regions');
+  });
+
+  it('renders nothing for other compute providers', () => {
+    expect(renderNotice('lambda')).not.toContain(knownIssuesUrl);
+    expect(renderNotice(undefined)).not.toContain(knownIssuesUrl);
+  });
+});

--- a/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/create-version-form.svelte
@@ -18,6 +18,7 @@
     getInitialComputeProvider,
   } from './shared';
 
+  import CloudRunLatencyNotice from './cloud-run-latency-notice.svelte';
   import ComputeFields from './compute-fields.svelte';
   import ComputeProviderPicker from './compute-provider-picker.svelte';
   import RecentVersions from './recent-versions.svelte';
@@ -124,6 +125,7 @@
         bind:provider={$form.provider}
         providers={computeProviders}
       >
+        <CloudRunLatencyNotice provider={$form.provider} />
         <ComputeFields
           provider={$form.provider}
           bind:lambdaArn={$form.lambdaArn}

--- a/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
+++ b/src/lib/components/workers/serverless-worker-form/serverless-worker-create-form.svelte
@@ -17,6 +17,7 @@
     getInitialComputeProvider,
   } from './shared';
 
+  import CloudRunLatencyNotice from './cloud-run-latency-notice.svelte';
   import ComputeFields from './compute-fields.svelte';
   import ComputeProviderPicker from './compute-provider-picker.svelte';
 
@@ -153,6 +154,7 @@
         bind:provider={$form.provider}
         providers={computeProviders}
       />
+      <CloudRunLatencyNotice provider={$form.provider} class="mt-4" />
       <ComputeFields
         provider={$form.provider}
         bind:lambdaArn={$form.lambdaArn}

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -340,6 +340,12 @@ export const Strings = {
   'terraform-description-after':
     ' to create the IAM role Temporal Cloud assumes to invoke your Lambda functions.',
   'cloud-run-setup-prompt': "Don't have a service account yet? Create one",
+  'cloud-run-latency-notice-title':
+    'Open Google Cloud issue: high deployment latency in some regions',
+  'cloud-run-latency-notice-before':
+    'Google currently reports that creating or updating Cloud Run resources takes longer than expected in some regions, including us-central1. Google recommends deploying to another region while the issue is open. For the current status, see ',
+  'cloud-run-latency-notice-link': 'High deployment latency in some regions',
+  'cloud-run-latency-notice-after': ' in the Cloud Run known issues.',
   'cloud-run-terraform-description-before': 'Use our Terraform ',
   'cloud-run-terraform-module-link': 'Google Cloud Run Module',
   'cloud-run-terraform-description-after':


### PR DESCRIPTION
## Description & motivation 💭

Google currently reports elevated latency creating or updating Cloud Run resources in some regions (notably `us-central1`), caused by a centralized scheduler bottleneck on their side. They're sharding the scheduler, with a fix expected around October 2026. This is a GCP-side issue, not a Temporal/WCI bug — Anthony Wong hit ~1 minute between triggering a workflow and it being processed on a Cloud Run worker pool demo.

This adds a temporary warning to the Worker Deployment Version creation forms, shown only when Cloud Run is the selected compute provider. Wording mirrors the docs notice Lenny added, provided by Eric.

It appears on both surfaces where a version gets created for GCP:

- Worker Deployment Version create (`create-version-form.svelte`)
- Worker Deployment create, which creates the deployment's first version (`serverless-worker-create-form.svelte`)

The edit form is intentionally left alone — this is guidance for choosing a region up front.

### Screenshots (if applicable) 📸

Storybook: **Workers/Cloud Run Latency Notice → Cloud Run selected**

The notice renders as a Holocene `Alert intent="warning"` directly under the provider radio cards, above the resource fields:

> ⚠ **Open Google Cloud issue: high deployment latency in some regions**
> Google currently reports that creating or updating Cloud Run resources takes longer than expected in some regions, including us-central1. Google recommends deploying to another region while the issue is open. For the current status, see [High deployment latency in some regions](https://cloud.google.com/run/docs/known-issues#deployment-latency) in the Cloud Run known issues.

### Design Considerations 🎨

The banner is deliberately its own component (`cloud-run-latency-notice.svelte`) so removing it when GCP ships the fix is deleting one file, two call sites, its story/test, and four i18n keys — nothing to untangle out of the forms.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

`cloud-run-latency-notice.test.ts` covers that the notice renders for `cloud-run` with the known-issues link opening in a new tab, and renders nothing for other providers. Rendered the story in Storybook to check placement and spacing on both forms.

`pnpm lint` (0 errors), `pnpm check` (0 errors), `pnpm test -- --run` (243 files, 3161 tests) all pass.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. `pnpm stories:dev` → **Workers/Cloud Run Latency Notice**, or
2. In cloud-ui with the packed UI: go to a GCP namespace → Workers → Deployments → Create, and to an existing deployment → Create version. Select **Google Cloud Run** and confirm the notice appears; select **AWS Lambda** and confirm it does not.

## Checklists

### Merge Checklist

- [ ] Remove this banner once the Google Cloud issue is resolved (expected ~Oct 2026)

### Issue(s) closed

FE-445

## Docs

### Any docs updates needed?

No — the docs already carry the same notice; this mirrors that wording in the product.
