### PR TITLE
SAA fields audit

### DIFF
--- a/src/lib/i18n/locales/en/standalone-activities.ts
+++ b/src/lib/i18n/locales/en/standalone-activities.ts
@@ -112,7 +112,6 @@ export const Strings = {
   attempt: 'Attempt',
   'schedule-time': 'Schedule Time',
   'execution-time': 'Execution Time',
-  'execution-duration': 'Execution Duration',
   'last-heartbeat': 'Last Heartbeat',
   'total-heartbeats': 'Total Heartbeats',
   'heartbeat-timeout': 'Heartbeat Timeout',

--- a/src/lib/pages/standalone-activity-details.svelte
+++ b/src/lib/pages/standalone-activity-details.svelte
@@ -88,7 +88,7 @@
     >{translate('standalone-activities.attempt')}</DetailListLabel
   >
   <DetailListValue>
-    <Badge type={badgeType} class="flex items-center gap-2">
+    <Badge type={badgeType} class="flex items-center gap-2 text-xs">
       <IconRetry class={failed ? 'text-red-400' : ''} />
       <span>{attempt} of {formatMaximumAttempts(maximumAttempts)}</span>
     </Badge>
@@ -141,6 +141,59 @@
             </DetailList>
           </div>
         {/if}
+
+        {#if isRetrying}
+          <div class="space-y-2">
+            <h5>
+              {translate('standalone-activities.retry-state')}
+            </h5>
+            <DetailList
+              rowCount={3 + (nextRetryDelay ? 1 : 0)}
+              aria-label={translate('standalone-activities.retry-state')}
+            >
+              <DetailListLabel
+                >{translate(
+                  'standalone-activities.current-retry-interval',
+                )}</DetailListLabel
+              >
+              <DetailListTextValue
+                text={fromSeconds(
+                  $activityExecution.info.currentRetryInterval,
+                ) || '-'}
+              />
+
+              {#if nextRetryDelay}
+                <DetailListLabel
+                  >{translate(
+                    'standalone-activities.next-retry-delay',
+                  )}</DetailListLabel
+                >
+                <DetailListTextValue text={fromSeconds(nextRetryDelay)} />
+              {/if}
+
+              <DetailListLabel
+                >{translate(
+                  'standalone-activities.last-attempt-complete-time',
+                )}</DetailListLabel
+              >
+              <DetailListTimestampValue
+                timestamp={$activityExecution.info.lastAttemptCompleteTime}
+                fallback="-"
+              />
+
+              <DetailListLabel
+                >{translate(
+                  'standalone-activities.next-attempt-schedule-time',
+                )}</DetailListLabel
+              >
+              <DetailListTimestampValue
+                timestamp={$activityExecution.info.nextAttemptScheduleTime}
+                fallback="-"
+              />
+            </DetailList>
+          </div>
+        {/if}
+
         <div class="space-y-2">
           <h5>
             {translate('standalone-activities.timing-and-progress')}
@@ -154,16 +207,6 @@
             aria-label={translate('standalone-activities.timing-and-progress')}
           >
             {#if isClosed}
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.execution-duration',
-                )}</DetailListLabel
-              >
-              <DetailListTextValue
-                text={formatDurationAbbreviated(
-                  $activityExecution.info.executionDuration ?? '',
-                )}
-              />
               {#if $activityExecution.info.attempt != undefined}
                 {#if $activityExecution.info.attempt > 1}
                   {@render activityExecutionAttemptsBadge(
@@ -192,16 +235,23 @@
             <DetailListTimestampValue
               timestamp={$activityExecution.info.scheduleTime}
             />
-            {#if $activityExecution.info.startDelay}
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.start-delay',
-                )}</DetailListLabel
-              >
-              <DetailListTextValue
-                text={fromSeconds($activityExecution.info.startDelay)}
-              />
-            {/if}
+            <DetailListLabel
+              >{translate('standalone-activities.start-delay')}</DetailListLabel
+            >
+            <DetailListTextValue
+              text={fromSeconds($activityExecution.info.startDelay ?? '') ||
+                '-'}
+            />
+            <DetailListLabel
+              >{translate(
+                'standalone-activities.execution-time',
+              )}</DetailListLabel
+            >
+            <DetailListTextValue
+              text={formatDurationAbbreviated(
+                $activityExecution.info.executionTime ?? '',
+              ) || '-'}
+            />
             <DetailListLabel
               >{translate(
                 'standalone-activities.last-started-time',
@@ -209,15 +259,11 @@
             >
             <DetailListTimestampValue
               timestamp={$activityExecution.info.lastStartedTime}
+              fallback="-"
             />
-            {#if isClosed}
-              <DetailListLabel>{translate('common.end')}</DetailListLabel>
-              <DetailListTimestampValue
-                timestamp={$activityExecution.info.lastStartedTime}
-              />
-            {/if}
           </DetailList>
         </div>
+
         {#if heartbeatRowCount > 0}
           <div class="space-y-2">
             <h5>
@@ -254,56 +300,9 @@
                   )}</DetailListLabel
                 >
                 <DetailListTextValue
-                  text={$activityExecution.info.totalHeartbeatCount ?? ''}
+                  text={$activityExecution.info.totalHeartbeatCount ?? '-'}
                 />
               {/if}
-            </DetailList>
-          </div>
-        {/if}
-        {#if isRetrying}
-          <div class="space-y-2">
-            <h5>
-              {translate('standalone-activities.retry-state')}
-            </h5>
-            <DetailList
-              rowCount={3 + (nextRetryDelay ? 1 : 0)}
-              aria-label={translate('standalone-activities.retry-state')}
-            >
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.current-retry-interval',
-                )}</DetailListLabel
-              >
-              <DetailListTextValue
-                text={fromSeconds($activityExecution.info.currentRetryInterval)}
-              />
-
-              {#if nextRetryDelay}
-                <DetailListLabel
-                  >{translate(
-                    'standalone-activities.next-retry-delay',
-                  )}</DetailListLabel
-                >
-                <DetailListTextValue text={fromSeconds(nextRetryDelay)} />
-              {/if}
-
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.last-attempt-complete-time',
-                )}</DetailListLabel
-              >
-              <DetailListTimestampValue
-                timestamp={$activityExecution.info.lastAttemptCompleteTime}
-              />
-
-              <DetailListLabel
-                >{translate(
-                  'standalone-activities.next-attempt-schedule-time',
-                )}</DetailListLabel
-              >
-              <DetailListTimestampValue
-                timestamp={$activityExecution.info.nextAttemptScheduleTime}
-              />
             </DetailList>
           </div>
         {/if}
@@ -324,7 +323,9 @@
               )}</DetailListLabel
             >
             <DetailListTextValue
-              text={fromSeconds($activityExecution.info.scheduleToStartTimeout)}
+              text={fromSeconds(
+                $activityExecution.info.scheduleToStartTimeout,
+              ) || '-'}
             />
             <DetailListLabel
               >{translate(
@@ -332,7 +333,9 @@
               )}</DetailListLabel
             >
             <DetailListTextValue
-              text={fromSeconds($activityExecution.info.scheduleToCloseTimeout)}
+              text={fromSeconds(
+                $activityExecution.info.scheduleToCloseTimeout,
+              ) || '-'}
             />
             <DetailListLabel
               >{translate(
@@ -340,7 +343,8 @@
               )}</DetailListLabel
             >
             <DetailListTextValue
-              text={fromSeconds($activityExecution.info.startToCloseTimeout)}
+              text={fromSeconds($activityExecution.info.startToCloseTimeout) ||
+                '-'}
             />
           </DetailList>
         </div>
@@ -369,10 +373,11 @@
               )}</DetailListLabel
             >
             <DetailListTextValue
-              text={$activityExecution.info.lastWorkerIdentity ?? ''}
+              text={$activityExecution.info.lastWorkerIdentity ?? '-'}
             />
           </DetailList>
         </div>
+
         {#if $activityExecution.info.priority}
           {@const { priorityKey, fairnessKey, fairnessWeight } =
             $activityExecution.info.priority}
@@ -405,7 +410,7 @@
                   >
                   <DetailListTextValue text={fairnessKey} />
                 {/if}
-                {#if fairnessWeight}
+                {#if fairnessWeight != null}
                   <DetailListLabel
                     >{translate(
                       'standalone-activities.fairness-weight',


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
