### PR TITLE
Honor modifier-clicks on links

### DIFF
--- a/src/lib/components/saved-query-views/saved-views-menu.svelte
+++ b/src/lib/components/saved-query-views/saved-views-menu.svelte
@@ -22,7 +22,8 @@
     draftView?: SavedQuery;
     dirty?: boolean;
     maxQueries: number;
-    onSelect: (view: SavedQuery) => void;
+    onSelect: (view: SavedQuery, event?: MouseEvent) => void;
+    viewHref: (view: SavedQuery) => string;
   }
 
   let {
@@ -33,6 +34,7 @@
     dirty = false,
     maxQueries,
     onSelect,
+    viewHref,
   }: Props = $props();
 
   const menuId = $derived(`${id}-saved-views-menu`);
@@ -164,7 +166,8 @@
       <MenuItem
         data-view-item
         selected={view.id === activeView?.id}
-        onclick={() => onSelect(view)}
+        href={viewHref(view)}
+        onclick={(event) => onSelect(view, event)}
         data-testid={view.name.toLowerCase().replace(/\s+/g, '-')}
         data-track-name="user-query-menu-item"
       >

--- a/src/lib/components/saved-query-views/saved-views.svelte
+++ b/src/lib/components/saved-query-views/saved-views.svelte
@@ -19,6 +19,7 @@
   } from '$lib/stores/saved-queries';
   import type { SearchAttributes } from '$lib/types/workflows';
   import { copyToClipboard } from '$lib/utilities/copy-to-clipboard';
+  import { isModifiedClick } from '$lib/utilities/is-modified-click';
   import { toListWorkflowFilters } from '$lib/utilities/query/to-list-workflow-filters';
   import { sortAlphabetically } from '$lib/utilities/sort-alphabetically';
   import { updateQueryParameters } from '$lib/utilities/update-query-parameters';
@@ -140,7 +141,20 @@
     }
   });
 
