### PR TITLE
Color the favicon by the status of the workflow being viewed

### DIFF
--- a/src/lib/components/page-title.svelte
+++ b/src/lib/components/page-title.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { statusFavicon } from '$lib/stores/favicon';
   import apple from '$lib/vendor/apple-touch-icon.png';
   import banner from '$lib/vendor/banner.png';
   import favicon from '$lib/vendor/favicon.ico';
@@ -19,7 +20,7 @@
 
 <svelte:head>
   <title>{title}</title>
-  <link rel="icon" href={favicon} />
+  <link rel="icon" href={$statusFavicon ?? favicon} />
   <link rel="manifest" href={manifest} />
   <link rel="apple-touch-icon" href={apple} />
 

--- a/src/lib/stores/favicon.test.ts
+++ b/src/lib/stores/favicon.test.ts
@@ -1,0 +1,33 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { statusFavicon } from '$lib/stores/favicon';
+import { initialWorkflowRun, workflowRun } from '$lib/stores/workflow-run';
+import type { WorkflowExecution } from '$lib/types/workflows';
+import { getWorkflowStatusFavicon } from '$lib/utilities/get-workflow-status-favicon';
+
+const runWithStatus = (status: WorkflowExecution['status']) => ({
+  ...initialWorkflowRun,
+  workflow: { status } as WorkflowExecution,
+});
+
+describe('statusFavicon', () => {
+  afterEach(() => {
+    workflowRun.set(initialWorkflowRun);
+  });
+
+  it('follows the status of the workflow being viewed', () => {
+    workflowRun.set(runWithStatus('Running'));
+    expect(get(statusFavicon)).toBe(getWorkflowStatusFavicon('Running'));
+
+    workflowRun.set(runWithStatus('Failed'));
+    expect(get(statusFavicon)).toBe(getWorkflowStatusFavicon('Failed'));
+  });
+
+  it('has no icon of its own once the workflow run is cleared', () => {
+    workflowRun.set(runWithStatus('Completed'));
+    workflowRun.set(initialWorkflowRun);
+
+    expect(get(statusFavicon)).toBeUndefined();
+  });
+});

--- a/src/lib/stores/favicon.ts
+++ b/src/lib/stores/favicon.ts
@@ -1,0 +1,9 @@
+import { derived, type Readable } from 'svelte/store';
+
+import { workflowRun } from '$lib/stores/workflow-run';
+import { getWorkflowStatusFavicon } from '$lib/utilities/get-workflow-status-favicon';
+
+export const statusFavicon: Readable<string | undefined> = derived(
+  workflowRun,
+  ($workflowRun) => getWorkflowStatusFavicon($workflowRun.workflow?.status),
+);

--- a/src/lib/utilities/get-workflow-status-favicon.test.ts
+++ b/src/lib/utilities/get-workflow-status-favicon.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { colorScales } from '$lib/theme/io/themes';
+import type { WorkflowStatus } from '$lib/types/workflows';
+
+import { getWorkflowStatusFavicon } from './get-workflow-status-favicon';
+
+const decode = (dataUri: string | undefined) =>
+  decodeURIComponent((dataUri ?? '').replace('data:image/svg+xml,', ''));
+
+describe('getWorkflowStatusFavicon', () => {
+  it('colors the icon by workflow status', () => {
+    expect(decode(getWorkflowStatusFavicon('Running'))).toContain(
+      `fill="${colorScales.blue[11]}"`,
+    );
+    expect(decode(getWorkflowStatusFavicon('Completed'))).toContain(
+      `fill="${colorScales.green[11]}"`,
+    );
+    expect(decode(getWorkflowStatusFavicon('Failed'))).toContain(
+      `fill="${colorScales.red[11]}"`,
+    );
+    expect(decode(getWorkflowStatusFavicon('TimedOut'))).toContain(
+      `fill="${colorScales.persimmon[11]}"`,
+    );
+    expect(decode(getWorkflowStatusFavicon('Terminated'))).toContain(
+      `fill="${colorScales.amber[11]}"`,
+    );
+    expect(decode(getWorkflowStatusFavicon('Canceled'))).toContain(
+      `fill="${colorScales.slate[9]}"`,
+    );
+  });
+
+  it('gives every status a distinct icon from its neighbours in the badge palette', () => {
+    expect(getWorkflowStatusFavicon('Failed')).not.toBe(
+      getWorkflowStatusFavicon('TimedOut'),
+    );
+    expect(getWorkflowStatusFavicon('Failed')).not.toBe(
+      getWorkflowStatusFavicon('Terminated'),
+    );
+  });
+
+  it('returns a data URI holding an svg', () => {
+    const icon = getWorkflowStatusFavicon('Running');
+    expect(icon?.startsWith('data:image/svg+xml,')).toBe(true);
+    expect(decode(icon)).toContain('<svg xmlns="http://www.w3.org/2000/svg"');
+    expect(icon).not.toContain('#');
+  });
+
+  it('has no icon for an unknown or missing status', () => {
+    expect(getWorkflowStatusFavicon(null)).toBeUndefined();
+    expect(getWorkflowStatusFavicon(undefined)).toBeUndefined();
+    expect(
+      getWorkflowStatusFavicon('Unspecified' as WorkflowStatus),
+    ).toBeUndefined();
+  });
+});

