### PR TITLE
Add Next Retry Delay under Retry State for SAA

### DIFF
--- a/src/lib/i18n/locales/en/standalone-activities.ts
+++ b/src/lib/i18n/locales/en/standalone-activities.ts
@@ -117,6 +117,7 @@ export const Strings = {
   'total-heartbeats': 'Total Heartbeats',
   'heartbeat-timeout': 'Heartbeat Timeout',
   'current-retry-interval': 'Current Retry Interval',
+  'next-retry-delay': 'Next Retry Delay',
   'last-attempt-complete-time': 'Last Attempted Complete Time',
   'next-attempt-schedule-time': 'Next Attempt Scheduled Time',
   'schedule-to-start-timeout': 'Schedule to Start Timeout',

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -16,7 +16,7 @@
   import CodeBlock from '$lib/holocene/code-block.svelte';
   import { translate } from '$lib/i18n/translate';
   import { IconRetry } from '$lib/io/icon';
-  import type { Failure } from '$lib/types';
+  import type { ActivityExecutionInfo } from '$lib/types/activity-execution';
   import {
     formatAttemptsLeft,
     formatMaximumAttempts,
@@ -61,6 +61,11 @@
       (hasHeartbeatTimeout ? 1 : 0),
   );
 
+  const nextRetryDelay = $derived(
+    $activityExecution?.info?.lastFailure?.applicationFailureInfo
+      ?.nextRetryDelay,
+  );
+
   const hasCodeBlocks = $derived(
     !!(
       $activityExecution?.info?.lastFailure ||
@@ -74,7 +79,7 @@
 {#snippet activityExecutionAttemptsBadge(
   attempt: number,
   maximumAttempts: number | null,
-  lastFailure: Failure | null,
+  lastFailure: ActivityExecutionInfo['lastFailure'],
 )}
   {@const failed = attempt > 1 && !!lastFailure}
   {@const badgeType = failed ? 'danger' : 'default'}
@@ -261,7 +266,7 @@
               {translate('standalone-activities.retry-state')}
             </h5>
             <DetailList
-              rowCount={3}
+              rowCount={3 + (nextRetryDelay ? 1 : 0)}
               aria-label={translate('standalone-activities.retry-state')}
             >
               <DetailListLabel
@@ -272,6 +277,15 @@
               <DetailListTextValue
                 text={fromSeconds($activityExecution.info.currentRetryInterval)}
               />
+
+              {#if nextRetryDelay}
+                <DetailListLabel
+                  >{translate(
+                    'standalone-activities.next-retry-delay',
+                  )}</DetailListLabel
+                >
+                <DetailListTextValue text={fromSeconds(nextRetryDelay)} />
+              {/if}
 
               <DetailListLabel
                 >{translate(

--- a/src/lib/types/activity-execution.ts
+++ b/src/lib/types/activity-execution.ts
@@ -70,6 +70,7 @@ export interface ActivityExecutionInfo extends Omit<
   | 'currentRetryInterval'
   | 'executionTime'
   | 'startDelay'
+  | 'lastFailure'
 > {
   status: ActivityExecutionStatus;
   runState?: PendingActivityState;
@@ -86,6 +87,16 @@ export interface ActivityExecutionInfo extends Omit<
   sdkVersion?: string;
   executionTime?: string;
   startDelay?: string;
+  lastFailure?:
+    | (Omit<Failure, 'applicationFailureInfo'> & {
+        applicationFailureInfo?:
+          | (Omit<
+              temporal.api.failure.v1.IApplicationFailureInfo,
+              'nextRetryDelay'
+            > & { nextRetryDelay?: string | null })
+          | null;
+      })
+    | null;
 }
 
 export interface ActivityExecution {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Make **Next Retry Delay** a first class field under Retry State on the Standalone Activity details page. 

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`FE-543`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
