### PR TITLE
Make nexus registry description reusable

### DIFF
--- a/src/lib/i18n/locales/en/nexus.ts
+++ b/src/lib/i18n/locales/en/nexus.ts
@@ -97,4 +97,20 @@ export const Strings = {
   operation: 'Operation',
   'operation-token': 'Operation Token',
   'cancellation-info': 'Cancellation Info',
+  'registry-empty-state-title': 'Get Started',
+  'registry-empty-state-nexus-link': 'Temporal Nexus',
+  'registry-empty-state-nexus-description':
+    "allows you to reliably connect Temporal Applications. It promotes a more modular architecture for sharing a subset of your team's capabilities with well-defined microservice contracts for other teams to use. Nexus was designed with Durable Execution in mind and enables each team to have their own Namespace for improved modularity, security, debugging, and fault isolation.",
+  'registry-empty-state-services-link': 'Nexus Services',
+  'registry-empty-state-services-preface': 'are exposed from a',
+  'registry-empty-state-endpoint-link': 'Nexus Endpoint',
+  'registry-empty-state-services-midface': 'created in the',
+  'registry-empty-state-registry-link': 'Nexus Registry',
+  'registry-empty-state-services-postface':
+    '. Adding a Nexus Endpoint to the Nexus Registry deploys the Endpoint, so it is available at runtime to serve Nexus requests.',
+  'registry-empty-state-proxy-preface':
+    'A Nexus Endpoint is a reverse proxy that decouples the caller from the handler and routes requests to upstream targets. It currently supports routing to a single target Namespace and Task Queue. Nexus Services and',
+  'registry-empty-state-operations-link': 'Nexus Operations',
+  'registry-empty-state-proxy-postface':
+    'are often registered in the same Worker as the underlying Temporal primitives they abstract.',
 } as const;

--- a/src/lib/pages/nexus-empty-state.svelte
+++ b/src/lib/pages/nexus-empty-state.svelte
@@ -16,7 +16,7 @@
   let { actions }: Props = $props();
 </script>
 
-<div class="flex min-h-screen flex-col gap-8 p-10">
+<div class="flex flex-col gap-8 p-10">
   <div class="flex flex-col gap-4 lg:flex-row">
     <div>
       <div class="mb-8 flex items-center gap-4">

--- a/src/lib/pages/nexus-empty-state.svelte
+++ b/src/lib/pages/nexus-empty-state.svelte
@@ -1,8 +1,11 @@
+<script module lang="ts">
+  import Link from '$lib/holocene/link.svelte';
+  import { translate } from '$lib/i18n/translate';
+</script>
+
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  import Link from '$lib/holocene/link.svelte';
-  import { translate } from '$lib/i18n/translate';
   import { useDarkMode } from '$lib/utilities/dark-mode';
   import andromeda from '$lib/vendor/andromeda.png';
 
@@ -25,38 +28,11 @@
         </h1>
       </div>
       <div class="flex w-full flex-col gap-4 pr-8 md:pr-24">
-        <h2 class="text-4xl">Get Started</h2>
+        <h2 class="text-4xl">
+          {translate('nexus.registry-empty-state-title')}
+        </h2>
 
-        <p>
-          <Link href="https://docs.temporal.io/evaluate/nexus" newTab
-            >Temporal Nexus</Link
-          > allows you to reliably connect Temporal Applications. It promotes a more
-          modular architecture for sharing a subset of your team's capabilities with
-          well-defined microservice contracts for other teams to use. Nexus was designed
-          with Durable Execution in mind and enables each team to have their own Namespace
-          for improved modularity, security, debugging, and fault isolation.
-        </p>
-        <p>
-          <Link href="https://docs.temporal.io/nexus/services" newTab
-            >Nexus Services</Link
-          > are exposed from a <Link
-            href="https://docs.temporal.io/nexus/endpoints"
-            newTab>Nexus Endpoint</Link
-          > created in the <Link
-            href="https://docs.temporal.io/nexus/registry"
-            newTab>Nexus Registry</Link
-          >. Adding a Nexus Endpoint to the Nexus Registry deploys the Endpoint,
-          so it is available at runtime to serve Nexus requests.
-        </p>
-        <p>
-          A Nexus Endpoint is a reverse proxy that decouples the caller from the
-          handler and routes requests to upstream targets. It currently supports
-          routing to a single target Namespace and Task Queue. Nexus Services
-          and <Link href="https://docs.temporal.io/nexus/operations" newTab
-            >Nexus Operations</Link
-          > are often registered in the same Worker as the underlying Temporal primitives
-          they abstract.
-        </p>
+        {@render nexusRegistryDescription()}
         {@render actions?.()}
       </div>
     </div>
@@ -65,6 +41,35 @@
     </div>
   </div>
 </div>
+
+{#snippet nexusRegistryDescription()}
+  <p>
+    <Link href="https://docs.temporal.io/evaluate/nexus" newTab>
+      {translate('nexus.registry-empty-state-nexus-link')}
+    </Link>
+    {translate('nexus.registry-empty-state-nexus-description')}
+  </p>
+  <p>
+    <Link href="https://docs.temporal.io/nexus/services" newTab>
+      {translate('nexus.registry-empty-state-services-link')}
+    </Link>
+    {translate('nexus.registry-empty-state-services-preface')}
+    <Link href="https://docs.temporal.io/nexus/endpoints" newTab>
+      {translate('nexus.registry-empty-state-endpoint-link')}
+    </Link>
+    {translate('nexus.registry-empty-state-services-midface')}
+    <Link href="https://docs.temporal.io/nexus/registry" newTab
+      >{translate('nexus.registry-empty-state-registry-link')}</Link
+    >{translate('nexus.registry-empty-state-services-postface')}
+  </p>
+  <p>
+    {translate('nexus.registry-empty-state-proxy-preface')}
+    <Link href="https://docs.temporal.io/nexus/operations" newTab>
+      {translate('nexus.registry-empty-state-operations-link')}
+    </Link>
+    {translate('nexus.registry-empty-state-proxy-postface')}
+  </p>
+{/snippet}
 
 <style>
   .invert {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## Description & motivation 💭 <!-- Describe what has changed in this PR and the motivation behind it -->

### Screenshots (if applicable) 📸 <!-- Add screenshots or videos -->

### Design Considerations 🎨 <!-- Any questions, concerns, thoughts for Design? -->

## Testing 🧪 <!-- Describe what has changed in this PR and the motivation behind it -->

### How was this tested 👻 <!--- Please describe how you tested your changes and tests that were added -->

- [ ] Manual testing
- [ ] E2E tests added
- [ ] Unit tests added

### Steps for others to test: 🚶🏽‍♂️🚶🏽‍♀️ <!--- Please describe how we can test the changes in the PR -->

## Checklists

### Draft Checklist <!-- Add todos if not ready to review -->

### Merge Checklist <!-- Add todos if not ready to merge -->

### Issue(s) closed <!-- add issue number here -->

## Docs

### Any docs updates needed? <!--- Update README if applicable or point out where to update docs.temporal.io -->

<!--
A11y audit PRs: if this PR closes one or more accessibility audit fix docs,
add an `A11y-Audit-Ref: <slug>` line per fix doc closed. Example:

  A11y-Audit-Ref: 2.5.8-chip-remove-button

The A11y PR Triage workflow uses these trailers to apply bucket labels.
See CLAUDE.md ("Accessibility Audit Follow-up") for details.
-->
