### PR TITLE
Match paginated table footer corner radius

### DIFF
--- a/src/lib/holocene/table/paginated-table/index.svelte
+++ b/src/lib/holocene/table/paginated-table/index.svelte
@@ -112,7 +112,7 @@
     {#if visibleItems.length}
       <div
         class={merge(
-          'sticky left-0 flex w-full shrink-0 flex-wrap items-center justify-between gap-2 rounded rounded-t-none border-t border-primary bg-surface-primary px-4 py-2 text-primary',
+          'sticky left-0 flex w-full shrink-0 flex-wrap items-center justify-between gap-2 rounded-b-lg border-t border-primary bg-surface-primary px-4 py-2 text-primary',
           scrollsInTable ? 'bottom-0 mt-auto' : 'md:bottom-0 md:mt-auto',
         )}
         bind:clientHeight={footerHeight}


### PR DESCRIPTION
## Description & motivation 💭

Follow up to #3902 by matching the footer bottom radius to the paginated table’s `rounded-lg` shell. The previous smaller `rounded` radius still exposed the corner mismatch.

## Testing 🧪

- `pnpm lint`
- `pnpm check`
- Svelte autofixer
