### PR TITLE
fix: Remove drop shadow from loading spinner

### DIFF
--- a/src/lib/holocene/loading.svelte
+++ b/src/lib/holocene/loading.svelte
@@ -62,13 +62,6 @@
       --horizontal-offset-start: -273;
       --horizontal-offset-shape2: -575;
 
-      /* Drop Shadow  */
-      --ellipse-shadow: color-mix(
-        in srgb,
-        var(--color-content-primary) 15%,
-        transparent
-      );
-      --ellipse-drop-shadow: drop-shadow(0 4px 12px var(--ellipse-shadow));
       --stroke-color: var(--color-content-primary);
     }
 
@@ -77,14 +70,12 @@
       stroke: var(--stroke-color);
       stroke-dasharray: 0 848;
       stroke-dashoffset: var(--vertical-offset-start);
-      filter: var(--ellipse-drop-shadow);
     }
 
     .horizontal-ellipse {
       stroke: var(--stroke-color);
       stroke-dasharray: 0 850;
       stroke-dashoffset: var(--horizontal-offset-start);
-      filter: var(--ellipse-drop-shadow);
     }
 
     /* Combined infinite loop animation */


### PR DESCRIPTION
## Description & motivation 💭

The Temporal logo loading spinner rendered each ellipse stroke with a `drop-shadow()` filter, producing a soft halo around the mark. This removes it so the strokes render clean. **This was an ask from Brand Design, as the logo should not have any shadows.**

Three deletions in `holocene/loading.svelte`: the `--ellipse-shadow` / `--ellipse-drop-shadow` custom properties, and the `filter:` application on both `.vertical-ellipse` and `.horizontal-ellipse`. Pure deletion — no reindentation, and no change to the stroke or rotation animations.

Note this is the shared component, so the change applies to the OSS UI as well as Temporal Cloud.

## Testing 🧪

### How was this tested 👻

- [x] Manual testing

Verified in Temporal Cloud UI that the spinner renders without the halo. `eslint`, `prettier`, and `stylelint` all pass via the pre-commit hook.

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️

Render `<Loading />` in Storybook, or trigger any in-app loading state, in both light and dark mode. The ellipse strokes should have no soft shadow beneath them.

## Docs

### Any docs updates needed?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)