### PR TITLE
Fix workflow empty state background color

### DIFF
--- a/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
+++ b/src/lib/components/workflow/workflows-summary-configurable-table/table-empty-state.svelte
@@ -114,7 +114,7 @@
       <div class="bg-surface-primary">
         <img src={noResultsImages} alt="" class="w-full" />
       </div>
-      <div class="flex-1 bg-[#818cf8]"></div>
+      <div class="flex-1 bg-[#8da4ef]"></div>
     </div>
   </div>
 {/if}


### PR DESCRIPTION
## Description & motivation 💭

Aligns the Workflow empty-state continuation background with the illustration and the equivalent Standalone Activities and Standalone Nexus Operations empty states. The background now uses `#8da4ef`, matching the bottom edge of `empty-state.svg`.

### Screenshots (if applicable) 📸

See the reported Workflow empty state. The visible seam between the SVG and its continuation background is removed.

### Design Considerations 🎨

This reuses the color already used by the other consumers of the shared illustration.

## Testing 🧪

### How was this tested 👻

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added
- Svelte autofixer: no issues
- `pnpm lint`: passed with existing warnings
- `pnpm check`: 0 errors; existing warnings remain

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

1. Open a namespace with no Workflow executions.
2. Confirm the illustration blends seamlessly into the background below it.

## Checklists

### Draft Checklist

N/A

### Merge Checklist

N/A

### Issue(s) closed

[FE-678: Workflow Empty State Background Mismatch](https://linear.app/temporal/issue/FE-678/workflow-empty-state-background-mismatch)

## Docs

### Any docs updates needed?

No.