### PR TITLE
Keep portal menus anchored when the layout shifts

### DIFF
--- a/src/lib/holocene/portal/portal.svelte
+++ b/src/lib/holocene/portal/portal.svelte
@@ -6,7 +6,11 @@
   import { twMerge as merge } from 'tailwind-merge';
 
   import { portal } from './portal-action';
-  import { calculatePosition, getElementRect } from './position-calculator';
+  import {
+    calculatePosition,
+    getElementRect,
+    hasMoved,
+  } from './position-calculator';
   import type { PortalProps } from './types';
 
   let {
@@ -28,7 +32,8 @@
   let positionY = $state(0);
   let anchorElement = $state<HTMLElement | null>(null);
   let scrollContainerElement = $state<HTMLElement | Window>(window);
-  let rafId = $state<number | null>(null);
+  let rafId: number | null = null;
+  let needsUpdate = false;
 
   const shouldShowPortal = $derived(
     open && anchorElement && (!hideWhenAnchorHidden || isVisible),
@@ -108,13 +113,7 @@
   }
 
   function scheduleUpdate() {
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId);
-    }
-    rafId = requestAnimationFrame(() => {
-      updatePosition();
-      rafId = null;
-    });
+    needsUpdate = true;
   }
 
   function getScrollableAncestors(element: HTMLElement): Set<EventTarget> {
@@ -138,16 +137,36 @@
   function setupPositioning(element: HTMLElement) {
     if (!anchorElement) return;
 
+    const anchorEl = anchorElement;
+
     untrack(() => updatePosition());
+
+    let lastAnchorRect = getElementRect(anchorEl);
+
+    const tick = () => {
+      rafId = requestAnimationFrame(tick);
+
+      if (!anchorEl.isConnected) return;
+
+      const anchorRect = getElementRect(anchorEl);
+
+      if (needsUpdate || hasMoved(anchorRect, lastAnchorRect)) {
+        needsUpdate = false;
+        lastAnchorRect = anchorRect;
+        updatePosition();
+      }
+    };
+
+    rafId = requestAnimationFrame(tick);
 
     const resizeObserver = new ResizeObserver(() => {
       scheduleUpdate();
     });
 
     resizeObserver.observe(element);
-    resizeObserver.observe(anchorElement);
+    resizeObserver.observe(anchorEl);
 
-    const scrollableAncestors = getScrollableAncestors(anchorElement);
+    const scrollableAncestors = getScrollableAncestors(anchorEl);
 
     const scrollCleanup = on(
       document,
@@ -169,6 +188,7 @@
         cancelAnimationFrame(rafId);
         rafId = null;
       }
+      needsUpdate = false;
       resizeObserver.disconnect();
       scrollCleanup();
       resizeCleanup();

--- a/src/lib/holocene/portal/portal.test.ts
+++ b/src/lib/holocene/portal/portal.test.ts
@@ -8,6 +8,7 @@ import {
   detectCollision,
   getFlippedOffset,
   getFlippedPosition,
+  hasMoved,
 } from './position-calculator';
 import type { PortalPosition, Rect } from './types';
 
@@ -275,6 +276,28 @@ describe('position-calculator', () => {
       const result = getFlippedOffset({ x: 4, y: 8 }, 'bottom', 'top');
       expect(result.x).toBe(4);
       expect(result.y).toBe(-8);
+    });
+  });
+
+  describe('hasMoved', () => {
+    it('should report no movement for an identical rect', () => {
+      expect(hasMoved(anchorRect, createRect(100, 100, 50, 30))).toBe(false);
+    });
+
+    it('should detect vertical movement', () => {
+      expect(hasMoved(anchorRect, createRect(100, 140, 50, 30))).toBe(true);
+    });
+
+    it('should detect horizontal movement', () => {
+      expect(hasMoved(anchorRect, createRect(180, 100, 50, 30))).toBe(true);
+    });
+
+    it('should detect a width change', () => {
+      expect(hasMoved(anchorRect, createRect(100, 100, 80, 30))).toBe(true);
+    });
+
+    it('should detect a height change', () => {
+      expect(hasMoved(anchorRect, createRect(100, 100, 50, 60))).toBe(true);
     });
   });
 

--- a/src/lib/holocene/portal/position-calculator.ts
+++ b/src/lib/holocene/portal/position-calculator.ts
@@ -28,6 +28,15 @@ export function getElementRect(element: HTMLElement): Rect {
   };
 }
 
+export function hasMoved(a: Rect, b: Rect): boolean {
+  return (
+    a.top !== b.top ||
+    a.left !== b.left ||
+    a.width !== b.width ||
+    a.height !== b.height
+  );
+}
+
 export function calculateBasePosition(
   anchorRect: Rect,
   portalRect: Rect,


### PR DESCRIPTION
## Description & motivation 💭

Portal-based menus (e.g. the search attribute filter bar dropdowns) could become detached from their button if the layout changed while they were open. This PR tracks the anchor's rect in a `requestAnimationFrame` loop while the portal is open, repositioning only when it actually changes.

### Screenshots (if applicable) 📸

### Design Considerations 🎨

## Testing 🧪

### How was this tested 👻

- [X] Manual testing
- [ ] E2E tests added
- [X] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Go to the workflows list and add a search attribute filter or two.
2. Open one of the filter chip dropdowns.
3. With the menu still open, change the layout around it. E.g. add another filter chip, remove a chip ahead of it, or narrow the window until the chip row wraps to a second line.
4. The menu should stay next to its button.

## Checklists

### Draft Checklist

### Merge Checklist

### Issue(s) closed

## Docs

### Any docs updates needed?