--- a/src/lib/utilities/get-workflow-status-favicon.ts
+++ b/src/lib/utilities/get-workflow-status-favicon.ts
@@ -1,0 +1,36 @@
+import { colorScales } from '$lib/theme/io/themes';
+import type { WorkflowStatus } from '$lib/types/workflows';
+
+type WorkflowStatusFaviconValue = NonNullable<WorkflowStatus>;
+
+const statusColors: Record<WorkflowStatusFaviconValue, string> = {
+  Running: colorScales.blue[11],
+  Paused: colorScales.blue[11],
+  Completed: colorScales.green[11],
+  ContinuedAsNew: colorScales.green[11],
+  Failed: colorScales.red[11],
+  TimedOut: colorScales.persimmon[11],
+  Terminated: colorScales.amber[11],
+  Canceled: colorScales.slate[9],
+};
+
+const logoPath =
+  'M65.816 34.224 C63.684 18.251 58.288 4.917 49.999 4.917 41.711 4.917 36.314 18.251 34.182 34.224 18.208 36.357 4.874 41.753 4.874 50.042 4.874 58.33 18.211 63.727 34.182 65.859 36.314 81.83 41.711 95.167 49.999 95.167 58.288 95.167 63.684 81.83 65.816 65.859 81.79 63.727 95.124 58.33 95.124 50.042 95.124 41.753 81.788 36.357 65.816 34.224 Z M33.661 61.206 C18.363 58.997 9.44 53.939 9.44 50.042 9.44 46.144 18.363 41.087 33.661 38.877 33.324 42.56 33.149 46.319 33.149 50.042 33.149 53.764 33.324 57.526 33.661 61.206 Z M49.999 9.483 C53.897 9.483 58.954 18.405 61.164 33.703 57.483 33.367 53.721 33.191 49.999 33.191 46.277 33.191 42.515 33.367 38.835 33.703 41.044 18.405 46.102 9.483 49.999 9.483 Z M66.338 61.206 C65.585 61.316 62.496 61.678 61.715 61.755 61.638 62.539 61.273 65.625 61.166 66.378 58.956 81.676 53.899 90.598 50.001 90.598 46.104 90.598 41.047 81.676 38.837 66.378 38.73 65.625 38.365 62.536 38.288 61.755 37.932 58.129 37.717 54.234 37.717 50.042 37.717 45.85 37.932 41.954 38.288 38.326 41.914 37.97 45.809 37.755 50.001 37.755 54.194 37.755 58.089 37.97 61.715 38.326 62.499 38.403 65.585 38.767 66.338 38.875 81.636 41.085 90.56 46.144 90.56 50.039 90.56 53.935 81.636 58.997 66.338 61.206 Z';
+
+const isWorkflowStatusFaviconValue = (
+  status: string,
+): status is WorkflowStatusFaviconValue => status in statusColors;
+
+export const getWorkflowStatusFavicon = (
+  status: WorkflowStatus | undefined,
+): string | undefined => {
+  if (!status || !isWorkflowStatusFaviconValue(status)) return undefined;
+
+  const svg =
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">' +
+    `<circle cx="50" cy="50" r="50" fill="${statusColors[status]}"/>` +
+    `<path d="${logoPath}" fill="#ffffff"/>` +
+    '</svg>';
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};


### PR DESCRIPTION
## Description & motivation 💭

A workflow run page is a page you leave open and come back to — while a backfill grinds, while a flaky run retries. Until you come back, the tab tells you nothing: every Temporal tab carries the same black mark, so finding the run that just failed means clicking through them.

This tints that mark. On a workflow run page the favicon's disc takes the colour of the status badge's scheme, and goes back to the static icon everywhere else. It follows the status live — terminate a running workflow with the tab open and the icon turns without a reload, because it is derived from the same `workflowRun` store the header renders from.

The glyph, its proportions and the disc are the ones already shipped in `favicon.ico` — only the disc's fill changes.

### Screenshots (if applicable) 📸

Top row at 64px, bottom row the actual 16px rendering (pixel-doubled):

![workflow status favicons](https://raw.githubusercontent.com/MoLow/ui/pr-assets/status-favicons.png)

### Design Considerations 🎨

Two choices worth a second opinion:

- **Colour source.** Each status maps to the same colour *scheme* its `BadgeStatus` uses, taken at step 11 of that scheme's scale — the step dark enough that the knocked-out white glyph still holds at 16px. `Canceled` is the one exception: its badge scheme is `neutral`, and neutral's step 11 is so close to black that the icon would be indistinguishable from the static one, so it uses `slate[9]`.
- **Statuses that share a colour.** `Running`/`Paused` and `Completed`/`ContinuedAsNew` share a colour, because their badges do. Happy to split them if you would rather the icon be more granular than the badge.

The mark is drawn as an inline SVG `data:` URI. The path is a copy of `vendor/logo.svg` — a `data:` URI cannot reference an external asset, so it has to be inlined somewhere.

Also happy to open an issue first and discuss the idea before this gets reviewed, if that is the preferred order.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

Unit tests cover the status → icon mapping and the store's fallback to no icon once the workflow run is cleared.

Manually verified in Chromium against a local `temporal server start-dev`, reading `link[rel~="icon"]` off the live page:

```
on open              {"badge":"Running","disc":"#0d74ce"}
after terminate      {"badge":"Terminated","disc":"#ab6400"}
back on the list     {"badge":"Running","disc":"(static: favicon.ico)"}
```

`pnpm lint` and `pnpm check` are clean, and `pnpm test --run` passes.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. `pnpm dev:temporal-cli`
2. `temporal workflow start --task-queue demo-q --type DemoWorkflow --workflow-id wf-1`
3. Open that workflow's run page — the tab icon is blue.
4. `temporal workflow terminate --workflow-id wf-1 --reason demo` and watch the icon turn amber without reloading.
5. Navigate back to the workflow list — the icon returns to the static one.

## Docs

### Any docs updates needed?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
