### PR TITLE
fix(workers): resolve worker deployment from task queue

### DIFF
--- a/src/lib/components/lines-and-dots/workflow-details.svelte
+++ b/src/lib/components/lines-and-dots/workflow-details.svelte
@@ -8,6 +8,7 @@
   import { fetchWorkflow } from '$lib/services/workflow-service';
   import { isCloud } from '$lib/stores/advanced-visibility';
   import { sdkInfo } from '$lib/stores/events';
+  import { workflowRun } from '$lib/stores/workflow-run';
   import type { WorkflowExecution } from '$lib/types/workflows';
   import { formatBytes } from '$lib/utilities/format-bytes';
   import {
@@ -15,6 +16,7 @@
     formatDuration,
   } from '$lib/utilities/format-time';
   import { getBuildIdFromVersion } from '$lib/utilities/get-deployment-build-id';
+  import { getWorkerDeploymentName } from '$lib/utilities/get-worker-deployment-name';
   import {
     routeForSchedule,
     routeForTaskQueue,
@@ -57,7 +59,7 @@
     }),
   );
   const deployment = $derived(
-    workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'],
+    getWorkerDeploymentName($workflowRun?.workers, workflow),
   );
   const deploymentVersion = $derived(
     workflow?.searchAttributes?.indexedFields?.[

--- a/src/lib/i18n/locales/en/workflows.ts
+++ b/src/lib/i18n/locales/en/workflows.ts
@@ -169,9 +169,6 @@ export const Strings = {
   'workflow-error-no-workers-serverless-description':
     'The {{taskQueue}} task queue is served by the serverless worker deployment {{deployment}}, which scales down to zero when idle. Workers will start automatically when there are tasks to process.',
   'view-worker-deployment': 'View Worker Deployment',
-  'workflow-error-no-compatible-workers-title': 'No Compatible Workers Running',
-  'workflow-error-no-compatible-workers-description':
-    'There are no compatible Workers polling the {{taskQueue}} Task Queue.',
   'dismiss-common-errors': 'Dismiss Common Errors',
   'state-transitions': 'State Transitions',
   relationships: 'Relationships',

--- a/src/lib/layouts/standalone-activity-layout.svelte
+++ b/src/lib/layouts/standalone-activity-layout.svelte
@@ -22,6 +22,7 @@
     activityWorkerCount,
   } from '$lib/stores/activities';
   import { workerCountEnabled } from '$lib/stores/workers';
+  import { getWorkerDeploymentName } from '$lib/utilities/get-worker-deployment-name';
   import { pathMatches } from '$lib/utilities/path-matches';
   import {
     routeForStandaloneActivities,
@@ -200,9 +201,10 @@
         <NoWorkersPollingAlert
           {namespace}
           taskQueue={$activityExecution.info.taskQueue ?? ''}
-          runningWithNoWorkers={!response.pollers &&
+          runningWithNoWorkers={!response.pollers?.length &&
             $activityExecution.info.status ===
               'ACTIVITY_EXECUTION_STATUS_RUNNING'}
+          deployment={getWorkerDeploymentName(response, null)}
         />
       {/await}
     {/if}

--- a/src/lib/layouts/workflow-header.svelte
+++ b/src/lib/layouts/workflow-header.svelte
@@ -32,6 +32,7 @@
   import { isCancelInProgress } from '$lib/utilities/cancel-in-progress';
   import { isWorkflowDelayed } from '$lib/utilities/delayed-workflows';
   import { getSharedFilterParams } from '$lib/utilities/event-filter-params';
+  import { getWorkerDeploymentName } from '$lib/utilities/get-worker-deployment-name';
   import {
     getWorkflowNexusLinksFromHistory,
     getWorkflowRelationships,
@@ -64,11 +65,9 @@
 
   let { headerSnippet }: { headerSnippet?: Snippet } = $props();
 
-  const { workflow, workerCount } = $derived($workflowRun);
+  const { workflow, workers, workerCount } = $derived($workflowRun);
   const runningWithNoWorkers = $derived(isRunningWithNoWorkers($workflowRun));
-  const workerDeployment = $derived(
-    workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'],
-  );
+  const workerDeployment = $derived(getWorkerDeploymentName(workers, workflow));
   const routeParameters = $derived({
     namespace,
     workflow: workflowId,

--- a/src/lib/utilities/get-worker-deployment-name.test.ts
+++ b/src/lib/utilities/get-worker-deployment-name.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { TaskQueueResponse } from '$lib/types';
+import type { WorkflowExecution } from '$lib/types/workflows';
+
+import { getWorkerDeploymentName } from './get-worker-deployment-name';
+
+const workers = (versioningInfo: unknown): TaskQueueResponse =>
+  ({ pollers: [], versioningInfo }) as TaskQueueResponse;
+
+const workflow = (deployment?: string): WorkflowExecution =>
+  ({
+    searchAttributes: {
+      indexedFields: deployment ? { TemporalWorkerDeployment: deployment } : {},
+    },
+  }) as unknown as WorkflowExecution;
+
+describe('getWorkerDeploymentName', () => {
+  it('reads the deployment from the task queue when there are no pollers', () => {
+    const result = getWorkerDeploymentName(
+      workers({
+        currentDeploymentVersion: {
+          deploymentName: 'orders-worker',
+          buildId: 'v1',
+        },
+      }),
+      workflow(),
+    );
+
+    expect(result).toBe('orders-worker');
+  });
+
+  it('returns undefined for an unversioned task queue that still has versioningInfo', () => {
+    const result = getWorkerDeploymentName(
+      workers({
+        currentVersion: '__unversioned__',
+        updateTime: '0001-01-01T00:00:00Z',
+      }),
+      workflow(),
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('falls back to the search attribute when the queue has no current version', () => {
+    const result = getWorkerDeploymentName(
+      workers({ currentVersion: '__unversioned__' }),
+      workflow('pinned-deployment'),
+    );
+
+    expect(result).toBe('pinned-deployment');
+  });
+
+  it('prefers the task queue over the search attribute', () => {
+    const result = getWorkerDeploymentName(
+      workers({
+        currentDeploymentVersion: { deploymentName: 'current', buildId: 'v2' },
+      }),
+      workflow('stale-from-search-attribute'),
+    );
+
+    expect(result).toBe('current');
+  });
+
+  it('returns undefined when neither source has a deployment', () => {
+    expect(
+      getWorkerDeploymentName(workers(undefined), workflow()),
+    ).toBeUndefined();
+    expect(getWorkerDeploymentName(undefined, null)).toBeUndefined();
+  });
+});

--- a/src/lib/utilities/get-worker-deployment-name.ts
+++ b/src/lib/utilities/get-worker-deployment-name.ts
@@ -1,0 +1,10 @@
+import type { TaskQueueResponse } from '$lib/types';
+import type { WorkflowExecution } from '$lib/types/workflows';
+
+export const getWorkerDeploymentName = (
+  workers: TaskQueueResponse | undefined,
+  workflow: WorkflowExecution | null | undefined,
+): string | undefined =>
+  workers?.versioningInfo?.currentDeploymentVersion?.deploymentName ||
+  workflow?.searchAttributes?.indexedFields?.['TemporalWorkerDeployment'] ||
+  undefined;


### PR DESCRIPTION
## Problem

When a workflow runs on a task queue served by a Worker Deployment with a compute provider, the worker has not cold-started yet. A user opening the workflow page in that window sees:

> **No workers polling**
> There are no workers polling the `orders-serverless` task queue. Check your deployment or orchestration system (Kubernetes, ECS, etc.). Review worker logs for crash information. Restart or redeploy workers.

Every actionable sentence is wrong. There is no Kubernetes or ECS, no worker logs to read, and nothing to restart — Temporal is invoking the customer's Lambda on their behalf.

## Cause

`workflow-header.svelte` read the deployment from the `TemporalWorkerDeployment` search attribute. The server only writes that attribute once a versioned worker completes the first workflow task, so during a cold start it is empty and `no-workers-polling-alert.svelte` falls through to the self-managed branch. The calm serverless message on the other branch was only reachable on a *second* scale-down — never on a first run.

`workflow-details.svelte` read the same attribute, so the Deployment / Build ID / Versioning Behavior column was blank at the same moment.

## Fix

Fall back to the **task queue** when the attribute is empty. The response the page already fetches carries `versioningInfo.currentDeploymentVersion.deploymentName` — a property of the queue, not the workflow, so it is present with zero pollers and needs no extra request.

The search attribute still comes first when present. It records the deployment the workflow actually runs on, and a pinned workflow keeps it after the queue's Current Version moves to another deployment. Current Version only routes new executions and unversioned or AutoUpgrade workflows, so reading the queue first would show the wrong deployment for a pinned workflow.

Extracted to `getWorkerDeploymentName()` rather than repeating the optional-chain across three call sites.

### Guard on `currentDeploymentVersion`, not `versioningInfo`

A task queue with no registered version still returns a `versioningInfo` object:

```json
{ "currentVersion": "__unversioned__", "updateTime": "0001-01-01T00:00:00Z" }
```

A truthiness check on `versioningInfo` therefore matches every unversioned queue and would pick the wrong branch for all of them. There is a test covering this.

## Also fixed: an alert that never rendered

`standalone-activity-layout.svelte` had:

```js
runningWithNoWorkers={!response.pollers && ...}
```

`reducePollerTypes` always returns an array from `.map()`, so `!response.pollers` is `![]` → **always false**. That alert has never rendered on the standalone activity page under any conditions. Now checks `.length`, matching what `isRunningWithNoWorkers` already does.

That layout also passed no `deployment` prop at all, so even once visible it could only ever show the self-managed message.

## Also removed

`workflow-error-no-compatible-workers-title` / `-description` — no component references either.

## Verification

Against a local server (1.31.2) with `workercontroller.enabled` and a **real AWS Lambda serverless worker** invoked through the worker controller:

- One `DescribeTaskQueue` response returned `pollers: []` alongside `currentDeploymentVersion: {ross-test, v1}`, via the same HTTP path the UI calls
- `TemporalWorkerDeployment` was confirmed empty on the running workflow at that moment
- 7 real Lambda cold starts measured at 2.17–2.43s (median 2.36s), confirming the window this fix covers is real but brief

Checks: ESLint clean, `svelte-check` clean, 5 new unit tests pass. Full suite is 2767 passing — the 26 failing test *files* are pre-existing `@buf`/`@bufbuild` module-resolution failures present on `main` (verified by stashing).

## Deliberately not in this PR

The messaging rework is blocked on a product decision and would be rebuilt if it landed early. A correct cold start resolves in ~2.4s, so a "Starting a worker" message would appear and vanish faster than anyone can read — arguably worse than showing nothing. That decision changes the shape of the state model, so it is tracked separately on FE-489.

Also excluded: a `provisioning-failed` state. `providerValidation` is absent from the API response even for a deployment that passed real AWS validation, so `connection-status.ts` derives `pending` for a healthy deployment. There is no data source to build it on yet.

This PR is a strict improvement regardless of how those land: the right message fires, and the Deployment column populates.

