### PR TITLE
Make Build ID filterable and show worker status counts

### DIFF
--- a/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
+++ b/src/lib/components/search-attribute-filter/dropdown-filter-chip.svelte
@@ -3,7 +3,7 @@
 
   import { addHours, addMinutes, addSeconds, startOfDay } from 'date-fns';
   import { zonedTimeToUtc } from 'date-fns-tz';
-  import { getContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
 
   import { timestamp } from '$lib/components/timestamp.svelte';
   import Button from '$lib/holocene/button.svelte';
@@ -52,11 +52,6 @@
   import { getTimezone, TIME_UNIT_OPTIONS } from '$lib/utilities/timezone';
   import { toDate } from '$lib/utilities/to-duration';
 
-  import {
-    SEARCH_ATTRIBUTE_FILTER_CONTEXT,
-    type SearchAttributeFilterContext,
-  } from './filter.svelte';
-
   type Props = {
     filter: SearchAttributeFilter;
     onUpdate: (updatedFilter: SearchAttributeFilter) => void;
@@ -73,10 +68,6 @@
     openIndex = null,
   }: Props = $props();
 
-  const { includeNullConditions = true } =
-    getContext<SearchAttributeFilterContext>(SEARCH_ATTRIBUTE_FILTER_CONTEXT) ??
-    {};
-
   const open = writable(false);
   let localFilter = $state({ ...filter });
 
@@ -92,14 +83,10 @@
   const isTimeRange = $derived(localFilter.conditional === 'BETWEEN');
   const selectedTime = $derived(getSelectedTimezone($timeFormat));
 
-  const defaultConditionOptions = $derived(
-    includeNullConditions
-      ? [
-          { value: 'is', label: translate('common.is-null') },
-          { value: 'is not', label: translate('common.is-not-null') },
-        ]
-      : [],
-  );
+  const defaultConditionOptions = [
+    { value: 'is', label: translate('common.is-null') },
+    { value: 'is not', label: translate('common.is-not-null') },
+  ];
 
   const conditionalOptions = $derived([
     { value: '=', label: translate('common.equal-to'), id: 'equal-to' },

--- a/src/lib/components/search-attribute-filter/filter-bar.svelte
+++ b/src/lib/components/search-attribute-filter/filter-bar.svelte
@@ -25,7 +25,6 @@
     id: string;
     statusAttribute?: StatusAttribute;
     onManualSearch?: (query: string) => void;
-    includeNullConditions?: boolean;
   }
 
   let {
@@ -35,7 +34,6 @@
     id,
     statusAttribute = 'ExecutionStatus',
     onManualSearch,
-    includeNullConditions,
   }: Props = $props();
 
   let viewManualQuery = $state(false);
@@ -56,13 +54,7 @@
   <div
     class="flex w-full flex-wrap items-end justify-between gap-2 border border-b-0 border-subtle bg-primary p-1.5"
   >
-    <Filter
-      {filters}
-      {options}
-      {id}
-      {statusAttribute}
-      {includeNullConditions}
-    />
+    <Filter {filters} {options} {id} {statusAttribute} />
     <div class="flex shrink-0 items-center gap-1">
       <Tooltip
         text={viewManualQuery

--- a/src/lib/components/search-attribute-filter/filter.svelte
+++ b/src/lib/components/search-attribute-filter/filter.svelte
@@ -14,7 +14,6 @@
     resetFilter: () => void;
     chipOpenIndex: Writable<number | null>;
     id: string;
-    includeNullConditions: boolean;
   }
 </script>
 
@@ -38,16 +37,9 @@
     options: SearchAttributeOption[];
     id: string;
     statusAttribute?: StatusAttribute;
-    includeNullConditions?: boolean;
   }
 
-  let {
-    filters,
-    options,
-    id,
-    statusAttribute,
-    includeNullConditions = true,
-  }: Props = $props();
+  let { filters, options, id, statusAttribute }: Props = $props();
 
   const filter = writable<SearchAttributeFilter>(createFilter());
   const activeQueryIndex = writable<number | null>(null);
@@ -66,7 +58,6 @@
     resetFilter,
     chipOpenIndex,
     id,
-    includeNullConditions,
   });
 
   function handleSubmit() {

--- a/src/lib/components/workers/worker-details/worker-details.svelte
+++ b/src/lib/components/workers/worker-details/worker-details.svelte
@@ -180,23 +180,26 @@
       {#if buildId}
         <DetailListLabel>{translate('deployments.build-id')}</DetailListLabel>
         <span class="max-w-72">
-          <!-- TODO: Make filterable link for Build ID with DT-3745 -->
-          <DetailListTextValue
-            copyable={!!buildId}
-            copyableText={buildId}
+          <DetailListLinkValue
+            copyable
             text={buildId}
-            tooltipText={buildId}
+            href={routeForWorkersWithQuery({
+              namespace,
+              query: `BuildId="${buildId}"`,
+            }) ?? ''}
+            Icon={IconFilter}
           />
         </span>
       {/if}
-      {#if heartbeat?.deploymentVersion?.deploymentName}
+      {@const deploymentName = heartbeat?.deploymentVersion?.deploymentName}
+      {#if deploymentName}
         <DetailListLabel>{translate('deployments.deployment')}</DetailListLabel>
         <DetailListLinkValue
           copyable
-          text={heartbeat.deploymentVersion.deploymentName}
+          text={deploymentName}
           href={routeForWorkersWithQuery({
             namespace,
-            query: `DeploymentName="${heartbeat.deploymentVersion.deploymentName}"`,
+            query: `DeploymentName="${deploymentName}"`,
           }) ?? ''}
           Icon={IconFilter}
         />

--- a/src/lib/components/workers/worker-status-counts.svelte
+++ b/src/lib/components/workers/worker-status-counts.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { type ClassNameValue, twMerge as merge } from 'tailwind-merge';
+
+  import WorkerStatusBadge from '$lib/components/workers/worker-status.svelte';
+  import type { WorkerStatusCount } from '$lib/services/worker-service';
+
+  interface Props {
+    counts: WorkerStatusCount[];
+    class?: ClassNameValue;
+  }
+
+  let { counts, class: className }: Props = $props();
+
+  const visibleCounts = $derived(
+    counts.filter(({ count }) => count !== undefined),
+  );
+</script>
+
+<div class={merge('flex flex-wrap items-center gap-2', className)}>
+  {#each visibleCounts as { status, count } (status)}
+    <WorkerStatusBadge {status} {count} />
+  {/each}
+</div>

--- a/src/lib/components/workers/worker-status.svelte
+++ b/src/lib/components/workers/worker-status.svelte
@@ -8,9 +8,10 @@
   interface Props {
     delay?: number;
     status?: WorkerStatus;
+    count?: number;
   }
 
-  let { delay = 0, status = 'Running' }: Props = $props();
+  let { delay = 0, status = 'Running', count }: Props = $props();
 
   const label: Record<WorkerStatus, string> = {
     Running: translate('workflows.running'),
@@ -38,6 +39,9 @@
 
 <div class="relative flex items-center gap-0 text-center text-xs leading-4">
   <span class={workerStatus({ status })}>
+    {#if count !== undefined && count >= 0}
+      {count.toLocaleString()}
+    {/if}
     {label[status]}
     {#if isRunning}
       <HeartBeat {delay} />

--- a/src/lib/components/workers/workers-table/workers-table-row.svelte
+++ b/src/lib/components/workers/workers-table/workers-table-row.svelte
@@ -49,10 +49,10 @@
       : undefined}
     {filterable}
   />
-  <!-- TODO: Make Build ID filterable with DT-3745 -->
   <WorkersTableCell
     attribute="BuildId"
     value={worker?.deploymentVersion?.buildId}
+    {filterable}
   />
   <WorkersTableCell
     attribute="TaskQueue"

--- a/src/lib/i18n/locales/en/workers.ts
+++ b/src/lib/i18n/locales/en/workers.ts
@@ -3,6 +3,8 @@ export const Namespace = 'workers' as const;
 export const Strings = {
   worker: 'Worker',
   workers: 'Workers',
+  workers_one: 'Worker',
+  workers_other: 'Workers',
   pollers: 'Pollers',
   'worker-details': 'Worker Details',
   'worker-views': 'Worker Views',

--- a/src/lib/layouts/workers-layout.svelte
+++ b/src/lib/layouts/workers-layout.svelte
@@ -5,13 +5,17 @@
 
   import CountRefreshButton from '$lib/components/count-refresh-button.svelte';
   import { timestamp } from '$lib/components/timestamp.svelte';
-  import Badge from '$lib/holocene/badge.svelte';
+  import WorkerStatusCounts from '$lib/components/workers/worker-status-counts.svelte';
   import TabList from '$lib/holocene/tab/tab-list.svelte';
   import Tab from '$lib/holocene/tab/tab.svelte';
   import Tabs from '$lib/holocene/tab/tabs.svelte';
   import { translate } from '$lib/i18n/translate';
   import { createCountPoller } from '$lib/runes/count-poller.svelte';
-  import { fetchWorkerCount } from '$lib/services/worker-service';
+  import {
+    fetchWorkerCountByStatus,
+    sumWorkerStatusCounts,
+    type WorkerStatusCount,
+  } from '$lib/services/worker-service';
   import {
     refresh,
     workerCount,
@@ -50,33 +54,39 @@
     !!page.data?.namespace?.namespaceInfo?.capabilities?.workerHeartbeats,
   );
   const countEnabled = $derived(workerHeartbeatsEnabled && $workerCountEnabled);
+  const onWorkersTab = $derived(page.url.pathname.endsWith('/workers'));
+  const showCount = $derived(countEnabled && onWorkersTab);
 
-  let countLoaded = $state(false);
+  let statusCounts: WorkerStatusCount[] = $state([]);
 
   const countPoller = createCountPoller({
     getStore: () => workerCount,
     fetch: ({ signal }) =>
-      countEnabled
-        ? fetchWorkerCount({ namespace, query }, (input, init) =>
+      showCount
+        ? fetchWorkerCountByStatus({ namespace, query }, (input, init) =>
             fetch(input, { ...init, signal }),
           )
-        : Promise.resolve({ count: undefined }),
-    transform: (response) => response.count ?? $workerCount.count,
-    disabled: () => !countEnabled,
+        : Promise.resolve([]),
+    transform: (counts) => sumWorkerStatusCounts(counts) ?? $workerCount.count,
+    disabled: () => !showCount,
     watch() {
       void namespace;
       void query;
-      void countEnabled;
+      void showCount;
       void $refresh;
     },
     onReset: () => {
-      countLoaded = false;
+      statusCounts = [];
       workerCount.update((s) => ({ ...s, count: 0 }));
     },
-    onInitialFetch: (_count, response) => {
-      countLoaded = response.count !== undefined;
+    onInitialFetch: (_count, counts) => {
+      statusCounts = counts;
     },
   });
+
+  const statusCountTotal = $derived(
+    showCount ? sumWorkerStatusCounts(statusCounts) : undefined,
+  );
 
   const refreshTime = $derived(new Date(countPoller.refreshTime));
 
@@ -87,10 +97,24 @@
   <div class="flex min-h-10 flex-wrap items-start justify-between gap-2">
     <div>
       <div class="flex items-start gap-2">
-        <h1 class="leading-7" data-cy="workers-title">
-          {translate('workers.workers')}
+        <h1 class="flex items-center gap-2 leading-7" data-cy="workers-title">
+          <span
+            role="status"
+            aria-atomic="true"
+            class="flex items-center gap-2"
+          >
+            {#if statusCountTotal !== undefined}
+              {statusCountTotal.toLocaleString()}
+            {/if}
+            {translate('workers.workers', { count: statusCountTotal })}
+          </span>
         </h1>
-        <CountRefreshButton count={$workerCount.newCount} {refresh} />
+        <div class="flex flex-wrap items-center gap-2">
+          <CountRefreshButton count={$workerCount.newCount} {refresh} />
+          {#if showCount}
+            <WorkerStatusCounts counts={statusCounts} />
+          {/if}
+        </div>
       </div>
       <p class="mt-2 text-xs text-secondary">
         {refreshTimeFormatted}
@@ -106,14 +130,8 @@
         label={translate('workers.instance', { count: 2 })}
         id="workers-tab"
         href={workersHref}
-        active={page.url.pathname.endsWith('/workers')}
-      >
-        {#if countEnabled && countLoaded}
-          <Badge type="primary" class="px-2 py-0">
-            {$workerCount.count}
-          </Badge>
-        {/if}
-      </Tab>
+        active={onWorkersTab}
+      />
       <Tab
         label={translate('deployments.deployments')}
         id="deployments-tab"

--- a/src/lib/pages/workers.svelte
+++ b/src/lib/pages/workers.svelte
@@ -53,7 +53,6 @@
       searchAttributes={$workerSearchAttributes}
       id="worker"
       statusAttribute="WorkerStatus"
-      includeNullConditions={false}
     />
     {#key [namespace, query, $refresh]}
       <WorkersTable

--- a/src/lib/services/worker-service.test.ts
+++ b/src/lib/services/worker-service.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  fetchWorkerCountByStatus,
+  sumWorkerStatusCounts,
+  toWorkerStatusQuery,
+} from './worker-service';
+import { requestFromAPI } from '../utilities/request-from-api';
+
+vi.mock('../utilities/request-from-api', () => ({
+  requestFromAPI: vi.fn(),
+}));
+
+const namespace = 'test-namespace';
+
+describe('worker service', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('toWorkerStatusQuery', () => {
+    test('returns only the status clause without an existing query', () => {
+      expect(toWorkerStatusQuery('Running')).toBe('`WorkerStatus`="Running"');
+    });
+
+    test('wraps an existing query so it is not broken up by the status clause', () => {
+      expect(
+        toWorkerStatusQuery('ShuttingDown', 'TaskQueue="a" OR TaskQueue="b"'),
+      ).toBe(
+        '(TaskQueue="a" OR TaskQueue="b") AND `WorkerStatus`="ShuttingDown"',
+      );
+    });
+  });
+
+  describe('sumWorkerStatusCounts', () => {
+    test('adds up the statuses that returned a count', () => {
+      expect(
+        sumWorkerStatusCounts([
+          { status: 'Running', count: 12 },
+          { status: 'ShuttingDown', count: 3 },
+        ]),
+      ).toBe(15);
+    });
+
+    test('ignores statuses without a count', () => {
+      expect(
+        sumWorkerStatusCounts([
+          { status: 'Running', count: 12 },
+          { status: 'ShuttingDown', count: undefined },
+        ]),
+      ).toBe(12);
+    });
+
+    test('returns undefined when no status returned a count', () => {
+      expect(
+        sumWorkerStatusCounts([
+          { status: 'Running', count: undefined },
+          { status: 'ShuttingDown', count: undefined },
+        ]),
+      ).toBeUndefined();
+    });
+
+    test('returns undefined when there are no counts at all', () => {
+      expect(sumWorkerStatusCounts([])).toBeUndefined();
+    });
+  });
+
+  describe('fetchWorkerCountByStatus', () => {
+    test('requests a count per status and returns parsed counts', async () => {
+      vi.mocked(requestFromAPI).mockResolvedValueOnce({ count: '12' });
+      vi.mocked(requestFromAPI).mockResolvedValueOnce({ count: '3' });
+
+      const counts = await fetchWorkerCountByStatus({ namespace }, vi.fn());
+
+      expect(counts).toEqual([
+        { status: 'Running', count: 12 },
+        { status: 'ShuttingDown', count: 3 },
+      ]);
+      expect(requestFromAPI).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(requestFromAPI).mock.calls[0][1]).toMatchObject({
+        params: { query: '`WorkerStatus`="Running"' },
+      });
+      expect(vi.mocked(requestFromAPI).mock.calls[1][1]).toMatchObject({
+        params: { query: '`WorkerStatus`="ShuttingDown"' },
+      });
+    });
+
+    test('combines the status with the current query', async () => {
+      vi.mocked(requestFromAPI).mockResolvedValue({ count: '1' });
+
+      await fetchWorkerCountByStatus(
+        { namespace, query: 'TaskQueue="hello"' },
+        vi.fn(),
+      );
+
+      expect(vi.mocked(requestFromAPI).mock.calls[0][1]).toMatchObject({
+        params: {
+          query: '(TaskQueue="hello") AND `WorkerStatus`="Running"',
+        },
+      });
+    });
+
+    test('returns undefined counts when the request fails', async () => {
+      vi.mocked(requestFromAPI).mockRejectedValue(new Error('nope'));
+
+      const counts = await fetchWorkerCountByStatus({ namespace }, vi.fn());
+
+      expect(counts).toEqual([
+        { status: 'Running', count: undefined },
+        { status: 'ShuttingDown', count: undefined },
+      ]);
+    });
+  });
+});

--- a/src/lib/services/worker-service.ts
+++ b/src/lib/services/worker-service.ts
@@ -1,3 +1,4 @@
+import { type WorkerStatus, workerStatuses } from '$lib/models/worker-status';
 import type {
   DescribeWorkerRequest,
   DescribeWorkerResponse,
@@ -8,6 +9,11 @@ import type {
 } from '$lib/types';
 import { requestFromAPI } from '$lib/utilities/request-from-api';
 import { routeForApi } from '$lib/utilities/route-for-api';
+
+export type WorkerStatusCount = {
+  status: WorkerStatus;
+  count: number | undefined;
+};
 
 type PaginatedWorkerListPromise = (
   pageSize: number,
@@ -67,6 +73,37 @@ export const fetchWorkerCount = async (
   } catch {
     return { count: undefined };
   }
+};
+
+export const toWorkerStatusQuery = (
+  status: WorkerStatus,
+  query = '',
+): string => {
+  const statusQuery = `\`WorkerStatus\`="${status}"`;
+  return query ? `(${query}) AND ${statusQuery}` : statusQuery;
+};
+
+export const fetchWorkerCountByStatus = async (
+  { namespace, query }: ListWorkersRequest,
+  request = fetch,
+): Promise<WorkerStatusCount[]> =>
+  Promise.all(
+    workerStatuses.map(async (status) => {
+      const { count } = await fetchWorkerCount(
+        { namespace, query: toWorkerStatusQuery(status, query ?? '') },
+        request,
+      );
+      return { status, count };
+    }),
+  );
+
+export const sumWorkerStatusCounts = (
+  counts: WorkerStatusCount[],
+): number | undefined => {
+  const counted = counts.flatMap(({ count }) => count ?? []);
+  return counted.length
+    ? counted.reduce((total, count) => total + count, 0)
+    : undefined;
 };
 
 export async function describeWorker(

--- a/src/lib/stores/search-attributes.ts
+++ b/src/lib/stores/search-attributes.ts
@@ -216,7 +216,7 @@ export const workerSearchAttributes: Readable<SearchAttributes> = readable({
   TaskQueue: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   StartTime: SEARCH_ATTRIBUTE_TYPE.DATETIME,
   DeploymentName: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
-  // BuildId: SEARCH_ATTRIBUTE_TYPE.KEYWORD, // TODO: Add back with DT-3745
+  BuildId: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   SdkName: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
   SdkVersion: SEARCH_ATTRIBUTE_TYPE.KEYWORD,
 });


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Build ID is filterable again.
- The Build ID cell in the workers table is now `filterable`, like the Deployment and Task Queue cells beside it.
- The Build ID row in worker details is now a `DetailListLinkValue` that links to the workers list filtered by that build ID, matching the Deployment, Task Queue, and Host Name rows.
- Null conditions (`is null` / `is not null`) are enabled on the worker filter bar, which had them suppressed via `includeNullConditions={false}`.

Worker status counts are now in the header.
- `fetchWorkerCountByStatus` issues one `worker-count` request per entry in`workerStatuses`.
- `sumWorkerStatusCounts` feeds the header total and the `workerCount` store, which is what `WorkersTable` already used for its pagination total.
- The count badge next to the Instances tab is removed, since the header total replaces it.
- The layout's poller now drives the statused requests instead of a separate un-statused one, so the page makes two count requests where it previously made three. Counts are only fetched on the Instances tab.
- `worker-status.svelte` takes an optional `count`, rendered before the label the same way `execution-status.svelte` does.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|<img width="517" height="240" alt="Screenshot 2026-09-08 at 2 39 24 PM" src="https://github.com/user-attachments/assets/fd2879aa-98f9-420d-afcc-3825e5dfd713" />| <img width="580" height="242" alt="Screenshot 2026-09-08 at 2 39 04 PM" src="https://github.com/user-attachments/assets/c3d8d997-9492-4d9c-8275-caea302e4fa6" />|


### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

#### Run temporal server from a local build
1. Ensure you have cloned the [temporal](https://github.com/temporalio/temporal) repo
1. Run `make bins` and `make start`
1. Running temporal server from a local build does not create the namespace, run `temporal operator namespace create --namespace default`

#### Run the UI against a local build of temporal server
1. Checkout the `laura/DT-3745-make-buildID-filterable` branch in the UI repo 
1. `cd server/ && make build` 
1. `cd .. && pnpm dev:local-temporal`

------

1. Go to a namespace's Workers page. Confirm the header reads "N Workers" with `Running` and `Shutting Down` badges beside Refresh, and that no count badge appears on the Instances tab.
2. Filter by task queue or status and confirm the total and badges follow the filter.
3. With exactly one worker, confirm the header reads "1 Worker".
4. Switch to the Deployments tab and confirm the header falls back to plain "Workers" with no counts.
5. On a worker's detail page, click the filter icon on Build ID and confirm it navigates to the workers list filtered to that build ID.
6. In the workers table, filter by the Build ID cell and confirm the query applies. Confirm `is null` / `is not null` appear in the filter dropdowns.

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`DT-3745`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
