### PR TITLE
Fix workflow list timestamp formatting

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-body-cell.svelte
@@ -184,15 +184,9 @@
         taskFailure={isWorkflowTaskFailure(workflow)}
       />
     {:else if label === 'End'}
-      <Timestamp
-        dateTime={workflow.endTime}
-        options={{ format: truncate ? 'short' : 'long' }}
-      />
+      <Timestamp dateTime={workflow.endTime} />
     {:else if label === 'Start'}
-      <Timestamp
-        dateTime={workflow.startTime}
-        options={{ format: truncate ? 'short' : 'long' }}
-      />
+      <Timestamp dateTime={workflow.startTime} />
     {:else if label === 'Task Queue'}
       <Tooltip
         usePortal
@@ -222,10 +216,7 @@
         ? workflow.stateTransitionCount
         : ''}
     {:else if label === 'Execution Time'}
-      <Timestamp
-        dateTime={workflow.executionTime}
-        options={{ format: truncate ? 'short' : 'long' }}
-      />
+      <Timestamp dateTime={workflow.executionTime} />
     {:else if label === 'Execution Duration'}
       {formatDistanceAbbreviated({
         start: workflow?.startTime,
@@ -238,20 +229,14 @@
       {@const content =
         workflow.searchAttributes?.indexedFields?.TemporalScheduledStartTime}
       {#if content && typeof content === 'string'}
-        <Timestamp
-          dateTime={content}
-          options={{ format: truncate ? 'short' : 'long' }}
-        />
+        <Timestamp dateTime={content} />
       {/if}
     {:else if label === 'Change Version'}
       {workflow.searchAttributes?.indexedFields?.TemporalChangeVersion}
     {:else if isCustomSearchAttribute(label) && workflowIncludesSearchAttribute(workflow, label)}
       {@const content = workflow.searchAttributes?.indexedFields?.[label]}
       {#if $customSearchAttributes[label] === SEARCH_ATTRIBUTE_TYPE.DATETIME && typeof content === 'string'}
-        <Timestamp
-          dateTime={content}
-          options={{ format: truncate ? 'short' : 'long' }}
-        />
+        <Timestamp dateTime={content} />
       {:else if $customSearchAttributes[label] === SEARCH_ATTRIBUTE_TYPE.BOOL}
         <Badge>{content}</Badge>
       {:else}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->
Use the default time format, don't hardcode it for dense/comfortable

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
