### PR TITLE
Fix extra horizontal scroll from filter bar dropdowns

### DIFF
--- a/src/lib/components/saved-query-views/saved-views-menu.svelte
+++ b/src/lib/components/saved-query-views/saved-views-menu.svelte
@@ -131,7 +131,11 @@
     {/if}
   </MenuButton>
 
-  <Menu id={menuId} class="w-max min-w-full max-w-[32rem]">
+  <Menu
+    id={menuId}
+    usePortal
+    class="w-max min-w-full max-w-[min(100dvw-1rem,32rem)]"
+  >
     <MenuItem
       class="p-0"
       hoverable={false}

--- a/src/lib/components/saved-query-views/saved-views-menu.svelte
+++ b/src/lib/components/saved-query-views/saved-views-menu.svelte
@@ -185,9 +185,10 @@
       </MenuItem>
     {/each}
 
-    <MenuDivider />
-
-    <li role="presentation" class="px-3 py-2 text-xs text-secondary">
+    <li
+      role="presentation"
+      class="surface-primary sticky bottom-0 z-10 border-t border-subtle px-3 py-2 text-xs text-secondary"
+    >
       {translate('common.views-used', {
         used: views.length,
         total: maxQueries,

--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -363,7 +363,11 @@
     </div>
   </MenuButton>
 
-  <Menu id={controlsId} class="max-h-fit w-64 p-4 lg:max-w-fit">
+  <Menu
+    id={controlsId}
+    usePortal
+    class="max-h-fit w-min min-w-0 max-w-[calc(100dvw-1rem)] p-4"
+  >
     <form onsubmit={applyChanges}>
       <div class="space-y-4">
         <div class="flex items-center justify-between">
@@ -394,6 +398,7 @@
                   clearLabel={translate('common.clear-input-button-label')}
                 />
                 <TimePicker
+                  class="flex-col sm:flex-row"
                   bind:hour={start.hour}
                   bind:minute={start.minute}
                   bind:second={start.second}
@@ -410,6 +415,7 @@
                   clearLabel={translate('common.clear-input-button-label')}
                 />
                 <TimePicker
+                  class="flex-col sm:flex-row"
                   bind:hour={end.hour}
                   bind:minute={end.minute}
                   bind:second={end.second}
@@ -473,6 +479,7 @@
                     disabled={$timeFormatType !== 'absolute' || isNullFilter}
                   />
                   <TimePicker
+                    class="flex-col sm:flex-row"
                     bind:hour={start.hour}
                     bind:minute={start.minute}
                     bind:second={start.second}

--- a/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
+++ b/src/lib/components/search-attribute-filter/search-attribute-menu.svelte
@@ -114,7 +114,7 @@
   >
     Add Filter
   </MenuButton>
-  <Menu id="{id}-search-attribute-menu">
+  <Menu id="{id}-search-attribute-menu" usePortal>
     <MenuItem
       class="p-0"
       hoverable={false}
@@ -130,7 +130,7 @@
         bind:value={searchAttributeValue}
         Icon={IconSearch}
         placeholder={translate('common.search')}
-        class="w-full min-w-[300px]"
+        class="w-full"
       />
     </MenuItem>
     <hr class="border-subtle" />
@@ -145,7 +145,7 @@
           !!$filters.find((f) => f.attribute === statusAttribute)}
       >
         <div>
-          <p class="leading-3">{label}</p>
+          <p class="break-all leading-3">{label}</p>
           <small class="text-secondary">{type}</small>
         </div>
       </MenuItem>

--- a/src/lib/components/search-attribute-filter/status-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/status-filter-chip.svelte
@@ -131,7 +131,7 @@
     </div>
   </MenuButton>
 
-  <Menu id={controlsId} class="max-h-fit w-80 max-w-fit p-4" keepOpen>
+  <Menu id={controlsId} usePortal class="max-h-fit w-80 max-w-fit p-4" keepOpen>
     <div class="space-y-2">
       <div class="flex items-center justify-between">
         <h3 class="text-sm font-medium">

--- a/src/lib/holocene/menu/menu-container.svelte
+++ b/src/lib/holocene/menu/menu-container.svelte
@@ -38,7 +38,10 @@
   const keepOpen = writable(false);
   const menuElement: Writable<HTMLUListElement | null> = writable(null);
 
-  const closeMenu = () => {
+  const closeMenu = (event?: MouseEvent) => {
+    if (event?.target instanceof Node && $menuElement?.contains(event.target))
+      return;
+
     if ($open) {
       onclose?.();
       $open = false;

--- a/src/lib/holocene/menu/menu.svelte
+++ b/src/lib/holocene/menu/menu.svelte
@@ -152,6 +152,7 @@
     anchor={anchorElement}
     open={$open}
     position={portalPosition}
+    offset={{ y: 4 }}
     {scrollContainer}
   >
     {@render menu({ _class: merge(sharedMenuStyles, maxHeight, className) })}

--- a/src/lib/holocene/time-picker.svelte
+++ b/src/lib/holocene/time-picker.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { type ClassNameValue, twMerge as merge } from 'tailwind-merge';
+
   import Input from '$lib/holocene/input/input.svelte';
   import ToggleButton from '$lib/holocene/toggle-button/toggle-button.svelte';
   import ToggleButtons from '$lib/holocene/toggle-button/toggle-buttons.svelte';
 
   interface Props {
+    class?: ClassNameValue;
     hour?: string;
     minute?: string;
     second?: string;
@@ -17,6 +20,7 @@
   }
 
   let {
+    class: className = '',
     hour = $bindable(''),
     minute = $bindable(''),
     second = $bindable(''),
@@ -35,7 +39,7 @@
   };
 </script>
 
-<div class="flex gap-2">
+<div class={merge('flex gap-2', className)}>
   <Input
     id="{idPrefix}hour"
     label="hrs"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Once filter chips filled the bar, the page picked up a horizontal scrollbar with nothing visible to scroll to. Every closed dropdown was still in the DOM as an absolutely-positioned `visibility: hidden` box and a hidden box still takes up space for overflow purposes. Any chip or button sitting near the right edge had its invisible 250–300px panel going past the bar. Opening that dropdown then ran it off the edge of the filter bar.

Filter bar and saved views menus now render through `Portal`, so they exist only while open, have position `fixed`, and get clamped to the viewport by the portal's existing collision handling. This fixes the phantom scrollbar when closed and means there is no panel hanging off the edge when open.


### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| | Before | After |
|-|-|-|
| Saved views w/ long name  |<img width="319" height="407" alt="Screenshot 2026-09-04 at 1 10 02 PM" src="https://github.com/user-attachments/assets/06a945f1-9538-4cca-a4b6-0feac655fd67" />| <img width="313" height="422" alt="Screenshot 2026-09-04 at 1 05 52 PM" src="https://github.com/user-attachments/assets/f1ffcb8c-f353-4b51-8942-46bea3d8777c" />|
| Datetime filter |<img width="316" height="424" alt="Screenshot 2026-09-04 at 1 09 36 PM" src="https://github.com/user-attachments/assets/fb4f436a-51bd-4076-b7e4-c8e2784cb7eb" />| <img width="318" height="502" alt="Screenshot 2026-09-04 at 1 06 18 PM" src="https://github.com/user-attachments/assets/6cb4cfff-2375-4f3a-9f3e-53fdcac477a6" />|




### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

Changes in `Holocene`:
- The **4px button-to-menu gap** that in-flow menus get from `mt-1` is now applied to portaled menus too via the portal's y offset. 
- **clickoutside** needed a guard. A portaled menu renders outside `MenuContainer`, so clicks on its own content counted as clicks away and closed it. That broke the chip's filter form and the `keepOpen` status filter. 
- **TimePicker** takes a `class` now (default unchanged) and the filter chip stacks hrs/min/sec below `sm` viewports so the datetime form fits inside a viewport-capped dropdown.

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`FE-615`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
