### PR TITLE
Fix portaled menu drift with a stable anchor

### DIFF
--- a/src/lib/holocene/menu/menu-button.svelte
+++ b/src/lib/holocene/menu/menu-button.svelte
@@ -87,41 +87,54 @@
   };
 </script>
 
-<Button
-  {id}
-  {disabled}
-  type="button"
-  onclick={handleClick}
-  onkeydown={handleKeyDown}
-  aria-haspopup={!disabled}
-  aria-controls={controls}
-  aria-expanded={$open}
-  aria-label={label}
-  {variant}
-  class={className}
-  {size}
-  active={$open}
-  disableTracking={true}
-  {...rest}
->
-  {@render leading?.()}
-  {#if children}
-    <div class="flex min-w-0 grow items-center">
-      {@render children()}
-    </div>
-  {/if}
-  {#if hasIndicator}
-    <div class="flex">
-      <IconChevronDown
-        class={merge('transition-transform', $open && 'rotate-180')}
+<span class="menu-button-anchor" data-menu-anchor={controls}>
+  <Button
+    {id}
+    {disabled}
+    type="button"
+    onclick={handleClick}
+    onkeydown={handleKeyDown}
+    aria-haspopup={!disabled}
+    aria-controls={controls}
+    aria-expanded={$open}
+    aria-label={label}
+    {variant}
+    class={className}
+    {size}
+    active={$open}
+    disableTracking={true}
+    {...rest}
+  >
+    {@render leading?.()}
+    {#if children}
+      <div class="flex min-w-0 grow items-center">
+        {@render children()}
+      </div>
+    {/if}
+    {#if hasIndicator}
+      <div class="flex">
+        <IconChevronDown
+          class={merge('transition-transform', $open && 'rotate-180')}
+        />
+      </div>
+    {/if}
+    {@render trailing?.()}
+    {#if count > 0}
+      <BadgeCount
+        class="absolute right-0 top-0 translate-x-[10px] translate-y-[-10px]"
+        value={count}
       />
-    </div>
-  {/if}
-  {@render trailing?.()}
-  {#if count > 0}
-    <BadgeCount
-      class="absolute right-0 top-0 translate-x-[10px] translate-y-[-10px]"
-      value={count}
-    />
-  {/if}
-</Button>
+    {/if}
+  </Button>
+</span>
+
+<style>
+  .menu-button-anchor {
+    display: inline-flex;
+    max-width: 100%;
+  }
+
+  .menu-button-anchor:has(> :global(button.w-full)) {
+    width: 100%;
+  }
+</style>

--- a/src/lib/holocene/menu/menu.stories.svelte
+++ b/src/lib/holocene/menu/menu.stories.svelte
@@ -16,6 +16,7 @@
     variant?: ComponentProps<typeof MenuButton>['variant'];
     keepOpen?: ComponentProps<typeof Menu>['keepOpen'];
     position?: ComponentProps<typeof Menu>['position'];
+    usePortal?: ComponentProps<typeof Menu>['usePortal'];
     menuElement?: ComponentProps<typeof Menu>['menuElement'];
   };
 
@@ -27,6 +28,7 @@
       variant: 'primary',
       keepOpen: false,
       position: 'left',
+      usePortal: false,
     },
     argTypes: {
       variant: {
@@ -42,6 +44,10 @@
         name: 'Position',
         control: 'inline-radio',
         options: ['left', 'right', 'top-left', 'top-right'],
+      },
+      usePortal: {
+        name: 'Use Portal',
+        control: 'boolean',
       },
       menuElement: {
         name: 'Menu Element',
@@ -70,6 +76,7 @@
         class="w-64"
         keepOpen={args.keepOpen}
         position={args.position}
+        usePortal={args.usePortal}
       >
         <MenuItem href="https://temporal.io" newTab onclick={action('click')}>
           Link

--- a/src/lib/holocene/menu/menu.svelte
+++ b/src/lib/holocene/menu/menu.svelte
@@ -99,9 +99,9 @@
 
   $effect(function getAnchorElement() {
     if (usePortal && id) {
-      anchorElement = document.querySelector(
-        `[aria-controls="${id}"]`,
-      ) as HTMLElement | null;
+      anchorElement = document.querySelector<HTMLElement>(
+        `[data-menu-anchor="${id}"]`,
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- anchor portaled menus to an untransformed wrapper around the trigger
- preserve the button press-scale animation without computed-style measurements
- add a portal control to the menu story

## Testing
- `pnpm lint`
- `pnpm check`
- `pnpm test -- --run src/lib/holocene/portal/portal.test.ts`