### PR TITLE
Fix portaled menus drifting while their trigger button is pressed

### DIFF
--- a/src/lib/holocene/menu/menu.stories.svelte
+++ b/src/lib/holocene/menu/menu.stories.svelte
@@ -16,6 +16,7 @@
     variant?: ComponentProps<typeof MenuButton>['variant'];
     keepOpen?: ComponentProps<typeof Menu>['keepOpen'];
     position?: ComponentProps<typeof Menu>['position'];
+    usePortal?: ComponentProps<typeof Menu>['usePortal'];
     menuElement?: ComponentProps<typeof Menu>['menuElement'];
   };
 
@@ -27,6 +28,7 @@
       variant: 'primary',
       keepOpen: false,
       position: 'left',
+      usePortal: false,
     },
     argTypes: {
       variant: {
@@ -42,6 +44,10 @@
         name: 'Position',
         control: 'inline-radio',
         options: ['left', 'right', 'top-left', 'top-right'],
+      },
+      usePortal: {
+        name: 'Use Portal',
+        control: 'boolean',
       },
       menuElement: {
         name: 'Menu Element',
@@ -70,6 +76,7 @@
         class="w-64"
         keepOpen={args.keepOpen}
         position={args.position}
+        usePortal={args.usePortal}
       >
         <MenuItem href="https://temporal.io" newTab onclick={action('click')}>
           Link

--- a/src/lib/holocene/portal/portal.svelte
+++ b/src/lib/holocene/portal/portal.svelte
@@ -9,6 +9,7 @@
   import {
     calculatePosition,
     getElementRect,
+    getLayoutRect,
     hasMoved,
   } from './position-calculator';
   import type { PortalProps } from './types';
@@ -88,7 +89,7 @@
   function updatePosition() {
     if (!portalElement || !anchorElement) return;
 
-    const anchorRect = getElementRect(anchorElement);
+    const anchorRect = getLayoutRect(anchorElement);
     const portalRect = getElementRect(portalElement);
 
     const containerRect =

--- a/src/lib/holocene/portal/portal.test.ts
+++ b/src/lib/holocene/portal/portal.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   applyOffset,
@@ -8,6 +8,7 @@ import {
   detectCollision,
   getFlippedOffset,
   getFlippedPosition,
+  getLayoutRect,
   hasMoved,
 } from './position-calculator';
 import type { PortalPosition, Rect } from './types';
@@ -298,6 +299,115 @@ describe('position-calculator', () => {
 
     it('should detect a height change', () => {
       expect(hasMoved(anchorRect, createRect(100, 100, 50, 60))).toBe(true);
+    });
+  });
+
+  describe('getLayoutRect', () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        'DOMMatrixReadOnly',
+        class {
+          a: number;
+          b: number;
+          c: number;
+          d: number;
+
+          constructor(value: string) {
+            if (!value.startsWith('matrix(')) {
+              throw new SyntaxError(`Failed to parse '${value}'`);
+            }
+
+            const [a, b, c, d] = value
+              .replace(/^matrix\(|\)$/g, '')
+              .split(',')
+              .map(Number);
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+          }
+        },
+      );
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    const stubElement = (
+      rect: Rect,
+      transform: string,
+      transformOrigin = '25px 15px',
+    ): HTMLElement => {
+      const element = document.createElement('button');
+      element.getBoundingClientRect = () => rect as DOMRect;
+      vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+        transform,
+        transformOrigin,
+      } as CSSStyleDeclaration);
+
+      return element;
+    };
+
+    const expectRect = (actual: Rect, expected: Rect) => {
+      expect(actual.left).toBeCloseTo(expected.left);
+      expect(actual.top).toBeCloseTo(expected.top);
+      expect(actual.width).toBeCloseTo(expected.width);
+      expect(actual.height).toBeCloseTo(expected.height);
+      expect(actual.right).toBeCloseTo(expected.right);
+      expect(actual.bottom).toBeCloseTo(expected.bottom);
+    };
+
+    it('should return the measured rect when the element is untransformed', () => {
+      expect(getLayoutRect(stubElement(anchorRect, 'none'))).toEqual(
+        anchorRect,
+      );
+    });
+
+    it('should undo a press scale applied about the center', () => {
+      const pressed = createRect(100.5, 100.3, 49, 29.4);
+      const element = stubElement(pressed, 'matrix(0.98, 0, 0, 0.98, 0, 0)');
+
+      expectRect(getLayoutRect(element), anchorRect);
+    });
+
+    it('should respect a non-center transform origin', () => {
+      const pressed = createRect(100, 100, 49, 29.4);
+      const element = stubElement(
+        pressed,
+        'matrix(0.98, 0, 0, 0.98, 0, 0)',
+        '0px 0px',
+      );
+
+      expectRect(getLayoutRect(element), anchorRect);
+    });
+
+    it('should return the measured rect for a rotation', () => {
+      const rotated = createRect(95, 95, 60, 40);
+      const element = stubElement(rotated, 'matrix(0.7, 0.7, -0.7, 0.7, 0, 0)');
+
+      expect(getLayoutRect(element)).toEqual(rotated);
+    });
+
+    it('should return the measured rect for a mirrored element', () => {
+      const mirrored = createRect(100, 100, 50, 30);
+      const element = stubElement(mirrored, 'matrix(-1, 0, 0, 1, 0, 0)');
+
+      expect(getLayoutRect(element)).toEqual(mirrored);
+    });
+
+    it('should return the measured rect for a half turn', () => {
+      const turned = createRect(100, 100, 50, 30);
+      const element = stubElement(turned, 'matrix(-1, 0, 0, -1, 0, 0)');
+
+      expect(getLayoutRect(element)).toEqual(turned);
+    });
+
+    it('should return the measured rect when the transform cannot be parsed', () => {
+      const element = stubElement(anchorRect, 'translateX(-50%) scale(0.98)');
+
+      expect(getLayoutRect(element)).toEqual(anchorRect);
     });
   });
 

