### PR TITLE
Fix payload input focus loss (FE-643)

### DIFF
--- a/src/lib/components/payload-input.svelte
+++ b/src/lib/components/payload-input.svelte
@@ -67,7 +67,7 @@
 <div class="flex flex-col gap-2">
   <span class="text-sm font-medium">{label}</span>
   <div class="flex gap-2">
-    {#key [loading, editing]}
+    {#key `${loading}-${editing}`}
       <CodeBlock
         {id}
         maxHeight={320}

--- a/tests/integration/schedule-edit.spec.ts
+++ b/tests/integration/schedule-edit.spec.ts
@@ -205,6 +205,12 @@ test.describe('Schedules List with schedules', () => {
     await page.getByRole('button', { name: 'Edit', exact: true }).click();
 
     await expect(payloadInput).toContainText('"message"');
+
+    await payloadInput.focus();
+    await payloadInput.press('End');
+    await payloadInput.press('x');
+    await expect(payloadInput).toBeFocused();
+
     expect(pageErrors.map(({ message }) => message).join('\n')).not.toContain(
       'split is not a function',
     );


### PR DESCRIPTION
## Description & motivation 💭

Schedule payload editing recreated the CodeMirror instance after bound input updates because the keyed block used a newly allocated array. This uses a stable primitive key so the editor is only recreated when loading or editing mode changes, preserving focus while typing.

Adds a Playwright regression assertion that verifies the schedule payload editor remains focused after a keystroke.

### Screenshots (if applicable) 📸

Not applicable.

### Design Considerations 🎨

None.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [x] E2E tests added
- [ ] Unit tests added
- pnpm test:integration --grep object-input-payload
- pnpm check
- pnpm lint

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open an existing schedule with an input payload.
2. Click Edit for the payload.
3. Type multiple characters and confirm the editor retains focus.

## Checklists

### Draft Checklist

None.

### Merge Checklist

None.

### Issue(s) closed

FE-643

## Docs

### Any docs updates needed?

No.