-  const setActiveQueryView = (view: SavedQuery) => {
+  const viewHref = (view: SavedQuery) => {
+    const url = new URL(page.url);
+    if (view.query) {
+      url.searchParams.set('query', view.query);
+    } else {
+      url.searchParams.delete('query');
+    }
+    url.searchParams.delete(currentPageKey);
+    return `${url.pathname}${url.search}`;
+  };
+
+  const setActiveQueryView = (view: SavedQuery, event?: MouseEvent) => {
+    if (isModifiedClick(event)) return;
+    event?.preventDefault();
     if (view.id === activeQueryView?.id) return;
     activeQueryView = view;
     pendingQueryTarget = view.query || '';
@@ -256,6 +270,7 @@
       draftView={unsavedQuery ? unsavedView : undefined}
       dirty={activeUserViewDirty}
       {maxQueries}
+      {viewHref}
       onSelect={setActiveQueryView}
     />
 
@@ -359,7 +374,6 @@
   >
     <Button
       variant="ghost"
-      aria-label={view.name}
       data-testid={view.type === 'system'
         ? view.id
         : view.name.toLowerCase().replace(/\s+/g, '-')}
@@ -368,7 +382,8 @@
         : 'user-query-button'}
       data-track-intent="action"
       data-track-text={view.name}
-      onclick={() => setActiveQueryView(view)}
+      href={viewHref(view)}
+      onclick={(event) => setActiveQueryView(view, event)}
       class={merge(
         'max-w-[240px]',
         (view.count ?? 0) > 0 && 'text-red-900 dark:text-red-300',
@@ -379,7 +394,7 @@
     >
       {@const Glyph = view.Icon || IconBookmark}
       <Glyph class="h-4 w-4 flex-shrink-0" />
-      <span class="hidden truncate font-normal xl:inline-block"
+      <span class="truncate font-normal max-xl:sr-only xl:inline-block"
         >{view.name}</span
       >
       {#if view.badge}

--- a/src/lib/holocene/button.svelte
+++ b/src/lib/holocene/button.svelte
@@ -101,6 +101,7 @@
 
   import Badge from '$lib/holocene/badge.svelte';
   import { IconSpinner } from '$lib/io/icon';
+  import { isModifiedClick } from '$lib/utilities/is-modified-click';
 
   let {
     variant = 'primary',
@@ -129,8 +130,8 @@
   }
 
   const onLinkClick = (event: MouseEvent) => {
-    // Skip if middle mouse click or new tab
-    if (event.button === 1 || target || event.metaKey) return;
+    // Skip if new tab/window click or navigation was already handled
+    if (isModifiedClick(event) || target || event.defaultPrevented) return;
     if (!href) return;
     event.preventDefault();
     goto(href);
@@ -138,8 +139,8 @@
 
   const handleLinkClick = (event: MouseEvent) => {
     event.stopPropagation();
-    onLinkClick(event);
     onclick?.(event);
+    onLinkClick(event);
   };
 
   const handleClick = (event: MouseEvent) => {
@@ -168,7 +169,6 @@
     bind:this={element}
     {href}
     {id}
-    role="button"
     target={target ? '_blank' : null}
     rel={target ? 'noreferrer' : null}
     data-variant={variant}

--- a/src/lib/holocene/link.svelte
+++ b/src/lib/holocene/link.svelte
@@ -7,6 +7,7 @@
   import { goto } from '$app/navigation';
 
   import type { IconComponent } from '$lib/io/icon';
+  import { isModifiedClick } from '$lib/utilities/is-modified-click';
 
   interface Props extends Omit<HTMLAnchorAttributes, 'class' | 'onclick'> {
     href: string;
@@ -43,8 +44,7 @@
   const hasIcon = $derived(!!(LeadingIcon || TrailingIcon));
 
   const onLinkClick = (e: MouseEvent) => {
-    if (e.button === 1 || newTab || e.metaKey || e.ctrlKey || e.shiftKey)
-      return;
+    if (isModifiedClick(e) || newTab) return;
 
     e.preventDefault();
     goto(href, gotoParams);

--- a/src/lib/holocene/menu/menu-button.svelte
+++ b/src/lib/holocene/menu/menu-button.svelte
@@ -77,7 +77,7 @@
   };
 
   const focusFirstMenuItem = () => {
-    const focusable: (HTMLInputElement | HTMLLIElement)[] = Array.from(
+    const focusable: HTMLElement[] = Array.from(
       $menuElement?.querySelectorAll(MENU_ITEM_SELECTORS) ?? [],
     );
 

--- a/src/lib/holocene/menu/menu-item.svelte
+++ b/src/lib/holocene/menu/menu-item.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
   export const MENU_ITEM_SELECTORS =
-    'input, li[role="option"]:not([aria-disabled="true"]), li[role="menuitem"]:not([aria-disabled="true"])';
+    'input, li[role="option"]:not([aria-disabled="true"]), li[role="menuitem"]:not([aria-disabled="true"]), a[role="menuitem"]:not([aria-disabled="true"])';
 </script>
 
 <script lang="ts">
@@ -13,7 +13,10 @@
   import { getContext, type Snippet } from 'svelte';
   import { type ClassNameValue, twMerge as merge } from 'tailwind-merge';
 
+  import { goto } from '$app/navigation';
+
   import { IconCheckmark, IconExternalLinkOptical } from '$lib/io/icon';
+  import { isModifiedClick } from '$lib/utilities/is-modified-click';
 
   import { MENU_CONTEXT, type MenuContext } from './menu-container.svelte';
 
@@ -26,7 +29,7 @@
     centered?: boolean;
     class?: ClassNameValue;
     hoverable?: boolean;
-    onclick?: () => void;
+    onclick?: (event?: MouseEvent) => void;
     children?: Snippet;
     leading?: Snippet;
     trailing?: Snippet;
@@ -66,6 +69,14 @@
 
   const { keepOpen, open } = getContext<MenuContext>(MENU_CONTEXT);
 
+  const isSameOrigin = (url: string) => {
+    try {
+      return new URL(url, location.href).origin === location.origin;
+    } catch {
+      return false;
+    }
+  };
+
   const handleKeydown: KeyboardEventHandler<
     HTMLLIElement | HTMLAnchorElement
   > = (event) => {
@@ -84,8 +95,17 @@
         break;
       case ' ':
       case 'Enter':
-        onclick?.();
-        if (!$keepOpen) $open = false;
+        // Links already activate on Enter, and leaving that to the browser
+        // keeps modifier+Enter opening a new tab, so only Space is synthesized
+        if (href) {
+          if (event.key === ' ') {
+            event.preventDefault();
+            (event.currentTarget as HTMLAnchorElement).click();
+          }
+        } else {
+          onclick?.();
+          if (!$keepOpen) $open = false;
+        }
         break;
       default:
         break;
@@ -100,7 +120,7 @@
       nextElement = nextElement.nextElementSibling;
     }
 
-    if (nextElement && nextElement instanceof HTMLLIElement) {
+    if (nextElement instanceof HTMLElement) {
       nextElement.focus();
     }
   };
@@ -115,7 +135,7 @@
       previousElement = previousElement.previousElementSibling;
     }
 
-    if (previousElement && previousElement instanceof HTMLLIElement) {
+    if (previousElement instanceof HTMLElement) {
       previousElement.focus();
     }
   };
@@ -123,6 +143,19 @@
   const handleClick = () => {
     if (!$keepOpen) $open = false;
     onclick?.();
+  };
+
+  const handleLinkClick = (event: MouseEvent) => {
+    const modified = isModifiedClick(event);
+    if (!$keepOpen && !modified) $open = false;
+    onclick?.(event);
+
+    const anchor = event.currentTarget as HTMLAnchorElement;
+    if (modified || anchor.target || event.defaultPrevented) return;
+    if (!href || !isSameOrigin(href)) return;
+
+    event.preventDefault();
+    goto(href);
   };
 </script>
 
@@ -142,6 +175,8 @@
     class:active
     class:disabled
     class:hoverable
+    class:destructive
+    class:selected
     aria-hidden={disabled ? 'true' : 'false'}
     aria-disabled={disabled}
     tabindex={disabled ? -1 : 0}
@@ -149,11 +184,24 @@
     data-track-intent="navigate"
     data-track-text="*textContent*"
     onkeydown={handleKeydown}
+    onclick={handleLinkClick}
     {...rest as HTMLAnchorAttributes}
   >
-    <div>
-      {@render children?.()}
+    {@render leading?.()}
+    <div class="min-w-0 grow">
+      <div class:centered class="menu-item-wrapper">
+        {@render children?.()}
+        {#if selected}
+          <IconCheckmark class="shrink-0" />
+        {/if}
+      </div>
+      {#if description}
+        <div class="menu-item-description" class:text-center={centered}>
+          {description}
+        </div>
+      {/if}
     </div>
+    {@render trailing?.()}
     {#if newTab}
       <IconExternalLinkOptical height={20} width={20} />
     {/if}

--- a/src/lib/utilities/is-modified-click.test.ts
+++ b/src/lib/utilities/is-modified-click.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { isModifiedClick } from './is-modified-click';
+
+const click = (init: Partial<MouseEvent> = {}) =>
+  ({
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...init,
+  }) as MouseEvent;
+
+describe('isModifiedClick', () => {
+  it('should return false for an unmodified primary click', () => {
+    expect(isModifiedClick(click())).toBe(false);
+  });
+
+  it('should return false without an event', () => {
+    expect(isModifiedClick(undefined)).toBe(false);
+  });
+
+  it.each([
+    ['meta', { metaKey: true }],
+    ['ctrl', { ctrlKey: true }],
+    ['shift', { shiftKey: true }],
+    ['alt', { altKey: true }],
+  ])('should return true for a %s click', (_, init) => {
+    expect(isModifiedClick(click(init))).toBe(true);
+  });
+
+  it('should return true for a non-primary button', () => {
+    expect(isModifiedClick(click({ button: 1 }))).toBe(true);
+  });
+});

--- a/src/lib/utilities/is-modified-click.ts
+++ b/src/lib/utilities/is-modified-click.ts
@@ -1,0 +1,11 @@
+export const isModifiedClick = (event: MouseEvent | undefined): boolean => {
+  if (!event) return false;
+
+  return Boolean(
+    event.button ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey,
+  );
+};


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Ctrl/cmd/shift-clicking a Saved View applied it in the current tab instead of opening it in a new one, because the views were rendered as `<button>`s. This makes them real links so the browser's default behavior works, while a plain click keeps doing exactly what it did before.

- **`Button`** — only `metaKey` and middle-click were honored, so ctrl and shift were swallowed on *every* href Button in the app. It now honors ctrl/shift/alt and non-primary buttons, and skips its own `goto` when a consumer already called `preventDefault`. `role="button"` is dropped from the anchor branch so links announce as links rather than buttons.
- **`MenuItem`** — the `href` branch never invoked `onclick`, wasn't reachable with arrow keys, and dropped the `selected` checkmark and `description`/`leading`/`trailing` snippets. It also fell back to a **full page load**: `Menu` stops click propagation on its `<ul>`, so SvelteKit's router (which listens on `documentElement`) never sees clicks inside a menu. Same-origin hrefs now route through `goto`. This also makes the schedule Actions → Edit item and the deployment version links navigate client-side instead of reloading the app.
- **Accessibility** — below `xl` the saved view label is visually hidden, which also removed it from the accessibility tree, leaving unnamed links. The label is now `max-xl:sr-only` so it's announced at every width.

New shared `isModifiedClick` utility applies the same rule SvelteKit's own router uses. `link.svelte` already had this logic inline while `Button` was the outlier. Now both use `isModifiedClick`. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

- **Alt/option-click now downloads** instead of navigating — for Saved Views *and* for every `Link` in the app, since `Link` previously ignored `altKey`. That's standard browser behavior and what SvelteKit does, but it is a change.
- **`newTab` menu items now close the menu on click** (e.g. the user menu's community links). They used to stay open.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

1. Go to a Namespace's Workflows page.
2. Ctrl/cmd-click a system view (Running, Today, …) → opens that view in a new tab; the current tab is unchanged, including its filter chips.
3. Shift-click one → new window. Middle-click → new tab.
4. Plain-click one → applies in place exactly as before (no scroll jump, filter chips update).
5. Open the Saved Views menu and repeat 2–4 on a custom view. On a modified click the menu should stay open so you can open several.
6. Keyboard: tab to a system view and press Enter → applies. Ctrl/cmd+Enter → new tab. In the menu, arrow keys move between views and Space activates one.
7. Regression check on the client-side routing change: schedule Actions → Edit, and the deployment version menu links, should navigate without a full page reload.
8. Narrow the window below 1280px and check with a screen reader that each system view still announces its name.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`FE-564`
## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