--- a/src/lib/holocene/portal/position-calculator.ts
+++ b/src/lib/holocene/portal/position-calculator.ts
@@ -28,6 +28,46 @@ export function getElementRect(element: HTMLElement): Rect {
   };
 }
 
+export function getLayoutRect(element: HTMLElement): Rect {
+  const rect = getElementRect(element);
+
+  if (typeof DOMMatrixReadOnly === 'undefined') return rect;
+
+  const { transform, transformOrigin } = window.getComputedStyle(element);
+  if (!transform || transform === 'none') return rect;
+
+  let matrix: DOMMatrixReadOnly;
+  try {
+    matrix = new DOMMatrixReadOnly(transform);
+  } catch {
+    return rect;
+  }
+
+  const { a: scaleX, b, c, d: scaleY } = matrix;
+
+  if (b !== 0 || c !== 0) return rect;
+  if (!(scaleX > 0) || !(scaleY > 0)) return rect;
+  if (scaleX === 1 && scaleY === 1) return rect;
+
+  const [originX = 0, originY = 0] = transformOrigin
+    .split(' ')
+    .map((value) => parseFloat(value) || 0);
+
+  const width = rect.width / scaleX;
+  const height = rect.height / scaleY;
+  const left = rect.left - originX * (1 - scaleX);
+  const top = rect.top - originY * (1 - scaleY);
+
+  return {
+    top,
+    left,
+    width,
+    height,
+    bottom: top + height,
+    right: left + width,
+  };
+}
+
 export function hasMoved(a: Rect, b: Rect): boolean {
   return (
     a.top !== b.top ||


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

Menu's using `usePortal` shift a pixel or two as it opens and closes, then drifts back after the button is released. This was caused because `Portal` positions itself by measuring its anchor with `getBoundingClientRect()`, which **includes** transforms and `Button` has `active:scale-[0.98]` with `transition-all duration-200` that animates down to 98% while the mouse is held and animates back on release. `Portal` re-checks the anchor every frame in a `requestAnimationFrame` loop and repositions whenever `hasMoved()` reports a change.

The new `getLayoutRect()` in `position-calculator.ts` measures an element and then divides out its **own** transform, recovering the untransformed layout box in viewport coordinates. The press animation is untouched and buttons still scale on press, the menu just stops chasing them.

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

| Before | After |
|-|-|
|https://github.com/user-attachments/assets/f98bf4c4-416c-4fb0-8352-060e49f5d928|https://github.com/user-attachments/assets/36c291f9-d715-46b6-9146-85be75b29439|

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [x] Manual testing
- [ ] E2E tests added
- [x] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->
`FE-704`

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
