### PR TITLE
Fix pagination corners and export theme preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,6 +308,11 @@
       "types": "./dist/io/tag/index.d.ts",
       "import": "./dist/io/tag/index.js"
     },
+    "./theme/preset": {
+      "types": "./dist/theme/preset.d.ts",
+      "import": "./dist/theme/preset.js",
+      "default": "./dist/theme/preset.js"
+    },
     "./*.svelte": {
       "types": "./dist/*.svelte.d.ts",
       "svelte": "./dist/*.svelte"

--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -112,7 +112,7 @@
     {#if visibleItems.length}
       <div
         class={merge(
-          'sticky left-0 flex w-full shrink-0 flex-wrap items-center justify-between gap-2 border-t border-primary bg-surface-primary px-4 py-2 text-primary',
+          'sticky left-0 flex w-full shrink-0 flex-wrap items-center justify-between gap-2 rounded rounded-t-none border-t border-primary bg-surface-primary px-4 py-2 text-primary',
           scrollsInTable ? 'bottom-0 mt-auto' : 'md:bottom-0 md:mt-auto',
         )}
         bind:clientHeight={footerHeight}


### PR DESCRIPTION
## Description & motivation 💭

- Export `@temporalio/ui/theme/preset` for package consumers.
- Round the paginated-table footer bottom corners.

## Testing 🧪

- `pnpm lint`
- `pnpm check`
- Linked `cloud-ui`: `pnpm build`
