### PR TITLE
Add size variants to IO badges

### DIFF
--- a/src/lib/io/badge-count/badge-count.stories.svelte
+++ b/src/lib/io/badge-count/badge-count.stories.svelte
@@ -2,17 +2,22 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import type { ComponentProps } from 'svelte';
 
+  import type { BadgeCountSize } from './badge-count.svelte';
   import BadgeCount from './badge-count.svelte';
+
+  const sizes: BadgeCountSize[] = ['sm', 'md'];
 
   const { Story } = defineMeta({
     title: 'IO/Design System/Badge Count',
     component: BadgeCount,
     args: {
       value: '12',
+      size: 'md',
     },
     argTypes: {
       value: { control: 'text' },
       total: { control: 'text' },
+      size: { control: 'select', options: sizes },
       class: { table: { disable: true } },
     },
     parameters: {
@@ -29,6 +34,21 @@
 {/snippet}
 
 <Story name="Playground" />
+
+<Story name="Sizes">
+  {#snippet template()}
+    <div
+      class="flex flex-wrap items-end gap-4 border border-primary bg-surface-primary p-6"
+    >
+      {#each sizes as size (size)}
+        <div class="flex flex-col items-start gap-2">
+          <span class="text-xs text-secondary">{size}</span>
+          <BadgeCount {size} value={12} total={20} />
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
 
 <Story name="Examples">
   {#snippet template()}

--- a/src/lib/io/badge-count/badge-count.svelte
+++ b/src/lib/io/badge-count/badge-count.svelte
@@ -1,8 +1,18 @@
 <script lang="ts" module>
+  export type BadgeCountSize = 'sm' | 'md';
+
   const sharedClasses =
-    'inline-flex whitespace-nowrap rounded-full border border-secondary bg-surface-tertiary font-mono text-xs font-medium leading-none text-primary uppercase';
+    'inline-flex whitespace-nowrap rounded-full border border-secondary bg-surface-tertiary font-mono font-medium leading-none text-primary uppercase';
   const segmentClasses =
-    'inline-flex flex-nowrap items-center justify-center gap-1 py-1 px-1.5';
+    'inline-flex flex-nowrap items-center justify-center gap-1';
+
+  const sizeClasses: Record<
+    BadgeCountSize,
+    { badge: string; segment: string }
+  > = {
+    sm: { badge: 'text-2xs', segment: 'py-0.5 px-1' },
+    md: { badge: 'text-xs', segment: 'py-1 px-1.5' },
+  };
 </script>
 
 <script lang="ts">
@@ -16,16 +26,29 @@
   > {
     value: string | number;
     total?: string | number;
+    size?: BadgeCountSize;
     class?: string;
   }
 
-  let { value, total, class: className, ...rest }: Props = $props();
+  let {
+    value,
+    total,
+    size = 'md',
+    class: className,
+    ...rest
+  }: Props = $props();
 </script>
 
-<span class={twMerge(sharedClasses, className)} {...rest}>
-  <span class={segmentClasses}>{value}</span>
+<span
+  class={twMerge(sharedClasses, sizeClasses[size].badge, className)}
+  {...rest}
+>
+  <span class={twMerge(segmentClasses, sizeClasses[size].segment)}>{value}</span
+  >
   {#if total !== undefined}
     <span class="inline-flex items-center justify-center py-0.5">/</span>
-    <span class={segmentClasses}>{total}</span>
+    <span class={twMerge(segmentClasses, sizeClasses[size].segment)}
+      >{total}</span
+    >
   {/if}
 </span>

--- a/src/lib/io/badge-count/index.ts
+++ b/src/lib/io/badge-count/index.ts
@@ -1,1 +1,3 @@
 export { default as BadgeCount } from './badge-count.svelte';
+
+export type { BadgeCountSize } from './badge-count.svelte';

--- a/src/lib/io/badge-status/badge-status.stories.svelte
+++ b/src/lib/io/badge-status/badge-status.stories.svelte
@@ -8,8 +8,13 @@
     IconHeartbeat,
   } from '$lib/io/icon';
 
-  import type { BadgeStatusValue } from './badge-status.svelte';
+  import type {
+    BadgeStatusSize,
+    BadgeStatusValue,
+  } from './badge-status.svelte';
   import BadgeStatus from './badge-status.svelte';
+
+  const sizes: BadgeStatusSize[] = ['sm', 'md'];
 
   const statuses: BadgeStatusValue[] = [
     'Running',
@@ -28,11 +33,13 @@
     args: {
       status: 'Running',
       count: 14,
+      size: 'md',
     },
     argTypes: {
       status: { control: 'select', options: statuses },
       text: { control: 'text' },
       count: { control: 'number' },
+      size: { control: 'select', options: sizes },
       TrailIcon: { control: false },
       extensions: { control: 'object' },
       class: { table: { disable: true } },
@@ -71,6 +78,21 @@
     ],
   }}
 />
+
+<Story name="Sizes">
+  {#snippet template()}
+    <div
+      class="flex flex-wrap items-end gap-4 border border-primary bg-surface-primary p-6"
+    >
+      {#each sizes as size (size)}
+        <div class="flex flex-col items-start gap-2">
+          <span class="text-xs text-secondary">{size}</span>
+          <BadgeStatus {size} status="Running" count={14} />
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
 
 <Story name="Statuses">
   {#snippet template()}

--- a/src/lib/io/badge-status/badge-status.svelte
+++ b/src/lib/io/badge-status/badge-status.svelte
@@ -20,6 +20,8 @@
     | 'danger'
     | 'error';
 
+  export type BadgeStatusSize = 'sm' | 'md';
+
   export type BadgeStatusExtension = {
     text?: string;
     colorScheme?: BadgeStatusColorScheme;
@@ -35,9 +37,17 @@
     extension !== false && extension !== null && extension !== undefined;
 
   const sharedClasses =
-    'inline-flex items-stretch overflow-hidden whitespace-nowrap rounded-full font-mono text-xs font-medium leading-none uppercase tracking-wide';
+    'inline-flex items-stretch overflow-hidden whitespace-nowrap rounded-full font-mono font-medium leading-none uppercase tracking-wide';
   const segmentClasses =
-    'inline-flex flex-nowrap items-center justify-center gap-1 border py-1 px-1.5';
+    'inline-flex flex-nowrap items-center justify-center gap-1 border';
+
+  const sizeClasses: Record<
+    BadgeStatusSize,
+    { badge: string; segment: string }
+  > = {
+    sm: { badge: 'text-2xs', segment: 'py-0.5 px-1' },
+    md: { badge: 'text-xs', segment: 'py-1 px-1.5' },
+  };
 
   const colorSchemeClasses: Record<BadgeStatusColorScheme, string> = {
     neutral: 'border-tertiary bg-surface-tertiary text-secondary',
@@ -73,6 +83,7 @@
     'children' | 'class'
   > {
     status: BadgeStatusValue;
+    size?: BadgeStatusSize;
     text?: string;
     count?: string | number;
     TrailIcon?: ConditionalValue<IconComponent>;
@@ -82,6 +93,7 @@
 
   let {
     status,
+    size = 'md',
     text,
     count,
     TrailIcon,
@@ -96,10 +108,14 @@
   );
 </script>
 
-<span class={twMerge(sharedClasses, className)} {...rest}>
+<span
+  class={twMerge(sharedClasses, sizeClasses[size].badge, className)}
+  {...rest}
+>
   <span
     class={twMerge(
       segmentClasses,
+      sizeClasses[size].segment,
       colorSchemeClasses[configuration.colorScheme],
       visibleExtensions.length ? 'rounded-l-full border-r-0' : 'rounded-full',
     )}
@@ -121,6 +137,7 @@
     <span
       class={twMerge(
         segmentClasses,
+        sizeClasses[size].segment,
         colorSchemeClasses[extension.colorScheme ?? configuration.colorScheme],
         index < visibleExtensions.length - 1 ? 'border-r-0' : 'rounded-r-full',
       )}

--- a/src/lib/io/badge-status/index.ts
+++ b/src/lib/io/badge-status/index.ts
@@ -2,6 +2,7 @@ export { default as BadgeStatus } from './badge-status.svelte';
 
 export type {
   BadgeStatusColorScheme,
+  BadgeStatusSize,
   BadgeStatusExtension,
   BadgeStatusExtensions,
   BadgeStatusValue,

--- a/src/lib/io/badge/badge.stories.svelte
+++ b/src/lib/io/badge/badge.stories.svelte
@@ -8,8 +8,10 @@
     IconHeartbeat,
   } from '$lib/io/icon';
 
-  import type { BadgeColorScheme } from './badge.svelte';
+  import type { BadgeColorScheme, BadgeSize } from './badge.svelte';
   import Badge from './badge.svelte';
+
+  const sizes: BadgeSize[] = ['sm', 'md'];
 
   const colorSchemes: BadgeColorScheme[] = [
     'neutral',
@@ -27,10 +29,12 @@
     args: {
       text: 'badge',
       colorScheme: 'neutral',
+      size: 'md',
     },
     argTypes: {
       text: { control: 'text' },
       colorScheme: { control: 'select', options: colorSchemes },
+      size: { control: 'select', options: sizes },
       Icon: { control: false },
       extension: { control: 'object' },
       class: { table: { disable: true } },
@@ -63,6 +67,25 @@
     },
   }}
 />
+
+<Story name="Sizes">
+  {#snippet template()}
+    <div
+      class="flex flex-wrap items-end gap-4 border border-primary bg-surface-primary p-6"
+    >
+      {#each sizes as size (size)}
+        <div class="flex flex-col items-start gap-2">
+          <span class="text-xs text-secondary">{size}</span>
+          <Badge
+            {size}
+            text="badge"
+            extension={{ text: '987', TrailIcon: IconExclamationOctagon }}
+          />
+        </div>
+      {/each}
+    </div>
+  {/snippet}
+</Story>
 
 <Story name="Color schemes">
   {#snippet template()}

--- a/src/lib/io/badge/badge.svelte
+++ b/src/lib/io/badge/badge.svelte
@@ -11,6 +11,8 @@
     | 'error'
     | 'accent';
 
+  export type BadgeSize = 'sm' | 'md';
+
   export type BadgeExtension = {
     text?: string;
     LeadIcon?: ConditionalValue<IconComponent>;
@@ -18,9 +20,14 @@
   };
 
   const sharedClasses =
-    'inline-flex whitespace-nowrap divide-x divide-inherit rounded-full border font-mono text-xs font-medium leading-none uppercase';
+    'inline-flex whitespace-nowrap divide-x divide-inherit rounded-full border font-mono font-medium leading-none uppercase';
   const segmentClasses =
-    'inline-flex flex-nowrap items-center justify-center gap-1 py-1 px-1.5';
+    'inline-flex flex-nowrap items-center justify-center gap-1';
+
+  const sizeClasses: Record<BadgeSize, { badge: string; segment: string }> = {
+    sm: { badge: 'text-2xs', segment: 'py-0.5 px-1' },
+    md: { badge: 'text-xs', segment: 'py-1 px-1.5' },
+  };
 
   const colorSchemeClasses: Record<BadgeColorScheme, string> = {
     neutral: 'border-tertiary bg-surface-tertiary text-secondary',
@@ -44,6 +51,7 @@
   > {
     text: string;
     colorScheme?: BadgeColorScheme;
+    size?: BadgeSize;
     Icon?: ConditionalValue<IconComponent>;
     extension?: ConditionalValue<BadgeExtension>;
     class?: string;
@@ -52,6 +60,7 @@
   let {
     text,
     colorScheme = 'neutral',
+    size = 'md',
     Icon,
     extension,
     class: className,
@@ -60,17 +69,22 @@
 </script>
 
 <span
-  class={twMerge(sharedClasses, colorSchemeClasses[colorScheme], className)}
+  class={twMerge(
+    sharedClasses,
+    sizeClasses[size].badge,
+    colorSchemeClasses[colorScheme],
+    className,
+  )}
   {...rest}
 >
-  <span class={segmentClasses}>
+  <span class={twMerge(segmentClasses, sizeClasses[size].segment)}>
     <span>{text}</span>
     {#if Icon}
       <Icon width="1em" height="1em" />
     {/if}
   </span>
   {#if extension}
-    <span class={segmentClasses}>
+    <span class={twMerge(segmentClasses, sizeClasses[size].segment)}>
       {#if extension.LeadIcon}
         <extension.LeadIcon width="1em" height="1em" />
       {/if}

--- a/src/lib/io/badge/index.ts
+++ b/src/lib/io/badge/index.ts
@@ -1,3 +1,7 @@
 export { default as Badge } from './badge.svelte';
 
-export type { BadgeColorScheme, BadgeExtension } from './badge.svelte';
+export type {
+  BadgeColorScheme,
+  BadgeExtension,
+  BadgeSize,
+} from './badge.svelte';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,9 @@ const config = {
       animation: {
         'spin-slow': 'spin 3s linear infinite',
       },
+      fontSize: {
+        '2xs': '0.625rem',
+      },
       zIndex: {
         100: '100',
       },


### PR DESCRIPTION
## Summary
- add default `md` and compact `sm` sizes to IO badges
- add a reusable `text-2xs` font-size token
- document sizes in Storybook

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test -- --run` (3 existing audit CLI failures: missing `scripts/audit-tailwind-colors` module; 3,198 tests passed)