### PR TITLE
Remove brittle provider picker story assertions

### DIFF
--- a/src/lib/components/workers/serverless-worker-form/compute-provider-picker.stories.svelte
+++ b/src/lib/components/workers/serverless-worker-form/compute-provider-picker.stories.svelte
@@ -85,26 +85,7 @@
   </div>
 </Story>
 
-<Story
-  name="Both enabled (cross-cloud)"
-  asChild
-  play={async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const publicPreviewBadge = canvas.getByText('Public Preview');
-    const preReleaseBadge = canvas.getByText('Pre-release');
-
-    await expect(publicPreviewBadge).toHaveClass(
-      'border-accent',
-      'bg-surface-accent',
-      'text-accent',
-    );
-    await expect(preReleaseBadge).toHaveClass(
-      'border-accent',
-      'bg-surface-accent',
-      'text-accent',
-    );
-  }}
->
+<Story name="Both enabled (cross-cloud)" asChild>
   <div class="max-w-[45rem] p-4">
     <ComputeProviderPicker
       provider="lambda"


### PR DESCRIPTION
Removes Tailwind class assertions already covered by Chromatic visual testing.